### PR TITLE
feat: add MessageUpdatedEvent and session manager subscription

### DIFF
--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -142,6 +142,24 @@ export class MessageAddedEvent extends HookableEvent {
 }
 
 /**
+ * Event triggered when a message in the conversation history is updated.
+ * Fired when a message is modified after being added to the conversation.
+ */
+export class MessageUpdatedEvent extends HookableEvent {
+  readonly type = 'messageUpdatedEvent' as const
+  readonly agent: AgentData
+  readonly message: Message
+  readonly index: number
+
+  constructor(data: { agent: AgentData; message: Message; index: number }) {
+    super()
+    this.agent = data.agent
+    this.message = data.message
+    this.index = data.index
+  }
+}
+
+/**
  * Event triggered just before a tool is executed.
  * Fired after tool lookup but before execution begins.
  */

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,6 +21,7 @@ export {
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,
+  MessageUpdatedEvent,
   BeforeToolCallEvent,
   AfterToolCallEvent,
   BeforeModelCallEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,7 @@ export {
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,
+  MessageUpdatedEvent,
   BeforeToolCallEvent,
   AfterToolCallEvent,
   BeforeModelCallEvent,

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -2,7 +2,7 @@ import type { SnapshotStorage, SnapshotLocation } from './storage.js'
 import type { SnapshotTriggerCallback } from './types.js'
 import type { HookProvider } from '../hooks/index.js'
 import type { HookRegistry } from '../hooks/registry.js'
-import { AfterInvocationEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
+import { AfterInvocationEvent, InitializedEvent, MessageAddedEvent, MessageUpdatedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
 import type { Agent } from '../agent/agent.js'
 import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
@@ -75,6 +75,9 @@ export class SessionManager implements HookProvider {
       registry.addCallback(MessageAddedEvent, async (event) => {
         await this._onMessageAdded(event)
       })
+      registry.addCallback(MessageUpdatedEvent, async (event) => {
+        await this._onMessageUpdated(event)
+      })
     }
     registry.addCallback(AfterInvocationEvent, async (event) => {
       await this._onAfterAgentInvocation(event)
@@ -127,6 +130,11 @@ export class SessionManager implements HookProvider {
   }
 
   private async _onMessageAdded(event: MessageAddedEvent): Promise<void> {
+    const agent = event.agent as Agent
+    await this.saveSnapshot({ target: agent, isLatest: true })
+  }
+
+  private async _onMessageUpdated(event: MessageUpdatedEvent): Promise<void> {
     const agent = event.agent as Agent
     await this.saveSnapshot({ target: agent, isLatest: true })
   }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -10,6 +10,7 @@ import type {
   BeforeToolCallEvent,
   AfterToolCallEvent,
   MessageAddedEvent,
+  MessageUpdatedEvent,
   ModelStreamUpdateEvent,
   ContentBlockEvent,
   ModelMessageEvent,
@@ -123,4 +124,5 @@ export type AgentStreamEvent =
   | BeforeToolCallEvent
   | AfterToolCallEvent
   | MessageAddedEvent
+  | MessageUpdatedEvent
   | AgentResultEvent


### PR DESCRIPTION
## Summary

Adds  for tracking message modifications in conversation history. This is a dependency to the upcoming guardrail feature.

## Changes

- **MessageUpdatedEvent**: New event fired when a message is updated after being added
  - Properties: , , 
  - Exported in hooks/index.ts, src/index.ts, and AgentStreamEvent union
- **SessionManager**: Subscribes to MessageUpdatedEvent when  to persist message updates

## Context: Guardrails Feature (Split from PR #573)

**This PR (Part 1)**: Message update infrastructure
- Provides event hooks for message modifications
- Ensures session persistence for updated messages

**Part 2 (upcoming)**: Guardrails implementation
- ModelRedactContentEvent for redaction signaling
- Guardrail configuration in BedrockModel
- Agent-layer redaction logic using MessageUpdatedEvent

Split rationale: Separates reusable event infrastructure from guardrails-specific implementation for clearer review and incremental testing.

## Documentation Changes
TODO