### PR TITLE
fix: remove deprecated eslint-env comments incompatible with flat config

### DIFF
--- a/src/vended-tools/bash/bash.ts
+++ b/src/vended-tools/bash/bash.ts
@@ -1,4 +1,3 @@
-/* eslint-env node */
 import { tool } from '../../tools/zod-tool.js'
 import { z } from 'zod'
 import { spawn, type ChildProcess } from 'child_process'

--- a/src/vended-tools/http_request/http-request.ts
+++ b/src/vended-tools/http_request/http-request.ts
@@ -1,4 +1,3 @@
-/* eslint-env browser, node */
 import { tool } from '../../tools/zod-tool.js'
 import { z } from 'zod'
 


### PR DESCRIPTION
## Description
### Motivation
ESLint v10 will error on /* eslint-env */ configuration comments when using flat config. Our two vended tool files (bash.ts and http-request.ts) still had these legacy comments from the eslintrc era, producing deprecation warnings on every lint run.

The comments were redundant since our eslint.config.js already defines the necessary globals (process, console) in the sdkRules config, and http-request.ts accesses browser/node APIs through globalThis rather than bare globals.

### Public API Changes
No public API changes.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Build bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
