### PR TITLE
Update repository url for TypeDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strands-agents/sdk-typescript.git"
+    "url": "git+https://github.com/strands-agents/sdk-typescript.git"
   },
   "bugs": {
     "url": "https://github.com/strands-agents/sdk-typescript/issues"


### PR DESCRIPTION
## Description

Our TS Api docs are pointing to an invalid URL.

 1. Go to https://strandsagents.com/latest/documentation/docs/api-reference/typescript/classes/NullConversationManager.html
 2. Notice the link is https://github.com/strands-agents/sdk-typescript.git//blob/0a412e4e60f29fe3c578e30bbbf5f89b7cdf743e/src/conversation-manager/null-conversation-manager.ts#L16 which is not valid

After these changes (tested locally) it points to https://github.com/strands-agents/sdk-typescript/blob/89118cd9ac1f6ee52427013abb47447960dd79b2/src/conversation-manager/null-conversation-manager.ts#L16

This is also the documented url pattern: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository

As far as I know, this is only an issue for generating our API Docs.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
