### PR TITLE
refactor: rename AppState to StateStore and Agent.state to Agent.appState

### DIFF
--- a/src/__fixtures__/agent-helpers.ts
+++ b/src/__fixtures__/agent-helpers.ts
@@ -6,7 +6,7 @@
 import type { Agent } from '../agent/agent.js'
 import { Message, TextBlock } from '../types/messages.js'
 import type { Role } from '../types/messages.js'
-import { AppState } from '../app-state.js'
+import { StateStore } from '../state-store.js'
 import type { JSONValue } from '../types/json.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
 import type { HookableEvent } from '../hooks/events.js'
@@ -31,7 +31,7 @@ export interface MockAgentData {
   /**
    * Initial state for the agent.
    */
-  state?: Record<string, JSONValue>
+  appState?: Record<string, JSONValue>
   /**
    * Optional tool registry for the agent.
    */
@@ -49,7 +49,7 @@ export type MockAgent = Agent & { trackedHooks: TrackedHook[] }
 
 /**
  * Helper to create a mock Agent for testing.
- * Provides minimal Agent interface with messages, state, and tool registry.
+ * Provides minimal Agent interface with messages, appState, and tool registry.
  * `addHook` captures registrations into `trackedHooks` for test inspection.
  *
  * @param data - Optional mock agent data
@@ -59,7 +59,7 @@ export function createMockAgent(data?: MockAgentData): MockAgent {
   const trackedHooks: TrackedHook[] = []
   return {
     messages: data?.messages ?? [],
-    state: new AppState(data?.state ?? {}),
+    appState: new StateStore(data?.appState ?? {}),
     toolRegistry: data?.toolRegistry ?? new ToolRegistry(),
     addHook: <T extends HookableEvent>(eventType: HookableEventConstructor<T>, callback: HookCallback<T>) => {
       trackedHooks.push({

--- a/src/__fixtures__/tool-helpers.ts
+++ b/src/__fixtures__/tool-helpers.ts
@@ -6,7 +6,7 @@
 import type { Tool, ToolContext } from '../tools/tool.js'
 import { ToolResultBlock } from '../types/messages.js'
 import type { JSONValue } from '../types/json.js'
-import { AppState } from '../app-state.js'
+import { StateStore } from '../state-store.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
 import type { PlainToolResultBlock } from './slim-types.js'
 
@@ -24,7 +24,7 @@ export function createMockContext(
   return {
     toolUse,
     agent: {
-      state: new AppState(appState),
+      appState: new StateStore(appState),
       messages: [],
       toolRegistry: new ToolRegistry(),
       addHook: () => () => {},

--- a/src/__tests__/state-store.test.ts
+++ b/src/__tests__/state-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AppState } from '../app-state.js'
+import { StateStore } from '../state-store.js'
 import {
   isStateSerializable,
   loadStateFromJSONSymbol,
@@ -8,22 +8,22 @@ import {
   stateToJSONSymbol,
 } from '../types/serializable.js'
 
-describe('AppState', () => {
+describe('StateStore', () => {
   describe('constructor', () => {
     it('creates empty state when no initial state provided', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(state.keys()).toEqual([])
     })
 
     it('creates state with initial values', () => {
-      const state = new AppState({ key1: 'value1', key2: 42 })
+      const state = new StateStore({ key1: 'value1', key2: 42 })
       expect(state.get('key1')).toBe('value1')
       expect(state.get('key2')).toBe(42)
     })
 
     it('stores deep copy of initial state', () => {
       const initial = { nested: { value: 'test' } }
-      const state = new AppState(initial)
+      const state = new StateStore(initial)
 
       // Mutate original
       initial.nested.value = 'changed'
@@ -34,7 +34,7 @@ describe('AppState', () => {
 
     it('throws error for function in initial state', () => {
       const invalidState = { func: () => 'test', value: 'keep' }
-      expect(() => new AppState(invalidState as never)).toThrow(
+      expect(() => new StateStore(invalidState as never)).toThrow(
         'initialState.func contains a function which cannot be serialized'
       )
     })
@@ -42,28 +42,28 @@ describe('AppState', () => {
     it('throws error for symbol in initial state', () => {
       const sym = Symbol('test')
       const invalidState = { sym, value: 'keep' }
-      expect(() => new AppState(invalidState as never)).toThrow(
+      expect(() => new StateStore(invalidState as never)).toThrow(
         'initialState.sym contains a symbol which cannot be serialized'
       )
     })
 
     it('throws error for undefined in initial state', () => {
       const invalidState = { undef: undefined, value: 'keep' }
-      expect(() => new AppState(invalidState as never)).toThrow(
+      expect(() => new StateStore(invalidState as never)).toThrow(
         'initialState.undef is undefined which cannot be serialized'
       )
     })
 
     it('throws error for nested function in initial state', () => {
       const invalidState = { nested: { func: () => 'test' } }
-      expect(() => new AppState(invalidState as never)).toThrow(
+      expect(() => new StateStore(invalidState as never)).toThrow(
         'initialState.nested.func contains a function which cannot be serialized'
       )
     })
 
     it('throws error for function in array in initial state', () => {
       const invalidState = { arr: [1, () => 'test', 3] }
-      expect(() => new AppState(invalidState as never)).toThrow(
+      expect(() => new StateStore(invalidState as never)).toThrow(
         'initialState.arr[1] contains a function which cannot be serialized'
       )
     })
@@ -71,23 +71,23 @@ describe('AppState', () => {
 
   describe('get', () => {
     it('throws error when key is null or undefined', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(() => state.get(null as any)).toThrow('key is required')
       expect(() => state.get(undefined as any)).toThrow('key is required')
     })
 
     it('returns undefined when key does not exist', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(state.get('nonexistent')).toBeUndefined()
     })
 
     it('returns value when key exists', () => {
-      const state = new AppState({ key1: 'value1' })
+      const state = new StateStore({ key1: 'value1' })
       expect(state.get('key1')).toBe('value1')
     })
 
     it('returns deep copy that cannot mutate stored state', () => {
-      const state = new AppState({ nested: { value: 'test' } })
+      const state = new StateStore({ nested: { value: 'test' } })
       const retrieved = state.get<{ nested: { value: string } }>('nested')
 
       // Mutate retrieved value
@@ -104,7 +104,7 @@ describe('AppState', () => {
         items: string[]
       }
 
-      const state = new AppState({ user: { name: 'John', age: 30 }, count: 5, items: ['a', 'b'] })
+      const state = new StateStore({ user: { name: 'John', age: 30 }, count: 5, items: ['a', 'b'] })
 
       // Type inference tests
       const user = state.get<TestState>('user')
@@ -121,13 +121,13 @@ describe('AppState', () => {
         existing: string
       }
 
-      const state = new AppState({ existing: 'value' })
+      const state = new StateStore({ existing: 'value' })
       const result = state.get<TestState>('existing')
 
       expect(result).toBe('value')
 
       // Non-existent key
-      const state2 = new AppState()
+      const state2 = new StateStore()
       const missing = state2.get<TestState>('existing')
 
       expect(missing).toBeUndefined()
@@ -139,49 +139,49 @@ describe('AppState', () => {
 
   describe('set', () => {
     it('sets string value successfully', () => {
-      const state = new AppState()
+      const state = new StateStore()
       state.set('key1', 'value1')
       expect(state.get('key1')).toBe('value1')
     })
 
     it('sets number value successfully', () => {
-      const state = new AppState()
+      const state = new StateStore()
       state.set('key1', 42)
       expect(state.get('key1')).toBe(42)
     })
 
     it('sets boolean value successfully', () => {
-      const state = new AppState()
+      const state = new StateStore()
       state.set('key1', true)
       expect(state.get('key1')).toBe(true)
     })
 
     it('sets null value successfully', () => {
-      const state = new AppState()
+      const state = new StateStore()
       state.set('key1', null)
       expect(state.get('key1')).toBeNull()
     })
 
     it('sets object value successfully', () => {
-      const state = new AppState()
+      const state = new StateStore()
       state.set('key1', { nested: 'value' })
       expect(state.get('key1')).toEqual({ nested: 'value' })
     })
 
     it('sets array value successfully', () => {
-      const state = new AppState()
+      const state = new StateStore()
       state.set('key1', [1, 2, 3])
       expect(state.get('key1')).toEqual([1, 2, 3])
     })
 
     it('overwrites existing value', () => {
-      const state = new AppState({ key1: 'old' })
+      const state = new StateStore({ key1: 'old' })
       state.set('key1', 'new')
       expect(state.get('key1')).toBe('new')
     })
 
     it('stores deep copy that cannot mutate stored state', () => {
-      const state = new AppState()
+      const state = new StateStore()
       const value = { nested: { value: 'test' } }
       state.set('key1', value)
 
@@ -193,7 +193,7 @@ describe('AppState', () => {
     })
 
     it('throws error for function in value', () => {
-      const state = new AppState({ existing: 'value' })
+      const state = new StateStore({ existing: 'value' })
       const obj = { func: () => 'test', value: 'keep' }
       expect(() => state.set('key1', obj)).toThrow(
         'value for key "key1".func contains a function which cannot be serialized'
@@ -201,7 +201,7 @@ describe('AppState', () => {
     })
 
     it('throws error for symbol in value', () => {
-      const state = new AppState()
+      const state = new StateStore()
       const sym = Symbol('test')
       expect(() => state.set('key1', { sym } as never)).toThrow(
         'value for key "key1".sym contains a symbol which cannot be serialized'
@@ -209,7 +209,7 @@ describe('AppState', () => {
     })
 
     it('throws error for nested function in value', () => {
-      const state = new AppState()
+      const state = new StateStore()
       const obj = { nested: { func: () => 'test' } }
       expect(() => state.set('key1', obj)).toThrow(
         'value for key "key1".nested.func contains a function which cannot be serialized'
@@ -217,7 +217,7 @@ describe('AppState', () => {
     })
 
     it('throws error for function in array', () => {
-      const state = new AppState()
+      const state = new StateStore()
       const arr = [1, () => 'test', 3]
       expect(() => state.set('key1', arr)).toThrow(
         'value for key "key1"[1] contains a function which cannot be serialized'
@@ -225,14 +225,14 @@ describe('AppState', () => {
     })
 
     it('throws error for top-level symbol values', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(() => state.set('key1', Symbol('test'))).toThrow(
         'value for key "key1" contains a symbol which cannot be serialized'
       )
     })
 
     it('throws error for top-level undefined values', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(() => state.set('key1', undefined)).toThrow('value for key "key1" is undefined which cannot be serialized')
     })
 
@@ -242,7 +242,7 @@ describe('AppState', () => {
         count: number
       }
 
-      const state = new AppState()
+      const state = new StateStore()
 
       state.set<TestState>('user', { name: 'Alice', age: 25 })
       state.set<TestState>('count', 10)
@@ -257,14 +257,14 @@ describe('AppState', () => {
 
   describe('delete', () => {
     it('removes existing key', () => {
-      const state = new AppState({ key1: 'value1', key2: 'value2' })
+      const state = new StateStore({ key1: 'value1', key2: 'value2' })
       state.delete('key1')
       expect(state.get('key1')).toBeUndefined()
       expect(state.get('key2')).toBe('value2')
     })
 
     it('does not throw error for non-existent key', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(() => state.delete('nonexistent')).not.toThrow()
     })
 
@@ -274,7 +274,7 @@ describe('AppState', () => {
         count: number
       }
 
-      const state = new AppState({ user: { name: 'Alice' }, count: 5 })
+      const state = new StateStore({ user: { name: 'Alice' }, count: 5 })
 
       // Typed delete
       state.delete<TestState>('user')
@@ -285,7 +285,7 @@ describe('AppState', () => {
 
   describe('clear', () => {
     it('removes all values', () => {
-      const state = new AppState({ key1: 'value1', key2: 'value2' })
+      const state = new StateStore({ key1: 'value1', key2: 'value2' })
       state.clear()
       expect(state.keys()).toEqual([])
       expect(state.get('key1')).toBeUndefined()
@@ -293,7 +293,7 @@ describe('AppState', () => {
     })
 
     it('works on empty state', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(() => state.clear()).not.toThrow()
       expect(state.keys()).toEqual([])
     })
@@ -301,29 +301,29 @@ describe('AppState', () => {
 
   describe('getAll', () => {
     it('returns object with all state', () => {
-      const state = new AppState({ key1: 'value1', key2: 42 })
+      const state = new StateStore({ key1: 'value1', key2: 42 })
       expect(state.getAll()).toEqual({ key1: 'value1', key2: 42 })
     })
 
     it('returns empty object for empty state', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(state.getAll()).toEqual({})
     })
   })
 
   describe('keys', () => {
     it('returns array of all keys', () => {
-      const state = new AppState({ key1: 'value1', key2: 'value2' })
+      const state = new StateStore({ key1: 'value1', key2: 'value2' })
       expect(state.keys().sort()).toEqual(['key1', 'key2'])
     })
 
     it('returns empty array for empty state', () => {
-      const state = new AppState()
+      const state = new StateStore()
       expect(state.keys()).toEqual([])
     })
 
     it('returns new array each time', () => {
-      const state = new AppState({ key1: 'value1' })
+      const state = new StateStore({ key1: 'value1' })
       const keys1 = state.keys()
       const keys2 = state.keys()
       expect(keys1).not.toBe(keys2)
@@ -332,13 +332,13 @@ describe('AppState', () => {
 
   describe('stateToJSONSymbol (via symbol)', () => {
     it('returns deep copy of state', () => {
-      const state = new AppState({ key1: 'value1', nested: { deep: true } })
+      const state = new StateStore({ key1: 'value1', nested: { deep: true } })
       const json = state[stateToJSONSymbol]()
       expect(json).toEqual({ key1: 'value1', nested: { deep: true } })
     })
 
     it('can be accessed via serializeStateSerializable helper', () => {
-      const state = new AppState({ key1: 'value1' })
+      const state = new StateStore({ key1: 'value1' })
       const json = serializeStateSerializable(state)
       expect(json).toEqual({ key1: 'value1' })
     })
@@ -346,27 +346,27 @@ describe('AppState', () => {
 
   describe('loadStateFromJSONSymbol (via symbol)', () => {
     it('replaces state with json data', () => {
-      const state = new AppState({ old: 'data' })
+      const state = new StateStore({ old: 'data' })
       state[loadStateFromJSONSymbol]({ new: 'data', count: 42 })
       expect(state.getAll()).toEqual({ new: 'data', count: 42 })
     })
 
     it('clears state when given non-object', () => {
-      const state = new AppState({ key: 'value' })
+      const state = new StateStore({ key: 'value' })
       state[loadStateFromJSONSymbol](null)
       expect(state.getAll()).toEqual({})
     })
 
     it('can be accessed via loadStateSerializable helper', () => {
-      const state = new AppState({ old: 'data' })
+      const state = new StateStore({ old: 'data' })
       loadStateSerializable(state, { new: 'data' })
       expect(state.getAll()).toEqual({ new: 'data' })
     })
   })
 
   describe('isStateSerializable', () => {
-    it('returns true for AppState instances', () => {
-      const state = new AppState()
+    it('returns true for StateStore instances', () => {
+      const state = new StateStore()
       expect(isStateSerializable(state)).toBe(true)
     })
 

--- a/src/agent/__tests__/snapshot.test.ts
+++ b/src/agent/__tests__/snapshot.test.ts
@@ -92,7 +92,7 @@ describe('Snapshot API', () => {
 
     it('creates snapshot with session preset', () => {
       agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
-      agent.state.set('key', 'value')
+      agent.appState.set('key', 'value')
       agent.systemPrompt = 'Test prompt'
 
       const snapshot = takeSnapshot(agent, { preset: 'session' })
@@ -120,7 +120,7 @@ describe('Snapshot API', () => {
 
     it('excludes specified fields', () => {
       agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
-      agent.state.set('key', 'value')
+      agent.appState.set('key', 'value')
 
       const snapshot = takeSnapshot(agent, { preset: 'session', exclude: ['messages'] })
 
@@ -180,7 +180,7 @@ describe('Snapshot API', () => {
 
       loadSnapshot(agent, snapshot)
 
-      expect(agent.state.get('restoredKey')).toBe('restoredValue')
+      expect(agent.appState.get('restoredKey')).toBe('restoredValue')
     })
 
     it('restores systemPrompt from snapshot', () => {
@@ -244,19 +244,19 @@ describe('Snapshot API', () => {
     })
 
     it('preserves state through save/load cycle', () => {
-      agent.state.set('userId', 'user-123')
-      agent.state.set('counter', 42)
+      agent.appState.set('userId', 'user-123')
+      agent.appState.set('counter', 42)
 
       const snapshot = takeSnapshot(agent, { preset: 'session' })
 
       // Modify state
-      agent.state.clear()
-      agent.state.set('different', 'value')
+      agent.appState.clear()
+      agent.appState.set('different', 'value')
 
       // Restore
       loadSnapshot(agent, snapshot)
 
-      expect(agent.state.getAll()).toEqual({ userId: 'user-123', counter: 42 })
+      expect(agent.appState.getAll()).toEqual({ userId: 'user-123', counter: 42 })
     })
 
     it('handles complex message content', () => {
@@ -288,7 +288,7 @@ describe('Snapshot API', () => {
     it('snapshot survives JSON.stringify/JSON.parse round-trip', () => {
       const agent = createTestAgent()
       agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
-      agent.state.set('userId', 'user-123')
+      agent.appState.set('userId', 'user-123')
       agent.systemPrompt = 'You are a helpful assistant'
 
       const snapshot = takeSnapshot(agent, { preset: 'session' })
@@ -304,7 +304,7 @@ describe('Snapshot API', () => {
     it('snapshot can be stored and retrieved as JSON string', () => {
       const agent = createTestAgent()
       agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Test message')] }))
-      agent.state.set('key', 'value')
+      agent.appState.set('key', 'value')
 
       const snapshot = takeSnapshot(agent, { preset: 'session' })
 
@@ -317,7 +317,7 @@ describe('Snapshot API', () => {
       loadSnapshot(newAgent, retrieved)
 
       expect(newAgent.messages).toHaveLength(1)
-      expect(newAgent.state.getAll()).toEqual({ key: 'value' })
+      expect(newAgent.appState.getAll()).toEqual({ key: 'value' })
     })
   })
 })

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -29,7 +29,7 @@ import { Model } from '../models/model.js'
 import type { BaseModelConfig, StreamAggregatedResult, StreamOptions } from '../models/model.js'
 import { isModelStreamEvent } from '../models/streaming.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
-import { AppState } from '../app-state.js'
+import { StateStore } from '../state-store.js'
 import { AgentPrinter, getDefaultAppender, type Printer } from './printer.js'
 import type { Plugin } from '../plugins/plugin.js'
 import { PluginRegistry } from '../plugins/registry.js'
@@ -111,7 +111,7 @@ export type AgentConfig = {
    */
   systemPrompt?: SystemPrompt | SystemPromptData
   /** Optional initial state values for the agent. */
-  state?: Record<string, JSONValue>
+  appState?: Record<string, JSONValue>
   /**
    * Enable automatic printing of agent output to console.
    * When true, prints text generation, reasoning, and tool usage as they occur.
@@ -175,7 +175,7 @@ export class Agent implements LocalAgent, InvokableAgent {
    * App state storage accessible to tools and application logic.
    * State is not passed to the model during inference.
    */
-  public readonly state: AppState
+  public readonly appState: StateStore
   private readonly _conversationManager: ConversationManager
 
   /**
@@ -223,7 +223,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   constructor(config?: AgentConfig) {
     // Initialize public fields
     this.messages = (config?.messages ?? []).map((msg) => (msg instanceof Message ? msg : Message.fromMessageData(msg)))
-    this.state = new AppState(config?.state)
+    this.appState = new StateStore(config?.appState)
     this._conversationManager = config?.conversationManager ?? new SlidingWindowConversationManager({ windowSize: 40 })
     this.name = config?.name ?? DEFAULT_AGENT_NAME
     this.id = config?.id ?? DEFAULT_AGENT_ID

--- a/src/agent/snapshot.ts
+++ b/src/agent/snapshot.ts
@@ -135,7 +135,7 @@ export function takeSnapshot(agent: Agent, options: TakeSnapshotOptions): Snapsh
   }
 
   if (fields.has('state')) {
-    data.state = serializeStateSerializable(agent.state)
+    data.state = serializeStateSerializable(agent.appState)
   }
 
   if (fields.has('systemPrompt')) {
@@ -177,7 +177,7 @@ export function loadSnapshot(agent: Agent, snapshot: Snapshot): void {
   }
 
   if (state !== undefined) {
-    loadStateSerializable(agent.state, state)
+    loadStateSerializable(agent.appState, state)
   }
 
   // Only restore systemPrompt if explicitly present and non-null in the snapshot

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
 export { Agent } from './agent/agent.js'
 
 // App state
-export { AppState } from './app-state.js'
+export { StateStore } from './state-store.js'
 
 // Agent types
 export { AgentResult } from './types/agent.js'

--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -430,7 +430,7 @@ describe('Graph', () => {
     it('preserves agent messages and state after execution', async () => {
       const agent = makeAgent('a', 'reply')
       const messagesBefore = [...agent.messages]
-      const stateBefore = agent.state.getAll()
+      const stateBefore = agent.appState.getAll()
 
       const graph = new Graph({
         nodes: [agent],
@@ -440,7 +440,7 @@ describe('Graph', () => {
       await graph.invoke('hello')
 
       expect(agent.messages).toStrictEqual(messagesBefore)
-      expect(agent.state.getAll()).toStrictEqual(stateBefore)
+      expect(agent.appState.getAll()).toStrictEqual(stateBefore)
     })
 
     it('executes join node exactly once when all parents complete concurrently', async () => {

--- a/src/multiagent/__tests__/nodes.test.ts
+++ b/src/multiagent/__tests__/nodes.test.ts
@@ -111,7 +111,7 @@ describe('AgentNode', () => {
 
   beforeEach(() => {
     const model = new MockMessageModel().addTurn(new TextBlock('reply'))
-    agent = new Agent({ model, printer: false, state: { key1: 'value1' }, id: 'agent-1' })
+    agent = new Agent({ model, printer: false, appState: { key1: 'value1' }, id: 'agent-1' })
     node = new AgentNode({ agent })
     state = new MultiAgentState({ nodeIds: ['agent-1'] })
   })
@@ -144,12 +144,12 @@ describe('AgentNode', () => {
 
     it('restores agent messages and state after execution', async () => {
       const messagesBefore = [...agent.messages]
-      const stateBefore = agent.state.getAll()
+      const stateBefore = agent.appState.getAll()
 
       await collectGenerator(node.stream([new TextBlock('prompt')], state))
 
       expect(agent.messages).toStrictEqual(messagesBefore)
-      expect(agent.state.getAll()).toStrictEqual(stateBefore)
+      expect(agent.appState.getAll()).toStrictEqual(stateBefore)
     })
 
     it('passes structuredOutputSchema from state to the agent', async () => {

--- a/src/multiagent/__tests__/swarm.test.ts
+++ b/src/multiagent/__tests__/swarm.test.ts
@@ -244,7 +244,7 @@ describe('Swarm', () => {
     it('preserves agent messages and state after execution', async () => {
       const agent = createFinalAgent('a', 'reply')
       const messagesBefore = [...agent.messages]
-      const stateBefore = agent.state.getAll()
+      const stateBefore = agent.appState.getAll()
 
       const swarm = new Swarm({
         nodes: [agent],
@@ -254,7 +254,7 @@ describe('Swarm', () => {
       await swarm.invoke('hello')
 
       expect(agent.messages).toStrictEqual(messagesBefore)
-      expect(agent.state.getAll()).toStrictEqual(stateBefore)
+      expect(agent.appState.getAll()).toStrictEqual(stateBefore)
     })
   })
 

--- a/src/multiagent/state.ts
+++ b/src/multiagent/state.ts
@@ -1,4 +1,4 @@
-import { AppState } from '../app-state.js'
+import { StateStore } from '../state-store.js'
 import type { ContentBlock } from '../types/messages.js'
 import type { z } from 'zod'
 
@@ -139,7 +139,7 @@ export class MultiAgentState {
   /** All node results in completion order. */
   readonly results: NodeResult[]
   /** App-level key-value state accessible from hooks, edge handlers, and custom nodes. */
-  readonly app: AppState
+  readonly app: StateStore
   /** Structured output schema to apply to node invocations. */
   readonly structuredOutputSchema?: z.ZodSchema
   private readonly _nodes: Map<string, NodeState>
@@ -148,7 +148,7 @@ export class MultiAgentState {
     this.startTime = Date.now()
     this.steps = 0
     this.results = []
-    this.app = new AppState()
+    this.app = new StateStore()
     if (data?.structuredOutputSchema) this.structuredOutputSchema = data.structuredOutputSchema
     this._nodes = new Map()
     for (const id of data?.nodeIds ?? []) {

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -18,7 +18,7 @@ function createMockAgent(id = 'agent'): Agent {
   const agent = {
     id,
     messages: [],
-    state: {
+    appState: {
       _m: new Map(),
       get(k: string) {
         return this._m.get(k)
@@ -331,7 +331,7 @@ describe('SessionManager', () => {
       expect(triggerSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           agentData: expect.objectContaining({
-            state: mockAgent.state,
+            appState: mockAgent.appState,
             messages: mockAgent.messages,
           }),
         })
@@ -389,7 +389,7 @@ describe('SessionManager', () => {
         sessionId: 'test-session',
         storage: { snapshot: storage },
         saveLatestOn: 'trigger',
-        snapshotTrigger: ({ agentData }) => (agentData.state as any).get('checkpoint') === true,
+        snapshotTrigger: ({ agentData }) => (agentData.appState as any).get('checkpoint') === true,
       })
 
       const pluginAgent = createMockAgentWithHooks()
@@ -401,7 +401,7 @@ describe('SessionManager', () => {
       })
       expect(ids.length).toBe(0) // state not set — no snapshot
 
-      mockAgent.state.set('checkpoint', true)
+      mockAgent.appState.set('checkpoint', true)
       await invokeTrackedHook(pluginAgent, new AfterInvocationEvent(createMockEvent(mockAgent)))
       ids = await storage.listSnapshotIds({
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'test-agent' },

--- a/src/state-store.ts
+++ b/src/state-store.ts
@@ -2,7 +2,7 @@ import { deepCopy, deepCopyWithValidation, type JSONValue } from './types/json.j
 import { loadStateFromJSONSymbol, stateToJSONSymbol, type StateSerializable } from './types/serializable.js'
 
 /**
- * App state provides key-value storage outside conversation context.
+ * Key-value storage for application state outside conversation context.
  * State is not passed to the model during inference but is accessible
  * by tools (via ToolContext) and application logic.
  *
@@ -11,16 +11,16 @@ import { loadStateFromJSONSymbol, stateToJSONSymbol, type StateSerializable } fr
  *
  * @example
  * ```typescript
- * const state = new AppState({ userId: 'user-123' })
+ * const state = new StateStore({ userId: 'user-123' })
  * state.set('sessionId', 'session-456')
  * const userId = state.get('userId') // 'user-123'
  * ```
  */
-export class AppState implements StateSerializable {
+export class StateStore implements StateSerializable {
   private _state: Record<string, JSONValue>
 
   /**
-   * Creates a new AppState instance.
+   * Creates a new StateStore instance.
    *
    * @param initialState - Optional initial state values
    * @throws Error if initialState is not JSON serializable
@@ -45,7 +45,7 @@ export class AppState implements StateSerializable {
    * @example
    * ```typescript
    * // Typed usage
-   * const user = state.get<AppState>('user')      // { name: string; age: number } | undefined
+   * const user = state.get<MyState>('user')      // { name: string; age: number } | undefined
    *
    * // Untyped usage
    * const value = state.get('someKey')            // JSONValue | undefined
@@ -80,7 +80,7 @@ export class AppState implements StateSerializable {
    * @example
    * ```typescript
    * // Typed usage
-   * state.set<AppState>('user', { name: 'Alice', age: 25 })
+   * state.set<MyState>('user', { name: 'Alice', age: 25 })
    *
    * // Untyped usage
    * state.set('someKey', { any: 'value' })
@@ -102,7 +102,7 @@ export class AppState implements StateSerializable {
    * @example
    * ```typescript
    * // Typed usage
-   * state.delete<AppState>('user')
+   * state.delete<MyState>('user')
    *
    * // Untyped usage
    * state.delete('someKey')

--- a/src/tools/__tests__/tool.test.ts
+++ b/src/tools/__tests__/tool.test.ts
@@ -499,7 +499,7 @@ describe('FunctionTool', () => {
           description: 'Uses context',
           inputSchema: { type: 'object' },
           callback: async (_input: unknown, context: ToolContext): Promise<JSONValue> => {
-            return context.agent.state.getAll()
+            return context.agent.appState.getAll()
           },
         })
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,4 +1,4 @@
-import type { AppState } from '../app-state.js'
+import type { StateStore } from '../state-store.js'
 import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason } from './messages.js'
 import type {
   BeforeInvocationEvent,
@@ -93,7 +93,7 @@ export interface LocalAgent {
   /**
    * App state storage accessible to tools and application logic.
    */
-  state: AppState
+  appState: StateStore
 
   /**
    * The conversation history of messages between user and assistant.

--- a/src/types/serializable.ts
+++ b/src/types/serializable.ts
@@ -5,7 +5,7 @@
  * their state, enabling persistence and restoration of runtime state.
  *
  * StateSerializable uses symbol-keyed methods to keep the serialization API internal,
- * preventing accidental usage by customers (e.g., accessing agent.state.toJSON() directly).
+ * preventing accidental usage by customers (e.g., accessing agent.appState.toJSON() directly).
  */
 
 import type { JSONValue } from './json.js'

--- a/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { bash } from '../index.js'
 import { BashTimeoutError, BashSessionError, type BashOutput } from '../index.js'
 import type { ToolContext } from '../../../index.js'
-import { AppState } from '../../../app-state.js'
+import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
 import { realpathSync } from 'fs'
 
 // Skip tests on Windows (bash not available)
 describe.skipIf(process.platform === 'win32')('bash tool', () => {
   // Helper to create fresh context
-  const createFreshContext = (): { state: AppState; context: ToolContext } => {
+  const createFreshContext = (): { state: StateStore; context: ToolContext } => {
     const agent = createMockAgent()
     const context: ToolContext = {
       toolUse: {
@@ -19,7 +19,7 @@ describe.skipIf(process.platform === 'win32')('bash tool', () => {
       },
       agent,
     }
-    return { state: agent.state, context }
+    return { state: agent.appState, context }
   }
 
   afterEach(() => {

--- a/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
+++ b/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { fileEditor } from '../file-editor.js'
 import type { ToolContext } from '../../../index.js'
-import { AppState } from '../../../app-state.js'
+import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
 import { promises as fs } from 'fs'
 import * as path from 'path'
@@ -12,7 +12,7 @@ describe('fileEditor tool', () => {
   let context: ToolContext
 
   // Helper to create fresh state and context for each test
-  const createFreshContext = (): { state: AppState; context: ToolContext } => {
+  const createFreshContext = (): { state: StateStore; context: ToolContext } => {
     const agent = createMockAgent()
     const toolContext: ToolContext = {
       toolUse: {
@@ -22,7 +22,7 @@ describe('fileEditor tool', () => {
       },
       agent,
     }
-    return { state: agent.state, context: toolContext }
+    return { state: agent.appState, context: toolContext }
   }
 
   // Helper to create a test file

--- a/src/vended-tools/notebook/README.md
+++ b/src/vended-tools/notebook/README.md
@@ -43,7 +43,7 @@ await agent.invoke('Add "- [ ] Review code" to the todo notebook')
 await agent.invoke('Add "- [ ] Write tests" to the todo notebook')
 
 // State is accessible via the agent
-console.log(agent.state.get('notebooks'))
+console.log(agent.appState.get('notebooks'))
 // Output: { todo: '# Tasks\n- [ ] Review code\n- [ ] Write tests' }
 ```
 
@@ -53,7 +53,7 @@ Save notebook state across application restarts:
 
 ```typescript
 // Save the current state
-const savedState = agent.state.getAll()
+const savedState = agent.appState.getAll()
 
 // Later, create a new agent with the saved state
 const restoredAgent = new Agent({
@@ -61,7 +61,7 @@ const restoredAgent = new Agent({
     region: 'us-east-1',
   }),
   tools: [notebook],
-  state: savedState, // Restore previous notebooks
+  appState: savedState, // Restore previous notebooks
 })
 
 // All notebooks are immediately available
@@ -106,7 +106,7 @@ await agent.invoke('Replace "- [ ] Morning standup" with "- [x] Morning standup"
 const result = await agent.invoke('Read the tasks notebook')
 
 // Save state for tomorrow
-const taskState = agent.state.getAll()
+const taskState = agent.appState.getAll()
 // Store taskState in your database/file system
 ```
 
@@ -116,10 +116,10 @@ You can also use the notebook tool directly without an agent:
 
 ```typescript
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
-import { AppState } from '@strands-agents/sdk'
+import { StateStore } from '@strands-agents/sdk'
 
-const state = new AppState({ notebooks: {} })
-const agent = { state }
+const state = new StateStore({ notebooks: {} })
+const agent = { appState: state }
 const context = {
   agent,
   toolUse: { name: 'notebook', toolUseId: 'test', input: {} },

--- a/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { notebook } from '../notebook.js'
 import type { NotebookState } from '../types.js'
 import type { ToolContext } from '../../../index.js'
-import { AppState } from '../../../app-state.js'
+import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
 
 describe('notebook tool', () => {
   // Helper to create fresh state and context for each test
-  const createFreshContext = (): { state: AppState; context: ToolContext } => {
-    const agent = createMockAgent({ state: { notebooks: {} } })
+  const createFreshContext = (): { state: StateStore; context: ToolContext } => {
+    const agent = createMockAgent({ appState: { notebooks: {} } })
     const context: ToolContext = {
       toolUse: {
         name: 'notebook',
@@ -17,7 +17,7 @@ describe('notebook tool', () => {
       },
       agent,
     }
-    return { state: agent.state, context }
+    return { state: agent.appState, context }
   }
 
   describe('create oper ation', () => {

--- a/src/vended-tools/notebook/notebook.ts
+++ b/src/vended-tools/notebook/notebook.ts
@@ -71,7 +71,7 @@ export const notebook = tool({
     }
 
     // Get notebooks from state, or initialize if not present
-    let notebooks = context.agent.state.get<NotebookState>('notebooks')
+    let notebooks = context.agent.appState.get<NotebookState>('notebooks')
 
     if (!notebooks) {
       notebooks = {}
@@ -110,7 +110,7 @@ export const notebook = tool({
     }
 
     // Persist notebooks back to state
-    context.agent.state.set('notebooks', notebooks)
+    context.agent.appState.set('notebooks', notebooks)
 
     return result
   },

--- a/test/integ/tools/notebook.test.ts
+++ b/test/integ/tools/notebook.test.ts
@@ -24,7 +24,7 @@ describe.skipIf(bedrock.skip)('Notebook Tool Integration', () => {
     )
 
     // Verify notebook was created
-    const notebooks1 = agent.state.get('notebooks') as any
+    const notebooks1 = agent.appState.get('notebooks') as any
     expect(notebooks1).toBeTruthy()
     expect(notebooks1).toHaveProperty('test')
     expect(notebooks1.test).toContain('# Test Notebook')
@@ -33,7 +33,7 @@ describe.skipIf(bedrock.skip)('Notebook Tool Integration', () => {
     const { items: _events2 } = await collectGenerator(agent.stream('Add "- First item" to the test notebook'))
 
     // Verify content was added
-    const notebooks2 = agent.state.get('notebooks') as any
+    const notebooks2 = agent.appState.get('notebooks') as any
     expect(notebooks2.test).toContain('- First item')
 
     // Step 3: Read the notebook
@@ -46,7 +46,7 @@ describe.skipIf(bedrock.skip)('Notebook Tool Integration', () => {
     expect(textBlocks.length).toBeGreaterThan(0)
 
     // The notebook should still contain both pieces of content
-    const notebooks3 = agent.state.get('notebooks') as any
+    const notebooks3 = agent.appState.get('notebooks') as any
     expect(notebooks3.test).toContain('# Test Notebook')
     expect(notebooks3.test).toContain('- First item')
   }, 30000) // 30 second timeout for network calls
@@ -59,21 +59,21 @@ describe.skipIf(bedrock.skip)('Notebook Tool Integration', () => {
     await collectGenerator(agent1.stream('Create a notebook called "persist" with "Persistent content"'))
 
     // Verify notebook was created
-    const notebooks1 = agent1.state.get('notebooks') as any
+    const notebooks1 = agent1.appState.get('notebooks') as any
     expect(notebooks1).toBeTruthy()
     expect(notebooks1.persist).toContain('Persistent content')
 
     // Save state
-    const savedState = agent1.state.getAll()
+    const savedState = agent1.appState.getAll()
 
     // Create second agent with restored state
     const agent2 = new Agent({
       ...agentParams,
-      state: savedState, // Pass state in constructor
+      appState: savedState, // Pass state in constructor
     })
 
     // Verify notebooks were restored
-    const notebooks2 = agent2.state.get('notebooks') as any
+    const notebooks2 = agent2.appState.get('notebooks') as any
     expect(notebooks2).toBeTruthy()
     expect(notebooks2.persist).toContain('Persistent content')
 
@@ -81,7 +81,7 @@ describe.skipIf(bedrock.skip)('Notebook Tool Integration', () => {
     await collectGenerator(agent2.stream('Read the persist notebook'))
 
     // Verify content still exists
-    const notebooks3 = agent2.state.get('notebooks') as any
+    const notebooks3 = agent2.appState.get('notebooks') as any
     expect(notebooks3.persist).toContain('Persistent content')
   }, 30000)
 


### PR DESCRIPTION
## Motivation

The current naming creates confusion about the purpose and scope of agent state:

- `AppState` implies the class is limited to application-level state, but it is a general-purpose key-value store that could serve broader use cases.
- `Agent.state` is ambiguous. It could refer to the agent's internal state (conversation history, config, etc.) rather than user-managed data.

Renaming clarifies intent: `StateStore` describes what the class is (a key-value store), and `Agent.appState` signals that this state belongs to the application/user, not the agent internals. The agent itself never reads or modifies this data. It exists for users to persist information across invocations and access it from plugins and tools.

This also opens a path for future namespaced scoping. Users can already store invocation-level data in `appState` with their own key namespacing. In the future, `appState` could be expanded to support structured scopes like `agent.appState.session` and `agent.appState.invocation`, where `agent.appState.get/set()` defaults to session scope for backward compatibility.

## Public API Changes

```typescript
// Before
import { AppState } from '@strands-agents/sdk'

const agent = new Agent({
  state: { userId: 'user-123' },
})

agent.state.get('userId')
agent.state.set('key', 'value')

// After
import { StateStore } from '@strands-agents/sdk'

const agent = new Agent({
  appState: { userId: 'user-123' },
})

agent.appState.get('userId')
agent.appState.set('key', 'value')
```

Tool context access changes from `context.agent.state` to `context.agent.appState`. Plugin access changes from `agent.state` to `agent.appState`.

This is a breaking change. We are in preview so no backward compatibility alias is provided.

## Documentation PR

strands-agents/docs#675

## Type of Change

Breaking change

## Testing

- [x] I ran `npm run check`

All 1594 tests pass, lint clean, type-check clean.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.