### PR TITLE
test: add structured output integration tests

### DIFF
--- a/test/integ/agent.test.ts
+++ b/test/integ/agent.test.ts
@@ -520,31 +520,6 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
         expect(result.structuredOutput).toStrictEqual({ answer: 4 })
       })
 
-      it('returns typed result matching zod schema', async () => {
-        const schema = z.object({
-          city: z.string(),
-          country: z.string(),
-          population_millions: z.number(),
-        })
-
-        const agent = new Agent({
-          model: createModel(),
-          structuredOutputSchema: schema,
-          printer: false,
-        })
-
-        const result = await agent.invoke('What is the capital of France? Include approximate population in millions.')
-
-        expect(result.stopReason).toBe('endTurn')
-        expect(result.structuredOutput).toBeDefined()
-
-        const output = result.structuredOutput as z.infer<typeof schema>
-        expect(typeof output.city).toBe('string')
-        expect(typeof output.country).toBe('string')
-        expect(typeof output.population_millions).toBe('number')
-        expect(output.city).toMatch(/Paris/i)
-      })
-
       it('returns structured output via streaming', async () => {
         const schema = z.object({
           animal: z.string(),

--- a/test/integ/agent.test.ts
+++ b/test/integ/agent.test.ts
@@ -519,6 +519,53 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
 
         expect(result.structuredOutput).toStrictEqual({ answer: 4 })
       })
+
+      it('returns typed result matching zod schema', async () => {
+        const schema = z.object({
+          city: z.string(),
+          country: z.string(),
+          population_millions: z.number(),
+        })
+
+        const agent = new Agent({
+          model: createModel(),
+          structuredOutputSchema: schema,
+          printer: false,
+        })
+
+        const result = await agent.invoke('What is the capital of France? Include approximate population in millions.')
+
+        expect(result.stopReason).toBe('endTurn')
+        expect(result.structuredOutput).toBeDefined()
+
+        const output = result.structuredOutput as z.infer<typeof schema>
+        expect(typeof output.city).toBe('string')
+        expect(typeof output.country).toBe('string')
+        expect(typeof output.population_millions).toBe('number')
+        expect(output.city).toMatch(/Paris/i)
+      })
+
+      it('returns structured output via streaming', async () => {
+        const schema = z.object({
+          animal: z.string(),
+          legs: z.number(),
+        })
+
+        const agent = new Agent({
+          model: createModel(),
+          structuredOutputSchema: schema,
+          printer: false,
+        })
+
+        const { result } = await collectGenerator(agent.stream('Describe a cat with number of legs.'))
+
+        expect(result.stopReason).toBe('endTurn')
+        expect(result.structuredOutput).toBeDefined()
+
+        const output = result.structuredOutput as z.infer<typeof schema>
+        expect(typeof output.animal).toBe('string')
+        expect(typeof output.legs).toBe('number')
+      })
     })
 
     it.skipIf(!supports.reasoning)('emits reasoning content with thinking model', async () => {
@@ -605,53 +652,5 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
       await collectGenerator(agent.stream('What was the result?'))
     })
 
-    describe.skipIf(!supports.tools)('Structured Output', () => {
-      it('returns typed result matching zod schema', async () => {
-        const schema = z.object({
-          city: z.string(),
-          country: z.string(),
-          population_millions: z.number(),
-        })
-
-        const agent = new Agent({
-          model: createModel(),
-          structuredOutputSchema: schema,
-          printer: false,
-        })
-
-        const result = await agent.invoke('What is the capital of France? Include approximate population in millions.')
-
-        expect(result.stopReason).toBe('endTurn')
-        expect(result.structuredOutput).toBeDefined()
-
-        const output = result.structuredOutput as z.infer<typeof schema>
-        expect(typeof output.city).toBe('string')
-        expect(typeof output.country).toBe('string')
-        expect(typeof output.population_millions).toBe('number')
-        expect(output.city).toMatch(/Paris/i)
-      })
-
-      it('returns structured output via streaming', async () => {
-        const schema = z.object({
-          animal: z.string(),
-          legs: z.number(),
-        })
-
-        const agent = new Agent({
-          model: createModel(),
-          structuredOutputSchema: schema,
-          printer: false,
-        })
-
-        const { result } = await collectGenerator(agent.stream('Describe a cat with number of legs.'))
-
-        expect(result.stopReason).toBe('endTurn')
-        expect(result.structuredOutput).toBeDefined()
-
-        const output = result.structuredOutput as z.infer<typeof schema>
-        expect(typeof output.animal).toBe('string')
-        expect(typeof output.legs).toBe('number')
-      })
-    })
   })
 })

--- a/test/integ/agent.test.ts
+++ b/test/integ/agent.test.ts
@@ -604,5 +604,54 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
       // Validate multi-turn works after built-in tool use
       await collectGenerator(agent.stream('What was the result?'))
     })
+
+    describe.skipIf(!supports.tools)('Structured Output', () => {
+      it('returns typed result matching zod schema', async () => {
+        const schema = z.object({
+          city: z.string(),
+          country: z.string(),
+          population_millions: z.number(),
+        })
+
+        const agent = new Agent({
+          model: createModel(),
+          structuredOutputSchema: schema,
+          printer: false,
+        })
+
+        const result = await agent.invoke('What is the capital of France? Include approximate population in millions.')
+
+        expect(result.stopReason).toBe('endTurn')
+        expect(result.structuredOutput).toBeDefined()
+
+        const output = result.structuredOutput as z.infer<typeof schema>
+        expect(typeof output.city).toBe('string')
+        expect(typeof output.country).toBe('string')
+        expect(typeof output.population_millions).toBe('number')
+        expect(output.city).toMatch(/Paris/i)
+      })
+
+      it('returns structured output via streaming', async () => {
+        const schema = z.object({
+          animal: z.string(),
+          legs: z.number(),
+        })
+
+        const agent = new Agent({
+          model: createModel(),
+          structuredOutputSchema: schema,
+          printer: false,
+        })
+
+        const { result } = await collectGenerator(agent.stream('Describe a cat with number of legs.'))
+
+        expect(result.stopReason).toBe('endTurn')
+        expect(result.structuredOutput).toBeDefined()
+
+        const output = result.structuredOutput as z.infer<typeof schema>
+        expect(typeof output.animal).toBe('string')
+        expect(typeof output.legs).toBe('number')
+      })
+    })
   })
 })


### PR DESCRIPTION
## Description

Add integration tests for structured output with Zod schemas, validating the feature works end-to-end with real model providers.

## Changes

- Test typed result matching Zod schema via `agent.invoke()`
- Test structured output via streaming with `agent.stream()`
- Validates schema fields (string, number) and content correctness

## Testing

- 2 new integration tests added to `test/integ/agent.test.ts`
- All existing tests pass