### PR TITLE
update package version to @VERSION@ placeholder. ci/cd uses git tags as the version id source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@strands-agents/sdk",
-  "version": "0.0.1",
+  "version": "@VERSION@",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@strands-agents/sdk",
-      "version": "0.0.1",
+      "version": "@VERSION@",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.911.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strands-agents/sdk",
-  "version": "0.0.1",
+  "version": "@VERSION@",
   "description": "TypeScript SDK for Strands Agents framework",
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",


### PR DESCRIPTION
*Issue #, if available:*
#74 

*Description of changes:*
Changes package.json to a placeholder version. The actual version for npm publishing comes from git tags in https://github.com/strands-agents/sdk-typescript/blob/main/.github/workflows/npm-publish-on-release.yml.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
