### PR TITLE
add env for langfuse

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -82,6 +82,9 @@ jobs:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           sessions_bucket: ${{ secrets.AGENT_SESSIONS_BUCKET }}
           write_permission: 'false'
+          langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          langfuse_host: ${{ secrets.LANGFUSE_HOST }}
 
   finalize:
     needs: [setup-and-process, execute-readonly-agent]


### PR DESCRIPTION
## Description

This pull request makes a minor update to the GitHub Actions workflow by adding new environment variables for Langfuse integration. These variables will allow the workflow to access Langfuse services using credentials stored in repository secrets.

- **Workflow configuration:**
  * Added `langfuse_public_key`, `langfuse_secret_key`, and `langfuse_host` environment variables to the `jobs:` section in `.github/workflows/strands-command.yml` for Langfuse integration.
  * 
## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
