### PR TITLE
feat: add ModelThrottleError for rate limiting

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { ModelError, ContextWindowOverflowError, MaxTokensError, normalizeError } from '../errors.js'
+import {
+  ModelError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  ModelThrottledError,
+  normalizeError,
+} from '../errors.js'
 import { Message, TextBlock } from '../types/messages.js'
 
 describe('ModelError', () => {
@@ -114,6 +120,50 @@ describe('MaxTokensError', () => {
       const error = new MaxTokensError('test', partialMessage)
 
       expect(error).toBeInstanceOf(ModelError)
+    })
+  })
+})
+
+describe('ModelThrottledError', () => {
+  describe('when instantiated with a message', () => {
+    it('creates an error with the correct message', () => {
+      const message = 'Rate limit exceeded'
+      const error = new ModelThrottledError(message)
+
+      expect(error.message).toBe(message)
+    })
+
+    it('has the correct error name', () => {
+      const error = new ModelThrottledError('test')
+
+      expect(error.name).toBe('ModelThrottledError')
+    })
+
+    it('is an instance of Error', () => {
+      const error = new ModelThrottledError('test')
+
+      expect(error).toBeInstanceOf(Error)
+    })
+
+    it('is an instance of ModelError', () => {
+      const error = new ModelThrottledError('test')
+
+      expect(error).toBeInstanceOf(ModelError)
+    })
+  })
+
+  describe('when instantiated with a cause', () => {
+    it('preserves the original error as cause', () => {
+      const originalError = new Error('Original rate limit error')
+      const error = new ModelThrottledError('Rate limit exceeded', { cause: originalError })
+
+      expect(error.cause).toBe(originalError)
+    })
+
+    it('has undefined cause when not provided', () => {
+      const error = new ModelThrottledError('Rate limit exceeded')
+
+      expect(error.cause).toBeUndefined()
     })
   })
 })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -112,6 +112,46 @@ export class ConcurrentInvocationError extends Error {
 }
 
 /**
+ * Error thrown when a model provider returns a throttling or rate limit error.
+ *
+ * This error indicates that the model API has rate limited the request. Users can
+ * handle this error in hooks to implement custom retry strategies using the
+ * `AfterModelCallEvent.retryModelCall` mechanism.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, AfterModelCallEvent, ModelThrottledError } from '@strands-agents/sdk'
+ *
+ * const retryOnThrottleHook = {
+ *   registerCallbacks(registry) {
+ *     registry.addCallback(AfterModelCallEvent, (event) => {
+ *       if (event.error instanceof ModelThrottledError) {
+ *         // Implement custom backoff logic
+ *         event.retryModelCall = true
+ *       }
+ *     })
+ *   }
+ * }
+ *
+ * const agent = new Agent({
+ *   hooks: [retryOnThrottleHook]
+ * })
+ * ```
+ */
+export class ModelThrottledError extends ModelError {
+  /**
+   * Creates a new ModelThrottledError.
+   *
+   * @param message - Error message describing the throttling condition
+   * @param options - Optional error options including cause for error chaining
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'ModelThrottledError'
+  }
+}
+
+/**
  * Normalizes an unknown error value to an Error instance.
  *
  * This helper ensures that any thrown value (Error, string, number, etc.)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
   MaxTokensError,
   JsonValidationError,
   ConcurrentInvocationError,
+  ModelThrottledError,
 } from './errors.js'
 
 // JSON types

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime'
 import { isNode } from '../../__fixtures__/environment.js'
 import { BedrockModel } from '../bedrock.js'
-import { ContextWindowOverflowError } from '../../errors.js'
+import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import type { Message } from '../../types/messages.js'
 import { TextBlock, GuardContentBlock, CachePointBlock } from '../../types/messages.js'
 import type { StreamOptions } from '../model.js'
@@ -1012,6 +1012,68 @@ describe('BedrockModel', () => {
           }
         })
       }
+    })
+
+    describe('throttling', () => {
+      afterEach(() => {
+        // Reset to a non-error mock to avoid affecting subsequent tests
+        setupMockSend(async function* () {
+          yield { messageStart: { role: 'assistant' } }
+          yield { contentBlockStart: {} }
+          yield { contentBlockDelta: { delta: { text: 'Hello' } } }
+          yield { contentBlockStop: {} }
+          yield { messageStop: { stopReason: 'end_turn' } }
+          yield { metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }
+        })
+      })
+
+      it('throws ModelThrottledError when throttlingException is received', async () => {
+        setupMockSend(async function* () {
+          yield { messageStart: { role: 'assistant' } }
+          yield { throttlingException: { message: 'Rate exceeded' } }
+        })
+
+        const provider = new BedrockModel()
+        const messages: Message[] = [{ type: 'message', role: 'user', content: [{ type: 'textBlock', text: 'Hello' }] }]
+
+        await expect(async () => {
+          for await (const _ of provider.stream(messages)) {
+            // consume stream
+          }
+        }).rejects.toThrow(ModelThrottledError)
+      })
+
+      it('includes throttling message in ModelThrottledError', async () => {
+        setupMockSend(async function* () {
+          yield { messageStart: { role: 'assistant' } }
+          yield { throttlingException: { message: 'Too many requests' } }
+        })
+
+        const provider = new BedrockModel()
+        const messages: Message[] = [{ type: 'message', role: 'user', content: [{ type: 'textBlock', text: 'Hello' }] }]
+
+        await expect(async () => {
+          for await (const _ of provider.stream(messages)) {
+            // consume stream
+          }
+        }).rejects.toThrow('Too many requests')
+      })
+
+      it('uses default message when throttlingException has no message', async () => {
+        setupMockSend(async function* () {
+          yield { messageStart: { role: 'assistant' } }
+          yield { throttlingException: {} }
+        })
+
+        const provider = new BedrockModel()
+        const messages: Message[] = [{ type: 'message', role: 'user', content: [{ type: 'textBlock', text: 'Hello' }] }]
+
+        await expect(async () => {
+          for await (const _ of provider.stream(messages)) {
+            // consume stream
+          }
+        }).rejects.toThrow('Request was throttled by the model provider')
+      })
     })
   })
 

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -41,7 +41,7 @@ import type { ContentBlock, Message, StopReason, ToolUseBlock } from '../types/m
 import type { ImageSource, VideoSource, DocumentSource } from '../types/media.js'
 import type { ModelStreamEvent, ReasoningContentDelta, Usage } from '../models/streaming.js'
 import type { JSONValue } from '../types/json.js'
-import { ContextWindowOverflowError, normalizeError } from '../errors.js'
+import { ContextWindowOverflowError, ModelThrottledError, normalizeError } from '../errors.js'
 import { ensureDefined } from '../types/validation.js'
 import { logger } from '../logging/logger.js'
 
@@ -985,9 +985,13 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       case 'internalServerException':
       case 'modelStreamErrorException':
       case 'serviceUnavailableException':
-      case 'validationException':
-      case 'throttlingException': {
+      case 'validationException': {
         throw eventData
+      }
+      case 'throttlingException': {
+        const message = (eventData as { message?: string }).message ?? 'Request was throttled by the model provider'
+        logger.debug(`throttled | error_message=<${message}>`)
+        throw new ModelThrottledError(message, { cause: eventData })
       }
       default:
         // Log warning for unsupported event types (for forward compatibility)


### PR DESCRIPTION
## Motivation

When model providers throttle requests due to rate limiting, developers need a consistent way to detect and handle these scenarios. This enables implementing retry strategies, backoff mechanisms, or graceful degradation in applications.

## Changes

Introduces `ModelThrottleError`, a new error type thrown when rate limiting is detected:

**Before:**
```typescript
// Bedrock: Error was thrown as raw event data
// OpenAI: Error was propagated as-is, requiring inspection of error properties
```

**After:**
```typescript
import { Agent, ModelThrottleError } from '@strands-agents/sdk'

try {
  for await (const event of agent.run('Generate a long story')) {
    // handle events
  }
} catch (error) {
  if (error instanceof ModelThrottleError) {
    // Implement retry logic with backoff
    console.log('Rate limited, retrying after delay...')
  }
}
```

### Provider-specific behavior

- **BedrockModel**: Detects `throttlingException` events during streaming
- **OpenAIModel**: Detects HTTP 429 status, `rate_limit_exceeded` error codes, and common rate limit message patterns

Closes #424