### PR TITLE
fix task impl trigger

### DIFF
--- a/.github/workflows/task-implementer-agent.yml
+++ b/.github/workflows/task-implementer-agent.yml
@@ -77,7 +77,7 @@ jobs:
             }
             
             // Task implementer continues when the request is from a pull request
-            const isContinuing = !!context.payload.pull_request;
+            const isContinuing = !!context.payload.pull_request || (context.payload.issue && context.payload.issue.pull_request);
             
             try {
               await github.rest.issues.removeLabel({


### PR DESCRIPTION
if task impl is triggered from a comment on a pr, it should continue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
