### PR TITLE
Change continuation logic based on the presense of a label, and add timeout

### DIFF
--- a/.github/workflows/task-implementer-agent.yml
+++ b/.github/workflows/task-implementer-agent.yml
@@ -32,13 +32,11 @@ on:
         description: 'Pull request ID to checkout code from (optional)'
         required: false
         type: string
-      execution_mode:
-        description: 'Execution mode for the agent'
-        required: true
-        type: choice
-        options:
-          - Initialize
-          - Continue
+      timeout_minutes:
+        description: 'Timeout in minutes for the agent execution'
+        required: false
+        type: number
+        default: 60
 
 jobs:
   task-implementer:
@@ -66,15 +64,26 @@ jobs:
       pull-requests: write
       id-token: write  # Required for OIDC
     steps:
-      - name: Replace implement-task label with task-implement-running
+      - name: Manage labels and check continuation status
+        id: manage-labels
         uses: actions/github-script@v7
         with:
           script: |
             const issueNumber = '${{ inputs.issue_id }}' || context.issue.number || context.payload.pull_request?.number;
             if (!issueNumber) {
               console.log('No issue number available, skipping label management');
+              core.setOutput('is_continuing', false);
               return;
             }
+            
+            // Check if project-task label exists to determine if continuing
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            const isContinuing = issue.labels.some(label => label.name === 'project-task');
+            
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
@@ -85,12 +94,15 @@ jobs:
             } catch (error) {
               console.log('implement-task label may not exist:', error.message);
             }
+            
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              labels: ['task-implement-running']
+              labels: ['task-implement-running', 'project-task']
             });
+            
+            core.setOutput('is_continuing', isContinuing);
 
       - name: Extract issue ID from PR body
         id: extract-issue
@@ -120,20 +132,17 @@ jobs:
             const fs = require('fs');
             
             const systemPrompt = fs.readFileSync('.github/agent-scripts/task-implementer.script.md', 'utf8');
+            const isContinuing = '${{ steps.manage-labels.outputs.is_continuing }}' === 'true';
             
-            // Determine task based on execution mode and event type
+            // Determine task based on continuation status
             let task;
             
             // Input prompt always overrides everything for testing
             if ('${{ inputs.prompt }}') {
               task = '${{ inputs.prompt }}';
             }
-            // If the mode is "Continue" or it's a PR-related event, tell agent to review feedback
-            else if ('${{ inputs.execution_mode }}' === 'Continue' || 
-                     '${{ github.event_name }}' === 'pull_request' || 
-                     '${{ github.event_name }}' === 'pull_request_comment' || 
-                     '${{ github.event_name }}' === 'pull_request_review' ||
-                     ('${{ github.event_name }}' === 'issue_comment' && '${{ github.event.issue.pull_request }}')) {
+            // If continuing, tell agent to review feedback
+            else if (isContinuing) {
               task = 'Review and address the feedback on the pr.';
             }
             // Otherwise, generate the full task with project overview
@@ -155,6 +164,7 @@ jobs:
             core.setOutput('task', task);
 
       - uses: strands-agents/strands-action@main
+        timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           system_prompt: ${{ steps.task-implementer-agent-script.outputs.system_prompt }}

--- a/.github/workflows/task-reviewer-agent.yml
+++ b/.github/workflows/task-reviewer-agent.yml
@@ -20,13 +20,11 @@ on:
         required: false
         type: string
         default: '.project/project-overview.md'
-      execution_mode:
-        description: 'Execution mode for the agent'
-        required: true
-        type: choice
-        options:
-          - Initialize
-          - Continue
+      timeout_minutes:
+        description: 'Timeout in minutes for the agent execution'
+        required: false
+        type: number
+        default: 60
 
 jobs:
   task-reviewer:
@@ -41,11 +39,21 @@ jobs:
       pull-requests: write
       id-token: write  # Required for OIDC
     steps:
-      - name: Replace review-task label with task-review-running
+      - name: Manage labels and check continuation status
+        id: manage-labels
         uses: actions/github-script@v7
         with:
           script: |
             const issueNumber = '${{ inputs.issue_id }}' || context.issue.number;
+            
+            // Check if project-task label exists to determine if continuing
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            const isContinuing = issue.labels.some(label => label.name === 'project-task');
+            
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
@@ -56,12 +64,15 @@ jobs:
             } catch (error) {
               console.log('review-task label may not exist:', error.message);
             }
+            
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              labels: ['task-review-running']
+              labels: ['task-review-running', 'project-task']
             });
+            
+            core.setOutput('is_continuing', isContinuing);
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -76,6 +87,7 @@ jobs:
             const fs = require('fs');
             
             const systemPrompt = fs.readFileSync('.github/agent-scripts/task-reviewer.script.md', 'utf8');
+            const isContinuing = '${{ steps.manage-labels.outputs.is_continuing }}' === 'true';
             
             // Determine task based on execution mode
             let task;
@@ -84,8 +96,8 @@ jobs:
             if ('${{ inputs.prompt }}') {
               task = '${{ inputs.prompt }}';
             }
-            // If the mode is "Continue", tell agent to review feedback
-            else if ('${{ inputs.execution_mode }}' === 'Continue') {
+            // If continuing, tell agent to review feedback
+            else if (isContinuing) {
               task = 'Review the feedback and continue.';
             }
             // Otherwise, generate the full task with project overview
@@ -107,6 +119,7 @@ jobs:
             core.setOutput('task', task);
 
       - uses: strands-agents/strands-action@main
+        timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           system_prompt: ${{ steps.task-reviewer-agent-script.outputs.system_prompt }}


### PR DESCRIPTION
Ive changes the tracking mechanism for a started task to be a label being present on the issue (or pr). Ive also added a timeout to execution so it doesn't run forever