### PR TITLE
fix: fix file editor replace bug

### DIFF
--- a/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
+++ b/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
@@ -308,6 +308,17 @@ describe('fileEditor tool', () => {
       expect(fileContent).toBe('Line 1\nNEW LINE\nLine 4')
     })
 
+    it('preserves dollar sign patterns in new_str literally', async () => {
+      const filePath = await createTestFile('test.txt', 'const value = getPrice()')
+      await fileEditor.invoke(
+        { command: 'str_replace', path: filePath, old_str: 'getPrice()', new_str: '$& is not $1 or $$' },
+        context
+      )
+
+      const fileContent = await fs.readFile(filePath, 'utf-8')
+      expect(fileContent).toBe('const value = $& is not $1 or $$')
+    })
+
     describe('error cases', () => {
       it('throws when old_str not found', async () => {
         const filePath = await createTestFile('test.txt', 'Line 1\nLine 2\nLine 3')

--- a/src/vended-tools/file-editor/file-editor.ts
+++ b/src/vended-tools/file-editor/file-editor.ts
@@ -351,7 +351,7 @@ async function handleStrReplace(
   }
 
   // Perform replacement
-  const newFileContent = fileContent.replace(expandedOldStr, expandedNewStr)
+  const newFileContent = fileContent.replace(expandedOldStr, () => expandedNewStr)
 
   // Write back to file
   await fs.writeFile(filePath, newFileContent, 'utf-8')


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

`handleStrReplace` in the file editor tool uses String.prototype.replace() to perform text substitution:

```
const newFileContent = fileContent.replace(expandedOldStr, expandedNewStr)
```

String.replace() interprets special $ patterns in the replacement string (second argument), even when the first argument is a plain string — $ & expands to the matched text, $ ` and $ ' expand to text before/after the match, and $$ collapses to a single $.

This means any new_str containing these patterns silently corrupts the replacement output. For example, replacing code with $& is not $1 or $$ produces getPrice() is not $1 or $ instead of the literal string.

The fix uses a function replacer, which bypasses all $-pattern processing:
```
const newFileContent = fileContent.replace(expandedOldStr, () => expandedNewStr)
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?
unit test:
"preserves dollar sign patterns in new_str literally" — creates a file containing getPrice(), replaces it with $& is not $1 or $$, and asserts the output contains the literal replacement string rather than expanded $ patterns.

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
