### PR TITLE
agent loop fast follows

### DIFF
--- a/src/agent/__tests__/agent-loop.test.ts
+++ b/src/agent/__tests__/agent-loop.test.ts
@@ -1,0 +1,529 @@
+import { describe, expect, it } from 'vitest'
+import { runAgentLoop } from '../agent-loop.js'
+import { collectGenerator, TestModelProvider } from '../../__fixtures__/model-test-helpers.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { ToolRegistry } from '../../tools/registry.js'
+import { Message, TextBlock } from '../../types/messages.js'
+import { MaxTokensError } from '../../errors.js'
+
+describe('runAgentLoop', () => {
+  describe('when handling simple completion without tools', () => {
+    it('yields events and returns final messages array', async () => {
+      const provider = new TestModelProvider(async function* () {
+        yield { type: 'modelMessageStartEvent', role: 'assistant' }
+        yield { type: 'modelContentBlockStartEvent', contentBlockIndex: 0 }
+        yield {
+          type: 'modelContentBlockDeltaEvent',
+          delta: { type: 'textDelta', text: 'Hello, how can I help?' },
+          contentBlockIndex: 0,
+        }
+        yield { type: 'modelContentBlockStopEvent', contentBlockIndex: 0 }
+        yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+      })
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Hi')],
+        }),
+      ]
+
+      const { items } = await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      // Verify agent events are present
+      expect(items).toContainEqual({ type: 'beforeInvocationEvent' })
+      expect(items).toContainEqual({
+        type: 'beforeModelCallEvent',
+        messages: expect.any(Array),
+      })
+      expect(items).toContainEqual({
+        type: 'afterModelCallEvent',
+        message: expect.objectContaining({ role: 'assistant' }),
+        stopReason: expect.any(String),
+      })
+      expect(items).toContainEqual({ type: 'afterInvocationEvent' })
+
+      // Verify model events are passed through
+      expect(items).toContainEqual({ type: 'modelMessageStartEvent', role: 'assistant' })
+
+      // Verify final messages array contains assistant response
+      expect(messages).toHaveLength(2)
+      expect(messages[1]).toEqual({
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'textBlock', text: 'Hello, how can I help?' }],
+      })
+    })
+  })
+
+  describe('when handling single tool use cycle', () => {
+    it('executes tool and continues loop until completion', async () => {
+      const provider = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'calculator',
+          toolUseId: 'tool-1',
+          input: { operation: 'add', a: 5, b: 3 },
+        })
+        .addTurn({ type: 'textBlock', text: 'The result is 8' })
+
+      const mockTool = createMockTool('calculator', () => ({
+        toolUseId: 'tool-1',
+        status: 'success',
+        content: [{ type: 'textBlock', text: '8' }],
+      }))
+
+      const registry = new ToolRegistry()
+      registry.register(mockTool)
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [{ type: 'textBlock', text: 'What is 5+3?' }],
+        }),
+      ]
+
+      const { items } = await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      // Verify tool execution events
+      expect(items).toContainEqual({
+        type: 'beforeToolCallsEvent',
+        message: expect.objectContaining({ role: 'assistant' }),
+      })
+      expect(items).toContainEqual({
+        type: 'afterToolCallsEvent',
+        message: expect.objectContaining({ role: 'user' }),
+      })
+
+      // Verify only one beforeInvocationEvent
+      const beforeEvents = items.filter((e) => e.type === 'beforeInvocationEvent')
+      expect(beforeEvents).toHaveLength(1)
+
+      // Verify two iterations using callCount
+      expect(provider.callCount).toBe(2)
+
+      // Verify final messages include tool use and result
+      expect(messages).toHaveLength(4) // user, assistant with tool use, user with tool result, assistant with final response
+      if (!messages[1] || !messages[1].content[0]) {
+        throw new Error('Expected content at index 1')
+      }
+      expect(messages[1].content[0]).toMatchObject({
+        type: 'toolUseBlock',
+        name: 'calculator',
+        toolUseId: 'tool-1',
+      })
+      if (!messages[2] || !messages[2].content[0]) {
+        throw new Error('Expected content at index 2')
+      }
+      expect(messages[2].content[0]).toMatchObject({
+        type: 'toolResultBlock',
+        toolUseId: 'tool-1',
+        status: 'success',
+      })
+    })
+  })
+
+  describe('when handling multiple tool uses in sequence', () => {
+    it('executes all tools sequentially', async () => {
+      const provider = new MockMessageModel()
+        .addTurn([
+          {
+            type: 'toolUseBlock',
+            name: 'tool1',
+            toolUseId: 'id-1',
+            input: {},
+          },
+          {
+            type: 'toolUseBlock',
+            name: 'tool2',
+            toolUseId: 'id-2',
+            input: {},
+          },
+        ])
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool1 = createMockTool('tool1', () => ({
+        toolUseId: 'id-1',
+        status: 'success',
+        content: [{ type: 'textBlock', text: 'result1' }],
+      }))
+
+      const tool2 = createMockTool('tool2', () => ({
+        toolUseId: 'id-2',
+        status: 'success',
+        content: [{ type: 'textBlock', text: 'result2' }],
+      }))
+
+      const registry = new ToolRegistry()
+      registry.register([tool1, tool2])
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      // Verify both tool results are present
+      const toolResultMessage = messages[2]
+      if (!toolResultMessage) {
+        throw new Error('Expected tool result message at index 2')
+      }
+      expect(toolResultMessage.content).toHaveLength(2)
+      expect(toolResultMessage.content[0]).toMatchObject({
+        type: 'toolResultBlock',
+        toolUseId: 'id-1',
+      })
+      expect(toolResultMessage.content[1]).toMatchObject({
+        type: 'toolResultBlock',
+        toolUseId: 'id-2',
+      })
+    })
+  })
+
+  describe('when handling multiple agentic loop iterations', () => {
+    it('continues through multiple tool-use cycles', async () => {
+      const provider = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'tool1',
+          toolUseId: 'id-1',
+          input: {},
+        })
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'tool2',
+          toolUseId: 'id-2',
+          input: {},
+        })
+        .addTurn({ type: 'textBlock', text: 'Complete' })
+
+      const tool1 = createMockTool('tool1', () => ({
+        toolUseId: 'id-1',
+        status: 'success',
+        content: [{ type: 'textBlock', text: 'r1' }],
+      }))
+
+      const tool2 = createMockTool('tool2', () => ({
+        toolUseId: 'id-2',
+        status: 'success',
+        content: [{ type: 'textBlock', text: 'r2' }],
+      }))
+
+      const registry = new ToolRegistry()
+      registry.register([tool1, tool2])
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      const { items } = await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      // Verify only one beforeInvocationEvent
+      const beforeEvents = items.filter((e) => e.type === 'beforeInvocationEvent')
+      expect(beforeEvents).toHaveLength(1)
+
+      // Verify three iterations using callCount
+      expect(provider.callCount).toBe(3)
+
+      // Verify final message count (1 user + 2 assistant tool use + 2 user tool results + 1 assistant final)
+      expect(messages).toHaveLength(6)
+    })
+  })
+
+  describe('when handling transactional message success', () => {
+    it('adds assistant message to array after first model event', async () => {
+      const provider = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Response' })
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      // Verify assistant message was added
+      expect(messages).toHaveLength(2)
+      if (!messages[1]) {
+        throw new Error('Expected assistant message at index 1')
+      }
+      expect(messages[1].role).toBe('assistant')
+    })
+  })
+
+  describe('when handling transactional message with early error', () => {
+    it('throws error without adding message to array', async () => {
+      const provider = new MockMessageModel().addTurn(new Error('Model error before any events'))
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      // Verify error is thrown
+      await expect(
+        collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+      ).rejects.toThrow('Model error before any events')
+    })
+  })
+
+  describe('when model throws error after first event', () => {
+    it('propagates error with messages array preserved', async () => {
+      // For error after first event, we need to use TestModelProvider since TestMessageModelProvider
+      // throws errors before any events are generated
+      const provider = new TestModelProvider(async function* () {
+        yield { type: 'modelMessageStartEvent', role: 'assistant' }
+        throw new Error('Error after first event')
+      })
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      // Verify error is thrown
+      await expect(
+        collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+      ).rejects.toThrow('Error after first event')
+    })
+  })
+
+  describe('when tool throws exception', () => {
+    it('propagates the error from the tool', async () => {
+      const provider = new MockMessageModel().addTurn({
+        type: 'toolUseBlock',
+        name: 'badTool',
+        toolUseId: 'id-1',
+        input: {},
+      })
+
+      // eslint-disable-next-line require-yield
+      const badTool = createMockTool('badTool', async function* () {
+        throw new Error('Tool execution failed')
+      })
+
+      const registry = new ToolRegistry()
+      registry.register(badTool)
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      await expect(
+        collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+      ).rejects.toThrow('Tool execution failed')
+    })
+
+    it('does not add assistant message with tool uses when tool execution fails', async () => {
+      const provider = new MockMessageModel().addTurn({
+        type: 'toolUseBlock',
+        name: 'badTool',
+        toolUseId: 'id-1',
+        input: {},
+      })
+
+      // eslint-disable-next-line require-yield
+      const badTool = createMockTool('badTool', async function* () {
+        throw new Error('Tool execution failed')
+      })
+
+      const registry = new ToolRegistry()
+      registry.register(badTool)
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      try {
+        await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+        throw new Error('Expected error to be thrown')
+      } catch (error) {
+        if (error instanceof Error && error.message === 'Tool execution failed') {
+          // Verify that messages array only contains the initial user message
+          // The assistant message with tool uses should NOT be present since tool execution failed
+          expect(messages).toHaveLength(1)
+          expect(messages[0]).toEqual({
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'textBlock', text: 'Test' }],
+          })
+        } else {
+          throw error
+        }
+      }
+    })
+  })
+
+  describe('when tool is not found in registry', () => {
+    it('returns error tool result and continues loop', async () => {
+      const provider = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'nonexistent',
+          toolUseId: 'id-1',
+          input: {},
+        })
+        .addTurn({ type: 'textBlock', text: 'Tool not available' })
+
+      const registry = new ToolRegistry()
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      // Verify error tool result was returned
+      const toolResultMessage = messages[2]
+      if (!toolResultMessage || !toolResultMessage.content[0]) {
+        throw new Error('Expected tool result message at index 2')
+      }
+      expect(toolResultMessage.content[0]).toMatchObject({
+        type: 'toolResultBlock',
+        toolUseId: 'id-1',
+        status: 'error',
+      })
+
+      // Verify loop continued and completed
+      expect(messages).toHaveLength(4) // user, assistant tool use, user error result, assistant final
+    })
+  })
+
+  describe('when maxTokens stop reason occurs', () => {
+    it('throws MaxTokensError', async () => {
+      const provider = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Partial' }, 'maxTokens')
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Test')],
+        }),
+      ]
+
+      await expect(
+        collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+      ).rejects.toThrow(MaxTokensError)
+    })
+  })
+
+  describe('when constructing ContentBlocks via streamAggregated', () => {
+    it('handles TextBlock correctly', async () => {
+      const provider = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Hi')],
+        }),
+      ]
+
+      await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      if (!messages[1] || !messages[1].content[0]) {
+        throw new Error('Expected content at index 1')
+      }
+      expect(messages[1].content[0]).toEqual({
+        type: 'textBlock',
+        text: 'Hello',
+      })
+    })
+
+    it('handles ToolUseBlock correctly', async () => {
+      const provider = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'test',
+          toolUseId: 'id-1',
+          input: { key: 'value' },
+        })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('test', () => ({
+        toolUseId: 'id-1',
+        status: 'success',
+        content: [{ type: 'textBlock', text: 'ok' }],
+      }))
+
+      const registry = new ToolRegistry()
+      registry.register(tool)
+
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Hi')],
+        }),
+      ]
+
+      await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      const toolUseBlock = messages[1]?.content[0]
+      if (!toolUseBlock || toolUseBlock.type !== 'toolUseBlock') {
+        throw new Error('Expected tool use block at messages[1].content[0]')
+      }
+      expect(toolUseBlock).toEqual({
+        type: 'toolUseBlock',
+        name: 'test',
+        toolUseId: 'id-1',
+        input: { key: 'value' },
+      })
+    })
+
+    it('handles ReasoningBlock correctly', async () => {
+      const provider = new MockMessageModel().addTurn([
+        { type: 'reasoningBlock', text: 'thinking...' },
+        { type: 'textBlock', text: 'Response' },
+      ])
+
+      const registry = new ToolRegistry()
+      const messages: Message[] = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Hi')],
+        }),
+      ]
+      await collectGenerator(runAgentLoop({ model: provider, messages, toolRegistry: registry }))
+
+      if (!messages[1] || !messages[1].content[0]) {
+        throw new Error('Expected content blocks at index 1')
+      }
+      expect(messages[1].content[0]).toEqual({
+        type: 'reasoningBlock',
+        text: 'thinking...',
+      })
+      if (!messages[1].content[1]) {
+        throw new Error('Expected second content block at index 1')
+      }
+      expect(messages[1].content[1]).toEqual({
+        type: 'textBlock',
+        text: 'Response',
+      })
+    })
+  })
+})

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,0 +1,227 @@
+import { Message, TextBlock, ToolResultBlock, type SystemPrompt, type ToolUseBlock } from '../types/messages.js'
+import type { BaseModelConfig, Model, StreamOptions } from '../models/model.js'
+import type { ToolRegistry } from '../tools/registry.js'
+import type { AgentStreamEvent } from './streaming.js'
+import { MaxTokensError } from '../errors.js'
+import type { AgentResult } from '../types/agent.js'
+
+/**
+ * Internal configuration for the agent loop.
+ * @internal
+ */
+interface AgentLike {
+  /**
+   * Model provider instance for generating responses.
+   */
+  model: Model<BaseModelConfig>
+
+  /**
+   * Array of conversation messages (will be mutated as the loop progresses).
+   */
+  messages: Message[]
+
+  /**
+   * Registry containing available tools.
+   */
+  toolRegistry: ToolRegistry
+
+  /**
+   * Optional system prompt to guide model behavior.
+   */
+  systemPrompt?: SystemPrompt
+}
+
+/**
+ * Async generator that coordinates execution between model providers and tools.
+ *
+ * The agent loop manages the conversation flow by:
+ * 1. Streaming model responses and yielding all events
+ * 2. Executing tools when the model requests them
+ * 3. Continuing the loop until the model completes without tool use
+ *
+ * An explicit goal of this method is to always leave the message array in a way that
+ * the agent can be reinvoked with a user prompt after this method completes. To that end
+ * assistant messages containing tool uses are only added after tool execution succeeds
+ * with valid toolResponses
+ *
+ * @param agent - Configuration including model, messages, toolRegistry, and systemPrompt
+ * @returns Async generator that yields AgentStreamEvent objects and returns AgentResult
+ *
+ * @example
+ * ```typescript
+ * const messages = [{ type: 'message', role: 'user', content: [{ type: 'textBlock', text: 'Hello' }] }]
+ * const registry = new ToolRegistry()
+ * const provider = new BedrockModel(config)
+ *
+ * for await (const event of runAgentLoop({ model: provider, messages, toolRegistry: registry })) {
+ *   console.log('Event:', event.type)
+ * }
+ * // Messages array is mutated in place and contains the full conversation
+ * ```
+ */
+export async function* runAgentLoop(agent: AgentLike): AsyncGenerator<AgentStreamEvent, AgentResult, never> {
+  // Emit event before the loop starts
+  yield { type: 'beforeInvocationEvent' }
+
+  try {
+    // Main agent loop - continues until model stops without requesting tools
+    while (true) {
+      const modelResult = yield* invokeModel(agent)
+
+      // Handle stop reason
+      if (modelResult.stopReason === 'maxTokens') {
+        throw new MaxTokensError(
+          'Model reached maximum token limit. This is an unrecoverable state that requires intervention.',
+          modelResult.message
+        )
+      }
+
+      if (modelResult.stopReason !== 'toolUse') {
+        // Loop terminates - no tool use requested
+        // Add assistant message now that we're returning
+        agent.messages.push(modelResult.message)
+        return {
+          stopReason: modelResult.stopReason,
+          lastMessage: modelResult.message,
+        }
+      }
+
+      // Execute tools sequentially
+      const toolResultMessage = yield* executeTools(modelResult.message, agent.toolRegistry)
+
+      // Add assistant message with tool uses right before adding tool results
+      // This ensures we don't have dangling tool use messages if tool execution fails
+      agent.messages.push(modelResult.message)
+      agent.messages.push(toolResultMessage)
+
+      // Continue loop
+    }
+  } finally {
+    // Always emit final event
+    yield { type: 'afterInvocationEvent' }
+  }
+}
+
+/**
+ * Invokes the model provider and streams all events.
+ *
+ * @param agent - Agent configuration containing model, messages, toolRegistry, and systemPrompt
+ * @returns Object containing the assistant message and stop reason
+ */
+async function* invokeModel(
+  agent: AgentLike
+): AsyncGenerator<AgentStreamEvent, { message: Message; stopReason: string }, never> {
+  // Emit event before invoking model
+  yield { type: 'beforeModelCallEvent', messages: agent.messages }
+
+  const toolSpecs = agent.toolRegistry.list().map((tool) => tool.toolSpec)
+  const streamOptions: StreamOptions = { toolSpecs }
+  if (agent.systemPrompt !== undefined) {
+    streamOptions.systemPrompt = agent.systemPrompt
+  }
+
+  const { message, stopReason } = yield* agent.model.streamAggregated(agent.messages, streamOptions)
+
+  yield { type: 'afterModelCallEvent', message, stopReason }
+
+  return { message, stopReason }
+}
+
+/**
+ * Executes tools sequentially and streams all tool events.
+ *
+ * @param assistantMessage - The assistant message containing tool use blocks
+ * @param toolRegistry - Registry containing available tools
+ * @returns User message containing tool results
+ */
+async function* executeTools(
+  assistantMessage: Message,
+  toolRegistry: ToolRegistry
+): AsyncGenerator<AgentStreamEvent, Message, never> {
+  yield { type: 'beforeToolCallsEvent', message: assistantMessage }
+
+  // Extract tool use blocks from assistant message
+  const toolUseBlocks = assistantMessage.content.filter((block): block is ToolUseBlock => block.type === 'toolUseBlock')
+
+  if (toolUseBlocks.length === 0) {
+    // No tool use blocks found even though stopReason is toolUse
+    throw new Error('Model indicated toolUse but no tool use blocks found in message')
+  }
+
+  const toolResultBlocks: ToolResultBlock[] = []
+
+  for (const toolUseBlock of toolUseBlocks) {
+    const toolResultBlock = yield* executeTool(toolUseBlock, toolRegistry)
+    toolResultBlocks.push(toolResultBlock)
+
+    // Yield the tool result block as it's created
+    yield toolResultBlock as AgentStreamEvent
+  }
+
+  // Create user message with tool results
+  const toolResultMessage: Message = new Message({
+    role: 'user',
+    content: toolResultBlocks,
+  })
+
+  yield { type: 'afterToolCallsEvent', message: toolResultMessage }
+
+  return toolResultMessage
+}
+
+/**
+ * Executes a single tool and returns the result.
+ * If the tool is not found or fails to return a result, returns an error ToolResult
+ * instead of throwing an exception. This allows the agent loop to continue and
+ * let the model handle the error gracefully.
+ *
+ * @param toolUseBlock - Tool use block to execute
+ * @param toolRegistry - Registry containing available tools
+ * @returns Tool result block
+ */
+async function* executeTool(
+  toolUseBlock: ToolUseBlock,
+  toolRegistry: ToolRegistry
+): AsyncGenerator<AgentStreamEvent, ToolResultBlock, never> {
+  const tool = toolRegistry.get(toolUseBlock.name)
+
+  if (!tool) {
+    // Tool not found - return error result instead of throwing
+    return new ToolResultBlock({
+      toolUseId: toolUseBlock.toolUseId,
+      status: 'error',
+      content: [new TextBlock(`Tool '${toolUseBlock.name}' not found in registry`)],
+    })
+  }
+
+  // Execute tool and collect result
+  const toolContext = {
+    toolUse: {
+      name: toolUseBlock.name,
+      toolUseId: toolUseBlock.toolUseId,
+      input: toolUseBlock.input,
+    },
+    invocationState: {},
+  }
+
+  const toolGenerator = tool.stream(toolContext)
+
+  // Use yield* to delegate to the tool generator and capture the return value
+  const toolResult = yield* toolGenerator
+
+  if (!toolResult) {
+    // Tool didn't return a result - return error result instead of throwing
+    return new ToolResultBlock({
+      toolUseId: toolUseBlock.toolUseId,
+      status: 'error',
+      content: [new TextBlock(`Tool '${toolUseBlock.name}' did not return a result`)],
+    })
+  }
+
+  // Create ToolResultBlock from ToolResult
+  return new ToolResultBlock({
+    toolUseId: toolResult.toolUseId,
+    status: toolResult.status,
+    content: toolResult.content,
+  })
+}

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -169,7 +169,7 @@ export class Agent {
     args?: InvokeArgs
   ): AsyncGenerator<AgentStreamEvent, { message: Message; stopReason: string }, never> {
     // Emit event before invoking model
-    yield { type: 'beforeModelEvent', messages: [...this._messages] }
+    yield { type: 'beforeModelCallEvent', messages: [...this._messages] }
 
     const toolSpecs = this._toolRegistry.values().map((tool) => tool.toolSpec)
     const streamOptions: StreamOptions = { toolSpecs }
@@ -189,7 +189,7 @@ export class Agent {
 
     const { message, stopReason } = yield* this._model.streamAggregated(this._messages, streamOptions)
 
-    yield { type: 'afterModelEvent', message, stopReason }
+    yield { type: 'afterModelCallEvent', message, stopReason }
 
     return { message, stopReason }
   }
@@ -205,7 +205,7 @@ export class Agent {
     assistantMessage: Message,
     toolRegistry: ToolRegistry
   ): AsyncGenerator<AgentStreamEvent, Message, never> {
-    yield { type: 'beforeToolsEvent', message: assistantMessage }
+    yield { type: 'beforeToolCallsEvent', message: assistantMessage }
 
     // Extract tool use blocks from assistant message
     const toolUseBlocks = assistantMessage.content.filter(
@@ -233,7 +233,7 @@ export class Agent {
       content: toolResultBlocks,
     })
 
-    yield { type: 'afterToolsEvent', message: toolResultMessage }
+    yield { type: 'afterToolCallsEvent', message: toolResultMessage }
 
     return toolResultMessage
   }

--- a/src/agent/streaming.ts
+++ b/src/agent/streaming.ts
@@ -13,8 +13,8 @@ export type AgentStreamEvent =
   | ModelStreamEvent
   | ContentBlock
   | ToolStreamEvent
-  | BeforeModelEvent
-  | AfterModelEvent
+  | BeforeModelCallEvent
+  | AfterModelCallEvent
   | BeforeToolsEvent
   | AfterToolsEvent
   | BeforeInvocationEvent
@@ -23,11 +23,11 @@ export type AgentStreamEvent =
 /**
  * Event emitted before invoking the model provider.
  */
-export interface BeforeModelEvent {
+export interface BeforeModelCallEvent {
   /**
    * Discriminator for before model events.
    */
-  type: 'beforeModelEvent'
+  type: 'beforeModelCallEvent'
 
   /**
    * The messages that will be sent to the model.
@@ -38,11 +38,11 @@ export interface BeforeModelEvent {
 /**
  * Event emitted after the model provider completes.
  */
-export interface AfterModelEvent {
+export interface AfterModelCallEvent {
   /**
    * Discriminator for after model events.
    */
-  type: 'afterModelEvent'
+  type: 'afterModelCallEvent'
 
   /**
    * The assistant message returned by the model.
@@ -62,7 +62,7 @@ export interface BeforeToolsEvent {
   /**
    * Discriminator for before tools events.
    */
-  type: 'beforeToolsEvent'
+  type: 'beforeToolCallsEvent'
 
   /**
    * The assistant message containing tool use blocks.
@@ -77,7 +77,7 @@ export interface AfterToolsEvent {
   /**
    * Discriminator for after tools events.
    */
-  type: 'afterToolsEvent'
+  type: 'afterToolCallsEvent'
 
   /**
    * The user message containing tool results that will be added to the message array.

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,9 @@ export { FunctionTool } from './tools/function-tool.js'
 // Tool factory function
 export { tool } from './tools/zod-tool.js'
 
+// ToolRegistry implementation
+export { ToolRegistry } from './tools/registry.js'
+
 // Streaming event types
 export type {
   Usage,
@@ -76,8 +79,8 @@ export type { BedrockModelConfig, BedrockModelOptions } from './models/bedrock.j
 // Agent streaming event types
 export type {
   AgentStreamEvent,
-  BeforeModelEvent,
-  AfterModelEvent,
+  BeforeModelCallEvent,
+  AfterModelCallEvent,
   BeforeToolsEvent,
   AfterToolsEvent,
   BeforeInvocationEvent,

--- a/src/tools/__tests__/registry.test.ts
+++ b/src/tools/__tests__/registry.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest'
+import { ToolRegistry } from '../registry.js'
+import type { Tool, ToolStreamEvent } from '../tool.js'
+import type { ToolResult, ToolSpec } from '../types.js'
+import { TextBlock } from '../../types/messages.js'
+
+/**
+ * Helper function to create a mock Tool for testing.
+ * Creates a minimal Tool implementation with configurable name and description.
+ */
+function createMockTool(name: string, description = 'Test tool description'): Tool {
+  const toolSpec: ToolSpec = {
+    name,
+    description,
+    inputSchema: { type: 'object' },
+  }
+
+  return {
+    name: name,
+    description,
+    toolSpec,
+    // eslint-disable-next-line require-yield
+    async *stream(): AsyncGenerator<ToolStreamEvent, ToolResult, unknown> {
+      return {
+        toolUseId: 'test-id',
+        status: 'success',
+        content: [new TextBlock('test result')],
+      }
+    },
+  }
+}
+
+describe('ToolRegistry', () => {
+  describe('constructor', () => {
+    it('creates an empty registry', () => {
+      const registry = new ToolRegistry()
+      expect(registry).toBeDefined()
+      expect(registry.list()).toEqual([])
+    })
+  })
+
+  describe('register', () => {
+    describe('when registering a single tool', () => {
+      it('adds the tool to the registry', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('testTool')
+        registry.register(tool)
+
+        const retrieved = registry.get('testTool')
+        expect(retrieved).toBe(tool)
+      })
+
+      it('allows retrieval with get()', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('calculator')
+        registry.register(tool)
+
+        const retrieved = registry.get('calculator')
+        expect(retrieved?.name).toBe('calculator')
+      })
+    })
+
+    describe('when registering multiple tools', () => {
+      it('adds all tools to the registry', () => {
+        const registry = new ToolRegistry()
+        const tool1 = createMockTool('multiTool1')
+        const tool2 = createMockTool('multiTool2')
+        const tool3 = createMockTool('multiTool3')
+
+        registry.register([tool1, tool2, tool3])
+
+        expect(registry.get('multiTool1')).toBe(tool1)
+        expect(registry.get('multiTool2')).toBe(tool2)
+        expect(registry.get('multiTool3')).toBe(tool3)
+      })
+
+      it('allows retrieval of each tool', () => {
+        const registry = new ToolRegistry()
+        const tools = [createMockTool('alpha'), createMockTool('beta'), createMockTool('gamma')]
+
+        registry.register(tools)
+
+        const allTools = registry.list()
+        expect(allTools).toHaveLength(3)
+        expect(allTools[0]?.name).toBe('alpha')
+        expect(allTools[1]?.name).toBe('beta')
+        expect(allTools[2]?.name).toBe('gamma')
+      })
+    })
+
+    describe('when registering a duplicate tool name', () => {
+      it('throws an error with descriptive message', () => {
+        const registry = new ToolRegistry()
+        const tool1 = createMockTool('duplicateTool')
+        const tool2 = createMockTool('duplicateTool')
+
+        registry.register(tool1)
+
+        expect(() => registry.register(tool2)).toThrow("Tool with name 'duplicateTool' already registered")
+      })
+    })
+
+    describe('when registering a tool with empty name', () => {
+      it('throws an error with descriptive message', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('')
+
+        expect(() => registry.register(tool)).toThrow('Tool name must be between 1 and 64 characters')
+      })
+    })
+
+    describe('when registering a tool with name too long', () => {
+      it('throws an error with descriptive message', () => {
+        const registry = new ToolRegistry()
+        const longName = 'a'.repeat(65)
+        const tool = createMockTool(longName)
+
+        expect(() => registry.register(tool)).toThrow('Tool name must be between 1 and 64 characters')
+      })
+    })
+
+    describe('when registering a tool with invalid name characters', () => {
+      it('throws an error for spaces', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('invalid name')
+
+        expect(() => registry.register(tool)).toThrow(
+          'Tool name must contain only alphanumeric characters, hyphens, and underscores'
+        )
+      })
+
+      it('throws an error for special characters', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('invalid@name!')
+
+        expect(() => registry.register(tool)).toThrow(
+          'Tool name must contain only alphanumeric characters, hyphens, and underscores'
+        )
+      })
+
+      it('allows valid characters', () => {
+        const registry = new ToolRegistry()
+        const tool1 = createMockTool('valid_name')
+        const tool2 = createMockTool('valid-name')
+        const tool3 = createMockTool('ValidName123')
+
+        expect(() => {
+          registry.register([tool1, tool2, tool3])
+        }).not.toThrow()
+
+        expect(registry.list()).toHaveLength(3)
+      })
+    })
+
+    describe('when registering a tool with empty description', () => {
+      it('throws an error with descriptive message', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('validName', '')
+
+        expect(() => registry.register(tool)).toThrow('Tool description must be a non-empty string')
+      })
+    })
+
+    describe('when registering a tool with valid name at boundary', () => {
+      it('accepts name with 1 character', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('a')
+
+        expect(() => registry.register(tool)).not.toThrow()
+        expect(registry.get('a')).toBe(tool)
+      })
+
+      it('accepts name with 64 characters', () => {
+        const registry = new ToolRegistry()
+        const name64 = 'a'.repeat(64)
+        const tool = createMockTool(name64)
+
+        expect(() => registry.register(tool)).not.toThrow()
+        expect(registry.get(name64)).toBe(tool)
+      })
+    })
+  })
+
+  describe('get', () => {
+    describe('when tool exists', () => {
+      it('returns the tool instance', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('existingTool')
+        registry.register(tool)
+
+        const retrieved = registry.get('existingTool')
+        expect(retrieved).toBe(tool)
+      })
+    })
+
+    describe('when tool does not exist', () => {
+      it('returns undefined', () => {
+        const registry = new ToolRegistry()
+        expect(registry.get('nonExistentTool')).toBeUndefined()
+      })
+    })
+
+    describe('when registry is empty', () => {
+      it('returns undefined', () => {
+        const registry = new ToolRegistry()
+        expect(registry.get('anyTool')).toBeUndefined()
+      })
+    })
+  })
+  describe('remove', () => {
+    describe('when removing an existing tool', () => {
+      it('removes the tool from registry', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('removableTool')
+        registry.register(tool)
+
+        registry.remove('removableTool')
+
+        expect(registry.list()).toEqual([])
+      })
+
+      it('get() returns undefined after removal', () => {
+        const registry = new ToolRegistry()
+        const tool = createMockTool('temporaryTool')
+        registry.register(tool)
+
+        registry.remove('temporaryTool')
+
+        expect(registry.get('temporaryTool')).toBeUndefined()
+      })
+    })
+
+    describe('when tool does not exist', () => {
+      it('throws an error with descriptive message', () => {
+        const registry = new ToolRegistry()
+        expect(() => registry.remove('nonExistent')).toThrow("Tool with name 'nonExistent' not found")
+      })
+    })
+  })
+
+  describe('list', () => {
+    describe('when registry has tools', () => {
+      it('returns all registered tools', () => {
+        const registry = new ToolRegistry()
+        const tool1 = createMockTool('listTool1')
+        const tool2 = createMockTool('listTool2')
+        const tool3 = createMockTool('listTool3')
+
+        registry.register([tool1, tool2, tool3])
+
+        const tools = registry.list()
+        expect(tools).toEqual([tool1, tool2, tool3])
+      })
+
+      it('returns a copy (mutation does not affect registry)', () => {
+        const registry = new ToolRegistry()
+        const tool1 = createMockTool('copyTool1')
+        const tool2 = createMockTool('copyTool2')
+
+        registry.register([tool1, tool2])
+
+        const tools = registry.list()
+        tools.pop() // Mutate the returned array
+
+        // Verify registry still has both tools
+        expect(registry.list()).toEqual([tool1, tool2])
+      })
+
+      it('returns tools in insertion order', () => {
+        const registry = new ToolRegistry()
+        const toolA = createMockTool('orderA')
+        const toolB = createMockTool('orderB')
+        const toolC = createMockTool('orderC')
+
+        registry.register(toolA)
+        registry.register(toolB)
+        registry.register(toolC)
+
+        const tools = registry.list()
+        expect(tools).toHaveLength(3)
+        expect(tools[0]?.name).toBe('orderA')
+        expect(tools[1]?.name).toBe('orderB')
+        expect(tools[2]?.name).toBe('orderC')
+      })
+    })
+
+    describe('when registry is empty', () => {
+      it('returns an empty array', () => {
+        const registry = new ToolRegistry()
+        expect(registry.list()).toEqual([])
+      })
+    })
+
+    describe('after adding and removing tools', () => {
+      it('reflects current state', () => {
+        const registry = new ToolRegistry()
+        const tool1 = createMockTool('stateTool1')
+        const tool2 = createMockTool('stateTool2')
+        const tool3 = createMockTool('stateTool3')
+
+        registry.register([tool1, tool2, tool3])
+        expect(registry.list()).toHaveLength(3)
+
+        registry.remove('stateTool2')
+        const tools = registry.list()
+        expect(tools).toHaveLength(2)
+        expect(tools).toEqual([tool1, tool3])
+      })
+    })
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,0 +1,95 @@
+import type { Tool } from './tool.js'
+
+/**
+ * Registry for managing Tool instances.
+ */
+export class ToolRegistry {
+  private readonly _tools: Map<string, Tool>
+
+  /**
+   * Creates a new ToolRegistry instance with an empty registry.
+   */
+  constructor() {
+    this._tools = new Map<string, Tool>()
+  }
+
+  /**
+   * Registers one or more tools with the registry.
+   * Accepts single Tool or array of Tools for convenience.
+   *
+   * @param tool - Single Tool instance or array of Tool instances to register
+   * @throws If a tool with duplicate name already exists
+   * @throws If tool name is invalid (must be 1-64 chars, alphanumeric with hyphens/underscores)
+   * @throws If tool description is empty
+   */
+  public register(tool: Tool | Tool[]): void {
+    const tools = Array.isArray(tool) ? tool : [tool]
+
+    for (const t of tools) {
+      // Validate tool name is a string
+      if (typeof t.name !== 'string') {
+        throw new Error('Tool name must be a string')
+      }
+
+      // Validate tool name length (1-64 characters)
+      if (t.name.length < 1 || t.name.length > 64) {
+        throw new Error('Tool name must be between 1 and 64 characters')
+      }
+
+      // Validate tool name pattern (alphanumeric with hyphens and underscores)
+      const validNamePattern = /^[a-zA-Z0-9_-]+$/
+      if (!validNamePattern.test(t.name)) {
+        throw new Error('Tool name must contain only alphanumeric characters, hyphens, and underscores')
+      }
+
+      // Validate tool description if present
+      if (t.description !== undefined && t.description !== null) {
+        if (typeof t.description !== 'string' || t.description.length < 1) {
+          throw new Error('Tool description must be a non-empty string')
+        }
+      }
+
+      // Check for duplicate names
+      if (this._tools.has(t.name)) {
+        throw new Error(`Tool with name '${t.name}' already registered`)
+      }
+
+      this._tools.set(t.name, t)
+    }
+  }
+
+  /**
+   * Retrieves a tool by its unique name.
+   *
+   * @param name - The unique name of the tool to retrieve
+   * @returns The Tool instance, or undefined if not found
+   */
+  public get(name: string): Tool | undefined {
+    return this._tools.get(name)
+  }
+
+  /**
+   * Removes a tool from the registry.
+   *
+   * @param name - The name of the tool to remove
+   * @throws If tool with given name doesn't exist
+   */
+  public remove(name: string): void {
+    // Check if tool exists
+    if (!this._tools.has(name)) {
+      throw new Error(`Tool with name '${name}' not found`)
+    }
+
+    this._tools.delete(name)
+  }
+
+  /**
+   * Returns all registered tools as an array.
+   * Returns a copy of the internal array to prevent external mutation.
+   *
+   * @returns Array of all registered Tool instances, or empty array if no tools registered
+   */
+  public list(): Tool[] {
+    return Array.from(this._tools.values())
+  }
+}


### PR DESCRIPTION
Two small changes:

 - **feat: Add type for the built-up message from models**
 - **fix: Clean up events & types used in event-loop**

Fast follow to #99; part of #119  

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
