### PR TITLE
fix: add ImageBlock support to tool result content types

### DIFF
--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -7,6 +7,7 @@ import { Message, ReasoningBlock, ToolUseBlock, ToolResultBlock, JsonBlock } fro
 import type { SystemContentBlock } from '../../types/messages.js'
 import { TextBlock, GuardContentBlock, CachePointBlock } from '../../types/messages.js'
 import { CitationsBlock } from '../../types/citations.js'
+import { ImageBlock } from '../../types/media.js'
 import type { StreamOptions } from '../model.js'
 import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
 
@@ -451,6 +452,51 @@ describe('BedrockModel', () => {
                   ],
                   status: 'success',
                   toolUseId: 'tool-123',
+                },
+              },
+            ],
+            role: 'user',
+          },
+        ],
+        modelId: expect.any(String),
+      })
+    })
+
+    it('formats tool result messages with image content', async () => {
+      const provider = new BedrockModel()
+      const imageBytes = new Uint8Array([1, 2, 3])
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-img-1',
+              status: 'success',
+              content: [new TextBlock('Here is the screenshot'), new ImageBlock({ format: 'png', source: { bytes: imageBytes } })],
+            }),
+          ],
+        }),
+      ]
+
+      collectIterator(provider.stream(messages))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith({
+        messages: [
+          {
+            content: [
+              {
+                toolResult: {
+                  content: [
+                    { text: 'Here is the screenshot' },
+                    {
+                      image: {
+                        format: 'png',
+                        source: { bytes: imageBytes },
+                      },
+                    },
+                  ],
+                  status: 'success',
+                  toolUseId: 'tool-img-1',
                 },
               },
             ],

--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -418,10 +418,8 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
           .map((c) => {
             if (c.type === 'textBlock') return { type: 'text' as const, text: c.text }
             if (c.type === 'jsonBlock') return { type: 'text' as const, text: JSON.stringify(c.json) }
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            if ((c as any).type === 'imageBlock') {
-              const img = this._formatContentBlock(c as unknown as ContentBlock)
+            if (c.type === 'imageBlock') {
+              const img = this._formatContentBlock(c)
               if (img && img.type === 'image') return img
             }
             return undefined

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -647,6 +647,13 @@ export class BedrockModel extends Model<BedrockModelConfig> {
               return { text: content.text }
             case 'jsonBlock':
               return { json: content.json }
+            case 'imageBlock':
+              return {
+                image: {
+                  format: content.format as ImageFormat,
+                  source: this._formatMediaSource(content.source),
+                },
+              }
           }
         })
 

--- a/src/models/gemini/adapters.ts
+++ b/src/models/gemini/adapters.ts
@@ -272,6 +272,11 @@ function formatToolResultBlock(block: ToolResultBlock, toolUseIdToName: Map<stri
           return { text: c.text }
         case 'jsonBlock':
           return { json: c.json }
+        case 'imageBlock':
+          if (c.source.type === 'imageSourceBytes') {
+            return { inlineData: { data: encodeBase64(c.source.bytes), mimeType: `image/${c.format}` } }
+          }
+          return { text: `[image: ${c.format}]` }
       }
     }),
   }

--- a/src/tools/__tests__/tool.test.ts
+++ b/src/tools/__tests__/tool.test.ts
@@ -442,6 +442,45 @@ describe('FunctionTool', () => {
       })
     })
 
+    describe('with ImageBlock return', () => {
+      it('wraps ImageBlock in ToolResult with image content', async () => {
+        const { ImageBlock } = await import('../../types/media.js')
+        const tool = new FunctionTool({
+          name: 'imageTool',
+          description: 'Returns an image',
+          inputSchema: { type: 'object' },
+          callback: () => new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } }) as unknown as JSONValue,
+        })
+
+        const toolUse = { name: 'imageTool', toolUseId: 'test-image-1', input: {} }
+        const context = createMockContext(toolUse)
+        const { result } = await collectGenerator(tool.stream(context))
+
+        expect(result.status).toBe('success')
+        expect(result.content).toHaveLength(1)
+        expect(result.content[0]!.type).toBe('imageBlock')
+      })
+
+      it('wraps ToolResultBlock return directly', async () => {
+        const { ToolResultBlock: TRB, TextBlock: TB } = await import('../../types/messages.js')
+        const tool = new FunctionTool({
+          name: 'prebuiltTool',
+          description: 'Returns a pre-built ToolResultBlock',
+          inputSchema: { type: 'object' },
+          callback: () => new TRB({ toolUseId: 'ignored', status: 'success', content: [new TB('pre-built')] }) as unknown as JSONValue,
+        })
+
+        const toolUse = { name: 'prebuiltTool', toolUseId: 'test-prebuilt-1', input: {} }
+        const context = createMockContext(toolUse)
+        const { result } = await collectGenerator(tool.stream(context))
+
+        expect(result.status).toBe('success')
+        expect(result.toolUseId).toBe('test-prebuilt-1')
+        expect(result.content).toHaveLength(1)
+        expect(result.content[0]!.type).toBe('textBlock')
+      })
+    })
+
     describe('with promise callback', () => {
       it('wraps resolved value in ToolResult', async () => {
         const tool = new FunctionTool({

--- a/src/tools/function-tool.ts
+++ b/src/tools/function-tool.ts
@@ -5,6 +5,7 @@ import type { ToolSpec } from './types.js'
 import type { JSONSchema, JSONValue } from '../types/json.js'
 import { deepCopy } from '../types/json.js'
 import { JsonBlock, TextBlock, ToolResultBlock } from '../types/messages.js'
+import { ImageBlock } from '../types/media.js'
 
 /**
  * Callback function for FunctionTool implementations.
@@ -245,6 +246,16 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
    */
   private _wrapInToolResult(value: unknown, toolUseId: string): ToolResultBlock {
     try {
+      // If the callback already returned a ToolResultBlock, use it directly (re-stamp the toolUseId)
+      if (value instanceof ToolResultBlock) {
+        return new ToolResultBlock({
+          toolUseId,
+          status: value.status,
+          content: value.content,
+          ...(value.error !== undefined && { error: value.error }),
+        })
+      }
+
       // Handle null with special string representation as text content
       if (value === null) {
         return new ToolResultBlock({
@@ -260,6 +271,15 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
           toolUseId,
           status: 'success',
           content: [new TextBlock('<undefined>')],
+        })
+      }
+
+      // Handle ImageBlock directly — return it as image content in the tool result
+      if (value instanceof ImageBlock) {
+        return new ToolResultBlock({
+          toolUseId,
+          status: 'success',
+          content: [value],
         })
       }
 

--- a/src/types/__tests__/messages.test.ts
+++ b/src/types/__tests__/messages.test.ts
@@ -72,6 +72,53 @@ describe('ToolResultBlock', () => {
       content: [new TextBlock('result')],
     })
   })
+
+  test('creates tool result block with image content', () => {
+    const imageBlock = new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } })
+    const block = new ToolResultBlock({
+      toolUseId: '456',
+      status: 'success',
+      content: [imageBlock],
+    })
+
+    expect(block.type).toBe('toolResultBlock')
+    expect(block.toolUseId).toBe('456')
+    expect(block.content).toHaveLength(1)
+    expect(block.content[0]).toBeInstanceOf(ImageBlock)
+    expect((block.content[0] as ImageBlock).format).toBe('png')
+  })
+
+  test('creates tool result block with mixed text and image content', () => {
+    const textBlock = new TextBlock('Here is the image:')
+    const imageBlock = new ImageBlock({ format: 'jpeg', source: { bytes: new Uint8Array([4, 5, 6]) } })
+    const block = new ToolResultBlock({
+      toolUseId: '789',
+      status: 'success',
+      content: [textBlock, imageBlock],
+    })
+
+    expect(block.content).toHaveLength(2)
+    expect(block.content[0]).toBeInstanceOf(TextBlock)
+    expect(block.content[1]).toBeInstanceOf(ImageBlock)
+  })
+
+  test('round-trips tool result block with image content through JSON', () => {
+    const imageBlock = new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } })
+    const block = new ToolResultBlock({
+      toolUseId: '123',
+      status: 'success',
+      content: [new TextBlock('caption'), imageBlock],
+    })
+
+    const json = block.toJSON()
+    const restored = ToolResultBlock.fromJSON(json)
+
+    expect(restored.toolUseId).toBe('123')
+    expect(restored.content).toHaveLength(2)
+    expect(restored.content[0]).toBeInstanceOf(TextBlock)
+    expect(restored.content[1]).toBeInstanceOf(ImageBlock)
+    expect((restored.content[1] as ImageBlock).format).toBe('png')
+  })
 })
 
 describe('ReasoningBlock', () => {
@@ -176,6 +223,28 @@ describe('Message.fromMessageData', () => {
     const toolResultBlock = message.content[0] as ToolResultBlock
     expect(toolResultBlock.content).toHaveLength(1)
     expect(toolResultBlock.content[0]).toBeInstanceOf(JsonBlock)
+  })
+
+  it('converts tool result block data to ToolResultBlock with image content', () => {
+    const messageData: MessageData = {
+      role: 'user',
+      content: [
+        {
+          toolResult: {
+            toolUseId: 'tool-123',
+            status: 'success',
+            content: [{ image: { format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } } }],
+          },
+        },
+      ],
+    }
+    const message = Message.fromMessageData(messageData)
+    expect(message.content).toHaveLength(1)
+    expect(message.content[0]).toBeInstanceOf(ToolResultBlock)
+    const toolResultBlock = message.content[0] as ToolResultBlock
+    expect(toolResultBlock.content).toHaveLength(1)
+    expect(toolResultBlock.content[0]).toBeInstanceOf(ImageBlock)
+    expect((toolResultBlock.content[0] as ImageBlock).format).toBe('png')
   })
 
   it('converts reasoning block data to ReasoningBlock', () => {
@@ -547,6 +616,7 @@ describe('toJSON/fromJSON round-trips', () => {
     ['ToolUseBlock with reasoningSignature',   () => new ToolUseBlock({ name: 'test-tool', toolUseId: '123', input: { param: 'value' }, reasoningSignature: 'sig123' })],
     ['ToolResultBlock with text content',      () => new ToolResultBlock({ toolUseId: '123', status: 'success', content: [new TextBlock('Result text')] })],
     ['ToolResultBlock with json content',      () => new ToolResultBlock({ toolUseId: '456', status: 'success', content: [new JsonBlock({ json: { result: 'data' } })] })],
+    ['ToolResultBlock with image content',     () => new ToolResultBlock({ toolUseId: '101', status: 'success', content: [new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } })] })],
     ['ToolResultBlock with error status',      () => new ToolResultBlock({ toolUseId: '789', status: 'error', content: [new TextBlock('Error message')] })],
     ['ReasoningBlock with text only',          () => new ReasoningBlock({ text: 'Thinking...' })],
     ['ReasoningBlock with signature',          () => new ReasoningBlock({ text: 'Thinking...', signature: 'sig123' })],

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -277,9 +277,9 @@ export class ToolUseBlock implements ToolUseBlockData, JSONSerializable<{ toolUs
  *
  * This is a discriminated union where the object key determines the content format.
  */
-export type ToolResultContentData = TextBlockData | JsonBlockData
+export type ToolResultContentData = TextBlockData | JsonBlockData | { image: MaybeSerializedInput<ImageBlockData> }
 
-export type ToolResultContent = TextBlock | JsonBlock
+export type ToolResultContent = TextBlock | JsonBlock | ImageBlock
 
 /**
  * Data for a tool result block.
@@ -311,7 +311,7 @@ export interface ToolResultBlockData {
 /**
  * Tool result content block.
  */
-export class ToolResultBlock implements ToolResultBlockData, JSONSerializable<{ toolResult: ToolResultBlockData }> {
+export class ToolResultBlock implements JSONSerializable<{ toolResult: ToolResultBlockData }> {
   /**
    * Discriminator for tool result content.
    */
@@ -375,6 +375,8 @@ export class ToolResultBlock implements ToolResultBlockData, JSONSerializable<{ 
         return new TextBlock(contentItem.text)
       } else if ('json' in contentItem) {
         return new JsonBlock(contentItem)
+      } else if ('image' in contentItem) {
+        return ImageBlock.fromJSON(contentItem)
       } else {
         throw new Error('Unknown ToolResultContentData type')
       }
@@ -862,6 +864,8 @@ export function contentBlockFromData(data: ContentBlockData): ContentBlock {
           return new TextBlock(contentItem.text)
         } else if ('json' in contentItem) {
           return new JsonBlock(contentItem)
+        } else if ('image' in contentItem) {
+          return ImageBlock.fromJSON(contentItem)
         } else {
           throw new Error('Unknown ToolResultContentData type')
         }


### PR DESCRIPTION
## Problem

`ToolResultContent` is typed as `TextBlock | JsonBlock` only. `ImageBlock` exists and is fully implemented in the SDK, but it's excluded from tool result content at the type level. This means:

- Tools that return image content (e.g. screenshot tools) can't properly type their results
- The Anthropic model works around this with an unsafe `(c as any).type === 'imageBlock'` cast
- The Bedrock model doesn't handle image content in tool results at all

## Solution

Expand the tool result content types to include `ImageBlock`:

1. **`src/types/messages.ts`** — Add `ImageBlock` to `ToolResultContent` and `{ image: MaybeSerializedInput<ImageBlockData> }` to `ToolResultContentData`. Update `ToolResultBlock.fromJSON()` and `contentBlockFromData()` to handle image content deserialization.

2. **`src/tools/function-tool.ts`** — Add `instanceof ImageBlock` and `instanceof ToolResultBlock` checks in `_wrapInToolResult()` so tool callbacks can return image content directly.

3. **`src/models/bedrock.ts`** — Add `imageBlock` case to the tool result content formatter, matching the existing top-level image block handling.

4. **`src/models/anthropic.ts`** — Remove the unsafe `(c as any)` cast now that `ImageBlock` is a proper member of `ToolResultContent`.

## Testing

- Added unit tests for `ToolResultBlock` with image content (creation, mixed content, JSON round-trip)
- Added `contentBlockFromData` test for image content in tool results
- Added `FunctionTool` tests for `ImageBlock` and `ToolResultBlock` return handling
- Added Bedrock model test for tool result formatting with image content
- All 1301 existing tests continue to pass