### PR TITLE
feat: structured output - per invocation override

### DIFF
--- a/src/agent/__tests__/agent.test.ts
+++ b/src/agent/__tests__/agent.test.ts
@@ -1057,6 +1057,35 @@ describe('Agent', () => {
 
       expect(result.structuredOutput).toEqual({ items: ['a', 'b', 'c'] })
     })
+
+    it('uses per-invocation override schema and restores constructor schema on next call', async () => {
+      const constructorSchema = z.object({ name: z.string() })
+      const overrideSchema = z.object({ value: z.number() })
+
+      const model = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'strands_structured_output',
+          toolUseId: 'tool-1',
+          input: { value: 99 },
+        })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'strands_structured_output',
+          toolUseId: 'tool-2',
+          input: { name: 'Bob' },
+        })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const agent = new Agent({ model, structuredOutputSchema: constructorSchema })
+
+      const first = await agent.invoke('First', { structuredOutputSchema: overrideSchema })
+      expect(first.structuredOutput).toEqual({ value: 99 })
+
+      const second = await agent.invoke('Second')
+      expect(second.structuredOutput).toEqual({ name: 'Bob' })
+    })
   })
 })
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -149,6 +149,16 @@ export type AgentConfig = {
  */
 export type InvokeArgs = string | ContentBlock[] | ContentBlockData[] | Message[] | MessageData[]
 
+/**
+ * Options for a single agent invocation.
+ */
+export interface InvokeOptions {
+  /**
+   * Zod schema for structured output validation, overriding the constructor-provided schema for this invocation only.
+   */
+  structuredOutputSchema?: z.ZodSchema
+}
+
 /** Fallback name used when no agent name is provided in the config. */
 const DEFAULT_AGENT_NAME = 'Strands Agent'
 
@@ -315,6 +325,7 @@ export class Agent implements AgentData {
    * streaming events.
    *
    * @param args - Arguments for invoking the agent
+   * @param options - Optional per-invocation options
    * @returns Promise that resolves to the final AgentResult
    *
    * @example
@@ -324,8 +335,8 @@ export class Agent implements AgentData {
    * console.log(result.lastMessage) // Agent's response
    * ```
    */
-  public async invoke(args: InvokeArgs): Promise<AgentResult> {
-    const gen = this.stream(args)
+  public async invoke(args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+    const gen = this.stream(args, options)
     let result = await gen.next()
     while (!result.done) {
       result = await gen.next()
@@ -350,6 +361,7 @@ export class Agent implements AgentData {
    * with valid toolResponses
    *
    * @param args - Arguments for invoking the agent
+   * @param options - Optional per-invocation options
    * @returns Async generator that yields AgentStreamEvent objects and returns AgentResult
    *
    * @example
@@ -362,13 +374,16 @@ export class Agent implements AgentData {
    * // Messages array is mutated in place and contains the full conversation
    * ```
    */
-  public async *stream(args: InvokeArgs): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
+  public async *stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     using _lock = this.acquireLock()
 
     await this.initialize()
 
     // Delegate to _stream and process events through printer and hooks
-    const streamGenerator = this._stream(args)
+    const streamGenerator = this._stream(args, options)
     let result = await streamGenerator.next()
 
     while (!result.done) {
@@ -399,15 +414,19 @@ export class Agent implements AgentData {
    * Separated to centralize printer event processing in the public stream method.
    *
    * @param args - Arguments for invoking the agent
+   * @param options - Optional per-invocation options
    * @returns Async generator that yields AgentStreamEvent objects and returns AgentResult
    */
-  private async *_stream(args: InvokeArgs): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
+  private async *_stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     let currentArgs: InvokeArgs | undefined = args
     let forcedToolChoice: ToolChoice | undefined = undefined
     let result: AgentResult | undefined
 
     // Create structured output context (uses null object pattern when no schema)
-    const schema = this._structuredOutputSchema
+    const schema = options?.structuredOutputSchema ?? this._structuredOutputSchema
     const context = createStructuredOutputContext(schema)
 
     // Emit event before the try block


### PR DESCRIPTION
## Motivation

Swarm orchestration will use structured output to drive handoff decisions between agents — each agent produces a structured handoff result (`agentName`, `message`, `context`) that determines routing. To inject this handoff schema per invocation without overwriting the agent's own constructor-level schema, the Agent needs to accept a structured output schema override at call time.

This interface change aligns with the Python SDK, which already supports per-invocation `structured_output_model` via `Agent.__call__()`.

Related to: #392 and #549

## Public API Changes

`Agent.invoke()` and `Agent.stream()` now accept an optional second parameter for per-invocation options:

```typescript
const agent = new Agent({
  model,
  structuredOutputSchema: defaultSchema,
})

// Override structured output schema for a single invocation
const result = await agent.invoke('Analyze this', {
  structuredOutputSchema: overrideSchema,
})

// Next invocation uses the constructor schema again
const result2 = await agent.invoke('Follow up')
```

The `InvokeOptions` interface currently supports:

```typescript
interface InvokeOptions {
  structuredOutputSchema?: z.ZodSchema
}
```

The change is backward compatible — all existing single-argument usage continues to work without modification.

## Documentation PR

Will coordinate with @mehtarac who is documenting structured output for TypeScript.

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
