### PR TITLE
Add continue-on-error to npm install step

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -202,6 +202,7 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+        continue-on-error: true # This step's failure will not stop the workflow
 
       - name: Run Strands Agent
         uses: ./.github/actions/strands-agent-runner


### PR DESCRIPTION
Allow workflow to continue even if dependency installation fails.
