### PR TITLE
tool result truncation should only occurs when an error is present

### DIFF
--- a/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -114,9 +114,9 @@ export class SlidingWindowConversationManager implements HookProvider {
    *         such as when the conversation is already minimal or when no valid trim point exists.
    */
   private reduceContext(messages: Message[], _error?: Error): void {
-    // Try to truncate the tool result first
+    // Only truncate tool results when handling a context overflow error, not for window size enforcement
     const lastMessageIdxWithToolResults = this.findLastMessageWithToolResults(messages)
-    if (lastMessageIdxWithToolResults !== undefined && this._shouldTruncateResults) {
+    if (_error && lastMessageIdxWithToolResults !== undefined && this._shouldTruncateResults) {
       const resultsTruncated = this.truncateToolResults(messages, lastMessageIdxWithToolResults)
       if (resultsTruncated) {
         return


### PR DESCRIPTION
This pull request fixes a bug that tool result truncation should only occurs when an error is present, and updates the logic in `SlidingWindowConversationManager` to match this behavior. The most important changes are grouped below:

**Testing improvements:**

* Added a new test to verify that `truncateToolResults` is not called during window size enforcement (i.e., when no error is passed), and that message trimming is used instead. (`src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts`)

**Logic correction in conversation manager:**

* Updated `reduceContext` in `SlidingWindowConversationManager` to only call `truncateToolResults` if an error is present, ensuring tool result truncation is reserved for error handling scenarios. (`src/conversation-manager/sliding-window-conversation-manager.ts`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
