### PR TITLE
Unify integ fixture loading and test skipping

### DIFF
--- a/test/integ/__fixtures__/model-test-helpers.ts
+++ b/test/integ/__fixtures__/model-test-helpers.ts
@@ -1,33 +1,5 @@
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
-import type { Message, ContentBlock } from '$/sdk/types/messages.js'
-
-/**
- * Determines whether AWS integration tests should run based on environment and credentials.
- *
- * In CI environments, tests always run (credentials are expected to be configured).
- * In local environments, tests run only if AWS credentials are available.
- *
- * @returns Promise<boolean> - true if tests should run, false if they should be skipped
- */
-export async function shouldRunTests(): Promise<boolean> {
-  // In a CI environment, we ALWAYS expect credentials to be configured.
-  // A failure is better than a skip.
-  if (process.env.CI) {
-    console.log('✅ Running in CI environment, integration tests will run.')
-    return true
-  }
-
-  // In a local environment, we check for credentials as a convenience.
-  try {
-    const credentialProvider = fromNodeProviderChain()
-    await credentialProvider()
-    console.log('✅ AWS credentials found locally, integration tests will run.')
-    return true
-  } catch {
-    console.log('⏭️ AWS credentials not available locally, integration tests will be skipped.')
-    return false
-  }
-}
+import type { ContentBlock, Message } from '$/sdk/types/messages.js'
 
 /**
  * Extracts plain text content from a Message object.
@@ -46,4 +18,69 @@ export const getMessageText = (message: Message): string => {
     .filter((block: ContentBlock) => block.type === 'textBlock')
     .map((block) => block.text)
     .join('\n')
+}
+
+/**
+ * Determines whether AWS integration tests should run based on environment and credentials.
+ *
+ * In CI environments, tests always run (credentials are expected to be configured).
+ * In local environments, tests run only if AWS credentials are available.
+ *
+ * @returns Promise<boolean> - true if tests should run, false if they should be skipped
+ */
+export async function shouldSkipBedrockTests(): Promise<boolean> {
+  // In a CI environment, we ALWAYS expect credentials to be configured.
+  // A failure is better than a skip.
+  if (process.env.CI) {
+    console.log('✅ Running in CI environment, integration tests will run.')
+    return false
+  }
+
+  // In a local environment, we check for credentials as a convenience.
+  try {
+    const credentialProvider = fromNodeProviderChain()
+    await credentialProvider()
+    console.log('✅ AWS credentials found locally, integration tests will run.')
+    return false
+  } catch {
+    console.log('⏭️ AWS credentials not available locally, integration tests will be skipped.')
+    return true
+  }
+}
+
+/**
+ * Determines if OpenAI integration tests should be skipped.
+ * In CI environments, throws an error if API key is missing (tests should not be skipped).
+ * In local development, skips tests if API key is not available.
+ *
+ * @returns true if tests should be skipped, false if they should run
+ * @throws Error if running in CI and API key is missing
+ */
+export function shouldSkipOpenAITests(): boolean {
+  try {
+    const isCI = !!process.env.CI
+    const hasKey = !!process.env.OPENAI_API_KEY
+
+    if (isCI && !hasKey) {
+      throw new Error('OpenAI API key must be available in CI environments')
+    }
+
+    if (hasKey) {
+      if (isCI) {
+        console.log('✅ Running in CI environment with OpenAI API key - tests will run')
+      } else {
+        console.log('✅ OpenAI API key found for integration tests')
+      }
+      return false
+    } else {
+      console.log('⏭️  OpenAI API key not available - integration tests will be skipped')
+      return true
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('CI environments')) {
+      throw error
+    }
+    console.log('⏭️  OpenAI API key not available - integration tests will be skipped')
+    return true
+  }
 }

--- a/test/integ/agent.test.ts
+++ b/test/integ/agent.test.ts
@@ -7,8 +7,8 @@ import { OpenAIModel } from '@strands-agents/sdk/openai'
 import { z } from 'zod'
 
 import { collectGenerator } from '$/sdk/__fixtures__/model-test-helpers.js'
-import { shouldRunTests } from './__fixtures__/model-test-helpers.js'
-import { loadFixture, shouldSkipOpenAITests } from './__fixtures__/test-helpers.js'
+import { shouldSkipBedrockTests, shouldSkipOpenAITests } from './__fixtures__/model-test-helpers.js'
+import { loadFixture } from './__fixtures__/test-helpers.js'
 
 // Import fixtures using Vite's ?url suffix
 import yellowPngUrl from './__resources__/yellow.png?url'
@@ -37,7 +37,7 @@ const calculatorTool = tool({
 const providers = [
   {
     name: 'BedrockModel',
-    skip: !(await shouldRunTests()),
+    skip: await shouldSkipBedrockTests(),
     createModel: () => new BedrockModel(),
   },
   {
@@ -144,7 +144,7 @@ describe.each(providers)('Agent with $name', ({ name, skip, createModel }) => {
         })
 
         // Create image block
-        const imageBytes = loadFixture(yellowPngUrl)
+        const imageBytes = await loadFixture(yellowPngUrl)
         const imageBlock = new ImageBlock({
           format: 'png',
           source: { bytes: imageBytes },

--- a/test/integ/bash.test.ts
+++ b/test/integ/bash.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { Agent, BedrockModel } from '$/sdk/index.js'
 import { bash } from '$/sdk/vended-tools/bash/index.js'
-import { getMessageText, shouldRunTests } from './__fixtures__/model-test-helpers.js'
+import { getMessageText, shouldSkipBedrockTests } from './__fixtures__/model-test-helpers.js'
 
-describe.skipIf(!(await shouldRunTests()) || process.platform === 'win32')(
+describe.skipIf((await shouldSkipBedrockTests()) || process.platform === 'win32')(
   'Bash Tool Integration',
   { timeout: 60000 },
   () => {

--- a/test/integ/bedrock.test.ts
+++ b/test/integ/bedrock.test.ts
@@ -9,9 +9,9 @@ import {
 } from '@strands-agents/sdk'
 
 import { collectIterator } from '$/sdk/__fixtures__/model-test-helpers.js'
-import { shouldRunTests } from './__fixtures__/model-test-helpers.js'
+import { shouldSkipBedrockTests } from './__fixtures__/model-test-helpers.js'
 
-describe.skipIf(!(await shouldRunTests()))('BedrockModel Integration Tests', () => {
+describe.skipIf(await shouldSkipBedrockTests())('BedrockModel Integration Tests', () => {
   describe('Streaming', () => {
     describe('Configuration', () => {
       it.concurrent('respects maxTokens configuration', async () => {

--- a/test/integ/browser/agent.browser.test.ts
+++ b/test/integ/browser/agent.browser.test.ts
@@ -11,26 +11,7 @@ import { collectGenerator } from '$/sdk/__fixtures__/model-test-helpers.js'
 
 // Import fixtures
 import yellowPngUrl from '../__resources__/yellow.png?url'
-
-// Environment detection for browser vs Node.js
-const isNode = typeof process !== 'undefined' && typeof process.versions !== 'undefined' && !!process.versions.node
-
-// Browser-compatible fixture loader
-const loadFixture = async (url: string): Promise<Uint8Array> => {
-  if (isNode) {
-    // In Node.js, use synchronous file reading
-    const { readFileSync } = await import('node:fs')
-    const { join } = await import('node:path')
-    const relativePath = url.startsWith('/') ? url.slice(1) : url
-    const filePath = join(process.cwd(), relativePath)
-    return new Uint8Array(readFileSync(filePath))
-  } else {
-    // In browser, use fetch API
-    const response = await globalThis.fetch(url)
-    const arrayBuffer = await response.arrayBuffer()
-    return new Uint8Array(arrayBuffer)
-  }
-}
+import { loadFixture } from '../__fixtures__/test-helpers.js'
 
 // Calculator tool for testing
 const calculatorTool = tool({

--- a/test/integ/file-editor.test.ts
+++ b/test/integ/file-editor.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { Agent, BedrockModel } from '$/sdk/index.js'
 import { fileEditor } from '$/sdk/vended-tools/file_editor/index.js'
 import { collectGenerator } from '$/sdk/__fixtures__/model-test-helpers.js'
-import { shouldRunTests } from './__fixtures__/model-test-helpers.js'
+import { shouldSkipBedrockTests } from './__fixtures__/model-test-helpers.js'
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import { tmpdir } from 'os'
 
-describe.skipIf(!(await shouldRunTests()))('FileEditor Tool Integration', () => {
+describe.skipIf(await shouldSkipBedrockTests())('FileEditor Tool Integration', () => {
   let testDir: string
 
   // Shared agent configuration for all tests

--- a/test/integ/http-request.test.ts
+++ b/test/integ/http-request.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { httpRequest } from '@strands-agents/sdk/vended_tools/http_request'
 import { Agent, BedrockModel } from '@strands-agents/sdk'
-import { shouldRunTests } from './__fixtures__/model-test-helpers.js'
+import { shouldSkipBedrockTests } from './__fixtures__/model-test-helpers.js'
 
-describe.skipIf(!(await shouldRunTests()))('httpRequest tool (integration)', () => {
+describe.skipIf(await shouldSkipBedrockTests())('httpRequest tool (integration)', () => {
   it('agent uses http_request tool to fetch weather from Open-Meteo', async () => {
     const agent = new Agent({
       model: new BedrockModel({ maxTokens: 500 }),

--- a/test/integ/notebook.test.ts
+++ b/test/integ/notebook.test.ts
@@ -3,9 +3,9 @@ import { Agent, BedrockModel } from '$/sdk/index.js'
 import type { AgentStreamEvent, AgentResult } from '$/sdk/index.js'
 import { notebook } from '$/sdk/vended-tools/notebook/index.js'
 import { collectGenerator } from '$/sdk/__fixtures__/model-test-helpers.js'
-import { shouldRunTests } from './__fixtures__/model-test-helpers.js'
+import { shouldSkipBedrockTests } from './__fixtures__/model-test-helpers.js'
 
-describe.skipIf(!(await shouldRunTests()))('Notebook Tool Integration', () => {
+describe.skipIf(await shouldSkipBedrockTests())('Notebook Tool Integration', () => {
   // Shared agent configuration for all tests
   const agentParams = {
     model: new BedrockModel({

--- a/test/integ/openai.test.ts
+++ b/test/integ/openai.test.ts
@@ -4,7 +4,8 @@ import { Message } from '@strands-agents/sdk'
 import type { ToolSpec } from '@strands-agents/sdk'
 
 import { collectIterator } from '$/sdk/__fixtures__/model-test-helpers.js'
-import { shouldSkipOpenAITests } from './__fixtures__/test-helpers.js'
+
+import { shouldSkipOpenAITests } from './__fixtures__/model-test-helpers.js'
 
 describe.skipIf(shouldSkipOpenAITests())('OpenAIModel Integration Tests', () => {
   describe('Configuration', () => {


### PR DESCRIPTION
## Description

Two changes to unify the browser & node tests to have a more unified test suite:

 1. Update the integ tests to have a single `loadFixture` method that is usable from the browser & node tests
 2. Update `shouldRunTests` -> `shouldSkipBedrockTests` to match the naming of `shouldSkipOpenAITests`; so that we have the same style of "skipping" between the two

Follow-up PRs will:

 - Centralize the client creation for Bedrock & OpenAI, giving us a shared way of creating clients
 - Share more tests between the browser and node

### Notes

 - This is a variant of #318 and #283

## Related Issues

Related to #225 - as part of #283, I realized we couldn't just have a vite import that really works for both

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Refactor

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
