### PR TITLE
refactor(ci): extract code quality checks into separate workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,39 @@
+name: Code Quality
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+jobs:
+  code-quality:
+    name: Code Quality
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linting
+        run: npm run lint
+
+      - name: Check code formatting
+        run: npm run format:check
+
+      - name: Run type checking
+        run: npm run type-check

--- a/.github/workflows/npm-publish-on-release.yml
+++ b/.github/workflows/npm-publish-on-release.yml
@@ -6,8 +6,15 @@ on:
       - published
 
 jobs:
-  call-test-lint:
-    uses: ./.github/workflows/test-lint.yml
+  call-code-quality:
+    uses: ./.github/workflows/code-quality.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.event.release.target_commitish }}
+
+  call-test:
+    uses: ./.github/workflows/test.yml
     permissions:
       contents: read
     with:
@@ -16,7 +23,8 @@ jobs:
   publish:
     name: Build and publish to NPM
     needs:
-      - call-test-lint
+      - call-code-quality
+      - call-test
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -20,8 +20,15 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
 
-  call-test-lint:
-    uses: ./.github/workflows/test-lint.yml
+  call-code-quality:
+    uses: ./.github/workflows/code-quality.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  call-test:
+    uses: ./.github/workflows/test.yml
     permissions:
       contents: read
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test and Lint
+name: Test
 
 on:
   workflow_call:
@@ -8,8 +8,8 @@ on:
         type: string
 
 jobs:
-  test-lint:
-    name: Test and Lint (Node ${{ matrix.node-version }} on ${{ matrix.os }})
+  test:
+    name: Test (Node ${{ matrix.node-version }} on ${{ matrix.os }})
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
         os: [ubuntu-latest, windows-latest, macos-latest]
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -49,15 +49,6 @@ jobs:
           include-hidden-files: true # needed because the path has a directory starting with a '.'
           retention-days: 4
           if-no-files-found: ignore
-
-      - name: Run linting
-        run: npm run lint
-
-      - name: Check code formatting
-        run: npm run format:check
-
-      - name: Run type checking
-        run: npm run type-check
 
       - name: Build package
         run: npm run build


### PR DESCRIPTION
This avoids running lint, format, and type checks 9 times across the test matrix when once is sufficient.

----

Reasoning: We don't need all of our unit test workflows to fail because linting or type-checking failed; it's a waste of resources and a loss of signal when we could be more fine-grained 

Example run against my main branch: https://github.com/zastrowm/sdk-typescript/pull/36

----

Status checks are expected to be missing, as I changed the names of workflows