### PR TITLE
fix: missing export entry for vended_tools/bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "./vended_tools/http_request": {
       "types": "./dist/vended_tools/http_request/index.d.ts",
       "default": "./dist/vended_tools/http_request/index.js"
+    },
+    "./vended_tools/bash": {
+      "types": "./dist/vended_tools/bash/index.d.ts",
+      "default": "./dist/vended_tools/bash/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description

Adds the missing package.json export entry for `vended_tools/bash`.

## Related Issues

`N/A`

## Documentation PR

`N/A`

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
