### PR TITLE
Remove generic type parameter from AgentState and related interfaces

### DIFF
--- a/src/agent/state.ts
+++ b/src/agent/state.ts
@@ -8,8 +8,6 @@ import { deepCopy, deepCopyWithValidation, type JSONValue } from '../types/json.
  * All values are deep copied on get/set operations to prevent reference mutations.
  * Values must be JSON serializable.
  *
- * @typeParam TState - Optional type for strongly typing state keys and values
- *
  * @example
  * ```typescript
  * const state = new AgentState({ userId: 'user-123' })
@@ -17,7 +15,7 @@ import { deepCopy, deepCopyWithValidation, type JSONValue } from '../types/json.
  * const userId = state.get('userId') // 'user-123'
  * ```
  */
-export class AgentState<TState extends Record<string, JSONValue> = Record<string, JSONValue>> {
+export class AgentState {
   private _state: Record<string, JSONValue>
 
   /**
@@ -26,7 +24,7 @@ export class AgentState<TState extends Record<string, JSONValue> = Record<string
    * @param initialState - Optional initial state values
    * @throws Error if initialState is not JSON serializable
    */
-  constructor(initialState?: TState) {
+  constructor(initialState?: Record<string, JSONValue>) {
     if (initialState !== undefined) {
       this._state = deepCopyWithValidation(initialState, 'initialState') as Record<string, JSONValue>
     } else {

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,33 +1,14 @@
 import type { ToolSpec, ToolUse } from './types.js'
 import type { ToolResultBlock } from '../types/messages.js'
 import type { AgentData } from '../types/agent.js'
-import type { JSONValue } from '../types/json.js'
 
 export type { ToolSpec } from './types.js'
 
 /**
  * Context provided to tool implementations during execution.
  * Contains framework-level state and information from the agent invocation.
- *
- * @typeParam TAgentState - Optional type for strongly typing agent state keys and values
- *
- * @example
- * ```typescript
- * interface MyAgentState {
- *   userId: string
- *   sessionId: string
- * }
- *
- * const context: ToolContext<MyAgentState> = {
- *   toolUse: {
- *     name: 'testTool',
- *     toolUseId: 'test-123',
- *     input: {}
- *   },
- *   agent: agent
- * ```
  */
-export interface ToolContext<TAgentState extends Record<string, JSONValue> = Record<string, JSONValue>> {
+export interface ToolContext {
   /**
    * The tool use request that triggered this tool execution.
    * Contains the tool name, toolUseId, and input parameters.
@@ -38,7 +19,7 @@ export interface ToolContext<TAgentState extends Record<string, JSONValue> = Rec
    * The agent instance that is executing this tool.
    * Provides access to agent state and other agent-level information.
    */
-  agent: AgentData<TAgentState>
+  agent: AgentData
 }
 
 /**

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,18 +1,15 @@
 import type { AgentState } from '../agent/state.js'
 import type { Message } from './messages.js'
-import type { JSONValue } from './json.js'
 
 /**
  * Interface for objects that provide agent state.
  * Allows ToolContext to work with different agent types.
- *
- * @typeParam TState - Optional type for strongly typing state keys and values
  */
-export interface AgentData<TState extends Record<string, JSONValue> = Record<string, JSONValue>> {
+export interface AgentData {
   /**
    * Agent state storage accessible to tools and application logic.
    */
-  state: AgentState<TState>
+  state: AgentState
 }
 
 /**

--- a/vended_tools/notebook/__tests__/notebook.test.ts
+++ b/vended_tools/notebook/__tests__/notebook.test.ts
@@ -7,7 +7,7 @@ import { AgentState } from '../../../src/agent/state.js'
 describe('notebook tool', () => {
   // Helper to create fresh state and context for each test
   const createFreshContext = (): { state: AgentState; context: ToolContext } => {
-    const state = new AgentState<{ notebooks: NotebookState['notebooks'] }>({ notebooks: {} })
+    const state = new AgentState({ notebooks: {} })
     const context: ToolContext = {
       toolUse: {
         name: 'notebook',


### PR DESCRIPTION
Remove the generic type parameter from AgentState, AgentData, and ToolContext interfaces. The generic parameter was aspirational for strongly typing state keys and values but was not being used in practice. All usage relied on the default Record<string, JSONValue> type.

Resolves: #174

## Notes

We'll consider adding helpers later on to help consumers type it correctly, but as-is having AgentState be generic doesn't get us anything.

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
