### PR TITLE
feat: make Swarm start optional, defaulting to first node

### DIFF
--- a/src/multiagent/__tests__/swarm.test.ts
+++ b/src/multiagent/__tests__/swarm.test.ts
@@ -63,6 +63,14 @@ describe('Swarm', () => {
       expect(swarm.nodes.get('a')).toBeInstanceOf(AgentNode)
     })
 
+    it('defaults start to the first node when not specified', () => {
+      const swarm = new Swarm({
+        nodes: [createFinalAgent('first', 'hi'), createFinalAgent('second', 'bye')],
+      })
+
+      expect(swarm.start.id).toBe('first')
+    })
+
     it('throws when start references unknown agent', () => {
       expect(
         () =>
@@ -71,6 +79,10 @@ describe('Swarm', () => {
             start: 'missing',
           })
       ).toThrow('start=<missing> | start references unknown agent')
+    })
+
+    it('throws when nodes list is empty', () => {
+      expect(() => new Swarm({ nodes: [] })).toThrow('nodes list is empty')
     })
 
     it('throws on duplicate agent ids', () => {

--- a/src/multiagent/swarm.ts
+++ b/src/multiagent/swarm.ts
@@ -62,8 +62,8 @@ export interface SwarmOptions extends SwarmConfig {
   id?: string
   /** Swarm agents. Pass agents directly or use {@link AgentNodeOptions} for per-node config. */
   nodes: SwarmNodeDefinition[]
-  /** Agent id that receives the initial input. */
-  start: string
+  /** Agent id that receives the initial input. Defaults to the first agent in `nodes`. */
+  start?: string
   /** Plugins for event-driven extensibility. */
   plugins?: MultiAgentPlugin[]
 }
@@ -102,7 +102,7 @@ export class Swarm implements MultiAgentBase {
   readonly config: Required<SwarmConfig>
   private readonly _pluginRegistry: MultiAgentPluginRegistry
   private readonly _hookRegistry: HookRegistryImplementation
-  private readonly _start: AgentNode
+  readonly start: AgentNode
   private readonly _handoffSchema: z.ZodType<HandoffResult>
   private _initialized: boolean
 
@@ -117,7 +117,7 @@ export class Swarm implements MultiAgentBase {
     this._validateConfig()
 
     this.nodes = this._resolveNodes(nodes)
-    this._start = this._resolveStart(start)
+    this.start = this._resolveStart(start)
 
     this._handoffSchema = this._buildHandoffSchema()
 
@@ -193,7 +193,7 @@ export class Swarm implements MultiAgentBase {
 
     yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state })
 
-    let node = this._start
+    let node = this.start
     let handoff: HandoffResult | undefined
 
     try {
@@ -282,6 +282,10 @@ export class Swarm implements MultiAgentBase {
   }
 
   private _resolveNodes(definitions: SwarmNodeDefinition[]): Map<string, AgentNode> {
+    if (definitions.length === 0) {
+      throw new Error('nodes list is empty')
+    }
+
     const nodes = new Map<string, AgentNode>()
     for (const definition of definitions) {
       const node = definition instanceof Agent ? new AgentNode({ agent: definition }) : new AgentNode(definition)
@@ -293,7 +297,11 @@ export class Swarm implements MultiAgentBase {
     return nodes
   }
 
-  private _resolveStart(start: string): AgentNode {
+  private _resolveStart(start: string | undefined): AgentNode {
+    if (start === undefined) {
+      return this.nodes.values().next().value!
+    }
+
     const node = this.nodes.get(start)
     if (!node) {
       throw new Error(`start=<${start}> | start references unknown agent`)


### PR DESCRIPTION
## Motivation

When creating a Swarm, the `start` parameter is redundant in the common case where the first agent in the `nodes` list is the entry point. Requiring it adds unnecessary boilerplate, especially for simple swarms. Also, aligns with the Python SDK.

Resolves: https://github.com/strands-agents/sdk-typescript/issues/392

## Public API Changes

The `start` property on `SwarmOptions` is now optional. When omitted, the first agent in the `nodes` array is used as the entry point. `start` is also now a public readonly property on the `Swarm` class.

```typescript
// Before: start was required
const swarm = new Swarm({
  nodes: [agentA, agentB],
  start: "agentA",
})

// After: start defaults to first node
const swarm = new Swarm({
  nodes: [agentA, agentB],
})
swarm.start.id // "agentA"
```

The change is backward compatible — all existing usage with an explicit `start` continues to work without modification.

An empty `nodes` array now throws eagerly during construction rather than failing later at runtime.

## Type of Change

New feature

## Documentation

Working on Swarm documentation now.

## Testing

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published