### PR TITLE
fix: rename event loop to agent loop

### DIFF
--- a/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -81,7 +81,7 @@ export class SlidingWindowConversationManager implements HookProvider {
   /**
    * Apply the sliding window to the messages array to maintain a manageable history size.
    *
-   * This method is called after every event loop cycle to apply a sliding window if the message
+   * This method is called after every agent loop cycle to apply a sliding window if the message
    * count exceeds the window size. If the number of messages is within the window size, no action
    * is taken.
    *

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -170,7 +170,7 @@ export interface InvokableTool<TInput, TReturn> extends Tool {
 /**
  * Creates an error ToolResultBlock from an error object.
  * Ensures all errors are normalized to Error objects and includes the original error
- * in the ToolResultBlock for inspection by hooks, error handlers, and event loop.
+ * in the ToolResultBlock for inspection by hooks, error handlers, and agent loop.
  *
  * TODO: Implement consistent logging format as defined in #30
  * This error should be logged to the caller using the established logging pattern.

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -298,7 +298,7 @@ export interface ToolResultBlockData {
 
   /**
    * The original error object when status is 'error'.
-   * Available for inspection by hooks, error handlers, and event loop.
+   * Available for inspection by hooks, error handlers, and agent loop.
    * Tools must wrap non-Error thrown values into Error objects.
    */
   error?: Error
@@ -330,7 +330,7 @@ export class ToolResultBlock implements ToolResultBlockData, JSONSerializable<{ 
 
   /**
    * The original error object when status is 'error'.
-   * Available for inspection by hooks, error handlers, and event loop.
+   * Available for inspection by hooks, error handlers, and agent loop.
    * Tools must wrap non-Error thrown values into Error objects.
    */
   readonly error?: Error


### PR DESCRIPTION
## Description
- The team decided in Typescript going forward that we would abide by 'agent loop' naming
- I am implementing metrics using the 'agent loop' naming convention and wanted to clean this up for parity before metrics PRs

Bug fix

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
