### PR TITLE
Mock aws config file path env var

### DIFF
--- a/test/integ/bedrock.test.ts
+++ b/test/integ/bedrock.test.ts
@@ -162,6 +162,9 @@ describe.skipIf(bedrock.skip)('BedrockModel Integration Tests', () => {
       // Use vitest to stub environment variables
       vi.stubEnv('AWS_REGION', undefined)
       vi.stubEnv('AWS_DEFAULT_REGION', undefined)
+      // Point config and credential files to null values
+      vi.stubEnv('AWS_CONFIG_FILE', '/dev/null')
+      vi.stubEnv('AWS_SHARED_CREDENTIALS_FILE', '/dev/null')
 
       const provider = bedrock.createModel({
         maxTokens: 50,


### PR DESCRIPTION
## Description
Mock the aws config file path so that if its defined, it is ignored for this test. My local integ tests were failing due to this issue

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
