### PR TITLE
feat(bedrock): add guardLatestUserMessage guardrail option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5715,9 +5715,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -2895,6 +2895,258 @@ describe('BedrockModel', () => {
         )
       })
 
+      it('skips wrapping images with unsupported formats (gif)', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const imageBytes = new Uint8Array([1, 2, 3, 4])
+        const provider = new BedrockModel({
+          guardrailConfig: {
+            guardrailIdentifier: 'my-guardrail-id',
+            guardrailVersion: '1',
+            guardLatestUserMessage: true,
+          },
+        })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ImageBlock({
+                format: 'gif',
+                source: { bytes: imageBytes },
+              }),
+            ],
+          }),
+        ]
+
+        collectIterator(provider.stream(messages))
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "Image format 'gif' not supported by Bedrock guardrails, skipping guardContent wrap"
+        )
+        expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    image: {
+                      format: 'gif',
+                      source: { bytes: imageBytes },
+                    },
+                  },
+                ],
+              },
+            ],
+          })
+        )
+        consoleWarnSpy.mockRestore()
+      })
+
+      it('skips wrapping images with unsupported formats (webp)', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const imageBytes = new Uint8Array([1, 2, 3, 4])
+        const provider = new BedrockModel({
+          guardrailConfig: {
+            guardrailIdentifier: 'my-guardrail-id',
+            guardrailVersion: '1',
+            guardLatestUserMessage: true,
+          },
+        })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ImageBlock({
+                format: 'webp',
+                source: { bytes: imageBytes },
+              }),
+            ],
+          }),
+        ]
+
+        collectIterator(provider.stream(messages))
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "Image format 'webp' not supported by Bedrock guardrails, skipping guardContent wrap"
+        )
+        expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    image: {
+                      format: 'webp',
+                      source: { bytes: imageBytes },
+                    },
+                  },
+                ],
+              },
+            ],
+          })
+        )
+        consoleWarnSpy.mockRestore()
+      })
+
+      it('skips wrapping images with S3 source', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const provider = new BedrockModel({
+          guardrailConfig: {
+            guardrailIdentifier: 'my-guardrail-id',
+            guardrailVersion: '1',
+            guardLatestUserMessage: true,
+          },
+        })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ImageBlock({
+                format: 'png',
+                source: {
+                  s3Location: {
+                    uri: 's3://bucket/image.png',
+                  },
+                },
+              }),
+            ],
+          }),
+        ]
+
+        collectIterator(provider.stream(messages))
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Image source must be bytes for Bedrock guardrails, skipping guardContent wrap'
+        )
+        expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    image: {
+                      format: 'png',
+                      source: {
+                        s3Location: {
+                          uri: 's3://bucket/image.png',
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          })
+        )
+        consoleWarnSpy.mockRestore()
+      })
+
+      it('skips wrapping images with URL source', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const provider = new BedrockModel({
+          guardrailConfig: {
+            guardrailIdentifier: 'my-guardrail-id',
+            guardrailVersion: '1',
+            guardLatestUserMessage: true,
+          },
+        })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ImageBlock({
+                format: 'jpeg',
+                source: { url: 'https://example.com/image.jpg' },
+              }),
+            ],
+          }),
+        ]
+
+        collectIterator(provider.stream(messages))
+
+        // URL sources return undefined in _formatMediaSource, resulting in source: undefined
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Ignoring imageSourceUrl content block as its not supported by bedrock'
+        )
+        // The image block still appears but with undefined source (Bedrock will reject this)
+        expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    image: {
+                      format: 'jpeg',
+                      source: undefined,
+                    },
+                  },
+                ],
+              },
+            ],
+          })
+        )
+        consoleWarnSpy.mockRestore()
+      })
+
+      it('wraps supported image formats (png and jpeg) with bytes source', async () => {
+        const imageBytes = new Uint8Array([1, 2, 3, 4])
+        const provider = new BedrockModel({
+          guardrailConfig: {
+            guardrailIdentifier: 'my-guardrail-id',
+            guardrailVersion: '1',
+            guardLatestUserMessage: true,
+          },
+        })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ImageBlock({
+                format: 'png',
+                source: { bytes: imageBytes },
+              }),
+              new ImageBlock({
+                format: 'jpeg',
+                source: { bytes: imageBytes },
+              }),
+            ],
+          }),
+        ]
+
+        collectIterator(provider.stream(messages))
+
+        expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    guardContent: {
+                      image: {
+                        format: 'png',
+                        source: { bytes: imageBytes },
+                      },
+                    },
+                  },
+                  {
+                    guardContent: {
+                      image: {
+                        format: 'jpeg',
+                        source: { bytes: imageBytes },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          })
+        )
+      })
+
       it('does not wrap reasoning or cachePoint blocks', async () => {
         const provider = new BedrockModel({
           guardrailConfig: {

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -603,7 +603,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     return messages.reduce<BedrockMessage[]>((acc, message, idx) => {
       const shouldApplyGuardBlocks = idx === lastUserTextIdx
       const content = message.content
-        .map((block) => {
+        .map((block: ContentBlock) => {
           const formattedBlock = this._formatContentBlock(block)
           return shouldApplyGuardBlocks ? this._applyGuardBlocks(formattedBlock) : formattedBlock
         })
@@ -643,12 +643,30 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     }
 
     if ('image' in formattedBlock) {
-      // Extract image data and create guardContent with proper typing
+      // Extract image data and validate for guardContent compatibility
       const imageBlock = formattedBlock.image
+      if (!imageBlock?.format || !imageBlock?.source) {
+        return formattedBlock
+      }
+
+      const format = imageBlock.format
+
+      // Bedrock guardrails only support png/jpeg formats
+      if (format !== 'png' && format !== 'jpeg') {
+        console.warn(`Image format '${format}' not supported by Bedrock guardrails, skipping guardContent wrap`)
+        return formattedBlock
+      }
+
+      // Bedrock guardrails only support bytes source (not S3 or URL)
+      if (!('bytes' in imageBlock.source)) {
+        console.warn('Image source must be bytes for Bedrock guardrails, skipping guardContent wrap')
+        return formattedBlock
+      }
+
       return {
         guardContent: {
           image: {
-            format: imageBlock.format as 'png' | 'jpeg',
+            format: format as 'png' | 'jpeg',
             source: imageBlock.source as { bytes: Uint8Array },
           },
         },


### PR DESCRIPTION
## Motivation

When using Bedrock guardrails in multi-turn conversations, evaluating the entire conversation history with each request can be inefficient and costly. The Python SDK provides a `guardrail_latest_message` option that allows evaluating only the latest user message, improving performance and reducing token costs.

This PR adds the equivalent `guardLatestUserMessage` option to the TypeScript SDK's `BedrockGuardrailConfig`, bringing feature parity with the Python SDK implementation.

Resolves: #565

## Public API Changes

The `BedrockGuardrailConfig` interface now accepts an optional `guardLatestUserMessage` boolean:

```typescript
// Before: evaluate all messages with guardrails
const model = new BedrockModel({
  guardrailConfig: {
    guardrailIdentifier: 'my-guardrail-id',
    guardrailVersion: '1',
  },
})

// After: evaluate only the latest user message
const model = new BedrockModel({
  guardrailConfig: {
    guardrailIdentifier: 'my-guardrail-id',
    guardrailVersion: '1',
    guardLatestUserMessage: true,
  },
})
```

When enabled, the latest user message's text and image content are wrapped in `guardContent` blocks, signaling to Bedrock's guardrails to evaluate only that content.

The implementation finds the last user message containing text or image content (not just the last message in the array), ensuring correct behavior during tool execution cycles where `toolResult` messages (with `role='user'`) may follow the actual user input.

## Use Cases

- **Performance optimization**: Reduce latency in multi-turn conversations by avoiding re-evaluation of previously validated messages
- **Cost reduction**: Fewer tokens evaluated per request lowers guardrail evaluation costs
- **Avoiding redundant validation**: Messages that have already passed guardrail checks don't need to be re-evaluated

## Documentation
TODO