### PR TITLE
Address bugs in initial agent run

### DIFF
--- a/.github/agent-scripts/README.md
+++ b/.github/agent-scripts/README.md
@@ -26,6 +26,7 @@ Project Manager → Task Reviewer → Task Implementer
 
 **Triggers**:
 - `run-review` label added to issue
+- Post a comment on an issue which includes `/strands-review`
 - Manual workflow dispatch
 
 ### 3. Task Implementer Agent (`task-implementer.script.md`)
@@ -33,7 +34,11 @@ Project Manager → Task Reviewer → Task Implementer
 
 **Triggers**:
 - `run-implement` label added to issue or pull request
+- Post a comment on an issue/pull reqeust, or create a review, that includes `/strands-implement`
 - Manual workflow dispatch
+
+**Note**: You must enable "Allow GitHub Actions to create and approve pull requests" on your repo:
+- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests
 
 ## Project Structure
 

--- a/.github/agent-scripts/project-manager.script.md
+++ b/.github/agent-scripts/project-manager.script.md
@@ -84,7 +84,7 @@ Create GitHub issues for ready-to-start tasks that don't have existing issues.
 - You MUST create a GitHub issue with the title format: "Task <TASK_ID>: <TASK_TITLE>"
 - You MUST include all task information (description, work required, exit criteria, dependencies) in the issue body
 - You MUST NOT assign the issue to anyone
-- You MUST NOT add labels to the issues
+- You MUST add the `review-task` label to the issue
 - You MUST NOT read task files that are not ready to start
 - You SHOULD format the issue body clearly with sections for each task component
 - You SHOULD create a comment on the project tracking issue ONLY if you created an issue

--- a/.github/agent-scripts/task-implementer.script.md
+++ b/.github/agent-scripts/task-implementer.script.md
@@ -28,12 +28,15 @@ Initialize the project environment and discover repository instruction files.
   - `README.md`
 - You MAY explore more files in the repository if you did not find instructions
 - You MUST make a note of environment setup and testing instructions
+- You MUST make note of the tasks number from the issue title
+- You MUST make note of the issue number
 - You MUST run unit test to ensure the repository and environment are functional
 - You MAY run integration tests if your feature requires new tests to be added
-- You MUST comment on the github issue if the tests fail, and wait for user feedback on how to continue.
-- You MUST use `git checkout -b agent-tasks/{TASK_NUMBER}` to create and switch to a new feature branch
+- You MUST comment on the github issue if the tests fail, and use the handoff_to_user tool to get feedback on how to continue.
+- You MUST use `git checkout -b <BRANCH_NAME>` to create and switch to a new feature branch
+- You SHOULD use the BRANCH_NAME pattern `agent-tasks/{TASK_NUMBER}` unless this branch already exists
 - You MUST make note of the newly created branch name
-- You MUST use `git push origin agent-tasks/{TASK_NUMBER}` to create the feature branch in remote
+- You MUST use `git push origin <BRANCH_NAME>` to create the feature branch in remote
 
 
 ### 2. Explore Phase
@@ -160,7 +163,7 @@ Write test cases based on the outlines, following strict TDD principles.
   - Tests fail for unexpected reasons that you cannot resolve
   - There are structural issues with the test framework
   - You encounter environment issues that prevent test execution
-- You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction
+- You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction by using the handoff_to_user tool
 - You MUST otherwise continue automatically after verifying expected failures
 - You MUST follow the Build Output Management practices defined in the Best Practices section
 
@@ -189,7 +192,7 @@ Write implementation code to pass the tests, focusing on simplicity and correctn
   - Tests continue to fail after implementation for reasons you cannot resolve
   - You encounter a design decision that cannot be inferred from requirements
   - Multiple valid implementation approaches exist with significant trade-offs
-- You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction
+- You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction by using the handoff_to_user tool
 - You MUST otherwise continue automatically after verifying test results
 - You MUST follow the Build Output Management practices defined in the Best Practices section
 
@@ -238,7 +241,9 @@ If all tests are passing, draft a conventional commit message, perform the git c
 - You MUST use `git push origin <BRANCH_NAME>` to push the local branch to the remote 
 - You MUST use the `create_pull_request` tool to create the pull request if it does not exist yet
   - You MUST use the following title format: `Task <TASK_ID>: <TASK_NAME> Implementation`
-  - You MUST link to the Task issue in the pull request body
+  - You MUST use the task id recorded in your notes, not the issue id
+  - You MUST include "Resolves: #<ISSUE NUMBER>" in the body of the pull request
+    - You MUST NOT bold this line
   - You MUST give an overview of the feature being implemented
   - You MUST include any notes on key implementation decisions, ambiguity, or other information as part of the pull request description
 - You MUST use the `get_pull_request` tool to verify the pull request was created/updated properly
@@ -250,19 +255,20 @@ If all tests are passing, draft a conventional commit message, perform the git c
 
 #### 6.1 Report Ready for Review
 
-Request the user for feedback on the implementation and wait for PR comments.
+Request the user for feedback on the implementation using the handoff_to_user tool.
 
 **Constraints:**
-- You MUST ask the user to review the implementation and provide feedback
-- You MUST wait for the user to indicate they have added comments to the PR
-- You MUST NOT proceed to the next step until the user confirms feedback has been added
+- You MUST use the handoff_to_user tool to inform the user you want their feedback as comments on the pull request
 
 #### 6.2. Read User Responses
 
 Retrieve and analyze the user's responses from the pull request reviews and comments.
 
 **Constraints:**
-- You MUST fetch the latest comments from the PR using available tools
+- You MUST fetch the review and the review comments from the PR using available tools
+  - You MUST use the list_pr_reviews to list all pr reviews
+  - You MUST use get_pr_review_comments to list the comments from the review
+  - You MUST use get_issue_comments to list the comments on the pull request
 - You MUST analyze each comment to determine if the request is clear and actionable
 - You MUST categorize comments as:
   - Clear actionable requests that can be implemented
@@ -281,8 +287,9 @@ Based on the users feedback, you will review and update your implementation plan
 - You MUST update your implementation plan based on the feedback from the user
 - You MUST return to step 3 if you need to re-plan your implementation
 - You MUST return to step 4 if you only need to make minor fixes
+- You MUST NOT close the parent issue - only the user should close it after the pull request is merged
 - You MUST not attempt to merge the pull request
-- You MUST ask the user for any clarifying information on the pull request
+- You MUST use the handoff_to_user tool to inform the user you are ready for clarifying information on the pull request
 
 ## Desired Outcome
 
@@ -315,6 +322,7 @@ issue_number: 123
 
 ### Branch Creation Issues
 If feature branch creation fails:
+- Move any changes in the `.github` directory to the `.github_temp` directory
 - Check for existing branch with same name
 - Generate alternative branch name with timestamp
 - Ensure git repository is properly 

--- a/.github/agent-scripts/task-reviewer.script.md
+++ b/.github/agent-scripts/task-reviewer.script.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are a Task Reviewer, and your goal is to review the feature request for a task and prepare it for implementation. This task feature request is defined as a github issue. You read the feature request in the issue, identify ambiguities, post clarifying questions as comments, wait for responses, and iterate until confident that the feature request is ready to implement. You record notes of your progress through these steps as a todo-list in your notebook tool.
+You are a Task Reviewer, and your goal is to review the feature request for a task and prepare it for implementation. This task feature request is defined as a github issue. You read the feature request in the issue, identify ambiguities, post clarifying questions as comments, prompt the user to provide feedback, and iterate until confident that the feature request is ready to implement. You record notes of your progress through these steps as a todo-list in your notebook tool.
 
 ---
 *Generated with script-generator.script.md on 2025-09-19*
@@ -65,42 +65,53 @@ After performing the investigation of the feature request and understanding the 
 - You MUST identify the work required to implement this feature
 - You MUST review the current state of the repository, and identify any potential issues that might occur during implementation
 - You MUST determine if this task is small enough to be implemented in a single Pull Request
-  - You MUST note how to break this task down into multiple tasks so that it is of the propoer scope for a single developer to implement
+  - You should think if a single developer can implement this feature in about a week
 - You MUST consider test implementation complexities as part of this feature request
+- You MUST note if any github workflows are needed, or any changes to existing workflows are needed
 - You MUST note any concerns in your notebook
 
 ### 3 Clarification Phase
-#### 3.1 Generate Clarifying Questions
 
-Create a comprehensive list of questions to resolve ambiguities and gather missing information. Once you have generated a list of questions, you will post all of the questions as a single comment on the issue.
+### 3.1. Evaluate Completeness
+
+Deterime if you should ask clarifying questions, or if the task is already in an implementable state given your research.
+
+**Constraints:**
+- You MAY skip to step 4 if you do not have any clarifying questions
+- You SHOULD continue to the next step if you have identified questions to ask
+
+#### 3.2 Generate Clarifying Questions
+
+Create a numbered list of questions to resolve ambiguities and gather missing information. Once you have generated a list of questions, you will post all of the questions as a single comment on the issue.
 
 **Constraints:**
 - You MUST review relevant notes you made in your notebook
-- You MUST ask the user if the issue should be broken down smaller issues
-  - You MUST provide justification for why it should be broken down
-  - You MUST suggest how the issue should be broken down into smaller feature requests
-- You MUST ask about any ambiguous functionality
-- You MUST clarify technical implementation details
-- You MUST ask about user experience expectations
-- You MUST ask for user input on edge cases that might not be obvious from the requirements
-- You MUST ask clarify questions regarding information from provided links
-- You SHOULD ask about non-functional requirements that might not be explicitly stated
+- You MUST clarify if github workflow creations or changes are needed
+  - You MUST suggest creating them under a `.github_temp` directory since you do not have permission to push to `.github` directory
+- You MAY ask about any ambiguous functionality
+- You MAY clarify technical implementation details
+- You MAY ask about user experience expectations
+- You MAY ask for user input on edge cases that might not be obvious from the requirements
+- You MAY ask clarify questions regarding information from provided links
+- You MAY ask about non-functional requirements that might not be explicitly stated
 - You SHOULD group related questions logically
-- You MUST include questions about integration with existing systems
+- You MAY include questions about integration with existing systems
+- You MAY ask the user if the issue should be broken down smaller issues
+  - You SHOULD provide justification for why it should be broken down
+  - You SHOULD suggest how the issue should be broken down into smaller feature requests
 - You SHOULD ask about performance and scalability requirements
 - You MUST create a comment with all of your questions on the issue.
 
-#### 3.2 Wait for User Response
+#### 3.3 Handoff to User for Response
 
-Wait for manual confirmation that the user has responded to the questions on the issue.
+Use the handoff_to_user tool to inform the user they can reply to the clarifying questions on the issue.
 
 **Constraints:**
-- You MUST prompt the user to confirm when they have replied
-- You MUST NOT automatically poll for responses
-- You SHOULD provide clear instructions on what the user needs to do
-- You MUST be patient and wait for explicit user confirmation
+- You MUST use the handoff_to_user tool after posting your questions
+- You MUST ask your clarifying questions when handing off to user
+- You MUST tell the user to reply to your questions on the issue
 
-#### 3.3. Read User Responses
+#### 3.4. Read User Responses
 
 Retrieve and analyze the user's responses from the issue comments.
 
@@ -111,7 +122,7 @@ Retrieve and analyze the user's responses from the issue comments.
 - You MUST handle cases where responses are incomplete or unclear
 - You SHOULD take notes on how the repository can be updated (e.g. udpate AGENTS.md, CONTRIBUITNG.md, README.md, etc) to clarify ambiguity in the future
 
-#### 3.4 (Optional) Break Down Task
+#### 3.5 (Optional) Break Down Task
 
 Determine from the users responses if the task should be broken down into sub-task. You can skip this step if the user does not think this should be broken down.
 
@@ -123,7 +134,7 @@ Determine from the users responses if the task should be broken down into sub-ta
 - You MUST determine a name for each new task
 - You MUST number the new sub-tasks based on their parent task number. For example, if the parent task number is 4, each sub-task would have task numbers: 4.1, 4.2, 4.3, ...
 
-#### 3.5 Evaluate Completeness
+#### 3.6 Re-Evaluate Completeness
 
 Determine if the responses provide sufficient information for implementation
 
@@ -133,18 +144,13 @@ Determine if the responses provide sufficient information for implementation
 - You MUST determine if additional clarification is needed
 - You MUST be thorough in your assessment before proceeding
 - You SHOULD consider the repository context in your evaluation
-
-### 3.5. Iterate or Finalize
-
-Either ask additional questions or finalize the task.
-
-**Constraints:**
+- You MUST make note of your decision
+- You MAY continue to the next step if you have no more clarifying questions
+- You SHOULD make note of your decision to continue
 - You MAY return to step 2 if you need to do more research based on the answers the user provided
-- You MAY return to step 3.1 if significant questions remain unanswered
+- You MAY return to step 3.2 if significant questions remain unanswered
 - You MUST limit iterations to prevent endless loops (maximum 5 rounds of questions)
-- You SHOULD consolidate follow-up questions efficiently
-- You MUST proceed to finalization when confident about requirements
-- You SHOULD explain your decision to continue or finalize
+
 
 ### 4. Update Task
 #### 4.1 Update Task Description
@@ -159,6 +165,8 @@ Update the original issue with a comprehensive task description.
 - You MUST document any assumptions made
 - You MUST mention any ways to improve clarification in the repository going forward
 - You SHOULD include acceptance criteria
+- You MUST remove any github workflow requirnments if they must be created under the `.github` directory since you do not have permission to push to that directory
+- You MAY include github workflow requirnments if they can be created under the `.github_temp` directory
 - You MUST maintain professional formatting and clarity
 - You SHOULD include implementation approach based on repository analysis
 - You MAY include sub-tasks as requirnments to the parent task description if there are any sub-tasks

--- a/.github/workflows/project-manager-agent.yml
+++ b/.github/workflows/project-manager-agent.yml
@@ -81,5 +81,11 @@ jobs:
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           system_prompt: ${{ steps.project-manager-agent-script.outputs.system_prompt }}
-          tools: "editor,file_read,shell,http_request,add_comment,list_issues,list_pull_requests,create_issue,get_issue,get_pull_request,get_pr_reviews,update_issue,get_issue_comments,notebook"
+          thinking_type: "enabled"
+          budget_tokens: "8000"
+          model: "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+          anthropic_beta: "interleaved-thinking-2025-05-14"
+          max_tokens: "64000"
+
+          tools: "editor,file_read,shell,http_request,add_comment,list_issues,list_pull_requests,create_issue,get_issue,get_pull_request,get_pr_review_and_comments,update_issue,get_issue_comments,notebook"
           task: ${{ inputs.prompt || steps.project-manager-agent-script.outputs.task }}

--- a/.github/workflows/task-implementer-agent.yml
+++ b/.github/workflows/task-implementer-agent.yml
@@ -1,8 +1,16 @@
 name: Task Implementer Agent
 
 on:
+  # Pull requests created by workflows will never tirgger the `pull_request` event type
+  # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
   pull_request:
     types: [labeled]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
   issues:
     types: [labeled]
   workflow_dispatch:
@@ -35,76 +43,30 @@ on:
 jobs:
   task-implementer:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event.action == 'labeled' && github.event.label.name == 'run-implement')
+    # This workflow should trigger in the following cases:
+    # 1. Workflow dispatch for testing/debugging
+    # 2. Label added to an issue `implement-task`
+    # 3. Comment added to an issue `/strands-implement`
+    # 4. Comment added to a pull request `/strands-implement`
+    # *5. Label added to a pull request `implement-task`
+    # *6. Comment on pull request review with `/strands-implement`
+    # *7. Comment on a pull request review commetn with `strands-implement`
+    #
+    # Cases with '*' cannot be triggered if the pull request is created by a github workflow
+    # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+    if: |
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.action == 'labeled' && github.event.label.name == 'implement-task') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/strands-implement')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/strands-implement')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/strands-implement'))
     permissions:
       contents: write
       issues: write
       pull-requests: write
       id-token: write  # Required for OIDC
     steps:
-      - name: Replace run-implement label with implement-running
-        if: github.event_name == 'issues'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'run-implement'
-            });
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['implement-running']
-            });
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-            ref: ${{ inputs.pull_request_id && format('refs/pull/{0}/head', inputs.pull_request_id) || (github.event_name == 'pull_request' && github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number)) || 'main' }}
-
-      - name: Read task implementer script
-        id: task-implementer-agent-script
-        if: (github.event_name == 'workflow_dispatch' && inputs.execution_mode == 'Initialize') || (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'run-implement')
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            
-            const systemPrompt = fs.readFileSync('.github/agent-scripts/task-implementer.script.md', 'utf8');
-            const projectOverview = fs.readFileSync('${{ inputs.project_overview_file || '.project/project-overview.md' }}', 'utf8');
-            
-            const issueId = '${{ inputs.issue_id || github.event.issue.number }}';
-            
-            const task = `project_overview:
-            \`\`\`markdown
-            ${projectOverview}
-            \`\`\`
-
-            issue_number: ${issueId}
-
-            Implement the feature in issue #${issueId}`;
-
-            core.setOutput('system_prompt', systemPrompt);
-            core.setOutput('task', task);
-
-      - uses: strands-agents/strands-action@main
-        with:
-          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-          system_prompt: ${{ steps.task-implementer-agent-script.outputs.system_prompt }}
-          session_id: "implementer-${{ inputs.issue_id || github.event.issue.number || github.run_id }}"
-          session_s3_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
-          tools: "editor,file_read,shell,http_request,list_pull_requests,list_issues,add_comment,create_issue,get_issue,get_pull_request,update_pull_request,get_pr_reviews,create_pull_request,update_issue,get_issue_comments,reply_to_pr_review,notebook"
-          # Prompt always overrides the task prompt for any mode
-          # If the mode is "Initialize", then the prompt should provide the input parameters to the script
-          # If the mode is "Continue", then the prompt should tell the agent to review the feedback on the issue.
-          task: ${{ inputs.prompt || ((inputs.execution_mode == 'Continue' || github.event_name == 'pull_request') && 'Review the feedback and continue.') || steps.task-implementer-agent-script.outputs.task }}
-
-      - name: Remove agent-running label
-        if: always() && github.event_name == 'issues'
+      - name: Replace implement-task label with task-implement-running
         uses: actions/github-script@v7
         with:
           script: |
@@ -113,7 +75,105 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                name: 'implement-running'
+                name: 'implement-task'
+              });
+            } catch (error) {
+              console.log('implement-task label may not exist:', error.message);
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['task-implement-running']
+            });
+
+      - name: Extract issue ID from PR body
+        id: extract-issue
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Extract issue number from PR body using GitHub linking keywords
+            // Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+            const prBody = context.payload.pull_request?.body || '';
+            const issueMatch = prBody.match(/(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?):\s*#(\d+)|(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\s+#(\d+)/i);
+            const issueNumber = issueMatch ? (issueMatch[1] || issueMatch[2]) : null;
+            core.setOutput('issue_number', issueNumber);
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+            ref: ${{ inputs.pull_request_id && format('refs/pull/{0}/head', inputs.pull_request_id) || (github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event.review.pull_request.number && format('refs/pull/{0}/head', github.event.review.pull_request.number)) || (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || 'main' }}
+
+      - name: Read task implementer script
+        id: task-implementer-agent-script
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const systemPrompt = fs.readFileSync('.github/agent-scripts/task-implementer.script.md', 'utf8');
+            
+            // Determine task based on execution mode and event type
+            let task;
+            
+            // Input prompt always overrides everything for testing
+            if ('${{ inputs.prompt }}') {
+              task = '${{ inputs.prompt }}';
+            }
+            // If the mode is "Continue" or it's a PR-related event, tell agent to review feedback
+            else if ('${{ inputs.execution_mode }}' === 'Continue' || 
+                     '${{ github.event_name }}' === 'pull_request' || 
+                     '${{ github.event_name }}' === 'pull_request_comment' || 
+                     '${{ github.event_name }}' === 'pull_request_review' ||
+                     ('${{ github.event_name }}' === 'issue_comment' && '${{ github.event.issue.pull_request }}')) {
+              task = 'Review and address the feedback on the pr.';
+            }
+            // Otherwise, generate the full task with project overview
+            else {
+              const projectOverview = fs.readFileSync('${{ inputs.project_overview_file || '.project/project-overview.md' }}', 'utf8');
+              const issueId = '${{ inputs.issue_id || github.event.issue.number }}';
+              
+              task = `project_overview:
+              \`\`\`markdown
+              ${projectOverview}
+              \`\`\`
+
+              issue_number: ${issueId}
+
+              Implement the feature in issue #${issueId}`;
+            }
+
+            core.setOutput('system_prompt', systemPrompt);
+            core.setOutput('task', task);
+
+      - uses: strands-agents/strands-action@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          system_prompt: ${{ steps.task-implementer-agent-script.outputs.system_prompt }}
+          session_id: "implementer-${{ inputs.issue_id || github.event.issue.number || steps.extract-issue.outputs.issue_number }}"
+          session_s3_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
+          thinking_type: "enabled"
+          budget_tokens: "8000"
+          model: "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+          anthropic_beta: "interleaved-thinking-2025-05-14"
+          max_tokens: "64000"
+          tools: "editor,file_read,shell,http_request,create_issue,get_issue,update_issue,list_issues,add_issue_comment,get_issue_comments,create_pull_request,get_pull_request,update_pull_request,list_pull_requests,get_pr_review_and_comments,notebook,handoff_to_user"
+          task: ${{ steps.task-implementer-agent-script.outputs.task }}
+
+      - name: Remove task-implement-running label
+        uses: actions/github-script@v7
+        # Always remove the label even on failure
+        if: always()
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'task-implement-running'
               });
             } catch (error) {
               console.log('Label may not exist:', error.message);

--- a/.github/workflows/task-reviewer-agent.yml
+++ b/.github/workflows/task-reviewer-agent.yml
@@ -3,6 +3,8 @@ name: Task Reviewer Agent
 on:
   issues:
     types: [labeled]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       prompt:
@@ -29,74 +31,17 @@ on:
 jobs:
   task-reviewer:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event.action == 'labeled' && github.event.label.name == 'run-review')
+    if: |
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.action == 'labeled' && github.event.label.name == 'review-task') ||
+      (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '/strands-review'))
     permissions:
       contents: write
       issues: write
       pull-requests: write
       id-token: write  # Required for OIDC
     steps:
-      - name: Replace run-review label with review-running
-        if: github.event_name == 'issues'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'run-review'
-            });
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['review-running']
-            });
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-
-      - name: Read task implementer script
-        id: task-reviewer-agent-script
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            
-            const systemPrompt = fs.readFileSync('.github/agent-scripts/task-reviewer.script.md', 'utf8');
-            const projectOverview = fs.readFileSync('${{ inputs.project_overview_file || '.project/project-overview.md' }}', 'utf8');
-            
-            const issueId = '${{ inputs.issue_id || github.event.issue.number }}';
-            
-            const task = `project_overview:
-            \`\`\`markdown
-            ${projectOverview}
-            \`\`\`
-
-            issue_number: ${issueId}
-
-            Review the feature in the issue.`;
-
-            core.setOutput('system_prompt', systemPrompt);
-            core.setOutput('task', task);
-
-      - uses: strands-agents/strands-action@main
-        with:
-          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-          system_prompt: ${{ steps.task-reviewer-agent-script.outputs.system_prompt }}
-          session_id: "reviewer-${{ inputs.issue_id || github.event.issue.number || github.run_id }}"
-          session_s3_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
-          tools: "editor,file_read,shell,http_request,list_pull_requests,list_issues,add_comment,create_issue,get_issue,get_pull_request,update_pull_request,get_pr_reviews,update_issue,get_issue_comments,notebook"
-          # Prompt always overrides the task prompt for any mode
-          # If the mode is "Initialize", then the prompt should provide the input parameters to the script
-          # If the mode is "Continue", then the prompt should tell the agent to review the feedback on the issue.
-          task: ${{ inputs.prompt || (inputs.execution_mode == 'Continue' && 'Review the feedback and continue.') || steps.task-reviewer-agent-script.outputs.task }}
-
-      - name: Remove agent-running label
-        if: always() && github.event_name == 'issues'
+      - name: Replace review-task label with task-review-running
         uses: actions/github-script@v7
         with:
           script: |
@@ -105,7 +50,89 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                name: 'review-running'
+                name: 'review-task'
+              });
+            } catch (error) {
+              console.log('review-task label may not exist:', error.message);
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['task-review-running']
+            });
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+      - name: Read task reviewer script
+        id: task-reviewer-agent-script
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const systemPrompt = fs.readFileSync('.github/agent-scripts/task-reviewer.script.md', 'utf8');
+            
+            // Determine task based on execution mode
+            let task;
+            
+            // Prompt always overrides the task prompt for any mode
+            if ('${{ inputs.prompt }}') {
+              task = '${{ inputs.prompt }}';
+            }
+            // If the mode is "Continue", tell agent to review feedback
+            else if ('${{ inputs.execution_mode }}' === 'Continue') {
+              task = 'Review the feedback and continue.';
+            }
+            // Otherwise, generate the full task with project overview
+            else {
+              const projectOverview = fs.readFileSync('${{ inputs.project_overview_file || '.project/project-overview.md' }}', 'utf8');
+              const issueId = '${{ inputs.issue_id || github.event.issue.number }}';
+              
+              task = `project_overview:
+              \`\`\`markdown
+              ${projectOverview}
+              \`\`\`
+
+              issue_number: ${issueId}
+
+              Review the feature in the issue.`;
+            }
+
+            core.setOutput('system_prompt', systemPrompt);
+            core.setOutput('task', task);
+
+      - uses: strands-agents/strands-action@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          system_prompt: ${{ steps.task-reviewer-agent-script.outputs.system_prompt }}
+          session_id: "reviewer-${{ inputs.issue_id || github.event.issue.number }}"
+          session_s3_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
+
+          thinking_type: "enabled"
+          budget_tokens: "8000"
+          model: "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+          anthropic_beta: "interleaved-thinking-2025-05-14"
+          max_tokens: "64000"
+
+          tools: "editor,file_read,shell,http_request,create_issue,get_issue,update_issue,list_issues,add_issue_comment,get_issue_comments,get_pull_request,update_pull_request,list_pull_requests,get_pr_review_and_comments,notebook,handoff_to_user"
+          task: ${{ steps.task-reviewer-agent-script.outputs.task }}
+
+      - name: Remove task-review-running label
+        uses: actions/github-script@v7
+        # Always remove the label even on failure
+        if: always()
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'task-review-running'
               });
             } catch (error) {
               console.log('Label may not exist:', error.message);


### PR DESCRIPTION
### From the initial run of the system, I identified the following bugs:
- The task-implement agent was not able to create a pull request due to repository rules
  - I added instructions in the readme to update the repo rules to allow workflows to create pull requests
- The task-implementer would not trigger when I added a label to the pull request
  - Pull Requests created by workflows do not trigger the github workflow `on: pull_request` action: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
  - To fix this, I added a new way to invoke the agent
    - If the user adds a `/strands-review` comment to an issue, then it triggers the review agent with the same session as it previously had
    - If the user adds a `/strands-implement` comment to an issue, pull request comment, or pull request review, it will trigger the task-implement agent
    - Made it `/strands-review` and `/strands-implement` because I figured that phrase would be pretty uncommon to type by coincidence
- Task implementation agent would lose session across invocation from an issue to pull request creation
  - This was because we did not have a consistent id to track across from issue to pr
  - To fix this, I used githubs ["link a pr to an issue"](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) feature by adding the phrase "Resolves: #<ISSUE NUMBER" to the body of the pr on creation. Then on a task-implementation agent restart, we scan the body of the pr for this phrase to restart it with
- The task implementation agent closed the parent issue
  - This was probably bad prompting and an issue with the lost session
  - I added additional instruction to not close the parent issue
- Agents were not getting invoked when expected
  - Re-wrote the workflow trigger logic for both agents
- Task implementer agent did not see the review comments
  - There were some bugs in the github action tools that I fixed. I simplified the pr review tools into a single tool

### Also added some quality-of life fixes and other improvements:
- Allow for different branch names if one already exists
- move `.github` changes to `.github_temp` as github workflows are not allowed to push to the `.github` directory
- Added a `handoff_to_user` tool to make it easier to prompt an agent to ask a user for feedback
 - Updated prompts to utilize this
- Enabled thinking, and interleaved tool thinking
- updated to Sonnet 4.5
- Re-wrote the task reviewer logic to put less emphasis on breaking down tasks
- Let the task review skip requirements clarification if it doesnt think its necessary
- Updated label names: `run-review` -> `review-task` and `run-implement` -> `implement-task` so that the labels didnt start with the same letter