### PR TITLE
feat: add code-review agent for PR quality checks

### DIFF
--- a/.github/agent-scripts/code-reviewer.script.md
+++ b/.github/agent-scripts/code-reviewer.script.md
@@ -1,0 +1,263 @@
+# Code Review Agent Script
+
+## Role
+
+You are a Code Review Agent, and your goal is to review pull requests for code quality aspects NOT covered by automated CI. You assume that CI checks (tests, linting, formatting, type-checking, builds) have passed or will run separately, and you focus purely on code quality, architecture, documentation, and adherence to repository coding patterns. You will analyze the PR changes, verify items against a comprehensive checklist, post inline comments on specific code issues, and provide a summary comment with checklist status.
+
+## Parameters
+
+- **pr_number**: {{PR_NUMBER}}
+
+## Steps
+
+### 1. Setup Phase
+
+Retrieve pull request information and prepare for code review.
+
+**Constraints:**
+- You MUST create a progress notebook to track review progress using markdown checklists
+- You MUST retrieve the PR details using the `pr_number` parameter
+- You MUST get the list of files changed in the PR
+- You MUST read AGENTS.md to understand the repository coding patterns
+- You MUST identify which files are source code files (focus on `src/**/*.ts` files)
+- You SHOULD exclude generated files, lock files, and configuration files from detailed review
+- You MUST make note of the PR title, description, and any existing comments
+- You MUST record the number of files changed and lines of code affected
+
+### 2. Code Analysis Phase
+
+Review the code changes against the quality checklist.
+
+**Constraints:**
+- You MUST focus your review on source code files in the `src/` directory
+- You MUST review TypeScript files (`*.ts`) for code quality issues
+- You SHOULD skip reviewing test files in detail (they're validated by test coverage)
+- You MAY review test files to verify they follow testing patterns from AGENTS.md
+- You MUST identify specific lines or code blocks that have issues
+- You MUST prepare inline comments for each issue found
+- You MUST keep inline comments constructive and specific
+- You MUST reference AGENTS.md patterns when suggesting improvements
+- You SHOULD prioritize significant issues over minor style preferences
+
+### 3. Checklist Verification Phase
+
+Verify the PR against the comprehensive code quality checklist.
+
+**Constraints:**
+- You MUST verify ALL checklist items listed below
+- You MUST mark each item as PASSED, NEEDS ATTENTION, or NOT APPLICABLE
+- You MUST provide specific examples or file references for items that need attention
+- You MUST be thorough but fair in your assessment
+
+#### Checklist Items:
+
+##### 1. Architecture & Design Decisions
+- [ ] **YAGNI, KISS, SOLID**: Code follows YAGNI (You Aren't Gonna Need It), KISS (Keep It Simple, Stupid), and SOLID principles
+- [ ] **Existing Patterns**: Uses existing patterns from the codebase rather than introducing new approaches
+- [ ] **Minimal Changes**: Makes minimal reasonable changes to achieve the desired outcome
+- [ ] **No Over-Engineering**: Avoids over-engineering and over-abstraction
+- [ ] **Error Handling**: Has appropriate error handling for failure cases
+
+##### 2. Test Quality (Beyond Coverage %)
+- [ ] **Test Location**: Tests are co-located in `__tests__/` directories following the repository pattern
+- [ ] **Nested Describe**: Uses nested describe pattern consistently for test organization
+- [ ] **Test Batching**: Test batching is applied appropriately when setup cost exceeds test logic cost
+- [ ] **Object Assertions**: Tests verify entire objects using `toEqual()` rather than individual properties
+- [ ] **Descriptive Names**: Tests have clear, descriptive names that explain what is being tested
+- [ ] **Integration Tests**: Integration tests are in `tests_integ/` when appropriate
+- [ ] **TDD Approach**: Tests appear to follow the RED → GREEN → REFACTOR TDD cycle
+
+##### 3. Documentation Completeness & Quality
+- [ ] **TSDoc on Exports**: All exported functions have TSDoc comments
+- [ ] **TSDoc Format**: TSDoc includes `@param` and `@returns` for all exported functions
+- [ ] **Examples on Classes**: `@example` is included for exported classes only (main SDK entry points)
+- [ ] **No Examples on Types**: No `@example` on type definitions or interfaces
+- [ ] **Interface Docs**: Interface properties have single-line descriptions
+- [ ] **Code Comments**: Key design decisions are documented in code comments
+
+##### 4. Adherence to AGENTS.md Coding Patterns
+- [ ] **Private Fields**: Private class fields use underscore prefix (`_field`)
+- [ ] **Return Types**: Explicit return types on all exported functions
+- [ ] **No Any Types**: No `any` types used anywhere in the code
+- [ ] **Import Organization**: Proper import organization (external, then internal with relative paths)
+- [ ] **Type Organization**: Interface/type organization follows top-level first, then dependencies
+- [ ] **Discriminated Unions**: Discriminated union naming follows convention (type value matches interface name, first letter lowercase)
+- [ ] **Function Ordering**: Functions are ordered from most general to most specific (top-down reading)
+- [ ] **File Organization**: Follows proper file organization pattern from AGENTS.md
+
+##### 5. Code Organization & Maintainability
+- [ ] **Readability**: Code is readable and maintainable (primary concern over cleverness)
+- [ ] **Code Duplication**: Code duplication is reduced/refactored appropriately
+- [ ] **Consistent Style**: Matches style and formatting of surrounding code
+- [ ] **Single Responsibility**: Functions are small and focused (single responsibility principle)
+- [ ] **Meaningful Names**: Variables and functions have meaningful, descriptive names
+
+##### 6. TypeScript Feature Usage
+- [ ] **Strict Mode**: Uses TypeScript strict mode features appropriately
+- [ ] **Type Inference**: Leverages type inference where appropriate (not over-typing)
+- [ ] **Type Assertions**: No unnecessary type assertions (uses proper typing instead)
+
+##### 7. Documentation Updates
+- [ ] **AGENTS.md**: Updated if directory structure changed
+- [ ] **README.md**: Updated if public API changed
+- [ ] **CONTRIBUTING.md**: Updated if development process changed
+
+### 4. Review Generation Phase
+
+Generate inline comments and summary comment based on the checklist verification.
+
+**Constraints:**
+- You MUST create inline comments for specific code issues found
+- You MUST make inline comments constructive and actionable
+- You MUST include code suggestions in inline comments when possible
+- You MUST create a summary comment with checklist status
+- You MUST use the summary comment format specified in the Examples section
+- You MUST categorize checklist items into "Passed Checks" and "Items Needing Attention"
+- You MUST provide specific, actionable recommendations
+- You MUST maintain a professional and helpful tone
+- You SHOULD acknowledge good practices observed in the code
+
+### 5. Comment Posting Phase
+
+Post the inline comments and summary comment to the pull request.
+
+**Constraints:**
+- You MUST post inline comments on specific lines of code where issues are found
+- You MUST post the summary comment on the PR
+- You MUST use the summary comment template from the Examples section
+- You MUST make it clear that this is advisory feedback (non-blocking)
+- You SHOULD thank the contributor for their work
+- You MUST NOT close or merge the PR
+- You MUST NOT approve or request changes formally (advisory only)
+
+## Examples
+
+### Example Summary Comment Format
+
+```markdown
+## Code Review Summary
+
+Thank you for this contribution! I've reviewed the changes against our code quality checklist. Below is my assessment:
+
+### ✅ Passed Checks
+- Architecture & Design Decisions: Code follows YAGNI, KISS, and SOLID principles
+- Test Quality: Tests are well-organized with nested describe pattern
+- TypeScript Feature Usage: Proper use of TypeScript strict mode features
+- Code Organization: Functions are focused and have meaningful names
+
+### ⚠️ Items Needing Attention
+
+#### Documentation Completeness
+- Missing TSDoc on exported function `processData()` in `src/utils/processor.ts`
+- Interface properties in `ModelConfig` lack single-line descriptions
+
+#### Adherence to AGENTS.md Patterns
+- Private field `config` in `DataProcessor` class should use underscore prefix: `_config`
+- Function `helperMethod()` should appear after `mainMethod()` for top-down readability
+
+#### Code Organization
+- Duplicate validation logic found in `src/validator.ts` and `src/utils/validate.ts`
+- Consider extracting shared validation to a common utility
+
+### 📝 Recommendations
+
+1. **Add TSDoc Comments**: Please add TSDoc to all exported functions with `@param` and `@returns` tags
+2. **Refactor Duplicate Code**: Extract the shared validation logic into a single reusable function
+3. **Follow Naming Conventions**: Update private fields to use underscore prefix per AGENTS.md guidelines
+4. **Function Ordering**: Reorder functions to place main/exported functions before helpers
+
+### Positive Observations
+- Excellent test coverage with clear test descriptions
+- Good use of TypeScript type safety
+- Clean separation of concerns in the module structure
+
+---
+**Note**: This is advisory feedback to help maintain code quality. Please address the items before merging. Feel free to ask questions or discuss any of these suggestions!
+```
+
+### Example Inline Comment
+
+```markdown
+The private field `config` should follow the naming convention from AGENTS.md and use an underscore prefix:
+
+```typescript
+// Suggested change:
+private readonly _config: Config
+```
+
+This improves readability by clearly distinguishing private from public members.
+
+Reference: [AGENTS.md - Class Field Naming Conventions](../AGENTS.md#class-field-naming-conventions)
+```
+
+## Troubleshooting
+
+### PR Has No Source Code Changes
+If the PR only modifies documentation, configuration, or other non-code files:
+1. Focus your review on documentation quality and accuracy
+2. Verify documentation follows repository style
+3. Skip code-specific checklist items and mark them as NOT APPLICABLE
+4. Provide feedback on documentation improvements
+
+### PR Is Very Large
+If the PR has many files or extensive changes:
+1. Prioritize reviewing core logic and public API changes
+2. Focus on significant issues rather than minor style points
+3. Suggest breaking large PRs into smaller ones if appropriate
+4. In your summary, note that the review focused on high-priority areas
+
+### PR Already Has Review Comments
+If the PR already has comments from other reviewers:
+1. Read existing comments to avoid duplication
+2. You MAY add +1 or agreement to existing comments
+3. Focus on areas not yet covered by other reviewers
+4. Reference previous comments when building on feedback
+
+### Unable to Access Files
+If you cannot read certain files in the PR:
+1. Note which files could not be accessed in your summary
+2. Review the files you can access
+3. Indicate that the review is partial due to access limitations
+4. Suggest manual review of inaccessible files
+
+### PR Modifies Generated or Lock Files
+If the PR includes changes to generated files (e.g., `package-lock.json`, `dist/`):
+1. Skip detailed review of generated files
+2. Focus on source code changes
+3. Verify that generated file changes are expected given source changes
+4. Mention in summary that generated files were excluded from review
+
+## Best Practices
+
+### Providing Constructive Feedback
+- Use "consider" or "suggest" rather than "you must" for non-critical items
+- Explain the reasoning behind recommendations
+- Provide code examples when suggesting changes
+- Link to AGENTS.md or other documentation for reference
+- Acknowledge good practices and improvements
+
+### Balancing Thoroughness and Pragmatism
+- Prioritize issues by severity (blocking vs. nice-to-have)
+- Consider the context and scope of the PR
+- Don't let perfect be the enemy of good
+- Focus on maintainability and long-term code health
+- Be flexible with minor style preferences if code is otherwise good
+
+### Maintaining Consistency
+- Apply the same standards to all PRs
+- Reference AGENTS.md patterns consistently
+- Use the checklist systematically
+- Provide similar feedback for similar issues
+- Update this script if patterns evolve
+
+## Advisory Nature of Reviews
+
+**Important**: This code review agent provides **advisory feedback only**. The review:
+- Does NOT block PR merging
+- Does NOT formally approve or request changes
+- Does NOT replace human code review
+- DOES help maintain code quality standards
+- DOES provide consistent feedback based on established patterns
+- DOES save reviewer time by catching common issues
+
+The final decision to merge rests with human reviewers and repository maintainers.

--- a/.github_temp/workflows/strands-command.yml
+++ b/.github_temp/workflows/strands-command.yml
@@ -1,0 +1,269 @@
+name: Strands Command Handler
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Issue ID to process (can be issue or PR number)'
+        required: true
+        type: string
+      command:
+        description: 'Strands command to execute'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  authorization-check:
+    if: startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch'
+    permissions: read-all
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.collab-check.outputs.result || steps.auto-approve.outputs.result }}
+    steps:
+      - name: Collaborator Check
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v8
+        id: collab-check
+        with:
+          result-encoding: string
+          script: |
+            try {
+              const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.comment.user.login,
+              });
+              const permission = permissionResponse.data.permission;
+              const hasWriteAccess = ['write', 'admin'].includes(permission);
+              if (!hasWriteAccess) {
+                console.log(`User ${context.payload.comment.user.login} does not have write access to the repository (permission: ${permission})`);
+                return "manual-approval"
+              } else {
+                console.log(`Verified ${context.payload.comment.user.login} has write access. Auto Approving strands command.`)
+                return "auto-approve"
+              }
+            } catch (error) {
+              console.log(`${context.payload.comment.user.login} does not have write access. Requiring Manual Approval to run strands command.`)
+              return "manual-approval"
+            }
+
+      - name: Auto-approve for workflow dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: auto-approve
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            return "auto-approve"
+
+  execute:
+    needs: [authorization-check]
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write # Required for OIDC
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Add strands-running label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ inputs.issue_id || github.event.issue.number }},
+              labels: ['strands-running']
+            });
+
+      - name: Determine PR context
+        id: determine-context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const issueId = context.eventName === 'workflow_dispatch' 
+                ? '${{ inputs.issue_id }}'
+                : context.payload.issue.number.toString();
+              const command = context.eventName === 'workflow_dispatch'
+                ? '${{ inputs.command }}'
+                : (context.payload.comment.body.match(/^\/strands\s*(.*)$/)?.[1]?.trim() || '');
+
+              console.log(`Event: ${context.eventName}, Issue ID: ${issueId}, Command: "${command}"`);
+
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueId
+              });
+              const isPrContext = !!issue.data.pull_request;
+              
+              // Determine mode based on command and context
+              let mode;
+              if (command.startsWith('pr') || command.startsWith('code-review')) {
+                mode = 'code-reviewer';
+              } else if (isPrContext || command.startsWith('implement')) {
+                mode = 'implementer';
+              } else {
+                mode = 'reviewer';
+              }
+
+              console.log(`Is PR: ${isPrContext}, Mode: ${mode}`);
+
+              let targetIssueId;
+              if (!isPrContext) {
+                targetIssueId = issueId;
+                console.log(`Target issue ID: ${targetIssueId} (same as issue)`);
+              } else {
+                const closingIssuesData = await github.graphql(`
+                  query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        closingIssuesReferences(first: 10) {
+                          nodes { number }
+                        }
+                      }
+                    }
+                  }
+                `, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  number: parseInt(issueId)
+                });
+                const issues = closingIssuesData?.repository?.pullRequest?.closingIssuesReferences?.nodes || [];
+                
+                console.log(`Found ${issues.length} closing issue(s)`);
+                
+                if (issues.length !== 1) {
+                  const errorMsg = issues.length > 1 
+                    ? `Pull request has ${issues.length} closing issues. Only one closing issue is allowed.`
+                    : 'Pull request must have exactly one closing issue.';
+                  console.error(errorMsg);
+                  core.setFailed(errorMsg);
+                  return;
+                }
+                
+                targetIssueId = issues[0].number.toString();
+                console.log(`Target issue ID: ${targetIssueId} (from closing issues)`);
+              }
+
+              console.log(`Setting outputs - issue_id: ${issueId}, target_issue_id: ${targetIssueId}, pr_id: ${isPrContext ? issueId : ''}, mode: ${mode}`);
+
+              core.setOutput('issue_id', issueId);
+              core.setOutput('target_issue_id', targetIssueId);
+              core.setOutput('pr_id', isPrContext ? issueId : '');
+              core.setOutput('mode', mode);
+              core.setOutput('command', command);
+
+            } catch (error) {
+              const errorMsg = `Failed to determine context: ${error.message}`;
+              console.error(errorMsg);
+              core.setFailed(errorMsg);
+            }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.determine-context.outputs.pr_id && format('refs/pull/{0}/head', steps.determine-context.outputs.pr_id) || 'main' }}
+
+      - name: Build prompts
+        id: process
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            try {
+              const mode = '${{ steps.determine-context.outputs.mode }}';
+              const targetIssueId = '${{ steps.determine-context.outputs.target_issue_id }}';
+              const issueId = '${{ steps.determine-context.outputs.issue_id }}';
+              const command = '${{ steps.determine-context.outputs.command }}';
+              const isPrContext = '${{ steps.determine-context.outputs.pr_id }}' !== '';
+              
+              console.log(`Building prompts - mode: ${mode}, target issue: ${targetIssueId}, is PR: ${isPrContext}`);
+              
+              const sessionId = mode === 'code-reviewer' ? `${mode}-${issueId}` : `${mode}-${targetIssueId}`;
+              console.log(`Session ID: ${sessionId}`);
+
+              let scriptFile;
+              let parameterName;
+              let parameterValue;
+              
+              if (mode === 'implementer') {
+                scriptFile = '.github/agent-scripts/task-implementer.script.md';
+                parameterName = 'ISSUE_NUMBER';
+                parameterValue = targetIssueId;
+              } else if (mode === 'code-reviewer') {
+                scriptFile = '.github/agent-scripts/code-reviewer.script.md';
+                parameterName = 'PR_NUMBER';
+                parameterValue = issueId;  // For code-reviewer, use the PR number directly
+              } else {
+                scriptFile = '.github/agent-scripts/task-reviewer.script.md';
+                parameterName = 'ISSUE_NUMBER';
+                parameterValue = targetIssueId;
+              }
+              
+              console.log(`Reading script file: ${scriptFile}`);
+              let systemPrompt = fs.readFileSync(scriptFile, 'utf8');
+              
+              systemPrompt = systemPrompt
+                .replace(new RegExp(`\\{\\{${parameterName}\\}\\}`, 'g'), parameterValue);
+              
+              const first20Lines = systemPrompt.split('\n').slice(0, 20).join('\n');
+              console.log(`System prompt (first 20 lines):\n${first20Lines}`);
+              
+              let prompt = '';
+              if (isPrContext) prompt += `The pull request id is: ${issueId}\n`;
+              prompt += `${command}\n`;
+              prompt += 'review and continue';
+              
+              console.log(`Task prompt: "${prompt}"`);
+
+              core.setOutput('session_id', sessionId);
+              core.setOutput('system_prompt', systemPrompt);
+              core.setOutput('prompt', prompt);
+
+            } catch (error) {
+              const errorMsg = `Failed to build prompts: ${error.message}`;
+              console.error(errorMsg);
+              core.setFailed(errorMsg);
+            }
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Strands Agent
+        uses: ./.github/actions/strands-agent-runner
+        with:
+          system_prompt: ${{ steps.process.outputs.system_prompt }}
+          session_id: ${{ steps.process.outputs.session_id }}
+          task_prompt: ${{ steps.process.outputs.prompt }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          sessions_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
+          github_token: ${{ github.token }}
+
+      - name: Remove strands-running label
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ inputs.issue_id || github.event.issue.number }},
+                name: 'strands-running'
+              });
+            } catch (error) {
+              console.log('Label removal failed (may not exist):', error.message);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,92 @@ This document provides guidance specifically for AI agents working on the Strand
 - Development workflow instructions for agents to follow when developing features
 - Coding patterns and testing patterns to follow when writing code
 - Style guidelines, organizational patterns, and best practices
+- Agent system overview and usage instructions
 
 **For human contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and contribution guidelines.
+
+## Agent System
+
+This repository uses three AI agents to assist with development tasks:
+
+### Task Reviewer (`/strands review`)
+Reviews and clarifies task requirements in GitHub issues. The agent:
+- Analyzes feature requests for ambiguities
+- Researches existing patterns in the codebase
+- Posts clarifying questions as issue comments
+- Updates the issue with comprehensive implementation requirements
+- Invoked on issues with `/strands review` command
+
+### Task Implementer (`/strands implement`)
+Implements tasks defined in GitHub issues using TDD principles. The agent:
+- Follows structured Explore, Plan, Code, Commit workflow
+- Writes tests first, then implementation
+- Creates pull requests for review
+- Iterates on feedback until PR is accepted
+- Invoked on issues with `/strands implement` command
+
+### Code Review Agent (`/strands pr`)
+Reviews pull requests for code quality aspects NOT covered by automated CI. The agent:
+- Assumes CI checks (tests, linting, formatting, type-checking) pass separately
+- Focuses on code quality, architecture, documentation, and adherence to patterns
+- Posts inline comments on specific code issues
+- Provides summary comment with checklist status
+- Gives advisory feedback only (non-blocking)
+- Invoked on pull requests with `/strands pr` or `/strands code-review` command
+
+#### Code Review Checklist
+
+The code review agent verifies PRs against the following checklist:
+
+**1. Architecture & Design Decisions**
+- Follows YAGNI, KISS, and SOLID principles
+- Uses existing patterns from the codebase
+- Makes minimal reasonable changes
+- Avoids over-engineering and over-abstraction
+- Has appropriate error handling
+
+**2. Test Quality (Beyond Coverage %)**
+- Tests are co-located in `__tests__/` directories
+- Uses nested describe pattern consistently
+- Test batching applied appropriately
+- Tests verify entire objects using `toEqual()`
+- Tests have clear, descriptive names
+- Integration tests in `tests_integ/` when appropriate
+- Tests follow RED → GREEN → REFACTOR TDD cycle
+
+**3. Documentation Completeness & Quality**
+- All exported functions have TSDoc comments
+- TSDoc includes `@param`, `@returns`, and `@example` (for exported classes only)
+- Interface properties have single-line descriptions
+- No examples on type definitions or interfaces
+- Key design decisions documented in code comments
+
+**4. Adherence to AGENTS.md Coding Patterns**
+- Private class fields use underscore prefix (`_field`)
+- Explicit return types on all exported functions
+- No `any` types used
+- Proper import organization (external, then internal with relative paths)
+- Interface/type organization: top-level first, then dependencies
+- Discriminated union naming: type value matches interface name (first letter lowercase)
+- Functions ordered from most general to most specific
+- Follows proper file organization pattern
+
+**5. Code Organization & Maintainability**
+- Code is readable and maintainable (primary concern over cleverness)
+- Code duplication is reduced/refactored
+- Matches style and formatting of surrounding code
+- Functions are small and focused (single responsibility)
+- Meaningful variable and function names
+
+**6. TypeScript Feature Usage**
+- Uses TypeScript strict mode features appropriately
+- Leverages type inference where appropriate
+- No unnecessary type assertions
+
+**7. Documentation Updates**
+- AGENTS.md updated if directory structure changed
+- README.md updated if public API changed
+- CONTRIBUTING.md updated if development process changed
 
 ## Directory Structure
 
@@ -58,8 +142,12 @@ sdk-typescript/
 │   ├── workflows/                # CI/CD workflows
 │   │   ├── pr-and-push.yml       # Triggers test/lint on PR and push
 │   │   ├── test-lint.yml         # Unit tests and linting
-│   │   └── integration-test.yml  # Secure integration tests with AWS
+│   │   ├── integration-test.yml  # Secure integration tests with AWS
+│   │   └── strands-command.yml   # Strands agent command handler
 │   └── agent-scripts/            # Agent system prompts and configs
+│       ├── task-reviewer.script.md      # Reviews and clarifies task requirements
+│       ├── task-implementer.script.md   # Implements tasks following TDD
+│       └── code-reviewer.script.md      # Reviews PRs for code quality
 │
 ├── .project/                     # Project management (tasks, tracking)
 │   ├── tasks/                    # Active tasks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,44 @@ Please read through this document before submitting any issues or pull requests.
 
 > **Note**: For AI agent-specific development patterns and guidelines, see [AGENTS.md](AGENTS.md).
 
+## AI Agent Assistance
+
+This repository uses AI agents to assist with development tasks. You can invoke them by commenting on GitHub issues or pull requests:
+
+### `/strands review` - Task Review Agent
+Use this command on an issue to have an AI agent review and clarify the task requirements:
+- Analyzes the feature request for ambiguities
+- Asks clarifying questions as comments
+- Updates the issue with comprehensive implementation requirements
+- Helps ensure the task is well-defined before implementation begins
+
+**Example**: Comment `/strands review` on any issue to invoke the task reviewer.
+
+### `/strands implement` - Task Implementation Agent
+Use this command on an issue to have an AI agent implement the task:
+- Follows test-driven development (TDD) principles
+- Creates implementation based on task requirements
+- Generates comprehensive tests
+- Creates a pull request for human review
+- Iterates on feedback until PR is ready to merge
+
+**Example**: Comment `/strands implement` on any issue with clear requirements.
+
+### `/strands pr` - Code Review Agent
+Use this command on a pull request to get automated code quality feedback:
+- Reviews code for architecture, design patterns, and maintainability
+- Checks adherence to repository coding standards (see [AGENTS.md](AGENTS.md))
+- Verifies documentation completeness (TSDoc coverage)
+- Posts inline comments on specific code issues
+- Provides summary with checklist of items passed/needing attention
+- **Advisory only** - does not block merging, complements human review
+
+The code review agent focuses on aspects **NOT** covered by automated CI (which handles tests, linting, formatting, and type-checking). Use this to get consistent feedback based on repository patterns before requesting human review.
+
+**Example**: Comment `/strands pr` or `/strands code-review` on any pull request.
+
+**Note**: All agent operations require appropriate repository permissions. The agents provide assistance but do not replace human judgment in code review and merging decisions.
+
 ## Development Tenets
 Our team follows these core principles when designing and implementing features. These tenets help us make consistent decisions, resolve trade-offs, and maintain the quality and coherence of the SDK. When contributing, please consider how your changes align with these principles:
 


### PR DESCRIPTION
Add code-review agent to complement task-reviewer and task-implementer agents. The agent reviews PRs for code quality aspects NOT covered by automated CI.

Changes:
- Create .github/agent-scripts/code-reviewer.script.md
  - Comprehensive checklist covering architecture, tests, docs, and patterns
  - Posts inline comments and summary with checklist status
  - Advisory feedback only (non-blocking)
- Update .github_temp/workflows/strands-command.yml
  - Add routing for /strands pr and /strands code-review commands
  - Support code-reviewer mode with PR_NUMBER parameter
- Update AGENTS.md
  - Document agent system overview
  - Add code review checklist reference
- Update CONTRIBUTING.md
  - Document /strands pr command for contributors
  - Explain code review process

Resolves: #116

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
