### PR TITLE
Allow issue ID extraction for multiple PR events

### DIFF
--- a/.github/workflows/task-implementer-agent.yml
+++ b/.github/workflows/task-implementer-agent.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Extract issue ID from PR body
         id: extract-issue
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Fixes this issue: https://github.com/strands-agents/sdk-typescript/pull/26