### PR TITLE
fix: remove bundler requirement by updating module resolution and adding file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "npm run lint && npm run format && npm run typecheck && npm run test:coverage && npm run test:types",
+    "check": "npm run lint && npm run format && npm run typecheck && npm run test:coverage && npm run test:types && npm run test:package",
     "clean": "rm -rf node_modules dist package-lock.json",
     "test": "vitest run --project unit-node",
     "test:watch": "vitest --project unit-node",
@@ -36,6 +36,7 @@
     "test:browser:install": "npx playwright install --with-deps chromium",
     "test:all": "vitest run --project unit-node --project unit-browser",
     "test:all:coverage": "vitest run --coverage --project unit-node --project unit-browser",
+    "test:package": "npm run build && cd test-package && npm install && node verify.js",
     "lint": "eslint src tests_integ",
     "lint:fix": "eslint src tests_integ --fix",
     "format": "prettier --write src tests_integ",

--- a/src/__fixtures__/mock-message-model.ts
+++ b/src/__fixtures__/mock-message-model.ts
@@ -5,10 +5,10 @@
  * construct events in tests.
  */
 
-import { Model } from '../models/model'
-import type { Message, ContentBlock } from '../types/messages'
-import type { ModelStreamEvent } from '../models/streaming'
-import type { BaseModelConfig, StreamOptions } from '../models/model'
+import { Model } from '../models/model.js'
+import type { Message, ContentBlock } from '../types/messages.js'
+import type { ModelStreamEvent } from '../models/streaming.js'
+import type { BaseModelConfig, StreamOptions } from '../models/model.js'
 
 /**
  * Represents a single turn in the test sequence.

--- a/src/__fixtures__/model-test-helpers.ts
+++ b/src/__fixtures__/model-test-helpers.ts
@@ -4,10 +4,10 @@
  * requiring actual API clients.
  */
 
-import { Model } from '../models/model'
-import type { Message } from '../types/messages'
-import type { ModelStreamEvent } from '../models/streaming'
-import type { BaseModelConfig, StreamOptions } from '../models/model'
+import { Model } from '../models/model.js'
+import type { Message } from '../types/messages.js'
+import type { ModelStreamEvent } from '../models/streaming.js'
+import type { BaseModelConfig, StreamOptions } from '../models/model.js'
 
 /**
  * Test model provider that returns a predefined stream of events.

--- a/src/__fixtures__/tool-helpers.ts
+++ b/src/__fixtures__/tool-helpers.ts
@@ -3,10 +3,10 @@
  * This module provides utilities for testing Tool implementations.
  */
 
-import type { Tool } from '../tools/tool'
-import type { ToolContext } from '../tools/tool'
-import type { ToolResult } from '../tools/types'
-import type { JSONValue } from '../types/json'
+import type { Tool } from '../tools/tool.js'
+import type { ToolContext } from '../tools/tool.js'
+import type { ToolResult } from '../tools/types.js'
+import type { JSONValue } from '../types/json.js'
 
 /**
  * Helper to create a mock ToolContext for testing.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ContextWindowOverflowError } from '../errors'
+import { ContextWindowOverflowError } from '../errors.js'
 
 describe('ContextWindowOverflowError', () => {
   describe('when instantiated with a message', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import * as SDK from '../index'
+import * as SDK from '../index.js'
 
 describe('index', () => {
   describe('when importing from main entry point', () => {

--- a/src/agent/__tests__/agent-loop.test.ts
+++ b/src/agent/__tests__/agent-loop.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { runAgentLoop } from '../agent-loop'
-import { TestModelProvider, collectGenerator } from '../../__fixtures__/model-test-helpers'
-import { MockMessageModel } from '../../__fixtures__/mock-message-model'
-import { createMockTool } from '../../__fixtures__/tool-helpers'
-import { ToolRegistry } from '../../tools/registry'
-import type { Message } from '../../types/messages'
-import { MaxTokensError } from '../../errors'
+import { runAgentLoop } from '../agent-loop.js'
+import { TestModelProvider, collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { ToolRegistry } from '../../tools/registry.js'
+import type { Message } from '../../types/messages.js'
+import { MaxTokensError } from '../../errors.js'
 
 describe('runAgentLoop', () => {
   describe('when handling simple completion without tools', () => {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,9 +1,9 @@
-import type { Message, SystemPrompt, ToolResultBlock, ToolUseBlock } from '../types/messages'
-import type { BaseModelConfig, Model, StreamOptions } from '../models/model'
-import type { ToolRegistry } from '../tools/registry'
-import type { AgentStreamEvent } from './streaming'
-import { MaxTokensError } from '../errors'
-import type { AgentResult } from '../types/agent'
+import type { Message, SystemPrompt, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
+import type { BaseModelConfig, Model, StreamOptions } from '../models/model.js'
+import type { ToolRegistry } from '../tools/registry.js'
+import type { AgentStreamEvent } from './streaming.js'
+import { MaxTokensError } from '../errors.js'
+import type { AgentResult } from '../types/agent.js'
 
 /**
  * Internal configuration for the agent loop.

--- a/src/agent/streaming.ts
+++ b/src/agent/streaming.ts
@@ -1,6 +1,6 @@
-import type { ModelStreamEvent } from '../models/streaming'
-import type { ToolStreamEvent } from '../tools/tool'
-import type { ContentBlock, Message } from '../types/messages'
+import type { ModelStreamEvent } from '../models/streaming.js'
+import type { ToolStreamEvent } from '../tools/tool.js'
+import type { ContentBlock, Message } from '../types/messages.js'
 
 /**
  * Union type representing all possible streaming events from an agent.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,7 +5,7 @@
  * during agent execution and model provider interactions.
  */
 
-import type { Message } from './types/messages'
+import type { Message } from './types/messages.js'
 
 /**
  * Error thrown when input exceeds the model's context window.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@
  */
 
 // Error types
-export { ContextWindowOverflowError, MaxTokensError } from './errors'
+export { ContextWindowOverflowError, MaxTokensError } from './errors.js'
 
 // JSON types
-export type { JSONSchema, JSONValue } from './types/json'
+export type { JSONSchema, JSONValue } from './types/json.js'
 
 // Message types
 export type {
@@ -24,7 +24,7 @@ export type {
   Message,
   SystemPrompt,
   SystemContentBlock,
-} from './types/messages'
+} from './types/messages.js'
 
 // Tool types
 export type {
@@ -36,19 +36,19 @@ export type {
   ToolResultStatus,
   ToolResult,
   ToolChoice,
-} from './tools/types'
+} from './tools/types.js'
 
 // Tool interface and related types
-export type { Tool, InvokableTool, ToolContext, ToolStreamEvent, ToolStreamGenerator } from './tools/tool'
+export type { Tool, InvokableTool, ToolContext, ToolStreamEvent, ToolStreamGenerator } from './tools/tool.js'
 
 // FunctionTool implementation
-export { FunctionTool } from './tools/function-tool'
+export { FunctionTool } from './tools/function-tool.js'
 
 // Tool factory function
-export { tool } from './tools/zod-tool'
+export { tool } from './tools/zod-tool.js'
 
 // ToolRegistry implementation
-export { ToolRegistry } from './tools/registry'
+export { ToolRegistry } from './tools/registry.js'
 
 // Streaming event types
 export type {
@@ -67,14 +67,14 @@ export type {
   ModelMessageStopEvent,
   ModelMetadataEvent,
   ModelStreamEvent,
-} from './models/streaming'
+} from './models/streaming.js'
 
 // Model provider types
-export type { BaseModelConfig, StreamOptions, Model } from './models/model'
+export type { BaseModelConfig, StreamOptions, Model } from './models/model.js'
 
 // Bedrock model provider
-export { BedrockModel as BedrockModel } from './models/bedrock'
-export type { BedrockModelConfig, BedrockModelOptions } from './models/bedrock'
+export { BedrockModel as BedrockModel } from './models/bedrock.js'
+export type { BedrockModelConfig, BedrockModelOptions } from './models/bedrock.js'
 
 // Agent streaming event types
 export type {
@@ -85,8 +85,8 @@ export type {
   AfterToolsEvent,
   BeforeInvocationEvent,
   AfterInvocationEvent,
-} from './agent/streaming'
+} from './agent/streaming.js'
 
 // Agent result type
 
-export type { AgentResult } from './types/agent'
+export type { AgentResult } from './types/agent.js'

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime'
-import { isNode } from '../../__fixtures__/environment'
-import { BedrockModel } from '../bedrock'
-import { ContextWindowOverflowError } from '../../errors'
-import type { Message } from '../../types/messages'
-import type { StreamOptions } from '../model'
-import { collectIterator } from '../../__fixtures__/model-test-helpers'
+import { isNode } from '../../__fixtures__/environment.js'
+import { BedrockModel } from '../bedrock.js'
+import { ContextWindowOverflowError } from '../../errors.js'
+import type { Message } from '../../types/messages.js'
+import type { StreamOptions } from '../model.js'
+import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
 
 /**
  * Helper function to setup mock send with custom stream generator.

--- a/src/models/__tests__/model.test.ts
+++ b/src/models/__tests__/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import type { Message } from '../../types/messages'
-import { TestModelProvider, collectGenerator } from '../../__fixtures__/model-test-helpers'
+import type { Message } from '../../types/messages.js'
+import { TestModelProvider, collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 
 describe('Model', () => {
   describe('streamAggregated', () => {

--- a/src/models/__tests__/openai.test.ts
+++ b/src/models/__tests__/openai.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import OpenAI from 'openai'
-import { isNode } from '../../__fixtures__/environment'
-import { OpenAIModel } from '../openai'
-import { ContextWindowOverflowError } from '../../errors'
-import { collectIterator } from '../../__fixtures__/model-test-helpers'
-import type { Message } from '../../types/messages'
+import { isNode } from '../../__fixtures__/environment.js'
+import { OpenAIModel } from '../openai.js'
+import { ContextWindowOverflowError } from '../../errors.js'
+import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
+import type { Message } from '../../types/messages.js'
 
 /**
  * Helper to create a mock OpenAI client with streaming support

--- a/src/models/__tests__/test-utils.ts
+++ b/src/models/__tests__/test-utils.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Shared test utilities for model tests
 // ABOUTME: Contains helper functions for collecting stream events and other common test operations
 
-import type { ModelStreamEvent } from '../streaming'
+import type { ModelStreamEvent } from '../streaming.js'
 
 /**
  * Helper function to collect all events from a stream.

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -30,12 +30,12 @@ import {
   ReasoningContentBlockDelta,
   ReasoningContentBlock,
 } from '@aws-sdk/client-bedrock-runtime'
-import { Model, type BaseModelConfig, type StreamOptions } from '../models/model'
-import type { Message, ContentBlock, ToolUseBlock } from '../types/messages'
-import type { ModelStreamEvent, ReasoningContentDelta, Usage } from '../models/streaming'
-import type { JSONValue } from '../types/json'
-import { ContextWindowOverflowError } from '../errors'
-import { ensureDefined } from '../types/validation'
+import { Model, type BaseModelConfig, type StreamOptions } from '../models/model.js'
+import type { Message, ContentBlock, ToolUseBlock } from '../types/messages.js'
+import type { ModelStreamEvent, ReasoningContentDelta, Usage } from '../models/streaming.js'
+import type { JSONValue } from '../types/json.js'
+import { ContextWindowOverflowError } from '../errors.js'
+import { ensureDefined } from '../types/validation.js'
 
 /**
  * Default Bedrock model ID.

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,6 +1,6 @@
-import type { Message, ContentBlock, Role, SystemPrompt } from '../types/messages'
-import type { ToolSpec, ToolChoice } from '../tools/types'
-import type { ModelStreamEvent } from './streaming'
+import type { Message, ContentBlock, Role, SystemPrompt } from '../types/messages.js'
+import type { ToolSpec, ToolChoice } from '../tools/types.js'
+import type { ModelStreamEvent } from './streaming.js'
 
 /**
  * Base configuration interface for all model providers.

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -8,11 +8,11 @@
  */
 
 import OpenAI, { type ClientOptions } from 'openai'
-import { Model } from '../models/model'
-import type { BaseModelConfig, StreamOptions } from '../models/model'
-import type { Message } from '../types/messages'
-import type { ModelStreamEvent } from '../models/streaming'
-import { ContextWindowOverflowError } from '../errors'
+import { Model } from '../models/model.js'
+import type { BaseModelConfig, StreamOptions } from '../models/model.js'
+import type { Message } from '../types/messages.js'
+import type { ModelStreamEvent } from '../models/streaming.js'
+import { ContextWindowOverflowError } from '../errors.js'
 
 /**
  * Error message patterns that indicate context window overflow.

--- a/src/models/streaming.ts
+++ b/src/models/streaming.ts
@@ -1,5 +1,5 @@
-import type { Role, StopReason } from '../types/messages'
-import type { JSONValue } from '../types/json'
+import type { Role, StopReason } from '../types/messages.js'
+import type { JSONValue } from '../types/json.js'
 
 /**
  * Union type representing all possible streaming events from a model provider.

--- a/src/tools/__tests__/registry.test.ts
+++ b/src/tools/__tests__/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { ToolRegistry } from '../registry'
-import type { Tool, ToolStreamEvent } from '../tool'
-import type { ToolResult, ToolSpec } from '../types'
+import { ToolRegistry } from '../registry.js'
+import type { Tool, ToolStreamEvent } from '../tool.js'
+import type { ToolResult, ToolSpec } from '../types.js'
 
 /**
  * Helper function to create a mock Tool for testing.

--- a/src/tools/__tests__/tool.test.ts
+++ b/src/tools/__tests__/tool.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { FunctionTool } from '../function-tool'
-import type { ToolContext } from '../tool'
-import type { JSONValue } from '../../types/json'
+import { FunctionTool } from '../function-tool.js'
+import type { ToolContext } from '../tool.js'
+import type { JSONValue } from '../../types/json.js'
 
-import { collectGenerator } from '../../__fixtures__/model-test-helpers'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 
 describe('FunctionTool', () => {
   describe('properties', () => {

--- a/src/tools/__tests__/zod-tool.test-d.ts
+++ b/src/tools/__tests__/zod-tool.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, it, expectTypeOf } from 'vitest'
 import { z } from 'zod'
-import { tool } from '../zod-tool'
+import { tool } from '../zod-tool.js'
 
 describe('zod-tool type tests', () => {
   describe('invoke return type matches callback return type', () => {

--- a/src/tools/__tests__/zod-tool.test.ts
+++ b/src/tools/__tests__/zod-tool.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
-import { tool } from '../zod-tool'
-import { createMockContext } from '../../__fixtures__/tool-helpers'
-import { collectGenerator } from '../../__fixtures__/model-test-helpers'
+import { tool } from '../zod-tool.js'
+import { createMockContext } from '../../__fixtures__/tool-helpers.js'
+import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 
 describe('tool', () => {
   describe('tool creation and properties', () => {

--- a/src/tools/function-tool.ts
+++ b/src/tools/function-tool.ts
@@ -1,7 +1,7 @@
-import type { Tool, ToolContext, ToolStreamEvent } from './tool'
-import type { ToolSpec, ToolResult } from './types'
-import type { JSONSchema, JSONValue } from '../types/json'
-import { deepCopy } from '../types/json'
+import type { Tool, ToolContext, ToolStreamEvent } from './tool.js'
+import type { ToolSpec, ToolResult } from './types.js'
+import type { JSONSchema, JSONValue } from '../types/json.js'
+import { deepCopy } from '../types/json.js'
 
 /**
  * Callback function for FunctionTool implementations.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,4 +1,4 @@
-import type { Tool } from './tool'
+import type { Tool } from './tool.js'
 
 /**
  * Registry for managing Tool instances.

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,6 +1,6 @@
-import type { ToolSpec, ToolUse, ToolResult } from './types'
+import type { ToolSpec, ToolUse, ToolResult } from './types.js'
 
-export type { ToolSpec } from './types'
+export type { ToolSpec } from './types.js'
 
 /**
  * Context provided to tool implementations during execution.

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema, JSONValue } from '../types/json'
+import type { JSONSchema, JSONValue } from '../types/json.js'
 
 /**
  * Result of a tool execution.

--- a/src/tools/zod-tool.ts
+++ b/src/tools/zod-tool.ts
@@ -1,6 +1,6 @@
-import type { InvokableTool, ToolContext, ToolStreamGenerator } from './tool'
-import type { JSONSchema, JSONValue } from '../types/json'
-import { FunctionTool } from './function-tool'
+import type { InvokableTool, ToolContext, ToolStreamGenerator } from './tool.js'
+import type { JSONSchema, JSONValue } from '../types/json.js'
+import { FunctionTool } from './function-tool.js'
 import { z } from 'zod'
 
 /**

--- a/src/types/__tests__/json.test.ts
+++ b/src/types/__tests__/json.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deepCopy } from '../json'
+import { deepCopy } from '../json.js'
 
 describe('deepCopy', () => {
   describe('primitive values', () => {

--- a/src/types/__tests__/validation.test.ts
+++ b/src/types/__tests__/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ensureDefined } from '../validation'
+import { ensureDefined } from '../validation.js'
 
 describe('ensureDefined', () => {
   describe('when value is defined', () => {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,4 +1,4 @@
-import type { Message } from './messages'
+import type { Message } from './messages.js'
 
 /**
  * Result returned by the agent loop.

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,5 +1,5 @@
-import type { JSONValue } from './json'
-import type { ToolResultContent } from '../tools/types'
+import type { JSONValue } from './json.js'
+import type { ToolResultContent } from '../tools/types.js'
 
 /**
  * A message in a conversation between user and assistant.

--- a/test-package/package.json
+++ b/test-package/package.json
@@ -1,0 +1,10 @@
+{
+  "type": "module",
+  "name": "test-package",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Test package to verify SDK works without bundler",
+  "dependencies": {
+    "@strands-agents/sdk": "file:.."
+  }
+}

--- a/test-package/verify.js
+++ b/test-package/verify.js
@@ -1,0 +1,54 @@
+/**
+ * Verification script to ensure the built package can be imported without a bundler.
+ * This script runs in a pure Node.js ES module environment.
+ */
+
+import { BedrockModel, ToolRegistry, FunctionTool } from '@strands-agents/sdk'
+
+console.log('✓ Import from main entry point successful')
+
+// Verify BedrockModel can be instantiated
+const model = new BedrockModel({ region: 'us-west-2' })
+console.log('✓ BedrockModel instantiation successful')
+
+// Verify basic functionality
+const config = model.getConfig()
+if (!config) {
+  throw new Error('BedrockModel config is invalid')
+}
+console.log('✓ BedrockModel configuration retrieval successful')
+
+// Verify ToolRegistry can be instantiated
+const registry = new ToolRegistry()
+console.log('✓ ToolRegistry instantiation successful')
+
+// Verify FunctionTool can be created
+const testTool = new FunctionTool({
+  name: 'testTool',
+  description: 'A test tool',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      value: { type: 'string' },
+    },
+    required: ['value'],
+  },
+  callback: (input) => {
+    return { result: input.value }
+  },
+})
+console.log('✓ FunctionTool creation successful')
+
+// Verify tool can be added to registry
+registry.register(testTool)
+console.log('✓ Tool registration successful')
+
+// Verify tool can be retrieved
+const retrievedTool = registry.get('testTool')
+if (!retrievedTool) {
+  throw new Error('Tool not found in registry')
+}
+console.log('✓ Tool retrieval successful')
+
+console.log('\n✅ All verification checks passed!')
+console.log('The package works correctly without a bundler.')

--- a/tests_integ/bedrock.test.ts
+++ b/tests_integ/bedrock.test.ts
@@ -3,7 +3,7 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
 import { BedrockModel, ContextWindowOverflowError, Message, ToolSpec, ModelStreamEvent } from '@strands-agents/sdk'
 
 // eslint-disable-next-line no-restricted-imports
-import { collectIterator, collectGenerator } from '../src/__fixtures__/model-test-helpers'
+import { collectIterator, collectGenerator } from '../src/__fixtures__/model-test-helpers.js'
 
 const shouldRunTests = await (async () => {
   // In a CI environment, we ALWAYS expect credentials to be configured.

--- a/tests_integ/openai.test.ts
+++ b/tests_integ/openai.test.ts
@@ -5,7 +5,7 @@ import type { Message } from '@strands-agents/sdk'
 import type { ToolSpec } from '@strands-agents/sdk'
 
 // eslint-disable-next-line no-restricted-imports
-import { collectGenerator, collectIterator } from '../src/__fixtures__/model-test-helpers'
+import { collectGenerator, collectIterator } from '../src/__fixtures__/model-test-helpers.js'
 
 // Check for OpenAI API key at module level so skipIf can use it
 let hasApiKey = false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
Right now, the way the project is built, it requires a bundler to be used when consuming the package; this is because the JS files are compiled without extensions.

We need to fix this so that an example project pulling in the typescript sdk could compile without a bundler.  To do this, we start referencing files with js file extensions which TS handles appropriately

---- 

Originally implemented via https://github.com/zastrowm/sdk-typescript/pull/14