### PR TITLE
ci(npm release): fix github workflow failing by merging build+publish steps

### DIFF
--- a/.github/workflows/npm-publish-on-release.yml
+++ b/.github/workflows/npm-publish-on-release.yml
@@ -13,13 +13,18 @@ jobs:
     with:
       ref: ${{ github.event.release.target_commitish }}
 
-  build:
-    name: Build distribution 📦
-    permissions:
-      contents: read
+  publish:
+    name: Build and publish to NPM
     needs:
       - call-test-lint
     runs-on: ubuntu-latest
+
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@strands-agents/sdk
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v6
@@ -31,6 +36,9 @@ jobs:
       with:
         node-version: '20'
         registry-url: 'https://registry.npmjs.org'
+
+    - name: Update npm to latest
+      run: npm install -g npm@latest
 
     - name: Extract version from tag
       id: version
@@ -53,45 +61,15 @@ jobs:
       run: |
         npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
-    - name: Install dependencies
+    - name: Install dependencies and build
       run: npm ci
-
-    - name: Build
-      run: npm run build
 
     - name: Store the distribution packages
       uses: actions/upload-artifact@v5
       with:
         name: npm-package-distributions
-        path: |
-          dist/
-          package.json
-
-  deploy:
-    name: Upload release to NPM
-    needs:
-    - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: npm
-      url: https://www.npmjs.com/package/@strands-agents/sdk
-    permissions:
-      id-token: write  # Required for OIDC auth
-    
-    steps:
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20'
-        registry-url: 'https://registry.npmjs.org'
-
-    - name: Download all the dists
-      uses: actions/download-artifact@v6
-      with:
-        name: npm-package-distributions
         path: .
 
-    - name: Publish distribution 📦 to NPM
+    - name: Publish to NPM
       # TODO: uncomment `--access public` for launch
-      run: npm publish --ignore-scripts # --access public
+      run: npm publish # --access public


### PR DESCRIPTION
*Issue #, if available:*
#74 

*Description of changes:*
`npm publish` calls the `prepare` script. We have `tsc` and `husky` being called from the `prepare` script, so dependencies and source need to be available to the github workflow when `npm publish` is ran. By not splitting the build and publish workflow steps (because publish already builds for us), building works fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
