### PR TITLE
refactor: unify AgentBase as the single agent interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,13 @@ const model = new BedrockModel({ maxTokens: 1024 })
 
 const researcher = new Agent({
   model,
-  agentId: 'researcher',
+  id: 'researcher',
   systemPrompt: 'Research the topic and provide key facts.',
 })
 
 const writer = new Agent({
   model,
-  agentId: 'writer',
+  id: 'writer',
   systemPrompt: 'Rewrite the research into a polished paragraph.',
 })
 
@@ -276,14 +276,14 @@ const model = new BedrockModel({ maxTokens: 1024 })
 
 const researcher = new Agent({
   model,
-  agentId: 'researcher',
+  id: 'researcher',
   description: 'Researches a topic and gathers key facts.',
   systemPrompt: 'Research the answer, then hand off to the writer.',
 })
 
 const writer = new Agent({
   model,
-  agentId: 'writer',
+  id: 'writer',
   description: 'Writes a polished final answer.',
   systemPrompt: 'Write the final answer. Do not hand off.',
 })

--- a/examples/graph/src/index.ts
+++ b/examples/graph/src/index.ts
@@ -7,14 +7,14 @@ async function main() {
   const researcher = new Agent({
     model,
     printer: false,
-    agentId: 'researcher',
+    id: 'researcher',
     systemPrompt: 'Research the topic and provide key facts in 2-3 sentences.',
   })
 
   const writer = new Agent({
     model,
     printer: false,
-    agentId: 'writer',
+    id: 'writer',
     systemPrompt: 'Rewrite the research into a polished, concise paragraph.',
   })
 
@@ -34,21 +34,21 @@ async function main() {
   const router = new Agent({
     model,
     printer: false,
-    agentId: 'router',
+    id: 'router',
     systemPrompt: 'Repeat the user input exactly.',
   })
 
   const capitals = new Agent({
     model,
     printer: false,
-    agentId: 'capitals',
+    id: 'capitals',
     systemPrompt: 'Answer with only the capital of France.',
   })
 
   const oceans = new Agent({
     model,
     printer: false,
-    agentId: 'oceans',
+    id: 'oceans',
     systemPrompt: 'Answer with only the largest ocean.',
   })
 

--- a/examples/swarm/src/index.ts
+++ b/examples/swarm/src/index.ts
@@ -7,7 +7,7 @@ async function main() {
   const researcher = new Agent({
     model,
     printer: false,
-    agentId: 'researcher',
+    id: 'researcher',
     description: 'Researches a topic and gathers key facts.',
     systemPrompt:
       'You are a researcher. Look up the answer, then hand off to the writer agent. Never produce a final response yourself.',
@@ -16,7 +16,7 @@ async function main() {
   const writer = new Agent({
     model,
     printer: false,
-    agentId: 'writer',
+    id: 'writer',
     description: 'Writes a polished final answer.',
     systemPrompt: 'Write the final answer in one clear paragraph. Do not hand off to another agent.',
   })

--- a/src/a2a/__tests__/executor.test.ts
+++ b/src/a2a/__tests__/executor.test.ts
@@ -3,7 +3,6 @@ import { A2AExecutor } from '../executor.js'
 import type { AgentExecutionEvent, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk'
 import { Agent } from '../../agent/agent.js'
-import type { AgentBase } from '../../agent/agent-base.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
 import { TextBlock } from '../../types/messages.js'
@@ -156,28 +155,27 @@ describe('A2AExecutor', () => {
 
     it('publishes image content blocks as separate file artifacts', async () => {
       const imageBytes = new Uint8Array([137, 80, 78, 71])
-      const mockAgent: AgentBase = {
-        invoke: vi.fn(),
-        async *stream() {
-          const agent = createMockAgent()
-          // Text delta
-          yield new ModelStreamUpdateEvent({
-            agent,
-            event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Here is the image:' } },
-          })
-          // Image content block
-          yield new ContentBlockEvent({
-            agent,
-            contentBlock: new ImageBlock({ format: 'png', source: { bytes: imageBytes } }),
-          })
-          return new AgentResult({
-            stopReason: 'endTurn',
-            lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Here is the image:')] }),
-          })
-        },
-      }
+      const baseAgent = createMockAgent()
+      baseAgent.invoke = vi.fn() as typeof baseAgent.invoke
+      baseAgent.stream = async function* () {
+        const agent = createMockAgent()
+        // Text delta
+        yield new ModelStreamUpdateEvent({
+          agent,
+          event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Here is the image:' } },
+        })
+        // Image content block
+        yield new ContentBlockEvent({
+          agent,
+          contentBlock: new ImageBlock({ format: 'png', source: { bytes: imageBytes } }),
+        })
+        return new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Here is the image:')] }),
+        })
+      } as typeof baseAgent.stream
 
-      const executor = new A2AExecutor(mockAgent)
+      const executor = new A2AExecutor(baseAgent)
       const eventBus = createMockEventBus()
 
       await executor.execute(createRequestContext('Generate an image'), eventBus)

--- a/src/a2a/a2a-agent.ts
+++ b/src/a2a/a2a-agent.ts
@@ -13,8 +13,17 @@ import { ClientFactory } from '@a2a-js/sdk/client'
 import type { AgentBase } from '../agent/agent-base.js'
 import type { InvokeArgs, InvokeOptions } from '../agent/agent.js'
 import { AgentResult, type AgentStreamEvent } from '../types/agent.js'
-import { Message, TextBlock, type ContentBlock, type ContentBlockData, type MessageData } from '../types/messages.js'
+import {
+  Message,
+  TextBlock,
+  type ContentBlock,
+  type ContentBlockData,
+  type MessageData,
+  type SystemPrompt,
+} from '../types/messages.js'
+import type { HookableEvent } from '../hooks/events.js'
 import { AgentResultEvent } from '../hooks/events.js'
+import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
 import { A2AStreamUpdateEvent, type A2AEventData } from './events.js'
 import { AppState } from '../app-state.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
@@ -29,6 +38,10 @@ export interface A2AAgentConfig {
   url: string
   /** Path to the agent card endpoint (default: '/.well-known/agent-card.json') */
   agentCardPath?: string
+  /** Unique identifier for this agent. Defaults to the URL. */
+  id?: string
+  /** Optional description of what this agent does. */
+  description?: string
 }
 
 /**
@@ -48,6 +61,13 @@ export interface A2AAgentConfig {
  * ```
  */
 export class A2AAgent implements AgentBase {
+  readonly type = 'agent' as const
+  readonly id: string
+  readonly description?: string
+  readonly messages: Message[] = []
+  readonly state = new AppState()
+  readonly toolRegistry = new ToolRegistry()
+  systemPrompt?: SystemPrompt
   private _config: A2AAgentConfig
   private _client: A2AClientSdk | undefined
   private _agentCard: AgentCard | undefined
@@ -59,6 +79,19 @@ export class A2AAgent implements AgentBase {
    */
   constructor(config: A2AAgentConfig) {
     this._config = config
+    this.id = config.id ?? config.url
+    if (config.description !== undefined) this.description = config.description
+  }
+  /**
+   * No-op. A2AAgent does not emit hookable events yet.
+   *
+   * @param _eventType - The event class constructor (unused)
+   * @param _callback - The callback function (unused)
+   * @returns No-op cleanup function
+   */
+  addHook<T extends HookableEvent>(_eventType: HookableEventConstructor<T>, _callback: HookCallback<T>): HookCleanup {
+    logger.warn('a2a agent does not emit hookable events yet')
+    return () => {}
   }
 
   /**
@@ -132,12 +165,7 @@ export class A2AAgent implements AgentBase {
     const result = this._buildResult(finalEvent, accumulatedText)
 
     yield new AgentResultEvent({
-      agent: {
-        state: new AppState(),
-        messages: [result.lastMessage],
-        toolRegistry: new ToolRegistry(),
-        addHook: (): (() => void) => () => {},
-      },
+      agent: this,
       result,
     })
     return result

--- a/src/agent/__tests__/agent.tracer.test.ts
+++ b/src/agent/__tests__/agent.tracer.test.ts
@@ -58,7 +58,7 @@ describe('Agent tracer integration', () => {
     })
   })
 
-  describe('name and agentId', () => {
+  describe('name and id', () => {
     it('defaults name to "Strands Agent"', () => {
       const agent = new Agent()
 
@@ -71,23 +71,23 @@ describe('Agent tracer integration', () => {
       expect(agent.name).toBe('My Agent')
     })
 
-    it('defaults agentId to "default"', () => {
+    it('defaults id to "agent"', () => {
       const agent = new Agent()
 
-      expect(agent.agentId).toBe('default')
+      expect(agent.id).toBe('agent')
     })
 
-    it('uses provided agentId', () => {
-      const agent = new Agent({ agentId: 'custom-id-123' })
+    it('uses provided id', () => {
+      const agent = new Agent({ id: 'custom-id-123' })
 
-      expect(agent.agentId).toBe('custom-id-123')
+      expect(agent.id).toBe('custom-id-123')
     })
   })
 
   describe('agent span lifecycle', () => {
     it('starts and ends agent span on successful invocation', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
-      const agent = new Agent({ model, name: 'TestAgent', agentId: 'test-id' })
+      const agent = new Agent({ model, name: 'TestAgent', id: 'test-id' })
       const tracer = getLatestTracer()
 
       await agent.invoke('Hi')

--- a/src/agent/agent-base.ts
+++ b/src/agent/agent-base.ts
@@ -1,13 +1,29 @@
 import type { InvokeArgs, InvokeOptions } from './agent.js'
-import type { AgentResult, AgentStreamEvent } from '../types/agent.js'
+import type { AgentData, AgentResult, AgentStreamEvent } from '../types/agent.js'
 
 /**
- * Interface defining the minimal contract for all agent types.
+ * Interface defining the contract for all agent types.
  *
- * Both `Agent` (full orchestration agent) and `A2AAgent` (remote agent proxy)
+ * Extends {@link AgentData} with invocation capabilities. Both `Agent`
+ * (full orchestration agent) and `A2AAgent` (remote agent proxy)
  * implement this interface, enabling polymorphic usage across the SDK.
  */
-export interface AgentBase {
+export interface AgentBase extends AgentData {
+  /**
+   * Discriminator identifying this as an agent type.
+   */
+  readonly type: 'agent'
+
+  /**
+   * The unique identifier of the agent instance.
+   */
+  readonly id: string
+
+  /**
+   * Optional description of what the agent does.
+   */
+  readonly description?: string
+
   /**
    * Invokes the agent and returns the final result.
    *

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -23,7 +23,6 @@ import type { BaseModelConfig, StreamAggregatedResult, StreamOptions } from '../
 import { isModelStreamEvent } from '../models/streaming.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
 import { AppState } from '../app-state.js'
-import type { AgentData } from '../types/agent.js'
 import type { AgentBase } from './agent-base.js'
 import { AgentPrinter, getDefaultAppender, type Printer } from './printer.js'
 import type { Plugin } from '../plugins/plugin.js'
@@ -146,7 +145,7 @@ export type AgentConfig = {
   /**
    * Optional unique identifier for the agent. Defaults to "default".
    */
-  agentId?: string
+  id?: string
 }
 
 /**
@@ -173,14 +172,15 @@ export interface InvokeOptions {
 const DEFAULT_AGENT_NAME = 'Strands Agent'
 
 /** Default identifier assigned to agents when none is provided. */
-const DEFAULT_AGENT_ID = 'default'
+const DEFAULT_AGENT_ID = 'agent'
 
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
  * The Agent is responsible for managing the lifecycle of tools and clients
  * and invoking the core decision-making loop.
  */
-export class Agent implements AgentData, AgentBase {
+export class Agent implements AgentBase {
+  readonly type = 'agent' as const
   /**
    * The conversation history of messages between user and assistant.
    */
@@ -210,7 +210,7 @@ export class Agent implements AgentData, AgentBase {
   /**
    * The unique identifier of the agent instance.
    */
-  public readonly agentId: string
+  public readonly id: string
 
   /**
    * Optional description of what the agent does.
@@ -240,7 +240,7 @@ export class Agent implements AgentData, AgentBase {
     this.state = new AppState(config?.state)
     this._conversationManager = config?.conversationManager ?? new SlidingWindowConversationManager({ windowSize: 40 })
     this.name = config?.name ?? DEFAULT_AGENT_NAME
-    this.agentId = config?.agentId ?? DEFAULT_AGENT_ID
+    this.id = config?.id ?? DEFAULT_AGENT_ID
     if (config?.description !== undefined) this.description = config.description
 
     if (typeof config?.model === 'string') {
@@ -485,7 +485,7 @@ export class Agent implements AgentData, AgentBase {
     const agentSpanOptions: Parameters<Tracer['startAgentSpan']>[0] = {
       messages: inputMessages,
       agentName: this.name,
-      agentId: this.agentId,
+      agentId: this.id,
       tools: this.tools,
     }
     if (agentModelId) agentSpanOptions.modelId = agentModelId

--- a/src/agent/snapshot.ts
+++ b/src/agent/snapshot.ts
@@ -14,7 +14,7 @@
 import type { JSONValue } from '../types/json.js'
 import type { MessageData, SystemPromptData } from '../types/messages.js'
 import { Message, systemPromptFromData, systemPromptToData } from '../types/messages.js'
-import type { Agent } from './agent.js'
+import type { AgentData } from '../types/agent.js'
 
 /**
  * Current schema version of the snapshot format.
@@ -124,7 +124,7 @@ export type TakeSnapshotOptions = {
  * @param options - Snapshot options
  * @returns A snapshot of the agent's state
  */
-export function takeSnapshot(agent: Agent, options: TakeSnapshotOptions): Snapshot {
+export function takeSnapshot(agent: AgentData, options: TakeSnapshotOptions): Snapshot {
   const fields = resolveSnapshotFields(options)
 
   const data: Record<string, JSONValue> = {}
@@ -159,7 +159,7 @@ export function takeSnapshot(agent: Agent, options: TakeSnapshotOptions): Snapsh
  * @param agent - The agent to restore state into
  * @param snapshot - The snapshot to load
  */
-export function loadSnapshot(agent: Agent, snapshot: Snapshot): void {
+export function loadSnapshot(agent: AgentData, snapshot: Snapshot): void {
   if (snapshot.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
     throw new Error(
       `Unsupported snapshot schema version: ${snapshot.schemaVersion}. Current version: ${SNAPSHOT_SCHEMA_VERSION}`

--- a/src/multiagent/__tests__/events.test.ts
+++ b/src/multiagent/__tests__/events.test.ts
@@ -16,6 +16,7 @@ import type { MultiAgentBase } from '../base.js'
 import type { AgentStreamEvent } from '../../types/agent.js'
 
 const mockOrchestrator: MultiAgentBase = {
+  type: 'multiAgent',
   id: 'test-orchestrator',
   invoke: async () => new MultiAgentResult({ results: [], duration: 0 }),
   // eslint-disable-next-line require-yield

--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -10,7 +10,7 @@ import { Graph } from '../graph.js'
 
 function makeAgent(id: string, text = 'reply'): Agent {
   const model = new MockMessageModel().addTurn(new TextBlock(text))
-  return new Agent({ model, printer: false, agentId: id })
+  return new Agent({ model, printer: false, id })
 }
 
 describe('Graph', () => {
@@ -34,7 +34,7 @@ describe('Graph', () => {
 
     it('accepts agent node options', () => {
       const graph = new Graph({
-        nodes: [{ type: 'agent', agent: makeAgent('a') }],
+        nodes: [{ type: 'agentOptions', agent: makeAgent('a') }],
         edges: [],
       })
       expect(graph.nodes.get('a')).toBeInstanceOf(AgentNode)
@@ -48,7 +48,7 @@ describe('Graph', () => {
       })
 
       const graph = new Graph({
-        nodes: [{ type: 'multiAgent', orchestrator: inner }],
+        nodes: [{ type: 'multiAgentOptions', orchestrator: inner }],
         edges: [],
       })
       expect(graph.nodes.get('inner')).toBeInstanceOf(MultiAgentNode)
@@ -317,7 +317,7 @@ describe('Graph', () => {
 
     it('returns failed result when agent throws', async () => {
       const model = new MockMessageModel().addTurn(new Error('agent exploded'))
-      const agent = new Agent({ model, printer: false, agentId: 'a' })
+      const agent = new Agent({ model, printer: false, id: 'a' })
 
       const graph = new Graph({
         nodes: [agent, makeAgent('b', 'b-reply')],

--- a/src/multiagent/__tests__/nodes.test.ts
+++ b/src/multiagent/__tests__/nodes.test.ts
@@ -90,7 +90,7 @@ describe('AgentNode', () => {
 
   beforeEach(() => {
     const model = new MockMessageModel().addTurn(new TextBlock('reply'))
-    agent = new Agent({ model, printer: false, state: { key1: 'value1' }, agentId: 'agent-1' })
+    agent = new Agent({ model, printer: false, state: { key1: 'value1' }, id: 'agent-1' })
     node = new AgentNode({ agent })
     state = new MultiAgentState({ nodeIds: ['agent-1'] })
   })
@@ -143,7 +143,7 @@ describe('AgentNode', () => {
         })
         .addTurn({ type: 'textBlock', text: 'Done' })
 
-      agent = new Agent({ model, printer: false, agentId: 'schema-agent' })
+      agent = new Agent({ model, printer: false, id: 'schema-agent' })
       node = new AgentNode({ agent })
       state = new MultiAgentState({ nodeIds: ['schema-agent'], structuredOutputSchema: schema })
 
@@ -168,6 +168,7 @@ describe('MultiAgentNode', () => {
    */
   function mockOrchestrator(id: string, events: MultiAgentStreamEvent[]): MultiAgentBase {
     return {
+      type: 'multiAgent',
       id,
       invoke: async () => new MultiAgentResult({ results: [], duration: 0 }),
       async *stream() {

--- a/src/multiagent/__tests__/swarm.test.ts
+++ b/src/multiagent/__tests__/swarm.test.ts
@@ -14,9 +14,9 @@ import { Swarm } from '../swarm.js'
  * The model returns a toolUseBlock with the handoff payload, then a text block to finish.
  */
 function createHandoffAgent(
-  agentId: string,
+  id: string,
   handoff: { agentId?: string; message: string; context?: Record<string, unknown> },
-  description: string = `Agent ${agentId}`
+  description: string = `Agent ${id}`
 ): Agent {
   const model = new MockMessageModel()
     .addTurn({
@@ -26,14 +26,14 @@ function createHandoffAgent(
       input: handoff as JSONValue,
     })
     .addTurn(new TextBlock('Done'))
-  return new Agent({ model, printer: false, agentId, description })
+  return new Agent({ model, printer: false, id, description })
 }
 
 /**
  * Creates a simple agent that produces a final response (no handoff).
  */
-function createFinalAgent(agentId: string, message: string, description: string = `Agent ${agentId}`): Agent {
-  return createHandoffAgent(agentId, { message }, description)
+function createFinalAgent(id: string, message: string, description: string = `Agent ${id}`): Agent {
+  return createHandoffAgent(id, { message }, description)
 }
 
 describe('Swarm', () => {
@@ -57,7 +57,7 @@ describe('Swarm', () => {
 
     it('accepts AgentNodeOptions with per-node config', () => {
       const swarm = new Swarm({
-        nodes: [{ agent: createFinalAgent('a', 'hi') }],
+        nodes: [{ type: 'agentOptions', agent: createFinalAgent('a', 'hi') }],
         start: 'a',
       })
       expect(swarm.nodes.get('a')).toBeInstanceOf(AgentNode)
@@ -207,10 +207,10 @@ describe('Swarm', () => {
 
     it('returns failed result when agent throws', async () => {
       const model = new MockMessageModel().addTurn(new Error('agent exploded'))
-      const agent = new Agent({ model, printer: false, agentId: 'a', description: 'Agent a' })
+      const agent = new Agent({ model, printer: false, id: 'a', description: 'Agent a' })
 
       const swarm = new Swarm({
-        nodes: [{ agent }],
+        nodes: [{ type: 'agentOptions', agent }],
         start: 'a',
       })
 

--- a/src/multiagent/base.ts
+++ b/src/multiagent/base.ts
@@ -10,6 +10,9 @@ import type { MultiAgentResult } from './state.js'
  * composed as nodes within other orchestrators via {@link MultiAgentNode}.
  */
 export interface MultiAgentBase {
+  /** Discriminator identifying this as a multi-agent orchestrator type. */
+  readonly type: 'multiAgent'
+
   /** Unique identifier for this orchestrator. */
   readonly id: string
 

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -1,4 +1,3 @@
-import { Agent } from '../agent/agent.js'
 import type { InvokeArgs } from '../agent/agent.js'
 import type { ContentBlock } from '../types/messages.js'
 import { TextBlock } from '../types/messages.js'
@@ -87,6 +86,7 @@ export interface GraphOptions extends GraphConfig {
  * ```
  */
 export class Graph implements MultiAgentBase {
+  readonly type = 'multiAgent' as const
   readonly id: string
   readonly nodes: ReadonlyMap<string, Node>
   readonly edges: readonly Edge[]
@@ -358,25 +358,23 @@ export class Graph implements MultiAgentBase {
 
       if (definition instanceof Node) {
         node = definition
-      } else if ('type' in definition) {
+      } else {
         switch (definition.type) {
-          case 'agent': {
-            const { type: _, ...options } = definition
-            node = new AgentNode(options)
+          case 'agent':
+            node = new AgentNode({ agent: definition })
             break
-          }
-          case 'multiAgent': {
-            const { type: _, ...options } = definition
-            node = new MultiAgentNode(options)
+          case 'multiAgent':
+            node = new MultiAgentNode({ orchestrator: definition })
             break
-          }
+          case 'agentOptions':
+            node = new AgentNode(definition)
+            break
+          case 'multiAgentOptions':
+            node = new MultiAgentNode(definition)
+            break
           default:
             throw new Error('unknown node definition type')
         }
-      } else if (definition instanceof Agent) {
-        node = new AgentNode({ agent: definition })
-      } else {
-        node = new MultiAgentNode({ orchestrator: definition })
       }
 
       if (nodes.has(node.id)) {

--- a/src/multiagent/nodes.ts
+++ b/src/multiagent/nodes.ts
@@ -1,4 +1,5 @@
-import type { Agent, InvokeArgs, InvokeOptions } from '../agent/agent.js'
+import type { AgentBase } from '../agent/agent-base.js'
+import type { InvokeArgs, InvokeOptions } from '../agent/agent.js'
 import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
 import type { MultiAgentStreamEvent } from './events.js'
 import { NodeStreamUpdateEvent, NodeResultEvent } from './events.js'
@@ -106,23 +107,23 @@ export abstract class Node {
  */
 export interface AgentNodeOptions {
   /** The agent to wrap as a node. */
-  agent: Agent
+  agent: AgentBase
 }
 
 /**
- * Node that wraps an Agent instance for multi-agent orchestration.
+ * Node that wraps an AgentBase instance for multi-agent orchestration.
  *
- * Each execution is isolated — the wrapped agent's internal state
- * is unchanged after the node completes.
+ * Each execution is isolated — the agent's internal state is snapshot/restored
+ * so it remains unchanged after the node completes.
  */
 export class AgentNode extends Node {
   readonly type = 'agentNode' as const
-  private readonly _agent: Agent
+  private readonly _agent: AgentBase
 
   constructor(options: AgentNodeOptions) {
     const { agent, ...config } = options
 
-    super(agent.agentId, {
+    super(agent.id, {
       ...config,
       ...(agent.description !== undefined && { description: agent.description }),
     })
@@ -130,7 +131,7 @@ export class AgentNode extends Node {
     this._agent = agent
   }
 
-  get agent(): Agent {
+  get agent(): AgentBase {
     return this._agent
   }
 
@@ -229,13 +230,13 @@ export class MultiAgentNode extends Node {
 /**
  * A node definition accepted by orchestration constructors.
  *
- * Pass an {@link Agent} or {@link MultiAgentBase} directly for the simple case,
+ * Pass an {@link AgentBase} or {@link MultiAgentBase} directly for the simple case,
  * use typed options objects for per-node configuration, or provide pre-built
  * {@link Node} instances for full control.
  */
 export type NodeDefinition =
-  | Agent
+  | AgentBase
   | MultiAgentBase
   | Node
-  | (AgentNodeOptions & { type: 'agent' })
-  | (MultiAgentNodeOptions & { type: 'multiAgent' })
+  | (AgentNodeOptions & { type: 'agentOptions' })
+  | (MultiAgentNodeOptions & { type: 'multiAgentOptions' })

--- a/src/multiagent/swarm.ts
+++ b/src/multiagent/swarm.ts
@@ -1,5 +1,5 @@
 import { logger } from '../logging/logger.js'
-import { Agent } from '../agent/agent.js'
+import type { AgentBase } from '../agent/agent-base.js'
 import type { InvokeArgs } from '../agent/agent.js'
 import { z } from 'zod'
 import { HookableEvent } from '../hooks/events.js'
@@ -55,7 +55,7 @@ interface HandoffResult {
  * Input type for swarm nodes. Pass an {@link Agent} directly for the simple case,
  * or {@link AgentNodeOptions} for per-node config.
  */
-export type SwarmNodeDefinition = Agent | AgentNodeOptions
+export type SwarmNodeDefinition = AgentBase | (AgentNodeOptions & { type: 'agentOptions' })
 
 export interface SwarmOptions extends SwarmConfig {
   /** Unique identifier. Defaults to `'swarm'`. */
@@ -97,6 +97,7 @@ export interface SwarmOptions extends SwarmConfig {
  * ```
  */
 export class Swarm implements MultiAgentBase {
+  readonly type = 'multiAgent' as const
   readonly id: string
   readonly nodes: ReadonlyMap<string, AgentNode>
   readonly config: Required<SwarmConfig>
@@ -288,7 +289,7 @@ export class Swarm implements MultiAgentBase {
 
     const nodes = new Map<string, AgentNode>()
     for (const definition of definitions) {
-      const node = definition instanceof Agent ? new AgentNode({ agent: definition }) : new AgentNode(definition)
+      const node = definition.type === 'agentOptions' ? new AgentNode(definition) : new AgentNode({ agent: definition })
       if (nodes.has(node.id)) {
         throw new Error(`agent_id=<${node.id}> | duplicate agent id`)
       }

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -13,9 +13,9 @@ import { Message, TextBlock } from '../../types/messages.js'
 import { createMockAgent as createMockAgentWithHooks, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 
 // Test fixtures
-function createMockAgent(agentId = 'default'): Agent {
+function createMockAgent(id = 'default'): Agent {
   const agent = {
-    agentId,
+    id,
     messages: [],
     state: {
       _m: new Map(),

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -95,7 +95,7 @@ export class SessionManager implements Plugin {
   }
 
   private _location(agent: Agent): SnapshotLocation {
-    return { sessionId: this._sessionId, scope: 'agent', scopeId: agent.agentId }
+    return { sessionId: this._sessionId, scope: 'agent', scopeId: agent.id }
   }
 
   async saveSnapshot(params: { target: Agent; isLatest: boolean }): Promise<void> {

--- a/src/session/storage.ts
+++ b/src/session/storage.ts
@@ -8,7 +8,7 @@ export type SnapshotLocation = {
   sessionId: string
   /** Scope of the snapshot (agent or multi-agent) */
   scope: Scope
-  /** Scope-specific identifier (agentId or multiAgentId) */
+  /** Scope-specific identifier (agent id or multi-agent id) */
   scopeId: string
 }
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,5 +1,5 @@
 import type { AppState } from '../app-state.js'
-import type { Message, StopReason } from './messages.js'
+import type { Message, StopReason, SystemPrompt } from './messages.js'
 import type {
   BeforeInvocationEvent,
   AfterInvocationEvent,
@@ -38,6 +38,11 @@ export interface AgentData {
    * The conversation history of messages between user and assistant.
    */
   messages: Message[]
+
+  /**
+   * The system prompt that guides agent behavior.
+   */
+  systemPrompt?: SystemPrompt
 
   /**
    * The tool registry for registering tools with the agent.

--- a/test/integ/multiagent/graph.test.ts
+++ b/test/integ/multiagent/graph.test.ts
@@ -11,7 +11,7 @@ describe.skipIf(bedrock.skip)('Graph', () => {
     const agent = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'assistant',
+      id: 'assistant',
       systemPrompt: 'Answer in one word only.',
     })
 
@@ -48,14 +48,14 @@ describe.skipIf(bedrock.skip)('Graph', () => {
     const researcher = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'researcher',
+      id: 'researcher',
       systemPrompt: 'Research the topic and provide key facts in 1-2 sentences.',
     })
 
     const writer = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'writer',
+      id: 'writer',
       systemPrompt: 'Rewrite the input as a single polished sentence.',
     })
 
@@ -90,21 +90,21 @@ describe.skipIf(bedrock.skip)('Graph', () => {
     const router = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'router',
+      id: 'router',
       systemPrompt: 'Repeat the user input exactly.',
     })
 
     const capitals = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'capitals',
+      id: 'capitals',
       systemPrompt: 'Answer with only the capital of France in one word.',
     })
 
     const oceans = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'oceans',
+      id: 'oceans',
       systemPrompt: 'Answer with only the largest ocean in one word.',
     })
 
@@ -139,7 +139,7 @@ describe.skipIf(bedrock.skip)('Graph', () => {
         new Agent({
           model: createModel(),
           printer: false,
-          agentId: 'answerer',
+          id: 'answerer',
           description: 'Answers questions in one word.',
           systemPrompt: 'Answer in one word only.',
         }),
@@ -150,7 +150,7 @@ describe.skipIf(bedrock.skip)('Graph', () => {
     const summarizer = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'summarizer',
+      id: 'summarizer',
       systemPrompt: 'Repeat the input exactly as given.',
     })
 
@@ -179,7 +179,7 @@ describe.skipIf(bedrock.skip)('Graph', () => {
     const agent = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'counter',
+      id: 'counter',
       systemPrompt: 'Reply with the single word "counted".',
     })
 

--- a/test/integ/multiagent/swarm.test.ts
+++ b/test/integ/multiagent/swarm.test.ts
@@ -11,7 +11,7 @@ describe.skipIf(bedrock.skip)('Swarm', () => {
     const agent = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'assistant',
+      id: 'assistant',
       description: 'Answers questions briefly.',
       systemPrompt: 'Answer in one word only.',
     })
@@ -46,7 +46,7 @@ describe.skipIf(bedrock.skip)('Swarm', () => {
     const researcher = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'researcher',
+      id: 'researcher',
       description: 'Researches a topic then hands off to the writer.',
       systemPrompt:
         'You are a researcher. Look up the answer, then always hand off to the writer agent. Never produce a final response yourself.',
@@ -55,7 +55,7 @@ describe.skipIf(bedrock.skip)('Swarm', () => {
     const writer = new Agent({
       model: createModel(),
       printer: false,
-      agentId: 'writer',
+      id: 'writer',
       description: 'Writes a final one-sentence answer.',
       systemPrompt: 'Write the final answer in one sentence. Do not hand off to another agent.',
     })

--- a/test/integ/session-manager.test.node.ts
+++ b/test/integ/session-manager.test.node.ts
@@ -45,7 +45,7 @@ function makeS3Manager(sessionId: string, bucket: string, credentials: any): Ses
 
 async function getPersistedMessageCount(manager: SessionManager): Promise<number> {
   const snap = await (manager as any)._storage.snapshot.loadSnapshot({
-    location: (manager as any)._location({ agentId: 'default' }),
+    location: (manager as any)._location({ id: 'default' }),
   })
   return (snap?.data?.messages as unknown[])?.length ?? 0
 }

--- a/test/integ/session-manager.test.node.ts
+++ b/test/integ/session-manager.test.node.ts
@@ -45,7 +45,7 @@ function makeS3Manager(sessionId: string, bucket: string, credentials: any): Ses
 
 async function getPersistedMessageCount(manager: SessionManager): Promise<number> {
   const snap = await (manager as any)._storage.snapshot.loadSnapshot({
-    location: (manager as any)._location({ id: 'default' }),
+    location: (manager as any)._location({ id: 'agent' }),
   })
   return (snap?.data?.messages as unknown[])?.length ?? 0
 }
@@ -130,14 +130,14 @@ describe.skipIf(bedrock.skip)('Session Management - FileStorage', () => {
     expect(agent1.messages).toHaveLength(4)
 
     // Verify storage layout
-    const base = join(tempDir, sessionId, 'scopes', 'agent', 'default', 'snapshots')
+    const base = join(tempDir, sessionId, 'scopes', 'agent', 'agent', 'snapshots')
     await expect(fs.access(join(base, 'snapshot_latest.json'))).resolves.toBeUndefined()
     const files = await fs.readdir(join(base, 'immutable_history'))
     expect(files).toHaveLength(2)
     expect(files.every((f) => /^snapshot_[\w-]+\.json$/.test(f))).toBe(true)
 
     // Restore from snapshot 1 — should only have 2 messages
-    const snapshotIds = await storage.listSnapshotIds({ location: { sessionId, scope: 'agent', scopeId: 'default' } })
+    const snapshotIds = await storage.listSnapshotIds({ location: { sessionId, scope: 'agent', scopeId: 'agent' } })
     expect(snapshotIds[0]).toBeDefined()
     const sessionManager2 = new SessionManager({
       sessionId,
@@ -262,7 +262,7 @@ describe.skipIf(bedrock.skip)('Session Management - S3Storage', () => {
 
     // Verify UUID-based S3 key naming and restore from snapshot 1 (after turn 2)
     const s3Storage = new S3Storage({ bucket, s3Client: new S3Client({ region: AWS_REGION, credentials }) })
-    const snapshotIds = await s3Storage.listSnapshotIds({ location: { sessionId, scope: 'agent', scopeId: 'default' } })
+    const snapshotIds = await s3Storage.listSnapshotIds({ location: { sessionId, scope: 'agent', scopeId: 'agent' } })
     expect(snapshotIds).toHaveLength(1)
     expect(snapshotIds.every((id) => /^[\w-]{36}$/.test(id))).toBe(true)
     expect(snapshotIds[0]).toBeDefined()


### PR DESCRIPTION
## Motivation

The multiagent module previously depended on the concrete `Agent` class, preventing `A2AAgent` and future agent types from participating in orchestration. `AgentBase` and `AgentData` were separate interfaces with no inheritance relationship, forcing callers to use intersection types (`AgentBase & AgentData`) or duck typing to work with agents generically.

## Public API Changes

### AgentBase extends AgentData

`AgentBase` is now the single unified agent interface. It extends `AgentData` and adds `type`, `id`, `description`, and invocation methods:

```typescript
// Before: separate interfaces, no relationship
const agent: AgentBase & AgentData = ...

// After: AgentBase is the single interface
const agent: AgentBase = ...
```

### Agent.id replaces Agent.agentId

```typescript
// Before
const agent = new Agent({ agentId: "my-agent" })
console.log(agent.agentId)

// After
const agent = new Agent({ id: "my-agent" })
console.log(agent.id) // defaults to "agent"
```

### MultiAgentBase gains type discriminator

```typescript
// Before: no type field
const orchestrator: MultiAgentBase = { id: "graph", ... }

// After: type discriminator required
const orchestrator: MultiAgentBase = { type: "multiAgent", id: "graph", ... }
```

### NodeDefinition uses distinct type discriminants

Options objects now use `agentOptions` / `multiAgentOptions` to distinguish from `AgentBase` / `MultiAgentBase` instances, eliminating duck typing in node resolution:

```typescript
// Before
const nodes: NodeDefinition[] = [
  { type: "agent", agent: myAgent },
  { type: "multiAgent", orchestrator: inner },
]

// After
const nodes: NodeDefinition[] = [
  { type: "agentOptions", agent: myAgent },
  { type: "multiAgentOptions", orchestrator: inner },
]
```

### A2AAgent implements full AgentBase

`A2AAgent` now implements the complete `AgentBase` interface. `addHook` is a no-op that logs a warning since A2AAgent does not emit hookable events yet.

Note A2AAgent is experimental and so partially defining the interface is acceptable here in my opinion. This was already exhibited though in other ways. For example, A2AAgent was already producing a partial AgentResult. You'll see this in the diff.

### takeSnapshot / loadSnapshot accept AgentData

Snapshot functions now accept `AgentData` instead of the concrete `Agent` class, enabling snapshotting of any agent type.

## Breaking Changes

- `Agent.agentId` renamed to `Agent.id`; `AgentConfig.agentId` renamed to `AgentConfig.id`
- Default agent id changed from `"default"` to `"agent"`
- `MultiAgentBase` now requires `type: "multiAgent"`
- `NodeDefinition` options use `type: "agentOptions"` / `"multiAgentOptions"` instead of `"agent"` / `"multiAgent"`
- `AgentNodeOptions.agent` accepts `AgentBase` instead of `Agent`
- `SwarmNodeDefinition` options require `type: "agentOptions"`

### Migration

```typescript
// Agent id
- new Agent({ agentId: "my-agent" })
+ new Agent({ id: "my-agent" })

// Node definitions with options
- { type: "agent", agent: myAgent }
+ { type: "agentOptions", agent: myAgent }

// MultiAgentBase implementations
+ readonly type = "multiAgent" as const
```

## Documentation
https://github.com/strands-agents/docs/pull/657

Will follow up and create general documentation for AgentBase.

## Testing

- [x] I ran `npm run check`
- [x] All 1533 unit tests pass
- [x] All 7 multiagent integration tests pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.