### PR TITLE
Task 125: Remove contentBlockIndex field Implementation

### DIFF
--- a/src/__fixtures__/mock-message-model.ts
+++ b/src/__fixtures__/mock-message-model.ts
@@ -136,7 +136,7 @@ export class MockMessageModel extends Model<BaseModelConfig> {
     // Yield events for each content block
     for (let i = 0; i < content.length; i++) {
       const block = content[i]!
-      yield* this._generateEventsForBlock(block, i)
+      yield* this._generateEventsForBlock(block)
     }
 
     // Yield message stop event
@@ -180,7 +180,7 @@ export class MockMessageModel extends Model<BaseModelConfig> {
     // Yield events for each content block
     for (let i = 0; i < message.content.length; i++) {
       const block = message.content[i]!
-      yield* this._generateEventsForBlock(block, i)
+      yield* this._generateEventsForBlock(block)
     }
 
     // Yield message stop event
@@ -190,37 +190,31 @@ export class MockMessageModel extends Model<BaseModelConfig> {
   /**
    * Generates appropriate ModelStreamEvents for a content block.
    */
-  private async *_generateEventsForBlock(
-    block: ContentBlock,
-    contentBlockIndex: number
-  ): AsyncGenerator<ModelStreamEvent> {
+  private async *_generateEventsForBlock(block: ContentBlock): AsyncGenerator<ModelStreamEvent> {
     switch (block.type) {
       case 'textBlock':
-        yield { type: 'modelContentBlockStartEvent', contentBlockIndex }
+        yield { type: 'modelContentBlockStartEvent' }
         yield {
           type: 'modelContentBlockDeltaEvent',
           delta: { type: 'textDelta', text: block.text },
-          contentBlockIndex,
         }
-        yield { type: 'modelContentBlockStopEvent', contentBlockIndex }
+        yield { type: 'modelContentBlockStopEvent' }
         break
 
       case 'toolUseBlock':
         yield {
           type: 'modelContentBlockStartEvent',
-          contentBlockIndex,
           start: { type: 'toolUseStart', name: block.name, toolUseId: block.toolUseId },
         }
         yield {
           type: 'modelContentBlockDeltaEvent',
           delta: { type: 'toolUseInputDelta', input: JSON.stringify(block.input) },
-          contentBlockIndex,
         }
-        yield { type: 'modelContentBlockStopEvent', contentBlockIndex }
+        yield { type: 'modelContentBlockStopEvent' }
         break
 
       case 'reasoningBlock': {
-        yield { type: 'modelContentBlockStartEvent', contentBlockIndex }
+        yield { type: 'modelContentBlockStartEvent' }
         // Build delta object with only defined properties
         const delta: {
           type: 'reasoningContentDelta'
@@ -242,16 +236,15 @@ export class MockMessageModel extends Model<BaseModelConfig> {
         yield {
           type: 'modelContentBlockDeltaEvent',
           delta,
-          contentBlockIndex,
         }
-        yield { type: 'modelContentBlockStopEvent', contentBlockIndex }
+        yield { type: 'modelContentBlockStopEvent' }
         break
       }
 
       case 'cachePointBlock':
         // CachePointBlock doesn't generate delta events
-        yield { type: 'modelContentBlockStartEvent', contentBlockIndex }
-        yield { type: 'modelContentBlockStopEvent', contentBlockIndex }
+        yield { type: 'modelContentBlockStartEvent' }
+        yield { type: 'modelContentBlockStopEvent' }
         break
 
       case 'toolResultBlock':

--- a/src/__fixtures__/model-test-helpers.ts
+++ b/src/__fixtures__/model-test-helpers.ts
@@ -18,9 +18,9 @@ import type { BaseModelConfig, StreamOptions } from '../models/model.js'
  * ```typescript
  * const provider = new TestModelProvider(async function* () {
  *   yield { type: 'modelMessageStartEvent', role: 'assistant' }
- *   yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
- *   yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Hello' }, contentBlockIndex: 0 }
- *   yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+ *   yield { type: 'modelContentBlockStartEvent' }
+ *   yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Hello' } }
+ *   yield { type: 'modelContentBlockStopEvent' }
  *   yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
  * })
  *

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -35,9 +35,9 @@ vi.mock('@aws-sdk/client-bedrock-runtime', async (importOriginal) => {
       return {
         stream: (async function* (): AsyncGenerator<unknown> {
           yield { messageStart: { role: 'assistant' } }
-          yield { contentBlockStart: { contentBlockIndex: 0 } }
-          yield { contentBlockDelta: { delta: { text: 'Hello' }, contentBlockIndex: 0 } }
-          yield { contentBlockStop: { contentBlockIndex: 0 } }
+          yield { contentBlockStart: {} }
+          yield { contentBlockDelta: { delta: { text: 'Hello' } } }
+          yield { contentBlockStop: {} }
           yield { messageStop: { stopReason: 'end_turn' } }
           yield {
             metadata: {
@@ -455,9 +455,9 @@ describe('BedrockModel', () => {
           return {
             stream: (async function* (): AsyncGenerator<unknown> {
               yield { messageStart: { role: 'assistant' } }
-              yield { contentBlockStart: { contentBlockIndex: 0 } }
-              yield { contentBlockDelta: { delta: { text: 'Hello' }, contentBlockIndex: 0 } }
-              yield { contentBlockStop: { contentBlockIndex: 0 } }
+              yield { contentBlockStart: {} }
+              yield { contentBlockDelta: { delta: { text: 'Hello' } } }
+              yield { contentBlockStop: {} }
               yield { messageStop: { stopReason: 'end_turn' } }
               yield {
                 metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, metrics: { latencyMs: 100 } },
@@ -481,13 +481,12 @@ describe('BedrockModel', () => {
       const events = await collectIterator(provider.stream(messages))
 
       expect(events).toContainEqual({ role: 'assistant', type: 'modelMessageStartEvent' })
-      expect(events).toContainEqual({ type: 'modelContentBlockStartEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStartEvent' })
       expect(events).toContainEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: { type: 'textDelta', text: 'Hello' },
       })
-      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent' })
       expect(events).toContainEqual({ type: 'modelMessageStopEvent', stopReason: 'endTurn' })
       expect(events).toContainEqual({
         type: 'modelMetadataEvent',
@@ -504,17 +503,15 @@ describe('BedrockModel', () => {
               yield { messageStart: { role: 'assistant' } }
               yield {
                 contentBlockStart: {
-                  contentBlockIndex: 0,
                   start: { toolUse: { toolUseId: 'tool-use-123', name: 'get_weather' } },
                 },
               }
               yield {
                 contentBlockDelta: {
-                  contentBlockIndex: 0,
                   delta: { toolUse: { input: '{"location":"San Francisco"}' } },
                 },
               }
-              yield { contentBlockStop: { contentBlockIndex: 0 } }
+              yield { contentBlockStop: {} }
               yield { messageStop: { stopReason: 'tool_use' } }
               yield {
                 metadata: {
@@ -555,15 +552,13 @@ describe('BedrockModel', () => {
       expect(events).toContainEqual({ role: 'assistant', type: 'modelMessageStartEvent' })
       expect(startEvent).toStrictEqual({
         type: 'modelContentBlockStartEvent',
-        contentBlockIndex: 0,
         start: { type: 'toolUseStart', name: 'get_weather', toolUseId: 'tool-use-123' },
       })
       expect(inputDeltaEvent).toStrictEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: { type: 'toolUseInputDelta', input: '{"location":"San Francisco"}' },
       })
-      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent' })
       expect(events).toContainEqual({ stopReason: 'toolUse', type: 'modelMessageStopEvent' })
       expect(events).toContainEqual({
         type: 'modelMetadataEvent',
@@ -578,11 +573,11 @@ describe('BedrockModel', () => {
           return {
             stream: (async function* (): AsyncGenerator<unknown> {
               yield { messageStart: { role: 'assistant' } }
-              yield { contentBlockStart: { contentBlockIndex: 0 } }
+              yield { contentBlockStart: {} }
               yield {
-                contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'Thinking...' } } },
+                contentBlockDelta: { delta: { reasoningContent: { text: 'Thinking...' } } },
               }
-              yield { contentBlockStop: { contentBlockIndex: 0 } }
+              yield { contentBlockStop: {} }
               yield { messageStop: { stopReason: 'end_turn' } }
               yield {
                 metadata: {
@@ -615,13 +610,12 @@ describe('BedrockModel', () => {
       const events = await collectIterator(provider.stream(messages))
 
       expect(events).toContainEqual({ role: 'assistant', type: 'modelMessageStartEvent' })
-      expect(events).toContainEqual({ type: 'modelContentBlockStartEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStartEvent' })
       expect(events).toContainEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: { type: 'reasoningContentDelta', text: 'Thinking...' },
       })
-      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent' })
       expect(events).toContainEqual({ stopReason: 'endTurn', type: 'modelMessageStopEvent' })
       expect(events).toContainEqual({
         type: 'modelMetadataEvent',
@@ -638,14 +632,13 @@ describe('BedrockModel', () => {
           return {
             stream: (async function* (): AsyncGenerator<unknown> {
               yield { messageStart: { role: 'assistant' } }
-              yield { contentBlockStart: { contentBlockIndex: 0 } }
+              yield { contentBlockStart: {} }
               yield {
                 contentBlockDelta: {
-                  contentBlockIndex: 0,
                   delta: { reasoningContent: { redactedContent: redactedBytes } },
                 },
               }
-              yield { contentBlockStop: { contentBlockIndex: 0 } }
+              yield { contentBlockStop: {} }
               yield { messageStop: { stopReason: 'end_turn' } }
               yield {
                 metadata: { usage: { inputTokens: 15, outputTokens: 5, totalTokens: 20 }, metrics: { latencyMs: 110 } },
@@ -675,13 +668,12 @@ describe('BedrockModel', () => {
       const events = await collectIterator(provider.stream(messages))
 
       expect(events).toContainEqual({ role: 'assistant', type: 'modelMessageStartEvent' })
-      expect(events).toContainEqual({ type: 'modelContentBlockStartEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStartEvent' })
       expect(events).toContainEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: { type: 'reasoningContentDelta', redactedContent: redactedBytes },
       })
-      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent', contentBlockIndex: 0 })
+      expect(events).toContainEqual({ type: 'modelContentBlockStopEvent' })
       expect(events).toContainEqual({ stopReason: 'endTurn', type: 'modelMessageStopEvent' })
       expect(events).toContainEqual({
         type: 'modelMetadataEvent',
@@ -721,10 +713,10 @@ describe('BedrockModel', () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
         yield {
-          contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { name: 'calc', toolUseId: 'id' } } },
+          contentBlockStart: { start: { toolUse: { name: 'calc', toolUseId: 'id' } } },
         }
-        yield { contentBlockDelta: { delta: { toolUse: { input: '{"a": 1}' } }, contentBlockIndex: 0 } }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockDelta: { delta: { toolUse: { input: '{"a": 1}' } } } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'tool_use' } }
         yield { metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }
       })
@@ -736,7 +728,6 @@ describe('BedrockModel', () => {
 
       expect(events).toContainEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: {
           type: 'toolUseInputDelta',
           input: '{"a": 1}',
@@ -747,20 +738,18 @@ describe('BedrockModel', () => {
     it('handles reasoning content delta with both text and signature, as well as redactedContent', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
-        yield { contentBlockStart: { contentBlockIndex: 0 } }
+        yield { contentBlockStart: {} }
         yield {
           contentBlockDelta: {
             delta: { reasoningContent: { text: 'thinking...', signature: 'sig123' } },
-            contentBlockIndex: 0,
           },
         }
         yield {
           contentBlockDelta: {
             delta: { reasoningContent: { redactedContent: new Uint8Array(1) } },
-            contentBlockIndex: 0,
           },
         }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'end_turn' } }
         yield { metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }
       })
@@ -772,7 +761,6 @@ describe('BedrockModel', () => {
 
       expect(events).toContainEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: {
           type: 'reasoningContentDelta',
           text: 'thinking...',
@@ -781,7 +769,6 @@ describe('BedrockModel', () => {
       })
       expect(events).toContainEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: {
           type: 'reasoningContentDelta',
           redactedContent: new Uint8Array(1),
@@ -792,20 +779,18 @@ describe('BedrockModel', () => {
     it('handles reasoning content delta with only text, skips unsupported types', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
-        yield { contentBlockStart: { contentBlockIndex: 0 } }
+        yield { contentBlockStart: {} }
         yield {
           contentBlockDelta: {
             delta: { reasoningContent: { text: 'thinking...' } },
-            contentBlockIndex: 0,
           },
         }
         yield {
           contentBlockDelta: {
             delta: { unknown: 'type' },
-            contentBlockIndex: 0,
           },
         }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'end_turn' } }
         yield { metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }
         yield { unknown: 'type' }
@@ -832,14 +817,13 @@ describe('BedrockModel', () => {
     it('handles reasoning content delta with only signature', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
-        yield { contentBlockStart: { contentBlockIndex: 0 } }
+        yield { contentBlockStart: {} }
         yield {
           contentBlockDelta: {
             delta: { reasoningContent: { signature: 'sig123' } },
-            contentBlockIndex: 0,
           },
         }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'end_turn' } }
         yield { metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }
       })
@@ -865,9 +849,9 @@ describe('BedrockModel', () => {
     it('handles cache usage metrics', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
-        yield { contentBlockStart: { contentBlockIndex: 0 } }
-        yield { contentBlockDelta: { delta: { text: 'Hello' }, contentBlockIndex: 0 } }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockStart: {} }
+        yield { contentBlockDelta: { delta: { text: 'Hello' } } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'end_turn' } }
         yield {
           metadata: {
@@ -898,9 +882,9 @@ describe('BedrockModel', () => {
     it('handles trace in metadata', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
-        yield { contentBlockStart: { contentBlockIndex: 0 } }
-        yield { contentBlockDelta: { delta: { text: 'Hello' }, contentBlockIndex: 0 } }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockStart: {} }
+        yield { contentBlockDelta: { delta: { text: 'Hello' } } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'end_turn' } }
         yield {
           metadata: {
@@ -925,9 +909,9 @@ describe('BedrockModel', () => {
     it('handles additionalModelResponseFields', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }
-        yield { contentBlockStart: { contentBlockIndex: 0 } }
-        yield { contentBlockDelta: { delta: { text: 'Hello' }, contentBlockIndex: 0 } }
-        yield { contentBlockStop: { contentBlockIndex: 0 } }
+        yield { contentBlockStart: {} }
+        yield { contentBlockDelta: { delta: { text: 'Hello' } } }
+        yield { contentBlockStop: {} }
         yield { messageStop: { stopReason: 'end_turn', additionalModelResponseFields: { customField: 'value' } } }
         yield { metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }
       })

--- a/src/models/__tests__/model.test.ts
+++ b/src/models/__tests__/model.test.ts
@@ -8,13 +8,12 @@ describe('Model', () => {
       it('yields original events plus aggregated content block and returns final message', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'textDelta', text: 'Hello' },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
           yield {
             type: 'modelMetadataEvent',
@@ -29,13 +28,12 @@ describe('Model', () => {
         // Verify all yielded items (events + aggregated content block)
         expect(items).toEqual([
           { type: 'modelMessageStartEvent', role: 'assistant' },
-          { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 },
+          { type: 'modelContentBlockStartEvent' },
           {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'textDelta', text: 'Hello' },
-            contentBlockIndex: 0,
           },
-          { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 },
+          { type: 'modelContentBlockStopEvent' },
           { type: 'textBlock', text: 'Hello' },
           { type: 'modelMessageStopEvent', stopReason: 'endTurn' },
         ])
@@ -56,20 +54,18 @@ describe('Model', () => {
       it('yields all blocks in order', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'textDelta', text: 'First' },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 1 }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'textDelta', text: 'Second' },
-            contentBlockIndex: 1,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 1 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
           yield {
             type: 'modelMetadataEvent',
@@ -104,20 +100,17 @@ describe('Model', () => {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
           yield {
             type: 'modelContentBlockStartEvent',
-            contentBlockIndex: 0,
             start: { type: 'toolUseStart', toolUseId: 'tool1', name: 'get_weather' },
           }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'toolUseInputDelta', input: '{"location"' },
-            contentBlockIndex: 0,
           }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'toolUseInputDelta', input: ': "Paris"}' },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' }
           yield {
             type: 'modelMetadataEvent',
@@ -158,18 +151,16 @@ describe('Model', () => {
       it('yields complete reasoning block', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'reasoningContentDelta', text: 'Thinking about', signature: 'sig1' },
-            contentBlockIndex: 0,
           }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'reasoningContentDelta', text: ' the problem' },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
           yield {
             type: 'modelMetadataEvent',
@@ -206,13 +197,12 @@ describe('Model', () => {
       it('yields redacted content reasoning block', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'reasoningContentDelta', redactedContent: new Uint8Array(0) },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
           yield {
             type: 'modelMetadataEvent',
@@ -247,13 +237,12 @@ describe('Model', () => {
       it('omits signature if not present', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'reasoningContentDelta', text: 'Thinking' },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
           yield {
             type: 'modelMetadataEvent',
@@ -290,31 +279,27 @@ describe('Model', () => {
       it('yields all blocks in correct order', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'textDelta', text: 'Hello' },
-            contentBlockIndex: 0,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield {
             type: 'modelContentBlockStartEvent',
-            contentBlockIndex: 1,
             start: { type: 'toolUseStart', toolUseId: 'tool1', name: 'get_weather' },
           }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'toolUseInputDelta', input: '{"city": "Paris"}' },
-            contentBlockIndex: 1,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 1 }
-          yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 2 }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelContentBlockStartEvent' }
           yield {
             type: 'modelContentBlockDeltaEvent',
             delta: { type: 'reasoningContentDelta', text: 'Reasoning', signature: 'sig1' },
-            contentBlockIndex: 2,
           }
-          yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 2 }
+          yield { type: 'modelContentBlockStopEvent' }
           yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
           yield {
             type: 'modelMetadataEvent',

--- a/src/models/__tests__/openai.test.ts
+++ b/src/models/__tests__/openai.test.ts
@@ -388,21 +388,17 @@ describe('OpenAIModel', () => {
         expect(events[0]).toEqual({ type: 'modelMessageStartEvent', role: 'assistant' })
         expect(events[1]).toEqual({
           type: 'modelContentBlockStartEvent',
-          contentBlockIndex: 0,
         })
         expect(events[2]).toEqual({
           type: 'modelContentBlockDeltaEvent',
-          contentBlockIndex: 0,
           delta: { type: 'textDelta', text: 'Hello' },
         })
         expect(events[3]).toEqual({
           type: 'modelContentBlockDeltaEvent',
-          contentBlockIndex: 0,
           delta: { type: 'textDelta', text: ' world' },
         })
         expect(events[4]).toEqual({
           type: 'modelContentBlockStopEvent',
-          contentBlockIndex: 0,
         })
         expect(events[5]).toEqual({ type: 'modelMessageStopEvent', stopReason: 'endTurn' })
       })
@@ -583,7 +579,6 @@ describe('OpenAIModel', () => {
       expect(events[0]).toEqual({ type: 'modelMessageStartEvent', role: 'assistant' })
       expect(events[1]).toEqual({
         type: 'modelContentBlockStartEvent',
-        contentBlockIndex: 0,
         start: {
           type: 'toolUseStart',
           name: 'calculator',
@@ -592,7 +587,6 @@ describe('OpenAIModel', () => {
       })
       expect(events[2]).toEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: {
           type: 'toolUseInputDelta',
           input: '{"expr',
@@ -600,7 +594,6 @@ describe('OpenAIModel', () => {
       })
       expect(events[3]).toEqual({
         type: 'modelContentBlockDeltaEvent',
-        contentBlockIndex: 0,
         delta: {
           type: 'toolUseInputDelta',
           input: '":"2+2"}',
@@ -608,12 +601,11 @@ describe('OpenAIModel', () => {
       })
       expect(events[4]).toEqual({
         type: 'modelContentBlockStopEvent',
-        contentBlockIndex: 0,
       })
       expect(events[5]).toEqual({ type: 'modelMessageStopEvent', stopReason: 'toolUse' })
     })
 
-    it('handles multiple tool calls with correct contentBlockIndex', async () => {
+    it('handles multiple tool calls', async () => {
       const mockClient = createMockClient(async function* () {
         yield {
           choices: [{ delta: { role: 'assistant' }, index: 0 }],
@@ -665,8 +657,8 @@ describe('OpenAIModel', () => {
       // Should emit stop events for both tool calls
       const stopEvents = events.filter((e) => e.type === 'modelContentBlockStopEvent')
       expect(stopEvents).toHaveLength(2)
-      expect(stopEvents[0]).toEqual({ type: 'modelContentBlockStopEvent', contentBlockIndex: 0 })
-      expect(stopEvents[1]).toEqual({ type: 'modelContentBlockStopEvent', contentBlockIndex: 1 })
+      expect(stopEvents[0]).toEqual({ type: 'modelContentBlockStopEvent' })
+      expect(stopEvents[1]).toEqual({ type: 'modelContentBlockStopEvent' })
     })
 
     it('skips tool calls with invalid index', async () => {
@@ -799,7 +791,6 @@ describe('OpenAIModel', () => {
       expect(events[0]?.type).toBe('modelMessageStartEvent')
       // Text content block start
       expect(events[1]?.type).toBe('modelContentBlockStartEvent')
-      expect((events[1] as any).contentBlockIndex).toBe(0)
       // Text deltas
       expect(events[2]?.type).toBe('modelContentBlockDeltaEvent')
       expect((events[2] as any).delta.type).toBe('textDelta')

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -20,7 +20,6 @@ import {
   type MessageStartEvent as BedrockMessageStartEvent,
   type ContentBlockStartEvent as BedrockContentBlockStartEvent,
   type ContentBlockDeltaEvent as BedrockContentBlockDeltaEvent,
-  type ContentBlockStopEvent as BedrockContentBlockStopEvent,
   type MessageStopEvent as BedrockMessageStopEvent,
   type ConverseStreamMetadataEvent as BedrockConverseStreamMetadataEvent,
   type ToolConfiguration,
@@ -586,19 +585,17 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
     // Match on content blocks
     const blockHandlers = {
-      text: (textBlock: string, index: number): void => {
-        events.push({ type: 'modelContentBlockStartEvent', contentBlockIndex: index })
+      text: (textBlock: string): void => {
+        events.push({ type: 'modelContentBlockStartEvent' })
         events.push({
           type: 'modelContentBlockDeltaEvent',
-          contentBlockIndex: index,
           delta: { type: 'textDelta', text: textBlock },
         })
-        events.push({ type: 'modelContentBlockStopEvent', contentBlockIndex: index })
+        events.push({ type: 'modelContentBlockStopEvent' })
       },
-      toolUse: (block: ToolUseBlock, index: number): void => {
+      toolUse: (block: ToolUseBlock): void => {
         events.push({
           type: 'modelContentBlockStartEvent',
-          contentBlockIndex: index,
           start: {
             type: 'toolUseStart',
             name: ensureDefined(block.name, 'toolUse.name'),
@@ -607,14 +604,13 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         })
         events.push({
           type: 'modelContentBlockDeltaEvent',
-          contentBlockIndex: index,
           delta: { type: 'toolUseInputDelta', input: JSON.stringify(ensureDefined(block.input, 'toolUse.input')) },
         })
-        events.push({ type: 'modelContentBlockStopEvent', contentBlockIndex: index })
+        events.push({ type: 'modelContentBlockStopEvent' })
       },
-      reasoningContent: (block: ReasoningContentBlock, index: number): void => {
+      reasoningContent: (block: ReasoningContentBlock): void => {
         if (!block) return
-        events.push({ type: 'modelContentBlockStartEvent', contentBlockIndex: index })
+        events.push({ type: 'modelContentBlockStartEvent' })
 
         const delta: ReasoningContentDelta = { type: 'reasoningContentDelta' }
         if (block.reasoningText) {
@@ -625,20 +621,20 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         }
 
         if (Object.keys(delta).length > 1) {
-          events.push({ type: 'modelContentBlockDeltaEvent', contentBlockIndex: index, delta })
+          events.push({ type: 'modelContentBlockDeltaEvent', delta })
         }
 
-        events.push({ type: 'modelContentBlockStopEvent', contentBlockIndex: index })
+        events.push({ type: 'modelContentBlockStopEvent' })
       },
     }
 
     const content = ensureDefined(message.content, 'message.content')
-    content.forEach((block, index) => {
+    content.forEach((block) => {
       for (const key in block) {
         if (key in blockHandlers) {
           const handlerKey = key as keyof typeof blockHandlers
           // @ts-expect-error - We know the value type corresponds to the handler key.
-          blockHandlers[handlerKey](block[handlerKey], index)
+          blockHandlers[handlerKey](block[handlerKey])
         } else {
           console.warn(`Skipping unsupported block key: ${key}`)
         }
@@ -700,7 +696,6 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
         const event: ModelStreamEvent = {
           type: 'modelContentBlockStartEvent',
-          contentBlockIndex: ensureDefined(data.contentBlockIndex, 'contentBlockStart.contentBlockIndex'),
         }
 
         if (data.start?.toolUse) {
@@ -718,13 +713,11 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
       case 'contentBlockDelta': {
         const data = eventData as BedrockContentBlockDeltaEvent
-        const contentBlockIndex = ensureDefined(data.contentBlockIndex, 'contentBlockDelta.contentBlockIndex')
         const delta = ensureDefined(data.delta, 'contentBlockDelta.delta')
         const deltaHandlers = {
           text: (textValue: string): void => {
             events.push({
               type: 'modelContentBlockDeltaEvent',
-              contentBlockIndex,
               delta: { type: 'textDelta', text: textValue },
             })
           },
@@ -732,7 +725,6 @@ export class BedrockModel extends Model<BedrockModelConfig> {
             if (!toolUse?.input) return
             events.push({
               type: 'modelContentBlockDeltaEvent',
-              contentBlockIndex,
               delta: { type: 'toolUseInputDelta', input: toolUse.input },
             })
           },
@@ -744,7 +736,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
             if (reasoning.redactedContent) reasoningDelta.redactedContent = reasoning.redactedContent
 
             if (Object.keys(reasoningDelta).length > 1) {
-              events.push({ type: 'modelContentBlockDeltaEvent', contentBlockIndex, delta: reasoningDelta })
+              events.push({ type: 'modelContentBlockDeltaEvent', delta: reasoningDelta })
             }
           },
         }
@@ -763,10 +755,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       }
 
       case 'contentBlockStop': {
-        const data = eventData as BedrockContentBlockStopEvent
         events.push({
           type: 'modelContentBlockStopEvent',
-          contentBlockIndex: ensureDefined(data.contentBlockIndex, 'contentBlockStop.contentBlockIndex'),
         })
         break
       }

--- a/src/models/streaming.ts
+++ b/src/models/streaming.ts
@@ -40,11 +40,6 @@ export interface ModelContentBlockStartEvent {
   type: 'modelContentBlockStartEvent'
 
   /**
-   * Index of this content block within the message.
-   */
-  contentBlockIndex?: number
-
-  /**
    * Information about the content block being started.
    * Only present for tool use blocks.
    */
@@ -61,11 +56,6 @@ export interface ModelContentBlockDeltaEvent {
   type: 'modelContentBlockDeltaEvent'
 
   /**
-   * Index of the content block being updated.
-   */
-  contentBlockIndex?: number
-
-  /**
    * The incremental content update.
    */
   delta: ContentBlockDelta
@@ -79,11 +69,6 @@ export interface ModelContentBlockStopEvent {
    * Discriminator for content block stop events.
    */
   type: 'modelContentBlockStopEvent'
-
-  /**
-   * Index of the content block that stopped.
-   */
-  contentBlockIndex?: number
 }
 
 /**


### PR DESCRIPTION
Resolves: #125

## Overview
This PR removes the unused `contentBlockIndex` field from streaming event interfaces throughout the codebase.

See full PR description in the link