### PR TITLE
chore: Tweak agent runner to be more general-purpose

### DIFF
--- a/.github/scripts/python/agent_runner.py
+++ b/.github/scripts/python/agent_runner.py
@@ -109,13 +109,14 @@ def run_agent(query: str):
         system_prompt = os.getenv("INPUT_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT)
         session_id = os.getenv("SESSION_ID")
         s3_bucket = os.getenv("S3_SESSION_BUCKET")
+        s3_prefix = os.getenv("GITHUB_REPOSITORY", "")
 
         if s3_bucket and session_id:
             print(f"🤖 Using session manager with session ID: {session_id}")
             session_manager = S3SessionManager(
                 session_id=session_id,
                 bucket=s3_bucket,
-                prefix="",
+                prefix=s3_prefix,
             )
         else:
             raise ValueError("Both SESSION_ID and S3_SESSION_BUCKET must be set")

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -133,7 +133,7 @@ jobs:
           session_id: ${{ needs.setup-and-process.outputs.session_id }}
           task_prompt: ${{ needs.setup-and-process.outputs.prompt }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-          sessions_bucket: ${{ secrets.TYPESCRIPT_SESSIONS_BUCKET }}
+          sessions_bucket: ${{ secrets.AGENT_SESSIONS_BUCKET }}
           write_permission: 'false'
           ref: ${{ needs.setup-and-process.outputs.branch }}
 


### PR DESCRIPTION

## Description

Two changes:

  1. Change the variable name from TYPESCRIPT_SESSIONS_BUCKET -> AGENT_SESSIONS_BUCKET; this makes the agent code more general purpose than *just* TS
  2. Use a session prefix that is equal to the GH repo name - this enables different repositories (and forks) to not conflict with eachother

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Chore

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
