### PR TITLE
Rename issue template from 'v1' to 'V1 Release'

### DIFF
--- a/.github/ISSUE_TEMPLATE/v1.yml
+++ b/.github/ISSUE_TEMPLATE/v1.yml
@@ -1,4 +1,4 @@
-name: v1
+name: V1 Release
 description: Item associated with the release of Strands TypeScript SDK V1.
 labels:
 - milestone:v1


### PR DESCRIPTION
## Description
Name was too short (see error message in https://github.com/strands-agents/sdk-typescript/blob/main/.github/ISSUE_TEMPLATE/v1.yml).


## Related Issues

https://github.com/orgs/strands-agents/projects/17

## Documentation PR

N/A

## Type of Change

Bug fix

### Testing

Tested in fork.