### PR TITLE
Fix fallback_issue_id check for create_pull_request

### DIFF
--- a/.github/scripts/python/write_executor.py
+++ b/.github/scripts/python/write_executor.py
@@ -88,7 +88,7 @@ def process_jsonl_file(file_path: Path, default_issue_id: int | None = None):
                 func = function_map[func_name]
                 
                 # Set default issue ID for create_pull_request if not already set
-                if func_name == "create_pull_request" and default_issue_id and "fallback_issue_id" not in kwargs:
+                if func_name == "create_pull_request" and default_issue_id and not kwargs.get("fallback_issue_id"):
                     kwargs["fallback_issue_id"] = default_issue_id
                 
                 # Execute function


### PR DESCRIPTION
Before, `fallback_issue_id` was in kwargs, but it was set to none. This meant the check would evaluate to true even though the value was none. Now it will evaluate to false.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
