### PR TITLE
feat(swarm): add maxHandoffs to SwarmConfig

### DIFF
--- a/src/multiagent/swarm.ts
+++ b/src/multiagent/swarm.ts
@@ -29,6 +29,8 @@ import {
 export interface SwarmConfig {
   /** Max total agent executions (including start). Defaults to Infinity. */
   maxSteps?: number
+  /** Max transitions to a different agent. Defaults to Infinity. */
+  maxHandoffs?: number
 }
 
 /**
@@ -110,6 +112,7 @@ export class Swarm implements MultiAgentBase {
 
     this.config = {
       maxSteps: Infinity,
+      maxHandoffs: Infinity,
       ...config,
     }
     this._validateConfig()
@@ -181,6 +184,7 @@ export class Swarm implements MultiAgentBase {
 
     let node = this._start
     let handoff: HandoffResult | undefined
+    let handoffCount = 0
 
     try {
       while (state.steps < this.config.maxSteps) {
@@ -198,6 +202,10 @@ export class Swarm implements MultiAgentBase {
 
         // Hand off to next agent
         const target = this._nodes.get(handoff.agentId)!
+        if (target.id !== node.id) handoffCount++
+        if (handoffCount > this.config.maxHandoffs) {
+          throw new Error(`max_handoffs=<${this.config.maxHandoffs}> | swarm reached handoff limit`)
+        }
         yield new MultiAgentHandoffEvent({ source: node.id, targets: [target.id] })
         logger.debug(`source=<${node.id}>, target=<${target.id}> | swarm handoff`)
         node = target


### PR DESCRIPTION
## Summary

Adds `maxHandoffs` to `SwarmConfig`, defaulting to `Infinity` (no limit).

## Motivation

The Python SDK distinguishes between:
- `max_handoffs` — transitions to a *different* agent
- `max_iterations` — total node executions (including same-agent re-runs)

The TypeScript SDK collapsed both into `maxSteps` (total executions). This PR restores `maxHandoffs` as a separate limit.

## Behaviour

- `maxHandoffs` increments only when the target agent differs from the current agent — same-agent re-executions don't count
- `maxSteps` continues to count all executions as before
- Both default to `Infinity` — no breaking change

## Related

- Graph equivalent: #594
- Depends on: #606 (merged)