### PR TITLE
feat: Install dependencies before agent startup

### DIFF
--- a/.github/workflows/task-implementer-agent.yml
+++ b/.github/workflows/task-implementer-agent.yml
@@ -124,6 +124,12 @@ jobs:
             fetch-depth: 0
             ref: ${{ inputs.pull_request_id && format('refs/pull/{0}/head', inputs.pull_request_id) || (github.event.pull_request.number && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event.review.pull_request.number && format('refs/pull/{0}/head', github.event.review.pull_request.number)) || (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || 'main' }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
I've noticed that a bit of the agent's time is spent trying to run commands only to find out that dependencies are missing.  This should help to save tokens & time.


See https://productionresultssa19.blob.core.windows.net/actions-results/449a250b-f729-4441-a20a-653ac22745e6/workflow-job-run-44d3868c-7ec9-5b5a-b326-cb60c8b3abca/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-10-16T13%3A32%3A51Z&sig=I39H0LWbTek5T732Hu06JPOc83JF3n80Gom2UpAAGVI%3D&ske=2025-10-17T01%3A13%3A51Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-10-16T13%3A13%3A51Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-10-16T13%3A22%3A46Z&sv=2025-11-05 where it struggled for a bit trying to run `npm test` until I finally figured out that the packages were not installed
