### PR TITLE
chore: Provide better names for integ test jobs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,6 +7,7 @@ on:
     types: [checks_requested]
 jobs:
   authorization-check:
+    name: Check access
     permissions: read-all
     runs-on: ubuntu-latest
     outputs:
@@ -47,7 +48,8 @@ jobs:
           script: |
             return "auto-approve"
 
-  check-access-and-checkout:
+  run-integration-tests:
+    name: Run integration tests
     runs-on: ubuntu-latest
     needs: authorization-check
     environment: ${{ needs.authorization-check.outputs.approval-env }}


### PR DESCRIPTION
To make the GitHub Workflow logs more obvious/readable

Previous to these changes, it was showing this, which is not very obvious what they represent:

<img width="938" height="111" alt="image" src="https://github.com/user-attachments/assets/377e19c5-0989-4034-a9d3-04b8a0cde164" />

