### PR TITLE
Add AgentInitializedEvent to Hook System

### DIFF
--- a/src/__fixtures__/mock-hook-provider.ts
+++ b/src/__fixtures__/mock-hook-provider.ts
@@ -1,5 +1,6 @@
 import type { HookEvent, HookProvider, HookRegistry } from '../hooks/index.js'
 import {
+  InitializedEvent,
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,
@@ -24,6 +25,7 @@ export class MockHookProvider implements HookProvider {
 
   registerCallbacks(registry: HookRegistry): void {
     const lifecycleEvents: HookEventConstructor[] = [
+      InitializedEvent,
       BeforeInvocationEvent,
       AfterInvocationEvent,
       MessageAddedEvent,

--- a/src/agent/__tests__/agent.hook.test.ts
+++ b/src/agent/__tests__/agent.hook.test.ts
@@ -9,6 +9,7 @@ import {
   BeforeToolCallEvent,
   MessageAddedEvent,
   ModelStreamEventHook,
+  InitializedEvent,
 } from '../../hooks/index.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { MockHookProvider } from '../../__fixtures__/mock-hook-provider.js'
@@ -31,14 +32,15 @@ describe('Agent Hooks Integration', () => {
 
       await agent.invoke('Hi')
 
-      expect(lifecycleProvider.invocations).toHaveLength(6)
+      expect(lifecycleProvider.invocations).toHaveLength(7)
 
-      expect(lifecycleProvider.invocations[0]).toEqual(new BeforeInvocationEvent({ agent: agent }))
-      expect(lifecycleProvider.invocations[1]).toEqual(
-        new MessageAddedEvent({ agent: agent, message: new Message({ role: 'user', content: [new TextBlock('Hi')] }) })
+      expect(lifecycleProvider.invocations[0]).toEqual(new InitializedEvent({ agent }))
+      expect(lifecycleProvider.invocations[1]).toEqual(new BeforeInvocationEvent({ agent }))
+      expect(lifecycleProvider.invocations[2]).toEqual(
+        new MessageAddedEvent({ agent, message: new Message({ role: 'user', content: [new TextBlock('Hi')] }) })
       )
-      expect(lifecycleProvider.invocations[2]).toEqual(new BeforeModelCallEvent({ agent: agent }))
-      expect(lifecycleProvider.invocations[3]).toEqual(
+      expect(lifecycleProvider.invocations[3]).toEqual(new BeforeModelCallEvent({ agent }))
+      expect(lifecycleProvider.invocations[4]).toEqual(
         new AfterModelCallEvent({
           agent,
           stopData: {
@@ -47,13 +49,13 @@ describe('Agent Hooks Integration', () => {
           },
         })
       )
-      expect(lifecycleProvider.invocations[4]).toEqual(
+      expect(lifecycleProvider.invocations[5]).toEqual(
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
         })
       )
-      expect(lifecycleProvider.invocations[5]).toEqual(new AfterInvocationEvent({ agent }))
+      expect(lifecycleProvider.invocations[6]).toEqual(new AfterInvocationEvent({ agent }))
     })
 
     it('fires hooks during stream', async () => {
@@ -63,17 +65,18 @@ describe('Agent Hooks Integration', () => {
 
       await collectIterator(agent.stream('Hi'))
 
-      expect(lifecycleProvider.invocations).toHaveLength(6)
+      expect(lifecycleProvider.invocations).toHaveLength(7)
 
-      expect(lifecycleProvider.invocations[0]).toEqual(new BeforeInvocationEvent({ agent: agent }))
-      expect(lifecycleProvider.invocations[1]).toEqual(
+      expect(lifecycleProvider.invocations[0]).toEqual(new InitializedEvent({ agent }))
+      expect(lifecycleProvider.invocations[1]).toEqual(new BeforeInvocationEvent({ agent }))
+      expect(lifecycleProvider.invocations[2]).toEqual(
         new MessageAddedEvent({
-          agent: agent,
+          agent,
           message: new Message({ role: 'user', content: [new TextBlock('Hi')] }),
         })
       )
-      expect(lifecycleProvider.invocations[2]).toEqual(new BeforeModelCallEvent({ agent: agent }))
-      expect(lifecycleProvider.invocations[3]).toEqual(
+      expect(lifecycleProvider.invocations[3]).toEqual(new BeforeModelCallEvent({ agent }))
+      expect(lifecycleProvider.invocations[4]).toEqual(
         new AfterModelCallEvent({
           agent,
           stopData: {
@@ -82,13 +85,13 @@ describe('Agent Hooks Integration', () => {
           },
         })
       )
-      expect(lifecycleProvider.invocations[4]).toEqual(
+      expect(lifecycleProvider.invocations[5]).toEqual(
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
         })
       )
-      expect(lifecycleProvider.invocations[5]).toEqual(new AfterInvocationEvent({ agent }))
+      expect(lifecycleProvider.invocations[6]).toEqual(new AfterInvocationEvent({ agent }))
     })
   })
 
@@ -103,9 +106,9 @@ describe('Agent Hooks Integration', () => {
       await agent.invoke('Hi')
 
       // Should have all lifecycle events
-      expect(lifecycleProvider.invocations).toHaveLength(6)
-      expect(lifecycleProvider.invocations[0]).toEqual(new BeforeInvocationEvent({ agent }))
-      expect(lifecycleProvider.invocations[5]).toEqual(new AfterInvocationEvent({ agent }))
+      expect(lifecycleProvider.invocations).toHaveLength(7)
+      expect(lifecycleProvider.invocations[1]).toEqual(new BeforeInvocationEvent({ agent }))
+      expect(lifecycleProvider.invocations[6]).toEqual(new AfterInvocationEvent({ agent }))
     })
   })
 
@@ -120,13 +123,13 @@ describe('Agent Hooks Integration', () => {
 
       await agent.invoke('First message')
 
-      // First turn should have: BeforeInvocation, MessageAdded, BeforeModelCall, AfterModelCall, MessageAdded, AfterInvocation
-      expect(lifecycleProvider.invocations).toHaveLength(6)
+      // First turn: InitializedEvent + BeforeInvocation, MessageAdded, BeforeModelCall, AfterModelCall, MessageAdded, AfterInvocation
+      expect(lifecycleProvider.invocations).toHaveLength(7)
 
       await agent.invoke('Second message')
 
-      // Should have 10 events total (6 for each turn)
-      expect(lifecycleProvider.invocations).toHaveLength(12)
+      // Should have 13 events total (7 for first turn + 6 for second turn, no InitializedEvent on second)
+      expect(lifecycleProvider.invocations).toHaveLength(13)
 
       // Filter for just Invocation events to verify they fire for each turn
       const invocationEvents = lifecycleProvider.invocations.filter(

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -30,7 +30,7 @@ import { SlidingWindowConversationManager } from '../conversation-manager/slidin
 import { HookRegistryImplementation } from '../hooks/registry.js'
 import {
   HookEvent,
-  AgentInitializedEvent,
+  InitializedEvent,
   AfterInvocationEvent,
   AfterModelCallEvent,
   AfterToolCallEvent,
@@ -208,7 +208,7 @@ export class Agent implements AgentData {
       })
     )
 
-    await this.hooks.invokeCallbacks(new AgentInitializedEvent({ agent: this }))
+    await this.hooks.invokeCallbacks(new InitializedEvent({ agent: this }))
 
     this._initialized = true
   }

--- a/src/hooks/__tests__/events.test.ts
+++ b/src/hooks/__tests__/events.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
-  AgentInitializedEvent,
+  InitializedEvent,
   AfterInvocationEvent,
   AfterModelCallEvent,
   AfterToolCallEvent,
@@ -16,13 +16,13 @@ import { Agent } from '../../agent/agent.js'
 import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
 import { FunctionTool } from '../../tools/function-tool.js'
 
-describe('AgentInitializedEvent', () => {
+describe('InitializedEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
-    const event = new AgentInitializedEvent({ agent })
+    const event = new InitializedEvent({ agent })
 
     expect(event).toEqual({
-      type: 'agentInitializedEvent',
+      type: 'initializedEvent',
       agent: agent,
     })
     // @ts-expect-error verifying that property is readonly
@@ -31,7 +31,7 @@ describe('AgentInitializedEvent', () => {
 
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
-    const event = new AgentInitializedEvent({ agent })
+    const event = new InitializedEvent({ agent })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 })

--- a/src/hooks/__tests__/registry.test.ts
+++ b/src/hooks/__tests__/registry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { HookRegistryImplementation } from '../registry.js'
-import { AfterInvocationEvent, AgentInitializedEvent, BeforeInvocationEvent } from '../events.js'
+import { AfterInvocationEvent, BeforeInvocationEvent } from '../events.js'
 import type { HookProvider } from '../types.js'
 import { Agent } from '../../agent/agent.js'
 
@@ -19,15 +19,6 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, callback)
 
       await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
-
-      expect(callback).toHaveBeenCalledOnce()
-    })
-
-    it('registers callback for AgentInitializedEvent', async () => {
-      const callback = vi.fn()
-      registry.addCallback(AgentInitializedEvent, callback)
-
-      await registry.invokeCallbacks(new AgentInitializedEvent({ agent: mockAgent }))
 
       expect(callback).toHaveBeenCalledOnce()
     })

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -23,8 +23,8 @@ export abstract class HookEvent {
  * Event triggered when an agent has finished initialization.
  * Fired after the agent has been fully constructed and all built-in components have been initialized.
  */
-export class AgentInitializedEvent extends HookEvent {
-  readonly type = 'agentInitializedEvent' as const
+export class InitializedEvent extends HookEvent {
+  readonly type = 'initializedEvent' as const
   readonly agent: AgentData
 
   constructor(data: { agent: AgentData }) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,7 +8,7 @@
 // Event classes
 export {
   HookEvent,
-  AgentInitializedEvent,
+  InitializedEvent,
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ export type { AgentStreamEvent } from './types/agent.js'
 export {
   HookRegistry,
   HookEvent,
+  InitializedEvent,
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds AgentInitializedEvent to the TypeScript SDK hook system to enable SessionManager and other hooks to respond to agent initialization. This event fires after the agent has been fully constructed and all built-in components have been initialized.

## Follow up

yielding this event in *stream. 

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-typescript/issues/511

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
