### PR TITLE
Update strands agent to run in readonly sandbox

### DIFF
--- a/.github/actions/strands-agent-runner/action.yml
+++ b/.github/actions/strands-agent-runner/action.yml
@@ -16,14 +16,15 @@ inputs:
   sessions_bucket:
     description: 'S3 bucket for session storage'
     required: true
-  github_token:
-    description: 'GitHub token for authentication'
+  write_permission:
+    description: 'If this action runs with write permission. If this is false, you should run the `strands-write-executor` action after this one with write permission.'
     required: true
-    default: ${{ github.token }}
+    default: 'false'
 
 runs:
   using: 'composite'
   steps:
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -60,11 +61,12 @@ runs:
     - name: Execute strands command
       shell: bash
       env:
+        # Write Permission
+        GITHUB_WRITE: ${{ inputs.write_permission }}
+
         # GitHub Configuration
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_EVENT_NAME: ${{ github.event_name }}
-        GITHUB_ACTOR: ${{ github.actor }}
 
         # Task Configuration
         INPUT_TASK: ${{ inputs.task_prompt }}
@@ -76,5 +78,36 @@ runs:
         # Session Manager
         S3_SESSION_BUCKET: ${{ inputs.sessions_bucket }}
         SESSION_ID: ${{ inputs.session_id }}
+
+        # Strands Env Vars
+        STRANDS_TOOL_CONSOLE_MODE: 'enabled'
+        BYPASS_TOOL_CONSENT: 'true'
       run: |
         uv run .github/scripts/agent_runner.py "$INPUT_TASK"
+
+    - name: Capture repository state
+      shell: bash
+      run: |
+        mkdir -p .artifact
+        if git diff --quiet HEAD@{upstream} && git diff --quiet --cached; then
+          echo "📭 No changes to capture"
+        else
+          echo "📝 Capturing entire repository state"
+          tar -czf .artifact/repository_state.tar.gz --exclude='.artifact' .
+        fi
+
+    - name: Upload repository state artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: repository-state
+        path: .artifact/repository_state.tar.gz
+        retention-days: 1
+        if-no-files-found: ignore
+
+    - name: Upload artifact for write operations
+      uses: actions/upload-artifact@v4
+      with:
+        name: write-operations
+        path: .artifact/write_operations.jsonl
+        retention-days: 1
+        if-no-files-found: ignore

--- a/.github/actions/strands-write-executor/action.yml
+++ b/.github/actions/strands-write-executor/action.yml
@@ -1,0 +1,122 @@
+name: 'Strands Write Executor'
+description: 'Execute write GitHub operations from JSONL artifact files during workflow execution'
+inputs:
+  ref:
+    description: 'Ref to push changes to'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+
+    # Push code changes before running write commands in case we need to create a pull request
+    # Pull requests cannot be created if a branch has no diff with main, so push changes first, then create pr
+    - name: Log if ref equals main
+      shell: bash
+      run: |
+        if [ "${{ inputs.ref }}" = "main" ]; then
+          echo "🚫 Ref is 'main' - skipping push operations to prevent direct commits to main branch"
+        else
+          echo "✅ Ref is '${{ inputs.ref }}' - push operations will proceed"
+        fi
+    
+    - name: Download repository state artifact
+      if: inputs.ref != 'main'
+      uses: actions/download-artifact@v4
+      with:
+        name: repository-state
+      continue-on-error: true
+
+    - name: Apply Artifact and Push changes
+      if: inputs.ref != 'main'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+
+        if [ -f "repository_state.tar.gz" ]; then
+          echo "📝 Applying repository state"
+          tar -xzf repository_state.tar.gz
+          rm repository_state.tar.gz
+
+          # Configure Git
+          git config --local user.name "Strands Agent"
+          git config --local user.email "217235299+strands-agent@users.noreply.github.com"
+          git config --local core.pager cat
+          # We need to overwrite this since this is currently set by the previous readonly workflow artifact
+          # Overwrite this value with the current token that allows us to push the commit
+          git config --local http."https://github.com/".extraheader "AUTHORIZATION: basic $(echo -n x-access-token:${{ github.token }}| base64)"
+
+          # Fetch the remote repository
+          git fetch origin ${{ inputs.ref }}
+          
+          # Stage and commit any changes first
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "📝 Changes detected, staging all files"
+            git add -A
+            echo "📝 Committing changes"
+            git commit -m "Additional changes from write operations" -n
+          fi
+          
+          # Push if there are differences from remote
+          if ! git diff --quiet HEAD origin/${{ inputs.ref }}; then
+            echo "📝 Differences from remote:"
+            git diff HEAD origin/${{ inputs.ref }}
+            echo "📤 Pushing changes to ${{ inputs.ref }}"
+            git push --force origin ${{ inputs.ref }}
+          else
+            echo "📭 No changes to push"
+          fi
+        fi
+    
+    - name: Download artifact with write operations
+      uses: actions/download-artifact@v4
+      with:
+        name: write-operations
+      continue-on-error: true
+
+    - name: Check if write operations artifact exists
+      id: check-write-ops
+      shell: bash
+      run: |
+        if [ -f "write_operations.jsonl" ]; then
+          echo "✅ Write operations artifact exists! Continuing to execute commands!"
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "❌ Write operations artifact does not exist. Stopping execution."
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      
+    - name: Set up Python
+      if: steps.check-write-ops.outputs.exists == 'true'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install uv
+      if: steps.check-write-ops.outputs.exists == 'true'
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+        cache-dependency-glob: '.github/scripts/requirements.txt'
+
+    - name: Install dependencies
+      if: steps.check-write-ops.outputs.exists == 'true'
+      shell: bash
+      run: |
+        echo "📦 Installing from requirements.txt"
+        uv pip install --system -r .github/scripts/requirements.txt --quiet
+
+    - name: Execute write operations
+      if: steps.check-write-ops.outputs.exists == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+
+        # Strands Env Vars
+        STRANDS_TOOL_CONSOLE_MODE: 'enabled'
+        BYPASS_TOOL_CONSENT: 'true'
+      run: |
+        echo "🚀 Strands Write Executor - Processing write operations"
+        python .github/scripts/write_executor.py "write_operations.jsonl"

--- a/.github/agent-sops/task-implementer.sop.md
+++ b/.github/agent-sops/task-implementer.sop.md
@@ -18,6 +18,10 @@ Initialize the task environment and discover repository instruction files.
   - `CONTRIBUTING.md`
   - `README.md`
 - You MAY explore more files in the repository if you did not find instructions
+- You MUST check the `GITHUB_WRITE` environment variable value to determine if you have github write permission
+  - If the value is `true`, then you can run git write command like `add_comment` or run `git push`
+  - If the value is not `true`, you are running in a read-restricted sandbox. Any write commands you do run will be deferred to run outside the sandbox
+    - Any staged or unstaged changes will be pushed after you finish executing to the feature branch
 - You MUST make a note of environment setup and testing instructions
 - You MUST make note of the tasks number from the issue title
 - You MUST make note of the issue number
@@ -30,6 +34,7 @@ Initialize the task environment and discover repository instruction files.
   - You SHOULD use the BRANCH_NAME pattern `agent-tasks/{ISSUE_NUMBER}` unless this branch already exists
   - You MUST make note of the newly created branch name
   - You MUST use `git push origin <BRANCH_NAME>` to create the feature branch in remote
+  - If the push operation is deferred, continue with the workflow and note the deferred status
 - You MAY continue on the current branch if not on main branch
 
 
@@ -138,7 +143,7 @@ Write test cases based on the outlines, following strict TDD principles.
 - You MUST validate that the task environment is set up properly
   - If you already created a commit, ensure the latest commit matches the expected hash
   - If not, ensure the correct branch is checked out
-  - As a last resort, you MUST push your current work to the current branch, then leave a comment on the Task issue or Pull Request for feedback on how to proceed
+  - As a last resort, you MUST commit your current work to the current branch, then leave a comment on the Task issue or Pull Request for feedback on how to proceed
 - You MUST save test implementations to the appropriate test directories in repo_root
 - You MUST implement tests for ALL requirements before writing ANY implementation code
 - You MUST follow the testing framework conventions used in the existing codebase
@@ -186,7 +191,8 @@ Write implementation code to pass the tests, focusing on simplicity and correctn
   - Tests continue to fail after implementation for reasons you cannot resolve
   - You encounter a design decision that cannot be inferred from requirements
   - Multiple valid implementation approaches exist with significant trade-offs
-- You MUST commit and push your work before seeing user feedback
+- You MUST commit your work before seeing user feedback
+  - You MUST push your work if the `GITHUB_WRITE` environment variable is set to `true`
 - You MAY seek user input by commenting on the issue, and informing the user you are ready for their instruction by using the handoff_to_user tool
 - You MUST otherwise continue automatically after verifying test results
 - You MUST follow the Build Output Management practices defined in the Best Practices section
@@ -236,22 +242,25 @@ If all tests are passing, draft a conventional commit message, perform the git c
 - You MUST use `git status` to check which files have been modified
 - You MUST use `git add` to stage all relevant files
 - You MUST execute the `git commit -m <COMMIT_MESSAGE>` command with the prepared commit message
-- You MUST use `git push origin <BRANCH_NAME>` to push the local branch to the remote 
+- You MAY use `git push origin <BRANCH_NAME>` to push the local branch to the remote if the `GITHUB_WRITE` environment variable is set to `true`
+  - If the push operation is deferred, continue with PR creation and note the deferred status 
 - You MUST attempt to create the pull request using the `create_pull_request` tool if it does not exist yet
+  - If the PR creation is deferred, continue with the workflow and note the deferred status
   - You MUST use the task id recorded in your notes, not the issue id
   - You MUST include "Resolves: #<ISSUE NUMBER>" in the body of the pull request
     - You MUST NOT bold this line
   - You MUST give an overview of the feature being implemented
   - You MUST include any notes on key implementation decisions, ambiguity, or other information as part of the pull request description
-- If the `create_pull_request` tool fails:
+- If the `create_pull_request` tool fails (excluding deferred responses):
   - You MUST create a PR creation link using GitHub's query parameters
   - You MUST post the link as a comment on the issue
     - You MUST use the format: `https://github.com/{owner}/{repo}/compare/{base}...{head}?quick_pull=1&title={url_encoded_title}&body={url_encoded_body}`
     - URL-encode the title and body parameters
     - Include "Resolves: #{issue_number}" in the body
-- If PR creation succeeds:
+- If PR creation succeeds or is deferred:
   - You MUST review your notes for any updates to provide on the pull request
   - You MAY use the `update_pull_request` tool to update the pull request body or title
+    - If the update operation is deferred, continue with the workflow and note the deferred status
 - You MUST use your notebook to record the new commit hash and PR status (created or link provided)
 
 ### 6. Feedback Phase
@@ -280,6 +289,7 @@ Retrieve and analyze the user's responses from the pull request reviews and comm
   - Unclear requests that need clarification
   - General feedback that doesn't require code changes
 - You MUST reply to unclear comments asking for specific clarification
+  - If comment posting is deferred, continue with the workflow and note the deferred status
 - You MUST record your progress and update the implementation plan based on the feedback
 - You MUST return to step 6.1 if you needed further clarification
 
@@ -322,11 +332,18 @@ If feature branch creation fails:
 - As a last resort, leave a comment on the Task Issue mentioning the issue you are facing
 
 ### Pull Request Creation Issues
-If PR creation fails:
+If PR creation fails (excluding deferred responses):
 - Verify GitHub authentication and permissions
 - Check if remote repository exists and is accessible
-- You MUST push your current work to the branch
+- You MUST commit your current work to the branch
 - As a last resort, leave a comment on the Task Issue mentioning the issue you are facing
+
+### Deferred Operations
+When GitHub tools or git operations are deferred:
+- Continue with the workflow as if the operation succeeded
+- Note the deferred status in your progress tracking
+- The operations will be executed after agent completion
+- Do not retry or attempt alternative approaches for deferred operations
 
 ### Build Issues
 If builds fail during implementation:

--- a/.github/agent-sops/task-refiner.sop.md
+++ b/.github/agent-sops/task-refiner.sop.md
@@ -93,6 +93,7 @@ Create a numbered list of questions to resolve ambiguities and gather missing in
   - You SHOULD suggest how the issue should be broken down into smaller feature requests
 - You SHOULD ask about performance and scalability requirements
 - You MUST create a comment with all of your questions on the issue.
+  - If the comment posting is deferred, continue with the workflow and note the deferred status
 
 #### 3.3 Handoff to User for Response
 
@@ -151,6 +152,7 @@ Update the original issue with a comprehensive task description.
 
 **Constraints:**
 - You MUST edit the original issue description directly
+  - If the edit operation is deferred, continue with the workflow and note the deferred status
 - You MUST preserve the original request context
 - You MUST add a clear "Implementation Requirements" section
 - You MUST include all clarified specifications
@@ -169,8 +171,10 @@ Create new sub-tasks if you and the user have determined that this task is too c
 
 **Constraints:**
 - You MUST create new issue for each sub-task
+  - If issue creation is deferred, continue with the workflow and note the deferred status
 - You MUST create a description with a comprehensive overview of the work required, following the same description format as the parent task
 - You MUST add sub-task as sub-issues to the parent tasks issue using the `add_sub_issue` tool.
+  - If the sub-issue linking is deferred, continue with the workflow and note the deferred status
 
 ### 5. Record Completion as Comment
 
@@ -178,6 +182,7 @@ Record that the task review is complete and ready as a comment on the issue.
 
 **Constraints:**
 - You MUST only add a comment on the parent issue if any sub-issues were created
+  - If comment posting is deferred, continue with the workflow and note the deferred status
 - You MUST summarize what was accomplished in your comment
 - You MUST confirm in your comment that the issue is ready for implementation, or explain why it is not
 - You MUST record the estimated scope of work based on repository analysis
@@ -277,6 +282,13 @@ For very large repositories:
 1. Focus on key directories related to the feature
 2. Use search functionality to find relevant code patterns
 3. Prioritize understanding the main architecture over exhaustive exploration
+
+### Deferred Operations
+When GitHub tools are deferred:
+- Continue with the workflow as if the operation succeeded
+- Note the deferred status in your progress tracking
+- The operations will be executed after agent completion
+- Do not retry or attempt alternative approaches for deferred operations
 
 ### Incomplete Repository Understanding
 If the codebase is unclear or poorly documented:

--- a/.github/scripts/agent_runner.py
+++ b/.github/scripts/agent_runner.py
@@ -4,14 +4,13 @@ Strands GitHub Agent Runner
 A portable agent runner for use in GitHub Actions across different repositories.
 """
 
-import datetime
 import json
-import logging
 import os
 import sys
 from typing import Any
 
 from strands import Agent
+from strands.agent.conversation_manager import SlidingWindowConversationManager
 from strands.session import S3SessionManager
 from strands.models.bedrock import BedrockModel
 from botocore.config import Config
@@ -47,18 +46,6 @@ STRANDS_REGION = "us-west-2"
 
 # Default values for environment variables used only in this file
 DEFAULT_SYSTEM_PROMPT = "You are an autonomous GitHub agent powered by Strands Agents SDK."
-
-# Apply configuration defaults
-os.environ.setdefault("BYPASS_TOOL_CONSENT", "true")
-os.environ.setdefault("STRANDS_TOOL_CONSOLE_MODE",  "enabled")
-
-# Configure logging
-if os.getenv("STRANDS_DEBUG") == "1":
-    logging.getLogger("strands").setLevel(logging.DEBUG)
-    logging.basicConfig(
-        format="%(levelname)s | %(name)s | %(message)s",
-        handlers=[logging.StreamHandler()],
-    )
 
 def _get_all_tools() -> list[Any]:
     return [
@@ -139,6 +126,8 @@ def run_agent(query: str):
             system_prompt=system_prompt,
             tools=tools,
             session_manager=session_manager,
+            # Set really big context window so agent is aware of as much info as possible
+            conversation_manager=SlidingWindowConversationManager(window_size=10000)
         )
 
         print("Processing user query...")

--- a/.github/scripts/write_executor.py
+++ b/.github/scripts/write_executor.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Write Executor Script for GitHub Operations.
+
+This script reads JSONL artifact files containing deferred GitHub operations
+and executes them using functions from github_tools.py. It's designed to run
+after the strands-agent-runner to publish any write commands or commits.
+"""
+
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from github_tools import GitHubOperation
+
+# Import write only github_tools functions for dynamic execution
+from github_tools import (
+    create_issue,
+    update_issue, 
+    add_issue_comment,
+    create_pull_request,
+    update_pull_request,
+    reply_to_review_comment,
+)
+
+# Configure structured logging
+logging.basicConfig(
+    format="%(levelname)s | %(name)s | %(message)s",
+    handlers=[logging.StreamHandler()],
+    level=logging.INFO
+)
+logger = logging.getLogger("write_executor")
+
+
+def get_function_mapping() -> Dict[str, Any]:
+    """Get mapping of function names to actual functions."""
+    return {
+        create_issue.tool_name: create_issue,
+        update_issue.tool_name: update_issue,
+        add_issue_comment.tool_name: add_issue_comment,
+        create_pull_request.tool_name: create_pull_request,
+        update_pull_request.tool_name: update_pull_request,
+        reply_to_review_comment.tool_name: reply_to_review_comment,
+    }
+
+
+def process_jsonl_file(file_path: Path):
+    """Process JSONL file and execute operations.
+    
+    Args:
+        file_path: Path to the JSONL artifact file
+        
+    Returns:
+        Tuple of (total_operations, successful_operations, failed_operations)
+    """
+    function_map = get_function_mapping()
+    
+    logger.info(f"Starting JSONL processing: {file_path}")
+    total_ops = 0
+    with open(file_path, 'r') as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+                
+            total_ops += 1
+            logger.info(f"Processing operation {total_ops} (line {line_num})")
+            
+            try:
+                # Parse JSONL entry
+                operation: GitHubOperation = json.loads(line)
+                func_name = operation.get("function")
+                args = operation.get('args', [])
+                kwargs = operation.get('kwargs', {})
+                
+                if not func_name:
+                    logger.error(f"Line {line_num}: Missing function name")
+                    continue
+                
+                # Get function from mapping
+                if func_name not in function_map:
+                    logger.error(f"Line {line_num}: Unknown function '{func_name}'")
+                    continue
+                
+                func = function_map[func_name]
+                
+                # Execute function
+                logger.info(f"Executing {func_name} with args={args}, kwargs={kwargs}")
+                result = func(*args, **kwargs)
+                
+                logger.info(f"Line {line_num}: Operation {func_name} completed successfully")
+                logger.info(f"Function output: {str(result)}")
+                    
+            except Exception as e:
+                logger.error(f"Line {line_num}: Execution error - {e}")
+                    
+    
+    logger.info(f"JSONL processing completed.")
+
+
+def main():
+    """Main entry point for the write executor script."""
+    parser = argparse.ArgumentParser(
+        description="Execute deferred GitHub operations from JSONL artifact files"
+    )
+    parser.add_argument(
+        "artifact_file",
+        help="Path to JSONL artifact file containing deferred operations"
+    )
+    
+    args = parser.parse_args()
+    artifact_path = Path(args.artifact_file)
+    
+    logger.info(f"Write executor started with artifact file: {artifact_path}")
+    
+    # Check if file exists
+    if not artifact_path.exists():
+        logger.warning(f"Artifact file not found: {artifact_path}")
+        logger.warning("No deferred operations to execute")
+        return
+    
+    # Check if file is empty
+    if artifact_path.stat().st_size == 0:
+        logger.info("Artifact file is empty")
+        logger.info("No deferred operations to execute")
+        return
+    
+    # Set environment to enable write operations
+    os.environ['GITHUB_WRITE'] = 'true'
+    logger.info("GitHub write mode enabled")
+    
+    logger.info(f"Processing deferred operations from: {artifact_path}")
+    
+    # Process the JSONL file
+    process_jsonl_file(artifact_path)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -63,21 +63,24 @@ jobs:
           result-encoding: string
           script: |
             return "auto-approve"
-
-  execute:
+  
+  setup-and-process:
     needs: [authorization-check]
     environment: ${{ needs.authorization-check.outputs.approval-env }}
     permissions:
       contents: write
       issues: write
-      pull-requests: write
-      id-token: write # Required for OIDC
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    outputs:
+      branch: ${{ steps.process.outputs.branch_name }}
+      session_id: ${{ steps.process.outputs.session_id }}
+      system_prompt: ${{ steps.process.outputs.system_prompt }}
+      prompt: ${{ steps.process.outputs.prompt }}
     steps:
       - name: Add strands-running label
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -190,10 +193,20 @@ jobs:
               core.setFailed(errorMsg);
             }
 
+  execute-readonly:
+    needs: [setup-and-process]
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      id-token: write # Required for OIDC
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.process.outputs.branch_name }}
+          ref: ${{ needs.setup-and-process.outputs.branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -205,17 +218,43 @@ jobs:
         continue-on-error: true # This step's failure will not stop the workflow
 
       - name: Run Strands Agent
+        id: agent-runner
         uses: ./.github/actions/strands-agent-runner
         with:
-          system_prompt: ${{ steps.process.outputs.system_prompt }}
-          session_id: ${{ steps.process.outputs.session_id }}
-          task_prompt: ${{ steps.process.outputs.prompt }}
+          system_prompt: ${{ needs.setup-and-process.outputs.system_prompt }}
+          session_id: ${{ needs.setup-and-process.outputs.session_id }}
+          task_prompt: ${{ needs.setup-and-process.outputs.prompt }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           sessions_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
-          github_token: ${{ github.token }}
+          write_permission: 'false'
 
+  execute-write:
+    needs: [setup-and-process, execute-readonly]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write # Required for OIDC
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Execute write operations
+        # Some github action shenanigans: https://github.com/actions/runner/issues/3358
+        # Basically since we are downloading the repo artifact from the previous step here, that would
+        # cause issues with the github workflow cleanup step if we don't reference the action like this.
+        uses: strands-agents/sdk-typescript/.github/actions/strands-write-executor@main
+        with:
+          ref: ${{ needs.setup-and-process.outputs.branch }}
+
+
+  cleanup:
+    needs: [authorization-check, setup-and-process, execute-readonly, execute-write]
+    if: always()
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
       - name: Remove strands-running label
-        if: always()
         uses: actions/github-script@v8
         with:
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Github workflow artifacts
+.artifact

--- a/README.md
+++ b/README.md
@@ -124,5 +124,3 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information on reporting security issues.
-
-


### PR DESCRIPTION
Closes: #184

Update agent to run in a sandbox. This change does the following:

1. Update the agent to only have read permission in its step
2. Upload git artifacts of the entire workspace, and the locally collected write actions to a jsonl file
3. Create a follow up step to commit any unstaged changes, and force push the agents workspace
4. execute all of the write actions from the agent
5. Update agent sop so the agent is aware of the tool deferrals

There was some oddity creating an artifact of the repo and reapplying it (ref: https://github.com/Unshure/sdk-typescript/actions/runs/19446058763/job/55640934671), so I needed to reference the write action in a different way to get that to work properly

Here is a successful run of the new setup: https://github.com/Unshure/sdk-typescript/actions/runs/19446880819

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
