### PR TITLE
docs - when to modify package-lock.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,10 @@ When proposing solutions or reviewing code, we reference these principles to gui
    ```bash
    git clone https://github.com/strands-agents/sdk-typescript.git
    cd sdk-typescript
-   npm install
+   npm ci
    ```
+
+   > **Note**: Use `npm ci` for installing dependencies. Use `npm install` only when intentionally adding or updating dependencies. See [Dependency Guidelines](docs/DEPENDENCIES.md) for details.
 
 2. Install Playwright browsers for browser testing:
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -31,3 +31,25 @@ const agent = new Agent({ model, tools: [calculator] })
 ```
 
 Mark peer dependencies as **optional** when not all users need them (e.g., model provider SDKs). Optional peer dependencies must also be added to `devDependencies` for SDK development and testing.
+
+## Package Lock File
+
+The `package-lock.json` file ensures reproducible builds by locking exact dependency versions.
+
+| Command | When to Use |
+|---------|-------------|
+| `npm ci` | Installing dependencies without changes (fresh clone, after pulling, CI pipelines) |
+| `npm install` | Adding, removing, or updating dependencies |
+
+`npm ci` installs exactly what's in the lock file without modifying it, failing if there's a mismatch. This prevents accidental lock file changes.
+
+**When to modify:**
+
+- Adding, removing, or updating dependencies in `package.json`
+- Running `npm audit fix` to patch security vulnerabilities
+
+**Rules:**
+
+1. Never manually edit `package-lock.json` - always use `npm install` or `npm update`
+2. Commit `package-lock.json` changes in the same commit as the corresponding `package.json` changes
+3. If `package-lock.json` has merge conflicts, delete it and run `npm install` to regenerate


### PR DESCRIPTION
## Description
Document rules on when to modify package-lock.json. Currently, package-lock.json is updated unnecessarily in many PRs, which in turn leads to frequent merge conflicts ([example](https://github.com/strands-agents/sdk-typescript/pull/509)).

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
