### PR TITLE
Decrease window size

### DIFF
--- a/.github/scripts/python/agent_runner.py
+++ b/.github/scripts/python/agent_runner.py
@@ -127,7 +127,7 @@ def run_agent(query: str):
             tools=tools,
             session_manager=session_manager,
             # Set really big context window so agent is aware of as much info as possible
-            conversation_manager=SlidingWindowConversationManager(window_size=10000)
+            conversation_manager=SlidingWindowConversationManager(window_size=250)
         )
 
         print("Processing user query...")


### PR DESCRIPTION
As agents are getting stuck due to max errors and the inability to continue

I keep getting:

> bedrock threw context window overflow error

https://github.com/strands-agents/sdk-typescript/actions/runs/19523713375/job/55892056704