### PR TITLE
fix: Update package verification + add to github workflow

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -51,3 +51,6 @@ jobs:
 
       - name: Build package
         run: npm run build
+
+      - name: Test packaging
+        run: npm run test:package

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "npm run lint && npm run format && npm run typecheck && npm run test:coverage && npm run test:types && npm run test:package",
+    "check": "npm run lint && npm run format && npm run type-check && npm run test:coverage && npm run test:package",
     "clean": "rm -rf node_modules dist package-lock.json",
     "test": "vitest run --project unit-node",
     "test:watch": "vitest --project unit-node",


### PR DESCRIPTION
*Description of changes:*

Purpose of `npm run test:package` is that it ensures that the package can be imported like any other NPM package.  I fixed up the example and added the step the github workflow.  I did not add it to precommit because it adds a bit of overhead to the commit flow and I think we'll break this less often than others.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
