### PR TITLE
feat: add MultiAgentState to remaining multi-agent streaming events

### DIFF
--- a/src/multiagent/__tests__/events.test.ts
+++ b/src/multiagent/__tests__/events.test.ts
@@ -163,13 +163,15 @@ describe('AfterNodeCallEvent', () => {
 
 describe('NodeStreamUpdateEvent', () => {
   it('creates instance with correct properties', () => {
+    const state = new MultiAgentState()
     const innerEvent = { type: 'beforeInvocationEvent' } as AgentStreamEvent
-    const event = new NodeStreamUpdateEvent({ nodeId: 'node-1', nodeType: 'agentNode', event: innerEvent })
+    const event = new NodeStreamUpdateEvent({ nodeId: 'node-1', nodeType: 'agentNode', state, event: innerEvent })
 
     expect(event).toEqual({
       type: 'nodeStreamUpdateEvent',
       nodeId: 'node-1',
       nodeType: 'agentNode',
+      state,
       event: innerEvent,
     })
     // @ts-expect-error verifying that property is readonly
@@ -177,19 +179,23 @@ describe('NodeStreamUpdateEvent', () => {
     // @ts-expect-error verifying that property is readonly
     event.nodeType = 'agentNode'
     // @ts-expect-error verifying that property is readonly
+    event.state = state
+    // @ts-expect-error verifying that property is readonly
     event.event = innerEvent
   })
 })
 
 describe('NodeResultEvent', () => {
   it('creates instance with correct properties', () => {
+    const state = new MultiAgentState()
     const result = new NodeResult({ nodeId: 'node-1', status: Status.COMPLETED, duration: 100 })
-    const event = new NodeResultEvent({ nodeId: 'node-1', nodeType: 'agentNode', result })
+    const event = new NodeResultEvent({ nodeId: 'node-1', nodeType: 'agentNode', state, result })
 
     expect(event).toEqual({
       type: 'nodeResultEvent',
       nodeId: 'node-1',
       nodeType: 'agentNode',
+      state,
       result,
     })
     // @ts-expect-error verifying that property is readonly
@@ -197,21 +203,27 @@ describe('NodeResultEvent', () => {
     // @ts-expect-error verifying that property is readonly
     event.nodeType = 'agentNode'
     // @ts-expect-error verifying that property is readonly
+    event.state = state
+    // @ts-expect-error verifying that property is readonly
     event.result = result
   })
 })
 
 describe('NodeCancelEvent', () => {
   it('creates instance with correct properties', () => {
-    const event = new NodeCancelEvent({ nodeId: 'node-1', message: 'cancelled by hook' })
+    const state = new MultiAgentState()
+    const event = new NodeCancelEvent({ nodeId: 'node-1', state, message: 'cancelled by hook' })
 
     expect(event).toEqual({
       type: 'nodeCancelEvent',
       nodeId: 'node-1',
+      state,
       message: 'cancelled by hook',
     })
     // @ts-expect-error verifying that property is readonly
     event.nodeId = 'node-1'
+    // @ts-expect-error verifying that property is readonly
+    event.state = state
     // @ts-expect-error verifying that property is readonly
     event.message = 'cancelled by hook'
   })
@@ -219,17 +231,21 @@ describe('NodeCancelEvent', () => {
 
 describe('MultiAgentHandoffEvent', () => {
   it('creates instance with correct properties', () => {
-    const event = new MultiAgentHandoffEvent({ source: 'node-a', targets: ['node-b', 'node-c'] })
+    const state = new MultiAgentState()
+    const event = new MultiAgentHandoffEvent({ source: 'node-a', targets: ['node-b', 'node-c'], state })
 
     expect(event).toEqual({
       type: 'multiAgentHandoffEvent',
       source: 'node-a',
       targets: ['node-b', 'node-c'],
+      state,
     })
     // @ts-expect-error verifying that property is readonly
     event.source = 'node-a'
     // @ts-expect-error verifying that property is readonly
     event.targets = []
+    // @ts-expect-error verifying that property is readonly
+    event.state = state
   })
 })
 

--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -4,7 +4,7 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { AfterNodeCallEvent, BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import { TextBlock } from '../../types/messages.js'
-import { Status } from '../state.js'
+import { Status, MultiAgentState } from '../state.js'
 import { AgentNode, MultiAgentNode } from '../nodes.js'
 import { Graph } from '../graph.js'
 
@@ -509,6 +509,7 @@ describe('Graph', () => {
           type: 'multiAgentHandoffEvent',
           source: 'a',
           targets: ['b'],
+          state: expect.any(MultiAgentState),
         })
       )
     })
@@ -530,7 +531,9 @@ describe('Graph', () => {
       expect(result.results[0]).toEqual(expect.objectContaining({ nodeId: 'a', status: Status.CANCELLED, duration: 0 }))
 
       const cancelEvent = items.find((e) => e.type === 'nodeCancelEvent')
-      expect(cancelEvent).toEqual(expect.objectContaining({ nodeId: 'a', message: 'node cancelled by hook' }))
+      expect(cancelEvent).toEqual(
+        expect.objectContaining({ nodeId: 'a', state: expect.any(MultiAgentState), message: 'node cancelled by hook' })
+      )
     })
 
     it('returns cancelled result with custom message when cancel is a string', async () => {
@@ -548,7 +551,9 @@ describe('Graph', () => {
       expect(result.status).toBe(Status.CANCELLED)
 
       const cancelEvent = items.find((e) => e.type === 'nodeCancelEvent')
-      expect(cancelEvent).toEqual(expect.objectContaining({ nodeId: 'a', message: 'node not ready' }))
+      expect(cancelEvent).toEqual(
+        expect.objectContaining({ nodeId: 'a', state: expect.any(MultiAgentState), message: 'node not ready' })
+      )
     })
 
     it('cleans up running nodes when consumer breaks mid-stream', async () => {

--- a/src/multiagent/__tests__/nodes.test.ts
+++ b/src/multiagent/__tests__/nodes.test.ts
@@ -52,7 +52,16 @@ describe('Node', () => {
         return { content }
       })
 
-      const { result } = await collectGenerator(node.stream([], state))
+      const { items, result } = await collectGenerator(node.stream([], state))
+
+      const resultEvent = items.find((e) => e.type === 'nodeResultEvent')
+      expect(resultEvent).toEqual({
+        type: 'nodeResultEvent',
+        nodeId: 'test-node',
+        nodeType: 'node',
+        state,
+        result,
+      })
 
       expect(result).toEqual({
         type: 'nodeResult',
@@ -69,7 +78,16 @@ describe('Node', () => {
         throw new Error('boom')
       })
 
-      const { result } = await collectGenerator(node.stream([], state))
+      const { items, result } = await collectGenerator(node.stream([], state))
+
+      const resultEvent = items.find((e) => e.type === 'nodeResultEvent')
+      expect(resultEvent).toEqual({
+        type: 'nodeResultEvent',
+        nodeId: 'fail-node',
+        nodeType: 'node',
+        state,
+        result,
+      })
 
       expect(result).toEqual({
         type: 'nodeResult',
@@ -201,10 +219,11 @@ describe('MultiAgentNode', () => {
 
   describe('handle', () => {
     it('passes through inner NodeStreamUpdateEvents', async () => {
-      const innerUpdate = new MultiAgentHandoffEvent({ source: 'x', targets: ['y'] })
+      const innerUpdate = new MultiAgentHandoffEvent({ source: 'x', targets: ['y'], state })
       const innerEvent = new NodeStreamUpdateEvent({
         nodeId: 'deep-node',
         nodeType: 'agentNode',
+        state,
         event: innerUpdate,
       })
       const orchestrator = mockOrchestrator('inner', [innerEvent])
@@ -218,7 +237,7 @@ describe('MultiAgentNode', () => {
     })
 
     it('wraps non-NodeStreamUpdateEvents with this node identity', async () => {
-      const handoff = new MultiAgentHandoffEvent({ source: 'a', targets: ['b'] })
+      const handoff = new MultiAgentHandoffEvent({ source: 'a', targets: ['b'], state })
       const orchestrator = mockOrchestrator('inner', [handoff])
       node = new MultiAgentNode({ orchestrator })
 

--- a/src/multiagent/__tests__/swarm.test.ts
+++ b/src/multiagent/__tests__/swarm.test.ts
@@ -5,7 +5,7 @@ import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import type { JSONValue } from '../../types/json.js'
 import { TextBlock } from '../../types/messages.js'
-import { Status } from '../state.js'
+import { Status, MultiAgentState } from '../state.js'
 import { AgentNode } from '../nodes.js'
 import { Swarm } from '../swarm.js'
 
@@ -202,7 +202,9 @@ describe('Swarm', () => {
       expect(result.status).toBe(Status.CANCELLED)
 
       const cancelEvent = items.find((e) => e.type === 'nodeCancelEvent')
-      expect(cancelEvent).toEqual(expect.objectContaining({ nodeId: 'a', message: 'agent not ready' }))
+      expect(cancelEvent).toEqual(
+        expect.objectContaining({ nodeId: 'a', state: expect.any(MultiAgentState), message: 'agent not ready' })
+      )
     })
 
     it('returns failed result when agent throws', async () => {
@@ -295,6 +297,7 @@ describe('Swarm', () => {
           type: 'multiAgentHandoffEvent',
           source: 'a',
           targets: ['b'],
+          state: expect.any(MultiAgentState),
         })
       )
     })
@@ -316,7 +319,9 @@ describe('Swarm', () => {
       expect(result.results[0]).toEqual(expect.objectContaining({ nodeId: 'a', status: Status.CANCELLED, duration: 0 }))
 
       const cancelEvent = items.find((e) => e.type === 'nodeCancelEvent')
-      expect(cancelEvent).toEqual(expect.objectContaining({ nodeId: 'a', message: 'node cancelled by hook' }))
+      expect(cancelEvent).toEqual(
+        expect.objectContaining({ nodeId: 'a', state: expect.any(MultiAgentState), message: 'node cancelled by hook' })
+      )
     })
 
     it('returns cancelled result with custom message when cancel is a string', async () => {
@@ -334,7 +339,9 @@ describe('Swarm', () => {
       expect(result.status).toBe(Status.CANCELLED)
 
       const cancelEvent = items.find((e) => e.type === 'nodeCancelEvent')
-      expect(cancelEvent).toEqual(expect.objectContaining({ nodeId: 'a', message: 'agent not ready' }))
+      expect(cancelEvent).toEqual(
+        expect.objectContaining({ nodeId: 'a', state: expect.any(MultiAgentState), message: 'agent not ready' })
+      )
     })
   })
 })

--- a/src/multiagent/events.ts
+++ b/src/multiagent/events.ts
@@ -110,16 +110,19 @@ export class NodeStreamUpdateEvent extends HookableEvent {
   readonly type = 'nodeStreamUpdateEvent' as const
   readonly nodeId: string
   readonly nodeType: NodeType
+  readonly state: MultiAgentState
   readonly event: AgentStreamEvent | Exclude<MultiAgentStreamEvent, NodeStreamUpdateEvent>
 
   constructor(data: {
     nodeId: string
     nodeType: NodeType
+    state: MultiAgentState
     event: AgentStreamEvent | Exclude<MultiAgentStreamEvent, NodeStreamUpdateEvent>
   }) {
     super()
     this.nodeId = data.nodeId
     this.nodeType = data.nodeType
+    this.state = data.state
     this.event = data.event
   }
 }
@@ -132,12 +135,14 @@ export class NodeResultEvent extends HookableEvent {
   readonly type = 'nodeResultEvent' as const
   readonly nodeId: string
   readonly nodeType: NodeType
+  readonly state: MultiAgentState
   readonly result: NodeResult
 
-  constructor(data: { nodeId: string; nodeType: NodeType; result: NodeResult }) {
+  constructor(data: { nodeId: string; nodeType: NodeType; state: MultiAgentState; result: NodeResult }) {
     super()
     this.nodeId = data.nodeId
     this.nodeType = data.nodeType
+    this.state = data.state
     this.result = data.result
   }
 }
@@ -149,11 +154,13 @@ export class MultiAgentHandoffEvent extends HookableEvent {
   readonly type = 'multiAgentHandoffEvent' as const
   readonly source: string
   readonly targets: string[]
+  readonly state: MultiAgentState
 
-  constructor(data: { source: string; targets: string[] }) {
+  constructor(data: { source: string; targets: string[]; state: MultiAgentState }) {
     super()
     this.source = data.source
     this.targets = data.targets
+    this.state = data.state
   }
 }
 
@@ -163,11 +170,13 @@ export class MultiAgentHandoffEvent extends HookableEvent {
 export class NodeCancelEvent extends HookableEvent {
   readonly type = 'nodeCancelEvent' as const
   readonly nodeId: string
+  readonly state: MultiAgentState
   readonly message: string
 
-  constructor(data: { nodeId: string; message: string }) {
+  constructor(data: { nodeId: string; state: MultiAgentState; message: string }) {
     super()
     this.nodeId = data.nodeId
+    this.state = data.state
     this.message = data.message
   }
 }

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -227,6 +227,7 @@ export class Graph implements MultiAgentBase {
             yield new MultiAgentHandoffEvent({
               source: node.id,
               targets: ready.map((n) => n.id),
+              state,
             })
             targets.push(...ready)
           }
@@ -265,7 +266,7 @@ export class Graph implements MultiAgentBase {
       await queue.send({
         type: 'event',
         node,
-        event: new NodeCancelEvent({ nodeId: node.id, message }),
+        event: new NodeCancelEvent({ nodeId: node.id, state, message }),
       })
       await queue.send({
         type: 'event',

--- a/src/multiagent/nodes.ts
+++ b/src/multiagent/nodes.ts
@@ -84,7 +84,7 @@ export abstract class Node {
       nodeState.results.push(result!)
     }
 
-    yield new NodeResultEvent({ nodeId: this.id, nodeType: this.type, result })
+    yield new NodeResultEvent({ nodeId: this.id, nodeType: this.type, state, result })
     return result
   }
 
@@ -155,7 +155,7 @@ export class AgentNode extends Node {
       const gen = this._agent.stream(args, options)
       let next = await gen.next()
       while (!next.done) {
-        yield new NodeStreamUpdateEvent({ nodeId: this.id, nodeType: this.type, event: next.value })
+        yield new NodeStreamUpdateEvent({ nodeId: this.id, nodeType: this.type, state, event: next.value })
         next = await gen.next()
       }
 
@@ -209,7 +209,7 @@ export class MultiAgentNode extends Node {
    */
   async *handle(
     args: InvokeArgs,
-    _state: MultiAgentState
+    state: MultiAgentState
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
     const gen = this._orchestrator.stream(args)
     let next = await gen.next()
@@ -218,7 +218,7 @@ export class MultiAgentNode extends Node {
       if (event.type === 'nodeStreamUpdateEvent') {
         yield event
       } else {
-        yield new NodeStreamUpdateEvent({ nodeId: this.id, nodeType: this.type, event })
+        yield new NodeStreamUpdateEvent({ nodeId: this.id, nodeType: this.type, state, event })
       }
       next = await gen.next()
     }

--- a/src/multiagent/swarm.ts
+++ b/src/multiagent/swarm.ts
@@ -212,7 +212,7 @@ export class Swarm implements MultiAgentBase {
 
         // Hand off to next agent
         const target = this.nodes.get(handoff.agentId)!
-        yield new MultiAgentHandoffEvent({ source: node.id, targets: [target.id] })
+        yield new MultiAgentHandoffEvent({ source: node.id, targets: [target.id], state })
         logger.debug(`source=<${node.id}>, target=<${target.id}> | swarm handoff`)
         node = target
       }
@@ -247,7 +247,7 @@ export class Swarm implements MultiAgentBase {
       const result = new NodeResult({ nodeId: node.id, status: Status.CANCELLED, duration: 0 })
       nodeState.status = Status.CANCELLED
       nodeState.results.push(result)
-      yield new NodeCancelEvent({ nodeId: node.id, message })
+      yield new NodeCancelEvent({ nodeId: node.id, state, message })
       yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id })
       return result
     }


### PR DESCRIPTION
## Description

Add `MultiAgentState` to `NodeStreamUpdateEvent`, `NodeResultEvent`, `MultiAgentHandoffEvent`, and `NodeCancelEvent` so hook consumers can inspect orchestration state from any multi-agent streaming event.

## Motivation

Previously only the before/after invocation and node call events carried `MultiAgentState`. Hook consumers listening to handoff, cancel, stream update, or result events had no way to inspect the current orchestration state (node statuses, accumulated results, step count) without maintaining their own external tracking. Adding `state` to these events gives hooks a consistent, complete view of the orchestration at every point in the lifecycle.

Resolves: #433

## Public API Changes

Four event classes now include a readonly `state` field:

```typescript
// NodeStreamUpdateEvent, NodeResultEvent — state after nodeId/nodeType
event.state // MultiAgentState

// MultiAgentHandoffEvent — state after source/targets
event.state // MultiAgentState

// NodeCancelEvent — state after nodeId
event.state // MultiAgentState
```

The change is backward compatible — existing code that does not access `state` on these events is unaffected. `MultiAgentInitializedEvent` and `MultiAgentResultEvent` are intentionally unchanged (state does not exist yet at initialization, and the result already encapsulates final state).

## Related Issues

Resolves #433

## Type of Change

New feature

## Documentation
https://github.com/strands-agents/docs/pull/659

This however is dependent upon https://github.com/strands-agents/sdk-typescript/pull/663

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- [x] Unit tests updated and passing (events, nodes, graph, swarm)
- [x] Integration tests passing (test/integ/multiagent)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.