### PR TITLE
docs: fix broken API reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ await documentationTools.disconnect();
 For detailed guidance, tutorials, and concept overviews, please visit:
 
 - **[Official Documentation](https://strandsagents.com/)**: Comprehensive guides and tutorials
-- **[API Reference](.sop/summary/interfaces.md)**: Complete API documentation
+- **[API Reference](https://strandsagents.com/latest/documentation/docs/api-reference/typescript/)**: Complete API documentation
 - **[Examples](./examples/)**: Sample applications
 - **[Contributing Guide](CONTRIBUTING.md)**: Development setup and guidelines
 


### PR DESCRIPTION
## Description

  Fix broken API Reference link in README.md that was returning 404 error.

  The API Reference link was pointing to a non-existent local file (`.sop/summary/interfaces.md`). Updated to point to the correct
  online documentation URL: https://strandsagents.com/latest/documentation/docs/api-reference/typescript/

  ## Related Issues

  Fixes #312

  ## Documentation PR

  N/A - This is a documentation fix in this repository

  ## Type of Change

  Documentation update

  ## Testing

  How have you tested the change?

  - [x] I ran `npm run check`
  - [x] Manually verified the new link works and points to correct API documentation

  ## Checklist
  - [x] I have read the CONTRIBUTING document
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [x] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ----

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of
   your choice.