### PR TITLE
feat(agent): add generic type parameter to AgentState.getAll()

### DIFF
--- a/src/agent/__tests__/state.test.ts
+++ b/src/agent/__tests__/state.test.ts
@@ -302,6 +302,19 @@ describe('AgentState', () => {
       const state = new AgentState()
       expect(state.getAll()).toEqual({})
     })
+
+    it('supports typed usage with generic state interface', () => {
+      interface MyState extends Record<string, number | string> {
+        count: number
+        name: string
+      }
+
+      const state = new AgentState({ count: 10, name: 'test' })
+      const result = state.getAll<MyState>()
+
+      expect(result.count).toBe(10)
+      expect(result.name).toBe('test')
+    })
   })
 
   describe('keys', () => {

--- a/src/agent/state.ts
+++ b/src/agent/state.ts
@@ -124,8 +124,20 @@ export class AgentState implements StateSerializable {
   /**
    * Get a copy of all state as an object.
    *
+   * @typeParam TState - Optional state interface type for typed returns
    * @returns Deep copy of all state
+   *
+   * @example
+   * ```typescript
+   * // Typed usage
+   * const all = state.getAll<AppState>()   // AppState
+   *
+   * // Untyped usage
+   * const raw = state.getAll()             // Record<string, JSONValue>
+   * ```
    */
+  getAll<TState extends Record<string, JSONValue>>(): TState
+  getAll(): Record<string, JSONValue>
   getAll(): Record<string, JSONValue> {
     return deepCopy(this._state) as Record<string, JSONValue>
   }


### PR DESCRIPTION
The get, set, and delete methods all accept a <TState> generic for type-safe state access, but getAll() forced callers to use `as` casts. This adds a generic overload so callers can opt into a narrower return type (e.g. state.getAll<AppState>()) without a cast, while the unparameterized overload continues to return Record<string, JSONValue>.

No runtime behavior changes.

## Description

Adds a generic overload to `AgentState.getAll()` matching the existing pattern on `get`, `set`, and `delete`. Callers can now write `state.getAll<MyState>()` instead of `state.getAll() as MyState`. The `extends Record<string, JSONValue>` constraint ensures only compatible types can be asserted. The unparameterized `getAll()` overload continues to return `Record<string, JSONValue>` — no breaking changes.

## Related Issues

None

## Documentation PR

None — no new public API surface, just an additional overload on an existing method.

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.