### PR TITLE
add sqs arn from secret

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -85,6 +85,7 @@ jobs:
           langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
           langfuse_host: ${{ secrets.LANGFUSE_HOST }}
+          evals_sqs_queue_arn: ${{ secrets.EVALS_SQS_QUEUE_ARN }}
 
   finalize:
     needs: [setup-and-process, execute-readonly-agent]


### PR DESCRIPTION
## Description

This pull request makes a small change to the `.github/workflows/strands-command.yml` workflow by adding a new secret environment variable for use in jobs.

- Added the `evals_sqs_queue_arn` secret as an environment variable to the workflow jobs section to enable access to the SQS queue ARN.
## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
## Testing

How have you tested the change?

- [ ] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
