### PR TITLE
Add sqs arn

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -80,6 +80,7 @@ jobs:
         uses: strands-agents/devtools/strands-command/actions/strands-agent-runner@main
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          sessions_bucket: ${{ secrets.AGENT_SESSIONS_BUCKET }} # Optional. Ideally should be stored in aws secrets
           aws_secrets_manager_secret_id: ${{ secrets.STRANDS_SECRET_ID || 'strands-agent-config' }}
           write_permission: 'false'
 


### PR DESCRIPTION
## Description

This pull request updates the configuration for the `strands-agent-runner` step in the `.github/workflows/strands-command.yml` workflow. The main change is switching from using several individual secrets and session bucket references to using a single AWS Secrets Manager secret for configuration.

Configuration changes:

* Replaced the `sessions_bucket` input with `aws_secrets_manager_secret_id`, which now references the secret ID from AWS Secrets Manager, defaulting to `'strands-agent-config'` if not specified.
* Removed separate `langfuse_public_key`, `langfuse_secret_key`, and `langfuse_host` inputs, consolidating these configurations into the AWS Secrets Manager secret.

## Related Issues
Related PR: https://github.com/strands-agents/devtools/pull/17

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature
Breaking change

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
