### PR TITLE
Add default issue id injection

### DIFF
--- a/.github/actions/strands-write-executor/action.yml
+++ b/.github/actions/strands-write-executor/action.yml
@@ -4,6 +4,9 @@ inputs:
   ref:
     description: 'Ref to push changes to'
     required: true
+  issue_id:
+    description: 'Issue ID for fallback operations'
+    required: false
 
 runs:
   using: 'composite'
@@ -137,4 +140,8 @@ runs:
         BYPASS_TOOL_CONSENT: 'true'
       run: |
         echo "🚀 Strands Write Executor - Processing write operations"
-        python ./.github/scripts/python/write_executor.py "${{ runner.temp }}/write_operations.jsonl"
+        if [ -n "${{ inputs.issue_id }}" ]; then
+          python ./.github/scripts/python/write_executor.py "${{ runner.temp }}/write_operations.jsonl" --issue-id "${{ inputs.issue_id }}"
+        else
+          python ./.github/scripts/python/write_executor.py "${{ runner.temp }}/write_operations.jsonl"
+        fi

--- a/.github/scripts/python/agent_runner.py
+++ b/.github/scripts/python/agent_runner.py
@@ -126,8 +126,6 @@ def run_agent(query: str):
             system_prompt=system_prompt,
             tools=tools,
             session_manager=session_manager,
-            # Set really big context window so agent is aware of as much info as possible
-            conversation_manager=SlidingWindowConversationManager(window_size=250)
         )
 
         print("Processing user query...")

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -157,6 +157,7 @@ jobs:
         uses: ./.github/actions/strands-write-executor
         with:
           ref: ${{ needs.setup-and-process.outputs.branch }}
+          issue_id: ${{ inputs.issue_id || github.event.issue.number }}
 
 
   cleanup:


### PR DESCRIPTION
Add default issue id if its not included in the `create_pull_request` tool use. This way, we dont get instances of trying to create a pr where the agent fails: 
<img width="1270" height="733" alt="image" src="https://github.com/user-attachments/assets/b776c927-0613-44fc-958f-15634194f9cf" />


Also removing the increased sliding window value since its causing tons of context window overflows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
