### PR TITLE
fix: add retry logic for flaky integration tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
           include: ['tests_integ/**/*.test.ts'],
           name: { label: 'integ', color: 'magenta' },
           testTimeout: 30000,
+          retry: 1,
           globalSetup: './tests_integ/integ-setup.ts',
           sequence: {
             concurrent: true,


### PR DESCRIPTION
*Issue #, if available:*

Resolves #109

*Description of changes:*

Add `retry: 1` to vitest config for integration tests to handle transient downstream service timeouts and network issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
