### PR TITLE
feat: add SystemPromptData type and conversion function

### DIFF
--- a/src/agent/__tests__/agent.test.ts
+++ b/src/agent/__tests__/agent.test.ts
@@ -4,7 +4,7 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockTool, createRandomTool } from '../../__fixtures__/tool-helpers.js'
 import { ConcurrentInvocationError } from '../../errors.js'
-import { MaxTokensError, TextBlock, CachePointBlock, type SystemPromptData } from '../../index.js'
+import { MaxTokensError, TextBlock, CachePointBlock } from '../../index.js'
 import { AgentPrinter } from '../printer.js'
 
 describe('Agent', () => {
@@ -428,28 +428,19 @@ describe('Agent', () => {
 
     describe('when provided as array SystemPromptData', () => {
       it('converts TextBlockData to TextBlock', () => {
-        const systemPromptData: SystemPromptData = [{ text: 'System prompt text' }]
-        const agent = new Agent({ systemPrompt: systemPromptData })
+        const agent = new Agent({ systemPrompt: [{ text: 'System prompt text' }] })
         expect(agent).toBeDefined()
       })
 
       it('converts mixed block data types', () => {
-        const systemPromptData: SystemPromptData = [
-          { text: 'First block' },
-          { cachePoint: { cacheType: 'default' } },
-          { text: 'Second block' },
-        ]
-        const agent = new Agent({ systemPrompt: systemPromptData })
+        const agent = new Agent({
+          systemPrompt: [{ text: 'First block' }, { cachePoint: { cacheType: 'default' } }, { text: 'Second block' }],
+        })
         expect(agent).toBeDefined()
       })
     })
 
     describe('when provided as SystemPrompt (class instances)', () => {
-      it('accepts string SystemPrompt', () => {
-        const agent = new Agent({ systemPrompt: 'You are helpful' })
-        expect(agent).toBeDefined()
-      })
-
       it('accepts array of class instances', () => {
         const systemPrompt = [new TextBlock('System prompt'), new CachePointBlock({ cacheType: 'default' })]
         const agent = new Agent({ systemPrompt })

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -8,13 +8,13 @@ import {
   type MessageData,
   type SystemPrompt,
   type SystemPromptData,
-  systemPromptFromData,
   TextBlock,
   type Tool,
   type ToolContext,
   ToolResultBlock,
   type ToolUseBlock,
 } from '../index.js'
+import { systemPromptFromData } from '../types/messages.js'
 import { normalizeError, ConcurrentInvocationError, MaxTokensError } from '../errors.js'
 import type { BaseModelConfig, Model, StreamOptions } from '../models/model.js'
 import { ToolRegistry } from '../registry/tool-registry.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ export {
   GuardContentBlock,
   Message,
   JsonBlock,
-  systemPromptFromData,
 } from './types/messages.js'
 
 // Media classes

--- a/src/types/__tests__/messages.test.ts
+++ b/src/types/__tests__/messages.test.ts
@@ -318,10 +318,7 @@ describe('systemPromptFromData', () => {
     it('converts to TextBlock', () => {
       const data: SystemPromptData = [{ text: 'System prompt text' }]
       const result = systemPromptFromData(data)
-      expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(1)
-      expect(result[0]).toBeInstanceOf(TextBlock)
-      expect(result[0]).toEqual(new TextBlock('System prompt text'))
+      expect(result).toEqual([new TextBlock('System prompt text')])
     })
   })
 
@@ -329,11 +326,7 @@ describe('systemPromptFromData', () => {
     it('converts to CachePointBlock', () => {
       const data: SystemPromptData = [{ text: 'prompt' }, { cachePoint: { cacheType: 'default' } }]
       const result = systemPromptFromData(data)
-      expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(2)
-      expect(result[0]).toBeInstanceOf(TextBlock)
-      expect(result[1]).toBeInstanceOf(CachePointBlock)
-      expect(result[1]).toEqual(new CachePointBlock({ cacheType: 'default' }))
+      expect(result).toEqual([new TextBlock('prompt'), new CachePointBlock({ cacheType: 'default' })])
     })
   })
 
@@ -350,12 +343,14 @@ describe('systemPromptFromData', () => {
         },
       ]
       const result = systemPromptFromData(data)
-      expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(1)
-      expect(result[0]).toBeInstanceOf(GuardContentBlock)
-      if (Array.isArray(result)) {
-        expect(result[0]!.type).toBe('guardContentBlock')
-      }
+      expect(result).toEqual([
+        new GuardContentBlock({
+          text: {
+            text: 'guard this content',
+            qualifiers: ['guard_content'],
+          },
+        }),
+      ])
     })
   })
 
@@ -375,12 +370,17 @@ describe('systemPromptFromData', () => {
         },
       ]
       const result = systemPromptFromData(data)
-      expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(4)
-      expect(result[0]).toBeInstanceOf(TextBlock)
-      expect(result[1]).toBeInstanceOf(CachePointBlock)
-      expect(result[2]).toBeInstanceOf(TextBlock)
-      expect(result[3]).toBeInstanceOf(GuardContentBlock)
+      expect(result).toEqual([
+        new TextBlock('First text block'),
+        new CachePointBlock({ cacheType: 'default' }),
+        new TextBlock('Second text block'),
+        new GuardContentBlock({
+          text: {
+            text: 'guard content',
+            qualifiers: ['guard_content'],
+          },
+        }),
+      ])
     })
   })
 
@@ -388,8 +388,7 @@ describe('systemPromptFromData', () => {
     it('returns empty array', () => {
       const data: SystemPromptData = []
       const result = systemPromptFromData(data)
-      expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(0)
+      expect(result).toEqual([])
     })
   })
 
@@ -404,7 +403,7 @@ describe('systemPromptFromData', () => {
     it('returns them unchanged', () => {
       const systemPrompt = [new TextBlock('prompt'), new CachePointBlock({ cacheType: 'default' })]
       const result = systemPromptFromData(systemPrompt)
-      expect(result).toBe(systemPrompt)
+      expect(result).toEqual(systemPrompt)
     })
   })
 })

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -474,24 +474,18 @@ export function systemPromptFromData(data: SystemPromptData | SystemPrompt): Sys
     return data
   }
 
-  // Check if it's already class instances (has 'type' discriminator)
-  const firstElement = data[0]
-  if (data.length > 0 && firstElement !== undefined && 'type' in firstElement) {
-    return data as SystemPrompt
-  }
-
   // Convert data format to class instances
   return data.map((block) => {
-    switch (true) {
-      case 'cachePoint' in block:
-        return new CachePointBlock(block.cachePoint)
-      case 'guardContent' in block:
-        return new GuardContentBlock(block.guardContent)
-      case 'text' in block:
-        // After eliminating other options, this must be TextBlockData
-        return new TextBlock((block as TextBlockData).text)
-      default:
-        throw new Error('Unknown SystemContentBlockData type')
+    if ('type' in block) {
+      return block
+    } else if ('cachePoint' in block) {
+      return new CachePointBlock(block.cachePoint)
+    } else if ('guardContent' in block) {
+      return new GuardContentBlock(block.guardContent)
+    } else if ('text' in block) {
+      return new TextBlock(block.text)
+    } else {
+      throw new Error('Unknown SystemContentBlockData type')
     }
   })
 }


### PR DESCRIPTION
## Overview
This PR implements the SystemPromptData type and conversion function following the existing Data interface pattern used throughout the codebase (similar to MessageData / Message).

Resolves: #227

## Changes

### Type Definitions
- Added `SystemPromptData` type to `src/types/messages.ts`
  - Mirrors the structure of `SystemPrompt` but with Data types
  - Defined as `string | SystemContentBlockData[]`

### Conversion Function
- Added `systemPromptFromData()` function to `src/types/messages.ts`
  - Converts SystemPromptData to SystemPrompt
  - Handles string case (returns unchanged)
  - Handles array case (maps blocks to class instances)
  - Converts TextBlockData → TextBlock
  - Converts CachePointBlockData → CachePointBlock
  - Converts GuardContentBlockData → GuardContentBlock
  - Throws error for unknown block types

### Agent Updates
- Updated `AgentConfig` to accept both `SystemPrompt` and `SystemPromptData`
- Updated Agent constructor to detect format and convert data to class instances when needed

### Exports
- Exported `SystemPromptData` type from `src/index.ts`
- Exported `systemPromptFromData` function from `src/index.ts`

### Tests
- Added 7 test cases for `systemPromptFromData()` in `src/types/__tests__/messages.test.ts`
  - String input
  - TextBlock conversion
  - CachePointBlock conversion
  - GuardContentBlock conversion
  - Mixed content blocks
  - Empty array
  - Unknown block type error
- Added 4 test cases for Agent constructor in `src/agent/__tests__/agent.test.ts`
  - String SystemPromptData
  - Array SystemPromptData
  - String SystemPrompt (existing format)
  - Array SystemPrompt (existing format)

## Test Results
- All tests passing: 621 tests
- Test coverage: 90.03% (above 80% requirement)
- No linting errors
- No type errors

## Key Implementation Decisions

### Format Detection Logic
The Agent constructor detects whether the input is Data or Class format by checking:
1. If string → use as-is (both formats support strings)
2. If array:
   - Check if first element has 'type' property
   - If 'type' exists → SystemPrompt (class instances)
   - If 'type' missing → SystemPromptData (plain objects)
   - Call systemPromptFromData() only for data format

### Pattern Consistency
This implementation follows the exact same pattern as `Message.fromMessageData()`:
- Data interfaces for JSON-like structures
- Class instances with type discriminators
- Conversion function to transform data to classes
- Accepts both formats for flexibility