### PR TITLE
Update task refiner to use details & summary

### DIFF
--- a/.github/agent-sops/task-refiner.sop.md
+++ b/.github/agent-sops/task-refiner.sop.md
@@ -94,6 +94,9 @@ Create a numbered list of questions to resolve ambiguities and gather missing in
 - You SHOULD ask about performance and scalability requirements
 - You MUST create a comment with all of your questions on the issue.
   - If the comment posting is deferred, continue with the workflow and note the deferred status
+- You MUST wrap the comment body in a `<details><summary>` element so it is collapsed by default
+  - Use a brief, descriptive summary (e.g., "Repository Analysis & Clarifying Questions")
+  - Place all detailed content inside the `<details>` block
 
 #### 3.3 Handoff to User for Response
 
@@ -186,12 +189,15 @@ Record that the task review is complete and ready as a comment on the issue.
 - You MUST summarize what was accomplished in your comment
 - You MUST confirm in your comment that the issue is ready for implementation, or explain why it is not
 - You SHOULD mention any final recommendations or considerations
+- You MUST wrap the comment body in a `<details><summary>` element so it is collapsed by default
+  - Use a brief, descriptive summary (e.g., "Task Refinement Complete")
 
 ## Examples
 
 ### Example Repository Analysis Comment
 ```markdown
-## Repository Analysis & Clarifying Questions
+<details>
+<summary>Repository Analysis & Clarifying Questions</summary>
 
 I've analyzed the repository structure and have some questions to ensure proper implementation:
 
@@ -216,6 +222,8 @@ I've analyzed the repository structure and have some questions to ensure proper 
 6. What should the user interface look like for this feature?
 
 Please respond when you have a chance. Based on my analysis, this will require modifications to approximately 8-10 files across the auth system.
+
+</details>
 ```
 
 ### Example Final Issue Description Update


### PR DESCRIPTION

## Description

Update task refiner to use details & summary so that comments on issues don't become as noisy when reading issues

Compare:

 - Before: [N​o base class for ContentBlock · Issue #21 · zastrowm/sdk-typescript](https://github.com/zastrowm/sdk-typescript/issues/21)
 - After: [N​o base class for ContentBlock · Issue #24 · zastrowm/sdk-typescript](https://github.com/zastrowm/sdk-typescript/issues/24)

Note that the long-winded posts are now in an expandable box.  This does incur a little bit more overhead in two ways:

 - To read the reply, you need to expand it (obviously)
 - When quote replying, you need to expand *first* before quote replying

I think both of these are worth it, but LMK what you think

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Agent refactor


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
