### PR TITLE
chore: Group dependabot updates together + add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,40 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     open-pull-requests-limit: 100
     commit-message:
       prefix: ci
+    cooldown: # Set a cooldown so that we don't get updates immediately
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
+      # Group all development updates in a single PR
       development-dependencies:
-        dependency-type: "development"
-        patterns:
-          - "*"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+        dependency-type: 'development'
+        applies-to: version-updates
+      # Group minor production updates in a single PR
+      production-minor:
+        dependency-type: 'production'
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Because major production updates aren't matched by any group, they will have individual PRs
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     open-pull-requests-limit: 100
     commit-message:
       prefix: ci


### PR DESCRIPTION

## Description

Group more dependabot updates together to avoid having an excessive number of PRs.

We now group by:

 - All development dependencies together
 - Minor/patch updates to production dependencies

I also added a cooldown period so that updates aren't applied immediately - this helps avoid updating to dependencies that haven't seen broad adoption.

## Related Issues

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Dependency configuration

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
