### PR TITLE
chore: Make action.yml compatible with Python agents

### DIFF
--- a/.github/actions/strands-agent-runner/action.yml
+++ b/.github/actions/strands-agent-runner/action.yml
@@ -53,6 +53,8 @@ runs:
         node-version: '20'
 
     - name: Install dependencies
+      # If we have package.json then install the dependencies - this is for compatibility in multiple repos
+      if: hashFiles('package.json') != ''
       shell: bash
       run: npm install
       continue-on-error: true # This step's failure will not stop the workflow
@@ -147,7 +149,7 @@ runs:
         STRANDS_TOOL_CONSOLE_MODE: 'enabled'
         BYPASS_TOOL_CONSENT: 'true'
       run: |
-        uv run ${{ runner.temp }}/strands-agent-runner/.github/scripts/python/agent_runner.py "$INPUT_TASK"
+        uv run --no-project ${{ runner.temp }}/strands-agent-runner/.github/scripts/python/agent_runner.py "$INPUT_TASK"
 
     - name: Capture repository state
       shell: bash


### PR DESCRIPTION
To enable agents in sdk-python, I needed two fixes:

 - Only run npm install if we have a package.json
 - Don't use a project file for uv run (as it's not needed for TS, and python would try to use the wrong project)
