### PR TITLE
fix: Set a specific version of rollup to fix main build

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
   },
   "optionalDependencies": {
     "openai": "^6.7.0"
+  },
+  "overrides": {
+    "rollup": "4.52.5"
   }
 }


### PR DESCRIPTION
The latest release of rollup seems to have broken things.  We should eventually have a lock file but for now this shall do. See rollup/rollup/issues/6168
