### PR TITLE
feat: introduce bedrock guardrail redaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
+        "@aws-sdk/client-bedrock": "^3.943.0",
         "@aws-sdk/client-s3": "^3.943.0",
         "@aws-sdk/client-secrets-manager": "^3.943.0",
         "@aws-sdk/client-sts": "^3.996.0",
@@ -304,6 +305,58 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock": {
+      "version": "3.1005.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1005.0.tgz",
+      "integrity": "sha512-OHEGbCdSHr/Euig7dt3xDev5b8+Xpiy9pSfSovx9pvhJXrI2nXrVUPYenMXJ2dNy1VbeYJA51D70v3y+jAb/dA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/credential-provider-node": "^3.972.19",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/token-providers": "3.1005.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1000.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1000.0.tgz",
@@ -356,6 +409,25 @@
         "@smithy/util-retry": "^4.2.10",
         "@smithy/util-stream": "^4.5.15",
         "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1005.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1005.0.tgz",
+      "integrity": "sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -583,23 +655,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.17.tgz",
-      "integrity": "sha512-VtgGP0TjbCeyp6DQpiBqJKbemTSIaN2bZc3UbeTDCani3lBCyxn75ouJYD6koSSp0bh7rKLEbUpiFsNCI7tr0w==",
+      "version": "3.973.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.19.tgz",
+      "integrity": "sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/xml-builder": "^3.972.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/signature-v4": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -638,14 +710,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.15.tgz",
-      "integrity": "sha512-RhHQG1lhkWHL4tK1C/KDjaOeis+9U0tAMnWDiwiSVQZMC7CsST9Xin+sK89XywJ5g/tyABtb7TvFePJ4Te5XSQ==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.17.tgz",
+      "integrity": "sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -654,20 +726,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.17.tgz",
-      "integrity": "sha512-b/bDL76p51+yQ+0O9ZDH5nw/ioE0sRYkjwjOwFWAWZXo6it2kQZUOXhVpjohx3ldKyUxt/SwAivjUu1Nr/PWlQ==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.19.tgz",
+      "integrity": "sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/fetch-http-handler": "^5.3.12",
-        "@smithy/node-http-handler": "^4.4.13",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.16",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -675,23 +747,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.15.tgz",
-      "integrity": "sha512-qWnM+wB8MmU2kKY7f4KowKjOjkwRosaFxrtseEEIefwoXn1SjN+CbHzXBVdTAQxxkbBiqhPgJ/WHiPtES4grRQ==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.18.tgz",
+      "integrity": "sha512-vthIAXJISZnj2576HeyLBj4WTeX+I7PwWeRkbOa0mVX39K13SCGxCgOFuKj2ytm9qTlLOmXe4cdEnroteFtJfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/credential-provider-env": "^3.972.15",
-        "@aws-sdk/credential-provider-http": "^3.972.17",
-        "@aws-sdk/credential-provider-login": "^3.972.15",
-        "@aws-sdk/credential-provider-process": "^3.972.15",
-        "@aws-sdk/credential-provider-sso": "^3.972.15",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/credential-provider-env": "^3.972.17",
+        "@aws-sdk/credential-provider-http": "^3.972.19",
+        "@aws-sdk/credential-provider-login": "^3.972.18",
+        "@aws-sdk/credential-provider-process": "^3.972.17",
+        "@aws-sdk/credential-provider-sso": "^3.972.18",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.18",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -700,17 +772,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.15.tgz",
-      "integrity": "sha512-x92FJy34/95wgu+qOGD8SHcgh1hZ9Qx2uFtQEGn4m9Ljou8ICIv3Ybq5yxdB7A60S8ZGCQB0mIopmjJwiLbh5g==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.18.tgz",
+      "integrity": "sha512-kINzc5BBxdYBkPZ0/i1AMPMOk5b5QaFNbYMElVw5QTX13AKj6jcxnv/YNl9oW9mg+Y08ti19hh01HhyEAxsSJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -719,21 +791,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.16.tgz",
-      "integrity": "sha512-7mlt14Ee4rPFAFUVgpWE7+0CBhetJJyzVFqfIsMp7sgyOSm9Y/+qHZOWAuK5I4JNc+Y5PltvJ9kssTzRo92iXQ==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.19.tgz",
+      "integrity": "sha512-yDWQ9dFTr+IMxwanFe7+tbN5++q8psZBjlUwOiCXn1EzANoBgtqBwcpYcHaMGtn0Wlfj4NuXdf2JaEx1lz5RaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.15",
-        "@aws-sdk/credential-provider-http": "^3.972.17",
-        "@aws-sdk/credential-provider-ini": "^3.972.15",
-        "@aws-sdk/credential-provider-process": "^3.972.15",
-        "@aws-sdk/credential-provider-sso": "^3.972.15",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/credential-provider-env": "^3.972.17",
+        "@aws-sdk/credential-provider-http": "^3.972.19",
+        "@aws-sdk/credential-provider-ini": "^3.972.18",
+        "@aws-sdk/credential-provider-process": "^3.972.17",
+        "@aws-sdk/credential-provider-sso": "^3.972.18",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -742,15 +814,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.15.tgz",
-      "integrity": "sha512-PrH3iTeD18y/8uJvQD2s/T87BTGhsdS/1KZU7ReWHXsplBwvCqi7AbnnNbML1pFlQwRWCE2RdSZFWDVId3CvkA==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.17.tgz",
+      "integrity": "sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -759,17 +831,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.15.tgz",
-      "integrity": "sha512-M/+LBHTPKZxxXckM6m4dnJeR+jlm9NynH9b2YDswN4Zj2St05SK/crdL3Wy3WfJTZootnnhm3oTh87Usl7PS7w==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.18.tgz",
+      "integrity": "sha512-YHYEfj5S2aqInRt5ub8nDOX8vAxgMvd84wm2Y3WVNfFa/53vOv9T7WOAqXI25qjj3uEcV46xxfqdDQk04h5XQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/token-providers": "3.1002.0",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/token-providers": "3.1005.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -778,16 +850,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1002.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1002.0.tgz",
-      "integrity": "sha512-x972uKOydFn4Rb0PZJzLdNW59rH0KWC78Q2JbQzZpGlGt0DxjYdDRwBG6F42B1MyaEwHGqO/tkGc4r3/PRFfMw==",
+      "version": "3.1005.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1005.0.tgz",
+      "integrity": "sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -796,16 +868,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.15.tgz",
-      "integrity": "sha512-QTH6k93v+UOfFam/ado8zc71tH+enTVyuvLy9uEWXX1x894dN5ovtf/MdBDgFwq3g6c9mbtgVJ4B+yBqDtXvdA==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.18.tgz",
+      "integrity": "sha512-OqlEQpJ+J3T5B96qtC1zLLwkBloechP+fezKbCH0sbd2cCc0Ra55XpxWpk/hRj69xAOYtHvoC4orx6eTa4zU7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -937,13 +1009,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
-      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/protocol-http": "^5.3.10",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -967,12 +1039,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
-      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.5",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -981,14 +1053,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
-      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.5",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -1038,17 +1110,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.17.tgz",
-      "integrity": "sha512-HHArkgWzomuwufXwheQqkddu763PWCpoNTq1dGjqXzJT/lojX3VlOqjNSR2Xvb6/T9ISfwYcMOcbFgUp4EWxXA==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.20.tgz",
+      "integrity": "sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@smithy/core": "^3.23.7",
-        "@smithy/protocol-http": "^5.3.10",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.9",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
+        "@smithy/util-retry": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1079,48 +1152,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.5.tgz",
-      "integrity": "sha512-zn0WApcULn7Rtl6T+KP2CQTZo/7wOa2YV1yHQnbijTQoi4YXQHM8s21JcJzt33/mqPh8AdvWX1f+83KvKuxlZw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.8.tgz",
+      "integrity": "sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.2",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/fetch-http-handler": "^5.3.12",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.21",
-        "@smithy/middleware-retry": "^4.4.38",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.13",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.37",
-        "@smithy/util-defaults-mode-node": "^4.2.40",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1128,14 +1201,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
-      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/node-config-provider": "^4.3.10",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -1180,9 +1253,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
-      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -1206,15 +1279,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
-      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.5",
         "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1249,26 +1322,26 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
-      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.5",
         "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.2.tgz",
-      "integrity": "sha512-lpaIuekdkpw7VRiik0IZmd6TyvEUcuLgKZ5fKRGpCA3I4PjrD/XH15sSwW+OptxQjNU4DEzSxag70spC9SluvA==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.5.tgz",
+      "integrity": "sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/node-config-provider": "^4.3.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -1285,9 +1358,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
-      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2986,9 +3059,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
-      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
+      "version": "3.23.9",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
+      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.12",
@@ -3125,14 +3198,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.10.tgz",
-      "integrity": "sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
-        "@smithy/util-buffer-from": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3155,9 +3228,9 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.10.tgz",
-      "integrity": "sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3195,12 +3268,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.10.tgz",
-      "integrity": "sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -3209,12 +3282,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.22",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
-      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
+      "version": "4.4.23",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
+      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.8",
+        "@smithy/core": "^3.23.9",
         "@smithy/middleware-serde": "^4.2.12",
         "@smithy/node-config-provider": "^4.3.11",
         "@smithy/shared-ini-file-loader": "^4.4.6",
@@ -3228,15 +3301,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.39",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
-      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
+      "version": "4.4.40",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
+      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
         "@smithy/protocol-http": "^5.3.11",
         "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
         "@smithy/util-middleware": "^4.2.11",
         "@smithy/util-retry": "^4.2.11",
@@ -3384,18 +3457,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.10.tgz",
-      "integrity": "sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.1",
-        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-hex-encoding": "^4.2.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-uri-escape": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3403,13 +3476,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
-      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
+      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.8",
-        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-endpoint": "^4.4.23",
         "@smithy/middleware-stack": "^4.2.11",
         "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
@@ -3473,9 +3546,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.2.tgz",
-      "integrity": "sha512-4rHqBvxtJEBvsZcFQSPQqXP2b/yy/YlB66KlcEgcH2WNoOKCKB03DSLzXmOsXjbl8dJ4OEYTn31knhdznwk7zw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3510,13 +3583,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.38",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
-      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
+      "version": "4.3.39",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
+      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -3525,16 +3598,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.41",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
-      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
+      "version": "4.2.42",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
+      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.10",
         "@smithy/credential-provider-imds": "^4.2.11",
         "@smithy/node-config-provider": "^4.3.11",
         "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
+    "@aws-sdk/client-bedrock": "^3.943.0",
     "@aws-sdk/client-s3": "^3.943.0",
     "@aws-sdk/client-secrets-manager": "^3.943.0",
     "@aws-sdk/client-sts": "^3.996.0",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -40,7 +40,6 @@ import {
   BeforeToolsEvent,
   HookableEvent,
   MessageAddedEvent,
-  MessageUpdatedEvent,
   ModelStreamUpdateEvent,
   ContentBlockEvent,
   ModelMessageEvent,
@@ -486,14 +485,6 @@ export class Agent implements AgentData {
           const wasForced = forcedToolChoice !== undefined
           forcedToolChoice = undefined // Clear after use
 
-          // Handle user content redaction if guardrails blocked input
-          if (modelResult.redactionMessage) {
-            const redactionEvent = this._redactLastMessage(modelResult.redactionMessage)
-            if (redactionEvent) {
-              yield redactionEvent
-            }
-          }
-
           if (modelResult.stopReason !== 'toolUse') {
             // Special handling for maxTokens - always fail regardless of whether we have structured output
             if (modelResult.stopReason === 'maxTokens') {
@@ -675,25 +666,31 @@ export class Agent implements AgentData {
     })
 
     try {
-      const { message, stopReason, redactionMessage, metadata } = yield* this._streamFromModel(
-        this.messages,
-        streamOptions
-      )
-      const usage = metadata?.usage
+      const result = yield* this._streamFromModel(this.messages, streamOptions)
+      const usage = result.metadata?.usage
       // Accumulate token usage
       if (usage) {
         Agent._accumulateUsage(this._accumulatedTokenUsage, usage)
       }
 
       // End model span with usage
-      this._tracer.endModelInvokeSpan(modelSpan, { output: message, stopReason, ...(usage && { usage }) })
+      this._tracer.endModelInvokeSpan(modelSpan, {
+        output: result.message,
+        stopReason: result.stopReason,
+        ...(usage && { usage }),
+      })
 
-      yield new ModelMessageEvent({ agent: this, message, stopReason })
+      yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
+
+      // Handle user content redaction if guardrails blocked input
+      if (result.redaction?.userMessage) {
+        this._redactLastMessage(result.redaction.userMessage)
+      }
 
       const stopData: ModelStopData = {
-        message,
-        stopReason,
-        ...(redactionMessage && { redaction: { message: redactionMessage } }),
+        message: result.message,
+        stopReason: result.stopReason,
+        ...(result.redaction && { redaction: result.redaction }),
       }
 
       const afterModelCallEvent = new AfterModelCallEvent({ agent: this, stopData })
@@ -703,12 +700,7 @@ export class Agent implements AgentData {
         return yield* this.invokeModel(args)
       }
 
-      return {
-        message,
-        stopReason,
-        ...(metadata && { metadata }),
-        ...(redactionMessage && { redactionMessage }),
-      }
+      return result
     } catch (error) {
       const modelError = normalizeError(error)
 
@@ -930,29 +922,51 @@ export class Agent implements AgentData {
    * Redacts the last message in the conversation history.
    * Called when guardrails block user input and redaction is enabled.
    *
+   * Follows the redaction strategy:
+   * - If the message contains at least one toolResult block, all toolResult blocks
+   *   are kept with redacted content, and all other blocks are discarded.
+   * - Otherwise, the entire content is replaced with a single text block containing
+   *   the redaction message.
+   *
    * @param redactMessage - The redaction message to replace the content with
-   * @returns MessageUpdatedEvent to be yielded, or undefined if no message to redact
    */
-  private _redactLastMessage(redactMessage: string): MessageUpdatedEvent | undefined {
+  private _redactLastMessage(redactMessage: string): void {
     // Find and redact the last message
     const lastIndex = this.messages.length - 1
     if (lastIndex >= 0) {
       const lastMessage = this.messages[lastIndex]
       if (lastMessage && lastMessage.role === 'user') {
-        const updatedMessage = new Message({
+        // Collect only tool result blocks with redacted content
+        const redactedContent: ContentBlock[] = []
+        for (const block of lastMessage.content) {
+          if (block.type === 'toolResultBlock') {
+            // Preserve tool result block structure, only redact its content
+            redactedContent.push(
+              new ToolResultBlock({
+                toolUseId: block.toolUseId,
+                status: block.status,
+                content: [new TextBlock(redactMessage)],
+              })
+            )
+          }
+        }
+
+        // If no tool result blocks were found, replace entire content with redaction message
+        if (redactedContent.length === 0) {
+          redactedContent.push(new TextBlock(redactMessage))
+        }
+
+        this.messages[lastIndex] = new Message({
           role: 'user',
-          content: [new TextBlock(redactMessage)],
+          content: redactedContent,
         })
-        this.messages[lastIndex] = updatedMessage
-        return new MessageUpdatedEvent({ agent: this, message: updatedMessage, index: lastIndex })
       } else if (lastMessage) {
         // Unexpected state: redaction requested but last message is not from user
         logger.warn(
-          `role=<${lastMessage.role}> | Received user input redaction but last message is not from user. Redaction skipped.`
+          `role=<${lastMessage.role}> | Received input redaction but last message is not from user. Redaction skipped.`
         )
       }
     }
-    return undefined
   }
 
   /**

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -142,24 +142,6 @@ export class MessageAddedEvent extends HookableEvent {
 }
 
 /**
- * Event triggered when a message in the conversation history is updated.
- * Fired when guardrails trigger content redaction and a message is replaced.
- */
-export class MessageUpdatedEvent extends HookableEvent {
-  readonly type = 'messageUpdatedEvent' as const
-  readonly agent: AgentData
-  readonly message: Message
-  readonly index: number
-
-  constructor(data: { agent: AgentData; message: Message; index: number }) {
-    super()
-    this.agent = data.agent
-    this.message = data.message
-    this.index = data.index
-  }
-}
-
-/**
  * Event triggered just before a tool is executed.
  * Fired after tool lookup but before execution begins.
  */
@@ -245,13 +227,14 @@ export class BeforeModelCallEvent extends HookableEvent {
 }
 
 /**
- * Information about content redaction triggered by guardrails.
+ * Redaction information when guardrails block content.
  */
 export interface Redaction {
   /**
-   * The message to replace the redacted content with.
+   * The text to replace the user message with.
+   * When present, indicates the last user message should be redacted with this text.
    */
-  readonly message: string
+  userMessage: string
 }
 
 /**
@@ -267,8 +250,9 @@ export interface ModelStopData {
    */
   readonly stopReason: StopReason
   /**
-   * Optional redaction info when guardrails blocked user input.
-   * When present, indicates the last message should be redacted.
+   * Optional redaction info when guardrails blocked input.
+   * When present, indicates the last user message was redacted.
+   * The redacted message is available in `agent.messages` (last message).
    */
   readonly redaction?: Redaction
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,7 +21,6 @@ export {
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,
-  MessageUpdatedEvent,
   BeforeToolCallEvent,
   AfterToolCallEvent,
   BeforeModelCallEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,8 +149,10 @@ export type {
   ModelMessageStopEvent,
   ModelMetadataEventData,
   ModelMetadataEvent,
-  ModelRedactContentEventData,
-  ModelRedactContentEvent,
+  RedactInputContent,
+  RedactOutputContent,
+  ModelRedactEventData,
+  ModelRedactEvent,
   ModelStreamEvent,
 } from './models/streaming.js'
 export { isModelStreamEvent } from './models/streaming.js'
@@ -162,7 +164,12 @@ export { Model } from './models/model.js'
 
 // Bedrock model provider
 export { BedrockModel as BedrockModel } from './models/bedrock.js'
-export type { BedrockModelConfig, BedrockModelOptions, GuardrailConfig, GuardrailRedactionConfig } from './models/bedrock.js'
+export type {
+  BedrockModelConfig,
+  BedrockModelOptions,
+  GuardrailConfig,
+  GuardrailRedactionConfig,
+} from './models/bedrock.js'
 
 // Agent streaming event types
 export type { AgentStreamEvent } from './types/agent.js'
@@ -176,7 +183,6 @@ export {
   BeforeInvocationEvent,
   AfterInvocationEvent,
   MessageAddedEvent,
-  MessageUpdatedEvent,
   BeforeToolCallEvent,
   AfterToolCallEvent,
   BeforeModelCallEvent,

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -2043,11 +2043,11 @@ describe('BedrockModel', () => {
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
         const events = await collectIterator(provider.stream(messages))
 
-        const redactEvent = events.find((e) => e.type === 'modelRedactContentEvent')
+        const redactEvent = events.find((e) => e.type === 'modelRedactEvent')
         expect(redactEvent).toBeDefined()
         expect(redactEvent).toStrictEqual({
-          type: 'modelRedactContentEvent',
-          redactUserContentMessage: '[User input redacted.]',
+          type: 'modelRedactEvent',
+          inputRedaction: { message: '[User input redacted.]' },
         })
       })
 
@@ -2085,7 +2085,7 @@ describe('BedrockModel', () => {
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
         const events = await collectIterator(provider.stream(messages))
 
-        const redactEvent = events.find((e) => e.type === 'modelRedactContentEvent')
+        const redactEvent = events.find((e) => e.type === 'modelRedactEvent')
         expect(redactEvent).toBeDefined()
       })
 
@@ -2123,7 +2123,7 @@ describe('BedrockModel', () => {
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
         const events = await collectIterator(provider.stream(messages))
 
-        const redactEvent = events.find((e) => e.type === 'modelRedactContentEvent')
+        const redactEvent = events.find((e) => e.type === 'modelRedactEvent')
         expect(redactEvent).toBeUndefined()
       })
 
@@ -2156,7 +2156,7 @@ describe('BedrockModel', () => {
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
         const events = await collectIterator(provider.stream(messages))
 
-        const redactEvent = events.find((e) => e.type === 'modelRedactContentEvent')
+        const redactEvent = events.find((e) => e.type === 'modelRedactEvent')
         expect(redactEvent).toBeUndefined()
       })
     })
@@ -2189,8 +2189,8 @@ describe('BedrockModel', () => {
         )
 
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactUserContentMessage: '[User input redacted.]',
+          type: 'modelRedactEvent',
+          inputRedaction: { message: '[User input redacted.]' },
         })
       })
 
@@ -2224,8 +2224,8 @@ describe('BedrockModel', () => {
         )
 
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactUserContentMessage: '[Custom input message]',
+          type: 'modelRedactEvent',
+          inputRedaction: { message: '[Custom input message]' },
         })
       })
 
@@ -2258,9 +2258,7 @@ describe('BedrockModel', () => {
           provider.stream([new Message({ role: 'user', content: [new TextBlock('Hello')] })])
         )
 
-        const inputRedactEvent = events.find(
-          (e) => e.type === 'modelRedactContentEvent' && 'redactUserContentMessage' in e
-        )
+        const inputRedactEvent = events.find((e) => e.type === 'modelRedactEvent' && 'inputRedaction' in e)
         expect(inputRedactEvent).toBeUndefined()
       })
 
@@ -2294,8 +2292,8 @@ describe('BedrockModel', () => {
         )
 
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactAssistantContentMessage: '[Assistant output redacted.]',
+          type: 'modelRedactEvent',
+          outputRedaction: { message: '[Assistant output redacted.]' },
         })
       })
 
@@ -2330,8 +2328,8 @@ describe('BedrockModel', () => {
         )
 
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactAssistantContentMessage: '[Custom output message]',
+          type: 'modelRedactEvent',
+          outputRedaction: { message: '[Custom output message]' },
         })
       })
 
@@ -2366,12 +2364,57 @@ describe('BedrockModel', () => {
         )
 
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactUserContentMessage: '[User input redacted.]',
+          type: 'modelRedactEvent',
+          inputRedaction: { message: '[User input redacted.]' },
         })
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactAssistantContentMessage: '[Assistant output redacted.]',
+          type: 'modelRedactEvent',
+          outputRedaction: { message: '[Assistant output redacted.]' },
+        })
+      })
+
+      it('includes redactedContent from modelOutput when available', async () => {
+        setupMockSend(async function* () {
+          yield { messageStart: { role: 'assistant' } }
+          yield { contentBlockStart: {} }
+          yield { contentBlockDelta: { delta: { text: 'This content was blocked' } } }
+          yield { contentBlockStop: {} }
+          yield { messageStop: { stopReason: 'guardrail_intervened' } }
+          yield {
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              trace: {
+                guardrail: {
+                  modelOutput: ['This content ', 'was blocked'],
+                  outputAssessments: {
+                    '0': [{ topicPolicy: { topics: [{ action: 'BLOCKED', detected: true }] } }],
+                  },
+                },
+              },
+            },
+          }
+        })
+
+        const provider = new BedrockModel({
+          guardrailConfig: {
+            guardrailIdentifier: 'id',
+            guardrailVersion: '1',
+            redaction: {
+              output: true,
+              outputMessage: '[Blocked]',
+            },
+          },
+        })
+        const events = await collectIterator(
+          provider.stream([new Message({ role: 'user', content: [new TextBlock('Hello')] })])
+        )
+
+        expect(events).toContainEqual({
+          type: 'modelRedactEvent',
+          outputRedaction: {
+            message: '[Blocked]',
+            redactedContent: 'This content was blocked',
+          },
         })
       })
     })
@@ -2407,8 +2450,8 @@ describe('BedrockModel', () => {
         )
 
         expect(events).toContainEqual({
-          type: 'modelRedactContentEvent',
-          redactUserContentMessage: '[User input redacted.]',
+          type: 'modelRedactEvent',
+          inputRedaction: { message: '[User input redacted.]' },
         })
       })
     })

--- a/src/models/__tests__/model.test.ts
+++ b/src/models/__tests__/model.test.ts
@@ -630,7 +630,7 @@ describe('Model', () => {
     })
 
     describe('when receiving redact content events', () => {
-      it('returns redactionMessage when redactUserContentMessage is present', async () => {
+      it('returns redaction.userMessage when inputRedaction is present', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
           yield { type: 'modelContentBlockStartEvent' }
@@ -645,8 +645,8 @@ describe('Model', () => {
             usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
           }
           yield {
-            type: 'modelRedactContentEvent',
-            redactUserContentMessage: '[User input redacted.]',
+            type: 'modelRedactEvent',
+            inputRedaction: { message: '[User input redacted.]' },
           }
         })
 
@@ -654,14 +654,14 @@ describe('Model', () => {
 
         const { result } = await collectGenerator(provider.streamAggregated(messages))
 
-        // Verify redactionMessage is returned for agent to handle
-        expect(result.redactionMessage).toBe('[User input redacted.]')
+        // Verify redaction.userMessage is returned for agent to handle
+        expect(result.redaction?.userMessage).toBe('[User input redacted.]')
 
         // Messages array should NOT be modified (agent handles this)
         expect(messages[0]!.content).toEqual([{ type: 'textBlock', text: 'Sensitive content' }])
       })
 
-      it('redacts assistant message directly when redactAssistantContentMessage is present', async () => {
+      it('redacts assistant message directly when outputRedaction is present', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
           yield { type: 'modelContentBlockStartEvent' }
@@ -676,8 +676,8 @@ describe('Model', () => {
             usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
           }
           yield {
-            type: 'modelRedactContentEvent',
-            redactAssistantContentMessage: '[Assistant output redacted.]',
+            type: 'modelRedactEvent',
+            outputRedaction: { message: '[Assistant output redacted.]' },
           }
         })
 
@@ -689,8 +689,8 @@ describe('Model', () => {
         expect(result.message.role).toBe('assistant')
         expect(result.message.content).toEqual([{ type: 'textBlock', text: '[Assistant output redacted.]' }])
 
-        // No redactionMessage since assistant redaction is handled directly
-        expect(result.redactionMessage).toBeUndefined()
+        // No redaction.userMessage since assistant redaction is handled directly
+        expect(result.redaction?.userMessage).toBeUndefined()
       })
 
       it('returns redactionMessage and redacts assistant when both are present', async () => {
@@ -708,12 +708,12 @@ describe('Model', () => {
             usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
           }
           yield {
-            type: 'modelRedactContentEvent',
-            redactUserContentMessage: '[User input redacted.]',
+            type: 'modelRedactEvent',
+            inputRedaction: { message: '[User input redacted.]' },
           }
           yield {
-            type: 'modelRedactContentEvent',
-            redactAssistantContentMessage: '[Assistant output redacted.]',
+            type: 'modelRedactEvent',
+            outputRedaction: { message: '[Assistant output redacted.]' },
           }
         })
 
@@ -721,15 +721,15 @@ describe('Model', () => {
 
         const { result } = await collectGenerator(provider.streamAggregated(messages))
 
-        // Verify redactionMessage is returned for agent to handle user redaction
-        expect(result.redactionMessage).toBe('[User input redacted.]')
+        // Verify redaction.userMessage is returned for agent to handle user redaction
+        expect(result.redaction?.userMessage).toBe('[User input redacted.]')
 
         // Assistant message is redacted directly
         expect(result.message.role).toBe('assistant')
         expect(result.message.content).toEqual([{ type: 'textBlock', text: '[Assistant output redacted.]' }])
       })
 
-      it('does not include redactionMessage when no redact events are received', async () => {
+      it('does not include redaction when no redact events are received', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
           yield { type: 'modelContentBlockStartEvent' }
@@ -749,8 +749,8 @@ describe('Model', () => {
 
         const { result } = await collectGenerator(provider.streamAggregated(messages))
 
-        // Verify redactionMessage is undefined
-        expect(result.redactionMessage).toBeUndefined()
+        // Verify redaction.userMessage is undefined
+        expect(result.redaction?.userMessage).toBeUndefined()
       })
     })
   })

--- a/src/models/__tests__/streaming.test.ts
+++ b/src/models/__tests__/streaming.test.ts
@@ -39,10 +39,10 @@ describe('isModelStreamEvent', () => {
     expect(isModelStreamEvent(event)).toBe(true)
   })
 
-  it('returns true for modelRedactContentEvent', () => {
+  it('returns true for modelRedactEvent', () => {
     const event: ModelStreamEvent = {
-      type: 'modelRedactContentEvent',
-      redactUserContentMessage: '[User input redacted.]',
+      type: 'modelRedactEvent',
+      inputRedaction: { message: '[User input redacted.]' },
     }
     expect(isModelStreamEvent(event)).toBe(true)
   })

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -38,6 +38,9 @@ import {
   type CitationLocation as BedrockCitationLocation,
   type Citation as BedrockCitation,
   type CitationsContentBlock as BedrockCitationsContentBlock,
+  type ConverseTrace,
+  type GuardrailTraceAssessment,
+  type GuardrailAssessment,
 } from '@aws-sdk/client-bedrock-runtime'
 import { type BaseModelConfig, Model, type StreamOptions } from '../models/model.js'
 import type { ContentBlock, Message, StopReason, ToolUseBlock } from '../types/messages.js'
@@ -88,109 +91,55 @@ const STOP_REASON_MAP = {
 } as const
 
 /**
- * Default message for redacted user input.
+ * Default message for redacted input.
  */
 const DEFAULT_REDACT_INPUT_MESSAGE = '[User input redacted.]'
 
 /**
- * Default message for redacted assistant output.
+ * Default message for redacted output.
  */
 const DEFAULT_REDACT_OUTPUT_MESSAGE = '[Assistant output redacted.]'
 
 /**
- * Configuration for Bedrock guardrails.
- *
- * **Session Persistence Considerations:**
- *
- * When using SessionManager with guardrails, redacted messages are persisted based on
- * the `saveLatestOn` strategy:
- * - `'invocation'` (default): Redacted messages are saved at the end of each invocation.
- *   If the process crashes during invocation, un-redacted content may remain in storage.
- * - `'message'`: Redacted messages are saved immediately when MessageUpdatedEvent fires,
- *   providing the most durable protection for sensitive content.
- * - `'trigger'`: Redaction is only saved when the trigger condition fires or via manual
- *   saveSnapshot calls.
- *
- * For production use with sensitive content, consider using `saveLatestOn: 'message'`
- * to ensure redactions are persisted immediately.
- *
- * @see https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+ * Redaction configuration for guardrails.
+ * Controls whether and how blocked content is replaced.
  */
 export interface GuardrailRedactionConfig {
-  /**
-   * Redact user input when guardrail blocks it.
-   * When undefined or true, user input will be redacted.
-   * Set to false to disable user input redaction.
-   * @defaultValue true
-   */
+  /** Redact input when blocked. @defaultValue true */
   input?: boolean
 
-  /**
-   * Custom message to replace redacted user input.
-   * @defaultValue '[User input redacted.]'
-   */
+  /** Replacement message for redacted input. @defaultValue '[User input redacted.]' */
   inputMessage?: string
 
-  /**
-   * Redact assistant output when guardrail blocks it.
-   * When undefined or false, assistant output will not be redacted.
-   * Set to true to enable assistant output redaction.
-   * @defaultValue false
-   */
+  /** Redact output when blocked. @defaultValue false */
   output?: boolean
 
-  /**
-   * Custom message to replace redacted assistant output.
-   * @defaultValue '[Assistant output redacted.]'
-   */
+  /** Replacement message for redacted output. @defaultValue '[Assistant output redacted.]' */
   outputMessage?: string
 }
 
 /**
  * Configuration for Bedrock guardrails.
  *
- * **Session Persistence Considerations:**
- *
- * When using SessionManager with guardrails, redacted messages are persisted based on
- * the `saveLatestOn` strategy:
- * - `'invocation'` (default): Redacted messages are saved at the end of each invocation.
- *   If the process crashes during invocation, un-redacted content may remain in storage.
- * - `'message'`: Redacted messages are saved immediately when MessageUpdatedEvent fires,
- *   providing the most durable protection for sensitive content.
- * - `'trigger'`: Redaction is only saved when the trigger condition fires or via manual
- *   saveSnapshot calls.
- *
- * For production use with sensitive content, consider using `saveLatestOn: 'message'`
- * to ensure redactions are persisted immediately.
+ * For production use with sensitive content, consider `SessionManager` with `saveLatestOn: 'message'`
+ * to persist redactions immediately.
  *
  * @see https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
  */
 export interface GuardrailConfig {
-  /**
-   * ID of the guardrail to apply.
-   */
+  /** Guardrail identifier */
   guardrailIdentifier: string
 
-  /**
-   * Version of the guardrail (e.g., "1", "DRAFT").
-   */
+  /** Guardrail version (e.g., "1", "DRAFT") */
   guardrailVersion: string
 
-  /**
-   * Trace mode for guardrail evaluation.
-   * @defaultValue 'enabled'
-   */
+  /** Trace mode for evaluation. @defaultValue 'enabled' */
   trace?: 'enabled' | 'disabled' | 'enabled_full'
 
-  /**
-   * Stream processing mode for guardrail evaluation.
-   */
+  /** Stream processing mode */
   streamProcessingMode?: 'sync' | 'async'
 
-  /**
-   * SDK redaction behavior configuration.
-   * Controls how the SDK handles content blocked by guardrails.
-   */
+  /** Redaction behavior when content is blocked */
   redaction?: GuardrailRedactionConfig
 }
 
@@ -990,17 +939,16 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     }
 
     // Handle trace and guardrail check for non-streaming responses
-    const trace = (event as { trace?: unknown }).trace
-    if (trace) {
-      metadataEvent.trace = trace
+    if (event.trace) {
+      metadataEvent.trace = event.trace
 
       // Check for blocked guardrails and emit redaction events
       if (
         this._config.guardrailConfig &&
-        (trace as { guardrail?: unknown }).guardrail &&
-        this._hasBlockedGuardrail((trace as { guardrail: unknown }).guardrail)
+        event.trace.guardrail &&
+        this._findDetectedAndBlockedPolicy(event.trace.guardrail)
       ) {
-        for (const redactionEvent of this._generateRedactionEvents()) {
+        for (const redactionEvent of this._generateRedactionEvents(event.trace.guardrail)) {
           events.push(redactionEvent)
         }
       }
@@ -1169,10 +1117,10 @@ export class BedrockModel extends Model<BedrockModelConfig> {
           // Check for blocked guardrails in trace and emit redaction events
           if (
             this._config.guardrailConfig &&
-            (data.trace as { guardrail?: unknown }).guardrail &&
-            this._hasBlockedGuardrail((data.trace as { guardrail: unknown }).guardrail)
+            data.trace.guardrail &&
+            this._findDetectedAndBlockedPolicy(data.trace.guardrail)
           ) {
-            for (const redactionEvent of this._generateRedactionEvents()) {
+            for (const redactionEvent of this._generateRedactionEvents(data.trace.guardrail)) {
               events.push(redactionEvent)
             }
           }
@@ -1343,75 +1291,99 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     }
   }
 
-  /*
-   * Check if guardrail data contains any blocked policies.
-   * Recursively checks inputAssessment and outputAssessments for action: 'BLOCKED'.
-   *
-   * @param guardrailData - Guardrail data from trace information
-   * @returns True if any blocked guardrail is detected
-   */
-  private _hasBlockedGuardrail(guardrailData: unknown): boolean {
-    // Validate guardrail data structure before processing
-    if (!guardrailData || typeof guardrailData !== 'object') {
-      logger.warn('guardrail_data=<invalid> | Invalid guardrail data received from trace')
-      return false
-    }
-    return this._findDetectedAndBlockedPolicy(guardrailData)
-  }
-
   /**
-   * Recursively checks if the input contains a detected and blocked guardrail.
+   * Checks if guardrail trace contains any blocked policies.
    *
-   * @param input - The data to check for blocked policies
-   * @returns True if the input contains a detected and blocked guardrail
+   * @param guardrailData - Guardrail trace assessment data
+   * @returns True if any policy action is BLOCKED
    */
-  private _findDetectedAndBlockedPolicy(input: unknown): boolean {
-    // Handle arrays first
-    if (Array.isArray(input)) {
-      return input.some((item) => this._findDetectedAndBlockedPolicy(item))
+  private _findDetectedAndBlockedPolicy(guardrailData: GuardrailTraceAssessment): boolean {
+    // Check input assessment
+    if (guardrailData.inputAssessment) {
+      for (const assessment of Object.values(guardrailData.inputAssessment)) {
+        if (this._hasBlockedAction(assessment)) {
+          return true
+        }
+      }
     }
 
-    // Check if input is an object
-    if (input !== null && typeof input === 'object') {
-      const obj = input as Record<string, unknown>
-
-      // Check if current object has action: BLOCKED and detected: true
-      if (obj.action === 'BLOCKED' && obj.detected === true) {
-        return true
+    // Check output assessments
+    if (guardrailData.outputAssessments) {
+      for (const assessments of Object.values(guardrailData.outputAssessments)) {
+        // Handle both single assessment and array of assessments
+        const assessmentArray = Array.isArray(assessments) ? assessments : [assessments]
+        if (assessmentArray.some((assessment) => this._hasBlockedAction(assessment))) {
+          return true
+        }
       }
-
-      // Recursively check all values in the object
-      return Object.values(obj).some((v) => this._findDetectedAndBlockedPolicy(v))
     }
 
     return false
   }
 
   /**
+   * Recursively checks if an object contains action: 'BLOCKED'.
+   *
+   * @param obj - Object to search for blocked action
+   * @returns True if any nested property has action: 'BLOCKED'
+   */
+  private _hasBlockedAction(obj: unknown): boolean {
+    if (obj === null || typeof obj !== 'object') {
+      return false
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.some((item) => this._hasBlockedAction(item))
+    }
+
+    const record = obj as Record<string, unknown>
+
+    // Check if this object has action: 'BLOCKED'
+    if (record.action === 'BLOCKED') {
+      return true
+    }
+
+    // Recursively check all nested values
+    return Object.values(record).some((value) => this._hasBlockedAction(value))
+  }
+
+  /**
    * Generate redaction events based on guardrail configuration.
    *
+   * @param guardrailData - The guardrail trace assessment data
    * @returns Array of redaction events to emit
    */
-  private _generateRedactionEvents(): ModelStreamEvent[] {
+  private _generateRedactionEvents(guardrailData: GuardrailTraceAssessment): ModelStreamEvent[] {
     const events: ModelStreamEvent[] = []
     const redaction = this._config.guardrailConfig?.redaction
 
     // Default: redact input is true unless explicitly set to false
     if (redaction?.input !== false) {
-      logger.debug('redacting user input due to guardrail')
+      logger.debug('redacting input due to guardrail')
       events.push({
-        type: 'modelRedactContentEvent',
-        redactUserContentMessage: redaction?.inputMessage ?? DEFAULT_REDACT_INPUT_MESSAGE,
+        type: 'modelRedactEvent',
+        inputRedaction: {
+          message: redaction?.inputMessage ?? DEFAULT_REDACT_INPUT_MESSAGE,
+        },
       })
     }
 
     // Only redact output if explicitly enabled
     if (redaction?.output) {
-      logger.debug('redacting assistant output due to guardrail')
-      events.push({
-        type: 'modelRedactContentEvent',
-        redactAssistantContentMessage: redaction?.outputMessage ?? DEFAULT_REDACT_OUTPUT_MESSAGE,
-      })
+      logger.debug('redacting output due to guardrail')
+      const outputRedactionEvent: ModelStreamEvent = {
+        type: 'modelRedactEvent',
+        outputRedaction: {
+          message: redaction?.outputMessage ?? DEFAULT_REDACT_OUTPUT_MESSAGE,
+        },
+      }
+
+      // Include the original model output if available
+      if (guardrailData.modelOutput && guardrailData.modelOutput.length > 0) {
+        outputRedactionEvent.outputRedaction!.redactedContent = guardrailData.modelOutput.join('')
+      }
+
+      events.push(outputRedactionEvent)
     }
 
     return events

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -18,10 +18,11 @@ import {
   ModelMessageStartEvent,
   ModelMessageStopEvent,
   ModelMetadataEvent,
-  ModelRedactContentEvent,
+  ModelRedactEvent,
   type ModelStreamEvent,
 } from './streaming.js'
 import { MaxTokensError, ModelError, normalizeError } from '../errors.js'
+import type { Redaction } from '../hooks/events.js'
 
 class CitationAccumulator {
   citations: Citation[] = []
@@ -120,11 +121,10 @@ export interface StreamAggregatedResult {
   metadata?: ModelMetadataEvent
 
   /**
-   * Optional redaction message when guardrails blocked user input.
-   * When present, indicates the last message should be redacted with this text.
-   * Assistant output redaction is handled by updating the message directly.
+   * Optional redaction information when guardrails blocked input.
+   * Output redaction is handled by updating the message directly.
    */
-  redactionMessage?: string
+  redaction?: Redaction
 }
 
 /**
@@ -189,8 +189,8 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
         return new ModelMessageStopEvent(event_data)
       case 'modelMetadataEvent':
         return new ModelMetadataEvent(event_data)
-      case 'modelRedactContentEvent':
-        return new ModelRedactContentEvent(event_data)
+      case 'modelRedactEvent':
+        return new ModelRedactEvent(event_data)
       default:
         throw new Error(`Unsupported event type: ${event_data}`)
     }
@@ -346,22 +346,19 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
             metadata = event
             break
 
-          case 'modelRedactContentEvent':
+          case 'modelRedactEvent':
             // Handle content redaction from guardrails
-            if (event.redactUserContentMessage) {
-              // Store redaction message for agent to handle user message redaction
-              redactionMessage = event.redactUserContentMessage
+            if (event.inputRedaction) {
+              // Store redaction message for agent to handle input message redaction
+              redactionMessage = event.inputRedaction.message
             }
-            if (event.redactAssistantContentMessage) {
-              // Update assistant message directly with redacted content
-              contentBlocks.length = 0
-              contentBlocks.push(new TextBlock(event.redactAssistantContentMessage))
-              if (messageRole) {
-                stoppedMessage = new Message({
-                  role: messageRole,
-                  content: [...contentBlocks],
-                })
-              }
+            if (event.outputRedaction) {
+              // Update output message directly with redacted content
+              // Redaction event comes after modelMessageStopEvent, so we overwrite stoppedMessage
+              stoppedMessage = new Message({
+                role: 'assistant',
+                content: [new TextBlock(event.outputRedaction.message)],
+              })
             }
             break
 
@@ -400,7 +397,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
         result.metadata = metadata
       }
       if (redactionMessage !== undefined) {
-        result.redactionMessage = redactionMessage
+        result.redaction = { userMessage: redactionMessage }
       }
       return result
     } catch (error) {

--- a/src/models/streaming.ts
+++ b/src/models/streaming.ts
@@ -23,7 +23,7 @@ export type ModelStreamEvent =
   | ModelContentBlockStopEventData
   | ModelMessageStopEventData
   | ModelMetadataEventData
-  | ModelRedactContentEventData
+  | ModelRedactEventData
 
 /** Set of all ModelStreamEvent type discriminators. */
 const modelStreamEventTypes: ReadonlySet<string> = new Set<ModelStreamEvent['type']>([
@@ -33,7 +33,7 @@ const modelStreamEventTypes: ReadonlySet<string> = new Set<ModelStreamEvent['typ
   'modelContentBlockStopEvent',
   'modelMessageStopEvent',
   'modelMetadataEvent',
-  'modelRedactContentEvent',
+  'modelRedactEvent',
 ])
 
 /**
@@ -289,51 +289,80 @@ export class ModelMetadataEvent implements ModelMetadataEventData {
 }
 
 /**
- * Data for a redact content event.
+ * Information about input content redaction.
+ * Does not include redactedContent since the original input is already available
+ * in the messages array from BeforeModelCallEvent.
+ */
+export interface RedactInputContent {
+  /**
+   * The message to replace the redacted input with.
+   */
+  message: string
+}
+
+/**
+ * Information about output content redaction.
+ * May include the original content if captured during streaming.
+ */
+export interface RedactOutputContent {
+  /**
+   * The original content that was blocked by guardrails.
+   * May not be available for all providers.
+   */
+  redactedContent?: string
+
+  /**
+   * The message to replace the redacted output with.
+   */
+  message: string
+}
+
+/**
+ * Data for a redact event.
  * Emitted when guardrails block content and redaction is enabled.
  */
-export interface ModelRedactContentEventData {
+export interface ModelRedactEventData {
   /**
-   * Discriminator for redact content events.
+   * Discriminator for redact events.
    */
-  type: 'modelRedactContentEvent'
+  type: 'modelRedactEvent'
 
   /**
-   * Redaction message for user input (when input is blocked).
+   * Input redaction information (when input is blocked).
    */
-  redactUserContentMessage?: string
+  inputRedaction?: RedactInputContent
 
   /**
-   * Redaction message for assistant output (when output is blocked).
+   * Output redaction information (when output is blocked).
    */
-  redactAssistantContentMessage?: string
+  outputRedaction?: RedactOutputContent
 }
 
 /**
  * Event emitted when guardrails block content and trigger redaction.
  */
-export class ModelRedactContentEvent implements ModelRedactContentEventData {
+export class ModelRedactEvent implements ModelRedactEventData {
   /**
-   * Discriminator for redact content events.
+   * Discriminator for redact events.
    */
-  readonly type = 'modelRedactContentEvent' as const
+  readonly type = 'modelRedactEvent' as const
 
   /**
-   * Redaction message for user input (when input is blocked).
+   * Input redaction information (when input is blocked).
    */
-  readonly redactUserContentMessage?: string
+  readonly inputRedaction?: RedactInputContent
 
   /**
-   * Redaction message for assistant output (when output is blocked).
+   * Output redaction information (when output is blocked).
    */
-  readonly redactAssistantContentMessage?: string
+  readonly outputRedaction?: RedactOutputContent
 
-  constructor(data: ModelRedactContentEventData) {
-    if (data.redactUserContentMessage !== undefined) {
-      this.redactUserContentMessage = data.redactUserContentMessage
+  constructor(data: ModelRedactEventData) {
+    if (data.inputRedaction !== undefined) {
+      this.inputRedaction = data.inputRedaction
     }
-    if (data.redactAssistantContentMessage !== undefined) {
-      this.redactAssistantContentMessage = data.redactAssistantContentMessage
+    if (data.outputRedaction !== undefined) {
+      this.outputRedaction = data.outputRedaction
     }
   }
 }

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -5,7 +5,7 @@ import {
   HookRegistry,
   InitializedEvent,
   MessageAddedEvent,
-  MessageUpdatedEvent,
+  AfterModelCallEvent,
   AfterInvocationEvent,
 } from '../../hooks/index.js'
 import { Agent } from '../../agent/agent.js'
@@ -466,12 +466,12 @@ describe('SessionManager', () => {
     })
   })
 
-  describe('MessageUpdatedEvent handling', () => {
+  describe('AfterModelCallEvent with redaction handling', () => {
     beforeEach(() => {
       mockAgent = createMockAgent('test-agent')
     })
 
-    it('saves snapshot_latest when saveLatestOn is message', async () => {
+    it('saves snapshot_latest when saveLatestOn is message and redaction occurred', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',
         storage: { snapshot: storage },
@@ -479,15 +479,49 @@ describe('SessionManager', () => {
       })
       sessionManager.registerCallbacks(registry)
 
-      const redactedMessage = new Message({ role: 'user', content: [new TextBlock('[User input redacted.]')] })
-      const event = { agent: mockAgent, message: redactedMessage, index: 0 } as any
+      const assistantMessage = new Message({ role: 'assistant', content: [new TextBlock('Response')] })
+      const event = {
+        agent: mockAgent,
+        stopData: {
+          message: assistantMessage,
+          stopReason: 'endTurn' as const,
+          redaction: {
+            userMessage: '[User input redacted.]',
+          },
+        },
+      } as any
 
-      await registry.invokeCallbacks(new MessageUpdatedEvent(event))
+      await registry.invokeCallbacks(new AfterModelCallEvent(event))
 
       const snapshot = await storage.loadSnapshot({
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'test-agent' },
       })
       expect(snapshot).not.toBeNull()
+    })
+
+    it('does not save when saveLatestOn is message but no redaction occurred', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: storage },
+        saveLatestOn: 'message',
+      })
+      sessionManager.registerCallbacks(registry)
+
+      const assistantMessage = new Message({ role: 'assistant', content: [new TextBlock('Response')] })
+      const event = {
+        agent: mockAgent,
+        stopData: {
+          message: assistantMessage,
+          stopReason: 'endTurn' as const,
+        },
+      } as any
+
+      await registry.invokeCallbacks(new AfterModelCallEvent(event))
+
+      const snapshot = await storage.loadSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'test-agent' },
+      })
+      expect(snapshot).toBeNull()
     })
 
     it('does not save when saveLatestOn is invocation', async () => {
@@ -498,10 +532,19 @@ describe('SessionManager', () => {
       })
       sessionManager.registerCallbacks(registry)
 
-      const redactedMessage = new Message({ role: 'user', content: [new TextBlock('[User input redacted.]')] })
-      const event = { agent: mockAgent, message: redactedMessage, index: 0 } as any
+      const assistantMessage = new Message({ role: 'assistant', content: [new TextBlock('Response')] })
+      const event = {
+        agent: mockAgent,
+        stopData: {
+          message: assistantMessage,
+          stopReason: 'endTurn' as const,
+          redaction: {
+            userMessage: '[User input redacted.]',
+          },
+        },
+      } as any
 
-      await registry.invokeCallbacks(new MessageUpdatedEvent(event))
+      await registry.invokeCallbacks(new AfterModelCallEvent(event))
 
       const snapshot = await storage.loadSnapshot({
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'test-agent' },

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -2,7 +2,7 @@ import type { SnapshotStorage, SnapshotLocation } from './storage.js'
 import type { SnapshotTriggerCallback } from './types.js'
 import type { HookProvider } from '../hooks/index.js'
 import type { HookRegistry } from '../hooks/registry.js'
-import { AfterInvocationEvent, InitializedEvent, MessageAddedEvent, MessageUpdatedEvent } from '../hooks/events.js'
+import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
 import type { Agent } from '../agent/agent.js'
 import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
@@ -20,7 +20,7 @@ import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
  *
  * `SaveLatestStrategy` controls how frequently `snapshot_latest` is updated:
  * - `'invocation'`: after every agent invocation completes (default; balances durability and I/O)
- * - `'message'`: after every message added or updated (most durable, highest I/O; includes guardrail redactions)
+ * - `'message'`: after every message added and after model calls with guardrail redactions (most durable, highest I/O)
  * - `'trigger'`: only when a `snapshotTrigger` fires (or manually via `saveSnapshot`)
  */
 export type SaveLatestStrategy = 'message' | 'invocation' | 'trigger'
@@ -75,10 +75,10 @@ export class SessionManager implements HookProvider {
       registry.addCallback(MessageAddedEvent, async (event) => {
         await this._onMessageAdded(event)
       })
-      // Also listen to MessageUpdatedEvent when saving per-message to ensure
+      // Also listen to AfterModelCallEvent when saving per-message to ensure
       // message modifications (e.g., guardrail redactions) are persisted immediately
-      registry.addCallback(MessageUpdatedEvent, async (event) => {
-        await this._onMessageUpdated(event)
+      registry.addCallback(AfterModelCallEvent, async (event) => {
+        await this._onAfterModelCall(event)
       })
     }
     registry.addCallback(AfterInvocationEvent, async (event) => {
@@ -137,12 +137,15 @@ export class SessionManager implements HookProvider {
   }
 
   /**
-   * Saves snapshot when a message is updated.
+   * Saves snapshot when a message is redacted after a model call.
    * Critical for ensuring guardrail redactions are persisted immediately.
    */
-  private async _onMessageUpdated(event: MessageUpdatedEvent): Promise<void> {
-    const agent = event.agent as Agent
-    await this.saveSnapshot({ target: agent, isLatest: true })
+  private async _onAfterModelCall(event: AfterModelCallEvent): Promise<void> {
+    // Only save if there was a redaction
+    if (event.stopData?.redaction) {
+      const agent = event.agent as Agent
+      await this.saveSnapshot({ target: agent, isLatest: true })
+    }
   }
 
   /** Captures one snapshot and writes it to both immutable history and snapshot_latest. */

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -10,7 +10,6 @@ import type {
   BeforeToolCallEvent,
   AfterToolCallEvent,
   MessageAddedEvent,
-  MessageUpdatedEvent,
   ModelStreamUpdateEvent,
   ContentBlockEvent,
   ModelMessageEvent,
@@ -124,5 +123,4 @@ export type AgentStreamEvent =
   | BeforeToolCallEvent
   | AfterToolCallEvent
   | MessageAddedEvent
-  | MessageUpdatedEvent
   | AgentResultEvent

--- a/test/integ/models/bedrock-guardrails.test.ts
+++ b/test/integ/models/bedrock-guardrails.test.ts
@@ -1,0 +1,446 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { Agent, Message, TextBlock, FunctionTool, FileStorage, SessionManager } from '@strands-agents/sdk'
+import type { MessageData, ModelRedactEvent } from '@strands-agents/sdk'
+import { bedrock } from '../__fixtures__/model-providers.js'
+import { mkdtemp } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  BedrockClient,
+  CreateGuardrailCommand,
+  GetGuardrailCommand,
+  ListGuardrailsCommand,
+} from '@aws-sdk/client-bedrock'
+import { inject } from 'vitest'
+
+const BLOCKED_INPUT = 'BLOCKED_INPUT'
+const BLOCKED_OUTPUT = 'BLOCKED_OUTPUT'
+const GUARDRAIL_NAME = 'test-guardrail-block-cactus'
+
+let GUARDRAIL_ID: string | undefined
+
+/**
+ * Gets the guardrail ID by name if it exists
+ */
+async function getGuardrailId(client: BedrockClient, guardrailName: string): Promise<string | undefined> {
+  const response = await client.send(new ListGuardrailsCommand({}))
+  const guardrail = response.guardrails?.find((g) => g.name === guardrailName)
+  return guardrail?.id
+}
+
+/**
+ * Waits for the guardrail to become active
+ */
+async function waitForGuardrailActive(
+  client: BedrockClient,
+  guardrailId: string,
+  maxAttempts = 10,
+  delayMs = 5000
+): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await client.send(new GetGuardrailCommand({ guardrailIdentifier: guardrailId }))
+    const status = response.status
+
+    if (status === 'READY') {
+      console.log(`Guardrail ${guardrailId} is now active`)
+      return
+    }
+
+    console.log(`Waiting for guardrail to become active. Current status: ${status}`)
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+  }
+
+  throw new Error(`Guardrail did not become active within ${(maxAttempts * delayMs) / 1000} seconds`)
+}
+
+/**
+ * Creates or retrieves the test guardrail
+ */
+async function setupGuardrail(): Promise<string> {
+  const credentials = inject('provider-bedrock')?.credentials
+  if (!credentials) {
+    throw new Error('No Bedrock credentials provided')
+  }
+
+  const client = new BedrockClient({ region: 'us-east-1', credentials })
+
+  // Check if guardrail already exists
+  let guardrailId = await getGuardrailId(client, GUARDRAIL_NAME)
+
+  if (guardrailId) {
+    console.log(`Guardrail ${GUARDRAIL_NAME} already exists with ID: ${guardrailId}`)
+  } else {
+    console.log(`Creating guardrail ${GUARDRAIL_NAME}`)
+    const response = await client.send(
+      new CreateGuardrailCommand({
+        name: GUARDRAIL_NAME,
+        description: 'Testing Guardrail',
+        wordPolicyConfig: {
+          wordsConfig: [
+            {
+              text: 'CACTUS',
+            },
+          ],
+        },
+        blockedInputMessaging: BLOCKED_INPUT,
+        blockedOutputsMessaging: BLOCKED_OUTPUT,
+      })
+    )
+    guardrailId = response.guardrailId
+    if (!guardrailId) {
+      throw new Error('Failed to create guardrail: no ID returned')
+    }
+    console.log(`Created test guardrail with ID: ${guardrailId}`)
+    await waitForGuardrailActive(client, guardrailId)
+  }
+
+  if (!guardrailId) {
+    throw new Error('Failed to get or create guardrail')
+  }
+
+  return guardrailId
+}
+
+const shouldSkip = bedrock.skip
+
+describe.skipIf(shouldSkip)('BedrockModel Guardrails Integration Tests', () => {
+  beforeAll(async () => {
+    GUARDRAIL_ID = await setupGuardrail()
+  }, 60000)
+
+  describe('Input Intervention', () => {
+    it.each(['enabled', 'enabled_full'] as const)(
+      'blocks input and redacts message with trace=%s',
+      async (guardrailTrace) => {
+        const model = bedrock.createModel({
+          guardrailConfig: {
+            guardrailIdentifier: GUARDRAIL_ID!,
+            guardrailVersion: 'DRAFT',
+            trace: guardrailTrace,
+            redaction: {
+              input: true,
+              inputMessage: 'Redacted.',
+            },
+          },
+        })
+
+        const agent = new Agent({
+          model,
+          systemPrompt: 'You are a helpful assistant.',
+          printer: false,
+        })
+
+        const response1 = await agent.invoke('CACTUS')
+        const response2 = await agent.invoke('Hello!')
+
+        expect(response1.stopReason).toBe('guardrailIntervened')
+        expect(response1.toString().trim()).toBe(BLOCKED_INPUT)
+        expect(response2.stopReason).not.toBe('guardrailIntervened')
+        expect(response2.toString().trim()).not.toBe(BLOCKED_INPUT)
+        expect(agent.messages[0]?.content[0]?.type).toBe('textBlock')
+        const firstBlock = agent.messages[0]?.content[0]
+        if (firstBlock?.type === 'textBlock') {
+          expect(firstBlock.text).toBe('Redacted.')
+        }
+      },
+      30000
+    )
+  })
+
+  describe('Output Intervention', () => {
+    it.each(['sync', 'async'] as const)(
+      'blocks output without redaction in %s mode',
+      async (processingMode) => {
+        const model = bedrock.createModel({
+          guardrailConfig: {
+            guardrailIdentifier: GUARDRAIL_ID!,
+            guardrailVersion: 'DRAFT',
+            streamProcessingMode: processingMode,
+            redaction: {
+              output: false,
+            },
+          },
+        })
+
+        const agent = new Agent({
+          model,
+          systemPrompt: 'When asked to say the word, say CACTUS.',
+          printer: false,
+        })
+
+        const response1 = await agent.invoke('Say the word.')
+        const response2 = await agent.invoke('Hello!')
+
+        expect(response1.stopReason).toBe('guardrailIntervened')
+
+        if (processingMode === 'sync') {
+          // In sync mode, we can reliably check the response content
+          expect(response1.toString()).toContain(BLOCKED_OUTPUT)
+          expect(response2.stopReason).not.toBe('guardrailIntervened')
+          expect(response2.toString()).not.toContain(BLOCKED_OUTPUT)
+        } else {
+          // In async mode, either:
+          // - CACTUS was returned and blocked by input guardrail on next turn, or
+          // - CACTUS was blocked in response1, allowing normal response2
+          const cactusCaughtByInputGuardrail = response2.toString().includes(BLOCKED_INPUT)
+          const cactusBlockedAllowsNextResponse =
+            !response2.toString().includes(BLOCKED_OUTPUT) && response2.stopReason !== 'guardrailIntervened'
+          expect(cactusCaughtByInputGuardrail || cactusBlockedAllowsNextResponse).toBe(true)
+        }
+      },
+      30000
+    )
+
+    it.each([
+      ['sync', 'enabled'],
+      ['sync', 'enabled_full'],
+      ['async', 'enabled'],
+      ['async', 'enabled_full'],
+    ] as const)(
+      'blocks output with redaction in %s mode with trace=%s',
+      async (processingMode, guardrailTrace) => {
+        const REDACT_MESSAGE = 'Redacted.'
+        const model = bedrock.createModel({
+          guardrailConfig: {
+            guardrailIdentifier: GUARDRAIL_ID!,
+            guardrailVersion: 'DRAFT',
+            streamProcessingMode: processingMode,
+            trace: guardrailTrace,
+            redaction: {
+              output: true,
+              outputMessage: REDACT_MESSAGE,
+            },
+          },
+          temperature: 0, // Deterministic responses
+        })
+
+        const agent = new Agent({
+          model,
+          systemPrompt: 'When asked to say the word, say CACTUS. Otherwise, respond normally.',
+          printer: false,
+        })
+
+        const response1 = await agent.invoke('Say the word.')
+        // Use unrelated prompt to avoid model volunteering CACTUS
+        const response2 = await agent.invoke('What is 2+2? Reply with only the number.')
+
+        expect(response1.stopReason).toBe('guardrailIntervened')
+
+        if (processingMode === 'sync') {
+          expect(response1.toString()).toContain(REDACT_MESSAGE)
+          expect(response2.stopReason).not.toBe('guardrailIntervened')
+          expect(response2.toString()).not.toContain(REDACT_MESSAGE)
+        } else {
+          // In async mode, either:
+          // - CACTUS was returned and blocked by input guardrail on next turn, or
+          // - CACTUS was blocked in response1, allowing normal response2
+          const cactusCaughtByInputGuardrail = response2.toString().includes(BLOCKED_INPUT)
+          const cactusBlockedAllowsNextResponse =
+            !response2.toString().includes(REDACT_MESSAGE) && response2.stopReason !== 'guardrailIntervened'
+          expect(cactusCaughtByInputGuardrail || cactusBlockedAllowsNextResponse).toBe(true)
+        }
+      },
+      30000
+    )
+
+    it('captures redactedContent from modelOutput in sync mode', async () => {
+      const REDACT_MESSAGE = 'Content blocked.'
+      const model = bedrock.createModel({
+        guardrailConfig: {
+          guardrailIdentifier: GUARDRAIL_ID!,
+          guardrailVersion: 'DRAFT',
+          streamProcessingMode: 'sync',
+          trace: 'enabled_full', // Need full trace to get modelOutput
+          redaction: {
+            output: true,
+            outputMessage: REDACT_MESSAGE,
+          },
+        },
+        temperature: 0,
+      })
+
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Say CACTUS.')] })]
+
+      // Collect streaming events to check for redactedContent
+      const events: any[] = []
+      for await (const event of model.stream(messages)) {
+        events.push(event)
+      }
+
+      // Find the ModelRedactEvent with outputRedaction
+      const redactEvent = events.find((e) => e.type === 'modelRedactEvent' && e.outputRedaction) as
+        | ModelRedactEvent
+        | undefined
+
+      expect(redactEvent).toBeDefined()
+      expect(redactEvent?.outputRedaction?.message).toBe(REDACT_MESSAGE)
+
+      // In sync mode with full trace, we should get the original content
+      // The exact content may vary, but if blocked, redactedContent should be present
+      if (redactEvent?.outputRedaction?.redactedContent) {
+        expect(redactEvent.outputRedaction.redactedContent).toContain('CACTUS')
+      }
+    }, 30000)
+  })
+
+  describe('Tool Result Redaction', () => {
+    it.each(['sync', 'async'] as const)(
+      'properly redacts tool result in %s mode',
+      async (processingMode) => {
+        const INPUT_REDACT_MESSAGE = 'Input redacted.'
+        const OUTPUT_REDACT_MESSAGE = 'Output redacted.'
+
+        const model = bedrock.createModel({
+          guardrailConfig: {
+            guardrailIdentifier: GUARDRAIL_ID!,
+            guardrailVersion: 'DRAFT',
+            streamProcessingMode: processingMode,
+            redaction: {
+              input: true,
+              inputMessage: INPUT_REDACT_MESSAGE,
+              output: true,
+              outputMessage: OUTPUT_REDACT_MESSAGE,
+            },
+          },
+        })
+
+        const listUsers = new FunctionTool({
+          name: 'list_users',
+          description: 'List my users',
+          inputSchema: { type: 'object', properties: {} },
+          callback: async () => {
+            return '[{"name": "Jerry Merry"}, {"name": "Mr. CACTUS"}]'
+          },
+        })
+
+        const agent = new Agent({
+          model,
+          systemPrompt: 'You are a helpful assistant.',
+          tools: [listUsers],
+          printer: false,
+        })
+
+        const response1 = await agent.invoke('List my users.')
+        const response2 = await agent.invoke('Thank you!')
+
+        /*
+         * Message sequence:
+         * 0 (user): request1
+         * 1 (assistant): reasoning + tool call
+         * 2 (user): tool result
+         * 3 (assistant): response1 -> output guardrail intervenes
+         * 4 (user): request2
+         * 5 (assistant): response2
+         *
+         * Guardrail intervened on output in message 3 will cause
+         * the redaction of the preceding input (message 2) and message 3.
+         */
+
+        expect(response1.stopReason).toBe('guardrailIntervened')
+
+        if (processingMode === 'sync') {
+          // In sync mode the guardrail processing is blocking
+          expect(response1.toString()).toContain(OUTPUT_REDACT_MESSAGE)
+          expect(response2.toString()).not.toContain(OUTPUT_REDACT_MESSAGE)
+        }
+
+        // In both sync and async with output redaction:
+        // 1. Content should be properly redacted so response2 is not blocked
+        expect(response2.stopReason).not.toBe('guardrailIntervened')
+
+        // 2. Tool result block should be redacted properly
+        const toolUseMessage = agent.messages[1]
+        const toolResultMessage = agent.messages[2]
+
+        expect(toolUseMessage).toBeDefined()
+        expect(toolResultMessage).toBeDefined()
+
+        const toolUseBlock = toolUseMessage?.content.find((b) => b.type === 'toolUseBlock')
+        const toolResultBlock = toolResultMessage?.content.find((b) => b.type === 'toolResultBlock')
+
+        expect(toolUseBlock).toBeDefined()
+        expect(toolResultBlock).toBeDefined()
+
+        if (toolUseBlock?.type === 'toolUseBlock' && toolResultBlock?.type === 'toolResultBlock') {
+          expect(toolResultBlock.toolUseId).toBe(toolUseBlock.toolUseId)
+          const firstContent = toolResultBlock.content[0]
+          expect(firstContent).toBeDefined()
+          if (firstContent?.type === 'textBlock') {
+            expect((firstContent as TextBlock).text).toBe(INPUT_REDACT_MESSAGE)
+          }
+        }
+      },
+      30000
+    )
+  })
+
+  describe('Session Persistence', () => {
+    it('properly redacts input in session', async () => {
+      const model = bedrock.createModel({
+        guardrailConfig: {
+          guardrailIdentifier: GUARDRAIL_ID!,
+          guardrailVersion: 'DRAFT',
+          redaction: {
+            input: true,
+            inputMessage: 'BLOCKED!',
+          },
+        },
+      })
+
+      const testSessionId = `test-session-${Date.now()}`
+      const tempDir = await mkdtemp(join(tmpdir(), 'bedrock-guardrail-test-'))
+      const storage = new FileStorage(tempDir)
+      const sessionManager = new SessionManager({
+        sessionId: testSessionId,
+        storage: { snapshot: storage },
+        saveLatestOn: 'message',
+      })
+
+      const agent = new Agent({
+        model,
+        systemPrompt: 'You are a helpful assistant.',
+        sessionManager,
+        printer: false,
+      })
+
+      const response1 = await agent.invoke('CACTUS')
+
+      expect(response1.stopReason).toBe('guardrailIntervened')
+      const firstBlock = agent.messages[0]?.content[0]
+      if (firstBlock?.type === 'textBlock') {
+        expect(firstBlock.text).toBe('BLOCKED!')
+      }
+
+      // Load snapshot to verify persisted message is redacted
+      const snapshot = await storage.loadSnapshot({
+        location: { sessionId: testSessionId, scope: 'agent', scopeId: agent.agentId },
+      })
+      expect(snapshot).toBeDefined()
+      const snapshotMessages = snapshot?.data.messages as MessageData[] | undefined
+      expect(snapshotMessages).toBeDefined()
+      expect(snapshotMessages?.[0]?.content[0]).toBeDefined()
+      const firstContentBlock = snapshotMessages?.[0]?.content[0]
+      if (firstContentBlock && 'text' in firstContentBlock) {
+        expect(firstContentBlock.text).toBe('BLOCKED!')
+      }
+
+      // Restore agent from session and confirm input is still redacted
+      const agent2 = new Agent({
+        model,
+        systemPrompt: 'You are a helpful assistant.',
+        sessionManager,
+        printer: false,
+      })
+
+      const restored = await sessionManager.restoreSnapshot({ target: agent2 })
+      expect(restored).toBe(true)
+
+      expect(agent2.messages[0]?.content[0]?.type).toBe('textBlock')
+      const agent2FirstBlock = agent2.messages[0]?.content[0]
+      if (agent2FirstBlock?.type === 'textBlock') {
+        expect(agent2FirstBlock.text).toBe('BLOCKED!')
+      }
+      expect(agent.messages[0]).toEqual(agent2.messages[0])
+    }, 30000)
+  })
+})


### PR DESCRIPTION
## Description
Introduce bedrock guardrail redaction based on how it works in the python sdk. This feature:
- Redacts the latest message if its a user role and the input guardrail triggers
  - Overwrites tool result content directly to maintain tool use - result ordering
- Redacts assistant response if the output guardrail is triggered
- Emits a ModelRedactEvent when guardrails are triggered
  - Input redaction message included to determine what to overwrite the latest user input with
  - Output redaction message is included to show what the models output was redacted to
  -  output redacted message is included so you can see what the model responsed with
- Update session manager to update the snapshot if the model redacted some input

## Related Issues

N/A

## Documentation PR

TODO

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
