### PR TITLE
Refactor implementer agent to create branch before starting, rename to sop

### DIFF
--- a/.github/agent-sops/task-implementer.sop.md
+++ b/.github/agent-sops/task-implementer.sop.md
@@ -1,12 +1,8 @@
-# Task Implementer Script
+# Task Implementer SOP
 
 ## Role
 
 You are a Task Implementer, and your goal is to implement a task defined in a github issue. You will write code using test-driven development principles, following a structured Explore, Plan, Code, Commit workflow. During your implementation, you will write code that follows existing patterns, create comprehensive documentation, generate test cases,  create a pull requests for review, and iterate on the provided feedback until the pull request is accepted.
-
-## Parameters
-
-- **issue_number**: {{ISSUE_NUMBER}}
 
 ## Steps
 
@@ -28,10 +24,13 @@ Initialize the task environment and discover repository instruction files.
 - You MUST run unit test to ensure the repository and environment are functional
 - You MAY run integration tests if your feature requires new tests to be added
 - You MUST comment on the github issue if the tests fail, and use the handoff_to_user tool to get feedback on how to continue.
-- You MUST use `git checkout -b <BRANCH_NAME>` to create and switch to a new feature branch
-- You SHOULD use the BRANCH_NAME pattern `agent-tasks/{TASK_NUMBER}` unless this branch already exists
-- You MUST make note of the newly created branch name
-- You MUST use `git push origin <BRANCH_NAME>` to create the feature branch in remote
+- You MUST check the current branch using `git branch --show-current`
+- You MUST create a new feature branch if currently on main branch:
+  - You MUST use `git checkout -b <BRANCH_NAME>` to create and switch to a new feature branch
+  - You SHOULD use the BRANCH_NAME pattern `agent-tasks/{ISSUE_NUMBER}` unless this branch already exists
+  - You MUST make note of the newly created branch name
+  - You MUST use `git push origin <BRANCH_NAME>` to create the feature branch in remote
+- You MAY continue on the current branch if not on main branch
 
 
 ### 2. Explore Phase
@@ -239,7 +238,6 @@ If all tests are passing, draft a conventional commit message, perform the git c
 - You MUST execute the `git commit -m <COMMIT_MESSAGE>` command with the prepared commit message
 - You MUST use `git push origin <BRANCH_NAME>` to push the local branch to the remote 
 - You MUST attempt to create the pull request using the `create_pull_request` tool if it does not exist yet
-  - You MUST use the following title format: `Task <TASK_ID>: <TASK_NAME> Implementation`
   - You MUST use the task id recorded in your notes, not the issue id
   - You MUST include "Resolves: #<ISSUE NUMBER>" in the body of the pull request
     - You MUST NOT bold this line

--- a/.github/agent-sops/task-refiner.sop.md
+++ b/.github/agent-sops/task-refiner.sop.md
@@ -1,12 +1,8 @@
-# Task Reviewer Script
+# Task Refine SOP
 
 ## Role
 
-You are a Task Reviewer, and your goal is to review the feature request for a task and prepare it for implementation. This task feature request is defined as a github issue. You read the feature request in the issue, identify ambiguities, post clarifying questions as comments, prompt the user to provide feedback, and iterate until confident that the feature request is ready to implement. You record notes of your progress through these steps as a todo-list in your notebook tool.
-
-## Parameters
-
-- **issue_number**: {{ISSUE_NUMBER}}
+You are a Task Refiner, and your goal is to review the feature request for a task and prepare it for implementation. This task feature request is defined as a github issue. You read the feature request in the issue, identify ambiguities, post clarifying questions as comments, prompt the user to provide feedback, and iterate until confident that the feature request is ready to implement. You record notes of your progress through these steps as a todo-list in your notebook tool.
 
 ## Steps
 
@@ -173,7 +169,6 @@ Create new sub-tasks if you and the user have determined that this task is too c
 
 **Constraints:**
 - You MUST create new issue for each sub-task
-- You MUST give them a title in the following format: `Task <TASK_NUMBER>: <TASK_TITLE>`
 - You MUST create a description with a comprehensive overview of the work required, following the same description format as the parent task
 - You MUST add sub-task as sub-issues to the parent tasks issue using the `add_sub_issue` tool.
 

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ''
+      session_id:
+        description: 'Optional session ID to use'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   authorization-check:
@@ -81,11 +86,16 @@ jobs:
               labels: ['strands-running']
             });
 
-      - name: Determine PR context
-        id: determine-context
-        uses: actions/github-script@v7
+      # Check out main first so we only get committed code
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Process input
+        id: process
+        uses: actions/github-script@v8
         with:
           script: |
+            const fs = require('fs');
             try {
               const issueId = context.eventName === 'workflow_dispatch' 
                 ? '${{ inputs.issue_id }}'
@@ -101,58 +111,81 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issueId
               });
-              const isPrContext = !!issue.data.pull_request;
-              const mode = (isPrContext || command.startsWith('implement')) ? 'implementer' : 'reviewer';
+              const isPullRequest = !!issue.data.pull_request;
+              const mode = (isPullRequest || command.startsWith('implement')) ? 'implementer' : 'refiner';
 
-              console.log(`Is PR: ${isPrContext}, Mode: ${mode}`);
+              console.log(`Is PR: ${isPullRequest}, Mode: ${mode}`);
 
-              let targetIssueId;
-              if (!isPrContext) {
-                targetIssueId = issueId;
-                console.log(`Target issue ID: ${targetIssueId} (same as issue)`);
-              } else {
-                const closingIssuesData = await github.graphql(`
-                  query($owner: String!, $repo: String!, $number: Int!) {
-                    repository(owner: $owner, name: $repo) {
-                      pullRequest(number: $number) {
-                        closingIssuesReferences(first: 10) {
-                          nodes { number }
-                        }
-                      }
-                    }
-                  }
-                `, {
+              // Determine branch/ref to checkout
+              let branchName = 'main';
+
+              // If this is a non pr issue, and the command is implement, create a branch
+              if (mode === 'implementer' && !isPullRequest) {
+                branchName = `agent-tasks/${issueId}`;
+                
+                // Create branch from main
+                const mainRef = await github.rest.git.getRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  number: parseInt(issueId)
+                  ref: 'heads/main'
                 });
-                const issues = closingIssuesData?.repository?.pullRequest?.closingIssuesReferences?.nodes || [];
                 
-                console.log(`Found ${issues.length} closing issue(s)`);
-                
-                if (issues.length !== 1) {
-                  const errorMsg = issues.length > 1 
-                    ? `Pull request has ${issues.length} closing issues. Only one closing issue is allowed.`
-                    : 'Pull request must have exactly one closing issue.';
-                  console.error(errorMsg);
-                  core.setFailed(errorMsg);
-                  return;
+                try {
+                  await github.rest.git.createRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `refs/heads/${branchName}`,
+                    sha: mainRef.data.object.sha
+                  });
+                  console.log(`Created branch ${branchName}`);
+                } catch (error) {
+                  if (error.status === 422 || error.message?.includes('already exists')) {
+                    console.log(`Branch ${branchName} already exists`);
+                  } else {
+                    throw error;
+                  }
                 }
-                
-                targetIssueId = issues[0].number.toString();
-                console.log(`Target issue ID: ${targetIssueId} (from closing issues)`);
+              } else if (isPullRequest) {
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: issueId
+                });
+                branchName = pr.data.head.ref;
               }
 
-              console.log(`Setting outputs - issue_id: ${issueId}, target_issue_id: ${targetIssueId}, pr_id: ${isPrContext ? issueId : ''}, mode: ${mode}`);
+              console.log(`Building prompts - mode: ${mode}, issue: ${issueId}, is PR: ${isPullRequest}`);
+              
+              const sessionId = '${{ inputs.session_id }}' || (mode === 'implementer' 
+                ? `${mode}-${branchName}`.replace(/[\/\\]/g, '-')
+                : `${mode}-${issueId}`);
+              console.log(`Session ID: ${sessionId}`);
 
-              core.setOutput('issue_id', issueId);
-              core.setOutput('target_issue_id', targetIssueId);
-              core.setOutput('pr_id', isPrContext ? issueId : '');
-              core.setOutput('mode', mode);
-              core.setOutput('command', command);
+              const scriptFile = mode === 'implementer' 
+                ? '.github/agent-sops/task-implementer.sop.md'
+                : '.github/agent-sops/task-refiner.sop.md';
+              console.log(`Reading script file: ${scriptFile}`);
+              let systemPrompt = fs.readFileSync(scriptFile, 'utf8');
+              
+              const first20Lines = systemPrompt.split('\n').slice(0, 20).join('\n');
+              console.log(`System prompt (first 20 lines):\n${first20Lines}`);
+              
+              let prompt = (isPullRequest) 
+                ? 'The pull request id is:'
+                : 'The issue id is:';
+              prompt += `${issueId}\n`
+              prompt += `${command}\n`;
+              prompt += 'review and continue';
+              
+              console.log(`Task prompt: "${prompt}"`);
+
+              core.setOutput('branch_name', branchName);
+              core.setOutput('session_id', sessionId);
+              core.setOutput('system_prompt', systemPrompt);
+              core.setOutput('prompt', prompt);
 
             } catch (error) {
-              const errorMsg = `Failed to determine context: ${error.message}`;
+              const errorMsg = `Failed: ${error.message}`;
               console.error(errorMsg);
               core.setFailed(errorMsg);
             }
@@ -160,55 +193,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.determine-context.outputs.pr_id && format('refs/pull/{0}/head', steps.determine-context.outputs.pr_id) || 'main' }}
-
-      - name: Build prompts
-        id: process
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-
-            try {
-              const mode = '${{ steps.determine-context.outputs.mode }}';
-              const targetIssueId = '${{ steps.determine-context.outputs.target_issue_id }}';
-              const issueId = '${{ steps.determine-context.outputs.issue_id }}';
-              const command = '${{ steps.determine-context.outputs.command }}';
-              const isPrContext = '${{ steps.determine-context.outputs.pr_id }}' !== '';
-              
-              console.log(`Building prompts - mode: ${mode}, target issue: ${targetIssueId}, is PR: ${isPrContext}`);
-              
-              const sessionId = `${mode}-${targetIssueId}`;
-              console.log(`Session ID: ${sessionId}`);
-
-              const scriptFile = mode === 'implementer' 
-                ? '.github/agent-scripts/task-implementer.script.md'
-                : '.github/agent-scripts/task-reviewer.script.md';
-              console.log(`Reading script file: ${scriptFile}`);
-              let systemPrompt = fs.readFileSync(scriptFile, 'utf8');
-              
-              systemPrompt = systemPrompt
-                .replace(/\{\{ISSUE_NUMBER\}\}/g, targetIssueId);
-              
-              const first20Lines = systemPrompt.split('\n').slice(0, 20).join('\n');
-              console.log(`System prompt (first 20 lines):\n${first20Lines}`);
-              
-              let prompt = '';
-              if (isPrContext) prompt += `The pull request id is: ${issueId}\n`;
-              prompt += `${command}\n`;
-              prompt += 'review and continue';
-              
-              console.log(`Task prompt: "${prompt}"`);
-
-              core.setOutput('session_id', sessionId);
-              core.setOutput('system_prompt', systemPrompt);
-              core.setOutput('prompt', prompt);
-
-            } catch (error) {
-              const errorMsg = `Failed to build prompts: ${error.message}`;
-              console.error(errorMsg);
-              core.setFailed(errorMsg);
-            }
+          ref: ${{ steps.process.outputs.branch_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ sdk-typescript/
 │   │   ├── pr-and-push.yml       # Triggers test/lint on PR and push
 │   │   ├── test-lint.yml         # Unit tests and linting
 │   │   └── integration-test.yml  # Secure integration tests with AWS
-│   └── agent-scripts/            # Agent system prompts and configs
+│   └── agent-sops/               # Agent system prompts
 │
 ├── .project/                     # Project management (tasks, tracking)
 │   ├── tasks/                    # Active tasks
@@ -109,11 +109,11 @@ See [CONTRIBUTING.md - Development Environment](CONTRIBUTING.md#development-envi
 
 ### 2. Making Changes
 
-1. **Create feature branch**: `git checkout -b agent-tasks/{TASK_NUMBER}`
+1. **Create feature branch**: `git checkout -b agent-tasks/{ISSUE_NUMBER}`
 2. **Implement changes** following the patterns below
 3. **Run quality checks** before committing (pre-commit hooks will run automatically)
 4. **Commit with conventional commits**: `feat:`, `fix:`, `refactor:`, `docs:`, etc.
-5. **Push to remote**: `git push origin agent-tasks/{TASK_NUMBER}`
+5. **Push to remote**: `git push origin agent-tasks/{ISSUE_NUMBER}`
 
 ### 3. Quality Gates
 


### PR DESCRIPTION
This pull request does 2 things:
1. It renames the agent prompts to SOP's following our upcoming launch of the feature
2. Updates the invocation of the agents. (Pull Requests no longer need to be linked to issues)

Agent invocation is changing in the following way:
- Check out the main branch code base to get main branch agent sop's to avoid prompt injection from a pull request branch
- Link the implementer agent to a branch, and name the implementer session based on the name of the branch
- Create a branch when `strands implement` is types from an issue so the agent does not need to create the branch anymore
- Rename the `review` agent to the `refine` agent so the upcoming `pr review` agent can just be called `review
- No longer pass issue id in the system prompt. This is now passed as a message to the agent


Tested these changes as a part of this issue/pr: https://github.com/Unshure/sdk-typescript/issues/42