### PR TITLE
test: remove color assertions from image/video integ tests

### DIFF
--- a/test/integ/agent.test.ts
+++ b/test/integ/agent.test.ts
@@ -182,7 +182,6 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
         const textContent = result.lastMessage.content.find((block) => block.type === 'textBlock')
         expect(textContent).toBeDefined()
         expect(textContent?.text).toMatch(/zebra/i)
-        expect(textContent?.text).toMatch(/yellow/i)
       })
 
       it('processes PDF document input correctly', async () => {
@@ -260,7 +259,6 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
       expect(result.stopReason).toBe('endTurn')
       const textContent = result.lastMessage.content.find((block) => block.type === 'textBlock')
       expect(textContent).toBeDefined()
-      expect(textContent?.text).toMatch(/yellow/i)
     })
 
     describe.skipIf(!supports.citations)('Citations', () => {
@@ -405,7 +403,6 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
 
         const textContent = result.lastMessage.content.find((block) => block.type === 'textBlock')
         expect(textContent).toBeDefined()
-        expect(textContent?.text).toMatch(/yellow/i)
       })
 
       it('accepts Message[] input for conversation history', async () => {


### PR DESCRIPTION
## Motivation

Integration tests for image and video recognition fail intermittently because AI models cannot reliably identify colors in visual content.

One example here: https://github.com/strands-agents/sdk-typescript/actions/runs/22778020835/job/66077097725

## Changes

Removed `/yellow/i` assertions from three integration tests:
- `handles video input` - video color detection is non-deterministic
- `accepts ContentBlock[] input` - image color detection is non-deterministic  
- `handles multiple media blocks in single request` - image color detection is non-deterministic

## What's Preserved

- All API response structure checks (`stopReason`, `role`, `textContent` existence)
- Document text extraction assertions (`/zebra/i`) since text parsing is consistent
- Test coverage for multimodal input handling

Resolves #608