### PR TITLE
Enable vitest test reports + upload artifacts

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,11 +86,12 @@ jobs:
       - name: Run integration tests
         run: npm run test:integ:all
 
-      - name: Upload browser test screenshots
+      - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: browser-test-screenshots
-          path: tests_integ/browser/__screenshots__/
+          name: test-artifacts-integ
+          path: ./test/.artifacts/
           retention-days: 4
+          include-hidden-files: true # needed because the path has a directory starting with a '.'
           if-no-files-found: ignore

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -40,6 +40,16 @@ jobs:
       - name: Run unit tests
         run: npm run test:all:coverage
 
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-artifacts-${{ matrix.node-version }}-${{ matrix.os }}
+          path: ./test/.artifacts/
+          include-hidden-files: true # needed because the path has a directory starting with a '.'
+          retention-days: 4
+          if-no-files-found: ignore
+
       - name: Run linting
         run: npm run lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 
 # Github workflow artifacts
 .artifact
+
+# Test artifacts
+test/.artifacts

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,11 @@ const getOpenAIAPIKey: BrowserCommand<[], string | undefined> = async ({ testPat
 export default defineConfig({
   test: {
     unstubEnvs: true,
+    reporters: [
+      'default',
+      ['junit', { outputFile: 'test/.artifacts/test-report/junit/report.xml' }],
+      ['json', { outputFile: 'test/.artifacts/test-report/json/report.json' }],
+    ],
     projects: [
       {
         test: {
@@ -43,6 +48,7 @@ export default defineConfig({
           browser: {
             enabled: true,
             provider: playwright(),
+            screenshotDirectory: 'test/.artifacts/browser-screenshots/',
             instances: [
               {
                 browser: 'chromium',
@@ -72,6 +78,7 @@ export default defineConfig({
           browser: {
             enabled: true,
             provider: playwright(),
+            screenshotDirectory: 'test/.artifacts/browser-screenshots/',
             instances: [
               {
                 browser: 'chromium',


### PR DESCRIPTION

## Description

This way we can extract the test reports and view them offline

Here's an example of the output artifacts: https://github.com/zastrowm/sdk-typescript/actions/runs/19971829464

HTML reporters are not enabled right now, as I'm having difficulty getting it to work right.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
