### PR TITLE
fix: use source import for Agent in swarm integ tests

### DIFF
--- a/test/integ/multiagent/swarm.test.ts
+++ b/test/integ/multiagent/swarm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Agent } from '@strands-agents/sdk'
+import { Agent } from '$/sdk/agent/agent.js'
 import { Swarm, Status } from '$/sdk/multiagent/index.js'
 import { collectGenerator } from '$/sdk/__fixtures__/model-test-helpers.js'
 import { bedrock } from '../__fixtures__/model-providers.js'


### PR DESCRIPTION
## Motivation

The swarm integration tests import `Agent` from the compiled package (`@strands-agents/sdk`) while importing `Swarm` from source (`$/sdk/multiagent/index.js`). Because these resolve to different class identities, the `instanceof Agent` check in `Swarm._resolveNodes` fails — the agent is treated as `AgentNodeOptions` instead, destructuring yields `agent: undefined`, and the constructor crashes with `Cannot read properties of undefined (reading 'agentId')`.

This was introduced in #606 when the swarm feature landed.

## Public API Changes

No public API changes. This is a test-only fix aligning the `Agent` import to use the source path (`$/sdk/agent/agent.js`), consistent with how `Swarm` and other test utilities are already imported.