### PR TITLE
Task 38: Refactor ModelProviderStreamEvent to ModelStreamEvent Implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export type {
   ModelContentBlockStopEvent,
   ModelMessageStopEvent,
   ModelMetadataEvent,
-  ModelProviderStreamEvent,
+  ModelStreamEvent,
 } from './models/streaming'
 
 // Model provider types

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -4,13 +4,13 @@ import { BedrockModel } from '../bedrock'
 import { ContextWindowOverflowError } from '../../errors'
 import type { Message } from '../../types/messages'
 import type { StreamOptions } from '../model'
-import type { ModelProviderStreamEvent } from '../streaming'
+import type { ModelStreamEvent } from '../streaming'
 
 /**
  * Helper function to collect all events from a stream.
  */
-async function collectEvents(stream: AsyncIterable<ModelProviderStreamEvent>): Promise<ModelProviderStreamEvent[]> {
-  const events: ModelProviderStreamEvent[] = []
+async function collectEvents(stream: AsyncIterable<ModelStreamEvent>): Promise<ModelStreamEvent[]> {
+  const events: ModelStreamEvent[] = []
   for await (const event of stream) {
     events.push(event)
   }

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -28,7 +28,7 @@ import {
 } from '@aws-sdk/client-bedrock-runtime'
 import type { Model, BaseModelConfig, StreamOptions } from '../models/model'
 import type { Message, ContentBlock } from '../types/messages'
-import type { ModelProviderStreamEvent, ReasoningDelta, Usage } from '../models/streaming'
+import type { ModelStreamEvent, ReasoningDelta, Usage } from '../models/streaming'
 import type { JSONValue } from '../types/json'
 import { ContextWindowOverflowError } from '../errors'
 import { ensureDefined } from '../types/validation'
@@ -303,7 +303,7 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
    * }
    * ```
    */
-  async *stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelProviderStreamEvent> {
+  async *stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent> {
     try {
       // Format the request for Bedrock
       const request = this._formatRequest(messages, options)
@@ -503,8 +503,8 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
    * @param chunk - Bedrock event chunk
    * @returns Array of SDK streaming events
    */
-  private _mapBedrockEventToSDKEvents(chunk: ConverseStreamOutput): ModelProviderStreamEvent[] {
-    const events: ModelProviderStreamEvent[] = []
+  private _mapBedrockEventToSDKEvents(chunk: ConverseStreamOutput): ModelStreamEvent[] {
+    const events: ModelStreamEvent[] = []
 
     // Extract the event type key
     const eventType = ensureDefined(Object.keys(chunk)[0], 'eventType') as keyof ConverseStreamOutput
@@ -523,7 +523,7 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
       case 'contentBlockStart': {
         const data = eventData as BedrockContentBlockStartEvent
 
-        const event: ModelProviderStreamEvent = {
+        const event: ModelStreamEvent = {
           type: 'modelContentBlockStartEvent',
         }
 
@@ -547,7 +547,7 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
       case 'contentBlockDelta': {
         const data = eventData as BedrockContentBlockDeltaEvent
         const delta = ensureDefined(data.delta, 'contentBlockDelta.delta')
-        let event: ModelProviderStreamEvent | undefined = {
+        let event: ModelStreamEvent | undefined = {
           type: 'modelContentBlockDeltaEvent',
           delta: { type: 'textDelta', text: '' },
         }
@@ -604,7 +604,7 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
       case 'contentBlockStop': {
         const data = eventData as BedrockContentBlockStopEvent
 
-        const event: ModelProviderStreamEvent = {
+        const event: ModelStreamEvent = {
           type: 'modelContentBlockStopEvent',
         }
 
@@ -619,7 +619,7 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
       case 'messageStop': {
         const data = eventData as BedrockMessageStopEvent
 
-        const event: ModelProviderStreamEvent = {
+        const event: ModelStreamEvent = {
           type: 'modelMessageStopEvent',
         }
 
@@ -645,7 +645,7 @@ export class BedrockModel implements Model<BedrockModelConfig, BedrockRuntimeCli
       case 'metadata': {
         const data = eventData as BedrockConverseStreamMetadataEvent
 
-        const event: ModelProviderStreamEvent = {
+        const event: ModelStreamEvent = {
           type: 'modelMetadataEvent',
         }
 

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,6 +1,6 @@
 import type { Message } from '../types/messages'
 import type { ToolSpec, ToolChoice } from '../tools/types'
-import type { ModelProviderStreamEvent } from './streaming'
+import type { ModelStreamEvent } from './streaming'
 
 /**
  * Base configuration interface for all model providers.
@@ -85,5 +85,5 @@ export interface Model<T extends BaseModelConfig, _C = unknown> {
    * }
    * ```
    */
-  stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelProviderStreamEvent>
+  stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent>
 }

--- a/src/models/streaming.ts
+++ b/src/models/streaming.ts
@@ -26,7 +26,7 @@ import type { JSONValue } from '../types/json'
  * }
  * ```
  */
-export type ModelProviderStreamEvent =
+export type ModelStreamEvent =
   | ModelMessageStartEvent
   | ModelContentBlockStartEvent
   | ModelContentBlockDeltaEvent

--- a/tests_integ/bedrock.test.ts
+++ b/tests_integ/bedrock.test.ts
@@ -4,14 +4,14 @@ import { BedrockModel } from '@strands-agents/sdk'
 import { ContextWindowOverflowError } from '@strands-agents/sdk'
 import type { Message } from '@strands-agents/sdk'
 import type { ToolSpec } from '@strands-agents/sdk'
-import type { ModelProviderStreamEvent } from '@strands-agents/sdk'
+import type { ModelStreamEvent } from '@strands-agents/sdk'
 import { ValidationException } from '@aws-sdk/client-bedrock-runtime'
 
 /**
  * Helper function to collect all events from a stream.
  */
-async function collectEvents(stream: AsyncIterable<ModelProviderStreamEvent>): Promise<ModelProviderStreamEvent[]> {
-  const events: ModelProviderStreamEvent[] = []
+async function collectEvents(stream: AsyncIterable<ModelStreamEvent>): Promise<ModelStreamEvent[]> {
+  const events: ModelStreamEvent[] = []
   for await (const event of stream) {
     events.push(event)
   }


### PR DESCRIPTION
Resolves: #38

## Overview
This PR renames ModelProviderStreamEvent to ModelStreamEvent to improve naming consistency in the streaming API. All streaming event types now use the Model* prefix pattern.

## Changes Made
- **src/models/streaming.ts**: Updated type definition from ModelProviderStreamEvent to ModelStreamEvent
- **src/index.ts**: Updated public API export
- **src/models/model.ts**: Updated interface import and method signature
- **src/models/bedrock.ts**: Updated implementation imports and return types
- **tests_integ/bedrock.test.ts**: Updated integration test types
- **src/models/__tests__/bedrock.test.ts**: Updated unit test types

## Testing
✅ All unit tests pass (43 tests)
✅ TypeScript compilation succeeds with no errors
✅ ESLint passes with no errors
✅ Code formatting verified with Prettier

## Breaking Change Notice
This is a **breaking change** to the public API. The type ModelProviderStreamEvent has been renamed to ModelStreamEvent. All imports and type references must be updated.

This change is acceptable as the project is at version 0.1.0 (pre-1.0 development phase) per semantic versioning conventions