### PR TITLE
Add inline_session_policy to strands agent

### DIFF
--- a/.github/actions/strands-agent-runner/action.yml
+++ b/.github/actions/strands-agent-runner/action.yml
@@ -89,6 +89,38 @@ runs:
         role-session-name: GitHubActions-StrandsAgent-${{ github.run_id }}
         aws-region: us-west-2
         mask-aws-account-id: true
+        inline_session_policy: >-
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid":"Bedrock Access",
+                "Effect": "Allow",
+                "Action": [
+                  "bedrock:InvokeModelWithResponseStream",
+                  "bedrock:InvokeModel"
+                ],
+                "Resource": "*"
+              }, {
+                "Effect": "Allow",
+                "Action": [
+                  "s3:PutObject",
+                  "s3:GetObject",
+                  "s3:DeleteObject",
+                ],
+                "Resource": [
+                  "arn:aws:s3:::strands-typescript-project-sessions/*",
+                ]
+              }, {
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": [
+                  "arn:aws:s3:::strands-typescript-project-sessions",
+                ]
+              }
+            ]
+          }
+
 
     - name: Execute strands command
       shell: bash


### PR DESCRIPTION
Add inline_session_policy from appsec feedback.

Example of a working run: https://github.com/Unshure/sdk-typescript/actions/runs/19646033487/job/56261383769

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
