### PR TITLE
fix: remove circular import of barrel index.js in agent.ts

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,24 +1,22 @@
+import { AgentResult, type AgentStreamEvent } from '../types/agent.js'
+import { BedrockModel } from '../models/bedrock.js'
 import {
-  AgentResult,
-  type AgentStreamEvent,
-  BedrockModel,
   contentBlockFromData,
   type ContentBlock,
   type ContentBlockData,
-  type JSONValue,
-  McpClient,
   Message,
   type MessageData,
   type StopReason,
   type SystemPrompt,
   type SystemPromptData,
   TextBlock,
-  type Tool,
-  type ToolChoice,
-  type ToolContext,
   ToolResultBlock,
   ToolUseBlock,
-} from '../index.js'
+} from '../types/messages.js'
+import type { JSONValue } from '../types/json.js'
+import { McpClient } from '../mcp.js'
+import { type Tool, type ToolContext } from '../tools/tool.js'
+import type { ToolChoice } from '../tools/types.js'
 import { systemPromptFromData } from '../types/messages.js'
 import { normalizeError, ConcurrentInvocationError, MaxTokensError } from '../errors.js'
 import { Model } from '../models/model.js'


### PR DESCRIPTION
## Description

agent.ts was importing from ../index.js which is the main export. Since index.ts re-exports Agent, this created a cycle: `index.ts -> agent.ts -> index.ts`

Replace with direct imports from the canonical source modules.

This came as a result of #569 which was using a separate export because of the circular import.  This worked today only because Node/TypeScript's module system handles same-package cycles at runtime, but it's the root cause of why adding session to index.ts breaks things.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Documentation

Internal refactor only - no public API changes

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
