### PR TITLE
Use valid NPM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strands-agents/sdk",
-  "version": "@VERSION@",
+  "version": "0.0.1-development",
   "description": "TypeScript SDK for Strands Agents framework",
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",


### PR DESCRIPTION
So that you can install from GitHub

Previous to these changes, I'm getting:

> npm install https://github.com/strands-agents/sdk-typescript sdk_typescript                                                              
> npm error Invalid Version: @VERSION@
> npm error A complete log of this run can be found in: /Users/maczas/.npm/_logs/2025-12-01T22_32_28_191Z-debug-0.logs/.npm/_logs/2025-12-01T22_32_28_191Z-debug-0.log

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
