### PR TITLE
fix: fix unsafe ContentBlock[] cast in Graph._resolveNodeInput for Message[] inputs

### DIFF
--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -3,7 +3,7 @@ import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { AfterNodeCallEvent, BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
-import { TextBlock } from '../../types/messages.js'
+import { Message, TextBlock } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
 import { AgentNode, MultiAgentNode } from '../nodes.js'
 import { Graph } from '../graph.js'
@@ -313,6 +313,30 @@ describe('Graph', () => {
       expect(streamSpy).toHaveBeenCalled()
       const input = streamSpy.mock.calls[0]![0] as TextBlock[]
       expect(input.map((b) => b.text)).toStrictEqual(['task-input', '[node: a]', 'from-a'])
+    })
+
+    it('passes task + dependency content to downstream nodes with Message[] input', async () => {
+      const agentB = makeAgent('b')
+      const streamSpy = vi.spyOn(agentB, 'stream')
+
+      const graph = new Graph({
+        nodes: [makeAgent('a', 'from-a'), agentB],
+        edges: [['a', 'b']],
+      })
+
+      const messageInput = [new Message({ role: 'user', content: [new TextBlock('task-input')] })]
+      await graph.invoke(messageInput)
+
+      expect(streamSpy).toHaveBeenCalled()
+      const input = streamSpy.mock.calls[0]![0] as (TextBlock | Message)[]
+
+      // Every element passed to the downstream node should be a ContentBlock,
+      // not a Message. Before the fix, Message objects were cast as ContentBlock[]
+      // and spread into the array alongside dependency TextBlocks.
+      for (const block of input) {
+        expect(block).not.toBeInstanceOf(Message)
+      }
+      expect(input.map((b) => (b as TextBlock).text)).toContain('task-input')
     })
 
     it('returns failed result when agent throws', async () => {

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -1,6 +1,6 @@
 import type { InvokableAgent, InvokeArgs } from '../types/agent.js'
-import type { ContentBlock } from '../types/messages.js'
-import { TextBlock } from '../types/messages.js'
+import type { ContentBlock, ContentBlockData } from '../types/messages.js'
+import { Message, TextBlock, contentBlockFromData } from '../types/messages.js'
 import { HookableEvent } from '../hooks/events.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
@@ -447,8 +447,27 @@ export class Graph implements MultiAgent {
 
     if (deps.length === 0) return input
 
-    const blocks: ContentBlock[] = typeof input === 'string' ? [new TextBlock(input)] : (input as ContentBlock[])
+    const blocks: ContentBlock[] = typeof input === 'string' ? [new TextBlock(input)] : this._toContentBlocks(input)
     return [...blocks, ...deps]
+  }
+
+  /**
+   * Extracts ContentBlock[] from any non-string InvokeArgs variant.
+   */
+  private _toContentBlocks(input: Exclude<InvokeArgs, string>): ContentBlock[] {
+    if (!Array.isArray(input) || input.length === 0) return []
+
+    const first = input[0]!
+    if ('role' in first && typeof first.role === 'string') {
+      // Message[] or MessageData[]
+      return (input as (Message | { role: string; content: (ContentBlock | ContentBlockData)[] })[]).flatMap((msg) =>
+        msg instanceof Message
+          ? msg.content
+          : msg.content.map((b) => ('type' in b ? (b as ContentBlock) : contentBlockFromData(b as ContentBlockData)))
+      )
+    }
+    // ContentBlock[] or ContentBlockData[]
+    return input.map((b) => ('type' in b ? (b as ContentBlock) : contentBlockFromData(b as ContentBlockData)))
   }
 
   private _checkSteps(state: MultiAgentState): void {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
When a graph node has incoming edges with dependency content, _resolveNodeInput combines the original task input with dependency outputs into a single ContentBlock[]. Previously, it cast the input directly with input as ContentBlock[], which silently passed raw Message objects into the ContentBlock[] array when the graph was invoked with Message[] or MessageData[] input. Downstream agents then received a malformed input array — Message objects where ContentBlock objects were expected — causing content to be silently lost.

This change extracts content blocks from Message[] and MessageData[] inputs before merging with dependency content, matching how Agent._normalizeInput already handles these variants. A new _toContentBlocks helper distinguishes the four non-string InvokeArgs variants (Message[], MessageData[], ContentBlock[], ContentBlockData[]) and normalizes them all to ContentBlock[].

```
  const messageInput = [new Message({ role: 'user', content: [new TextBlock('task-input')] })]
      await graph.invoke(messageInput)
```


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

Testing: Added a regression test that invokes a two-node graph with Message[] input and verifies the downstream node receives only ContentBlock instances (not Message objects) with the original task text preserved.

- [ ] I ran `npm run check`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
