### PR TITLE
fix: Fix types & tool definition for first-agent

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -130,7 +130,7 @@ export class Agent implements AgentData {
    * // Messages array is mutated in place and contains the full conversation
    * ```
    */
-  public async *stream(args: InvokeArgs): AsyncGenerator<AgentStreamEvent, AgentResult, never> {
+  public async *stream(args: InvokeArgs): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     let currentArgs: InvokeArgs | undefined = args
 
     // Emit event before the loop starts
@@ -210,7 +210,7 @@ export class Agent implements AgentData {
    */
   private async *invokeModel(
     args?: InvokeArgs
-  ): AsyncGenerator<AgentStreamEvent, { message: Message; stopReason: string }, never> {
+  ): AsyncGenerator<AgentStreamEvent, { message: Message; stopReason: string }, undefined> {
     // Emit event before invoking model
     yield { type: 'beforeModelEvent', messages: [...this._messages] }
 
@@ -247,7 +247,7 @@ export class Agent implements AgentData {
   private async *executeTools(
     assistantMessage: Message,
     toolRegistry: ToolRegistry
-  ): AsyncGenerator<AgentStreamEvent, Message, never> {
+  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
     yield { type: 'beforeToolsEvent', message: assistantMessage }
 
     // Extract tool use blocks from assistant message
@@ -294,7 +294,7 @@ export class Agent implements AgentData {
   private async *executeTool(
     toolUseBlock: ToolUseBlock,
     toolRegistry: ToolRegistry
-  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, never> {
+  ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
     const tool = toolRegistry.find((t) => t.name === toolUseBlock.name)
 
     if (!tool) {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,13 +1,13 @@
 import {
+  type ContentBlock,
   Message,
   ReasoningBlock,
-  TextBlock,
-  ToolUseBlock,
-  type ContentBlock,
   type Role,
   type SystemPrompt,
+  TextBlock,
+  ToolUseBlock,
 } from '../types/messages.js'
-import type { ToolSpec, ToolChoice } from '../tools/types.js'
+import type { ToolChoice, ToolSpec } from '../tools/types.js'
 import {
   ModelContentBlockDeltaEvent,
   ModelContentBlockStartEvent,
@@ -136,7 +136,7 @@ export abstract class Model<T extends BaseModelConfig> {
   async *streamAggregated(
     messages: Message[],
     options?: StreamOptions
-  ): AsyncGenerator<ModelStreamEvent | ContentBlock, { message: Message; stopReason: string }, never> {
+  ): AsyncGenerator<ModelStreamEvent | ContentBlock, { message: Message; stopReason: string }, undefined> {
     // State maintained in closure
     let messageRole: Role | null = null
     const contentBlocks: ContentBlock[] = []

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -96,7 +96,7 @@ export class ToolStreamEvent implements ToolStreamEventData {
  * Type alias for the async generator returned by tool stream methods.
  * Yields ToolStreamEvents during execution and returns a ToolResultBlock.
  */
-export type ToolStreamGenerator = AsyncGenerator<ToolStreamEvent, ToolResultBlock, never>
+export type ToolStreamGenerator = AsyncGenerator<ToolStreamEvent, ToolResultBlock, undefined>
 
 /**
  * Interface for tool implementations.


### PR DESCRIPTION
Changes:

 - Update AsyncGenerators to use undefined as the last arg since that's what `for await` uses
 - Update first-agent example to use `tool` helper which uses zod
 - Some files reformatted, imports sorted

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
