### PR TITLE
fix: gemini model should handle throttling correctly

### DIFF
--- a/src/models/__tests__/gemini.test.ts
+++ b/src/models/__tests__/gemini.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GoogleGenAI, FunctionCallingConfigMode, type GenerateContentResponse } from '@google/genai'
 import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
 import { GeminiModel } from '../gemini/model.js'
-import { ContextWindowOverflowError } from '../../errors.js'
+import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import {
   Message,
   CachePointBlock,
@@ -266,6 +266,50 @@ describe('GeminiModel', () => {
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(collectIterator(provider.stream(messages))).rejects.toThrow(ContextWindowOverflowError)
+    })
+
+    it('throws ModelThrottledError for RESOURCE_EXHAUSTED status', async () => {
+      const mockClient = {
+        models: {
+          generateContentStream: vi.fn(async () => {
+            throw new Error(
+              JSON.stringify({
+                error: {
+                  status: 'RESOURCE_EXHAUSTED',
+                  message: 'Quota exceeded for the model',
+                },
+              })
+            )
+          }),
+        },
+      } as unknown as GoogleGenAI
+
+      const provider = new GeminiModel({ client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      await expect(collectIterator(provider.stream(messages))).rejects.toThrow(ModelThrottledError)
+    })
+
+    it('throws ModelThrottledError for UNAVAILABLE status', async () => {
+      const mockClient = {
+        models: {
+          generateContentStream: vi.fn(async () => {
+            throw new Error(
+              JSON.stringify({
+                error: {
+                  status: 'UNAVAILABLE',
+                  message: 'Service temporarily unavailable',
+                },
+              })
+            )
+          }),
+        },
+      } as unknown as GoogleGenAI
+
+      const provider = new GeminiModel({ client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      await expect(collectIterator(provider.stream(messages))).rejects.toThrow(ModelThrottledError)
     })
 
     it('rethrows unrecognized errors', async () => {

--- a/src/models/gemini/errors.ts
+++ b/src/models/gemini/errors.ts
@@ -12,7 +12,7 @@ import { logger } from '../../logging/logger.js'
  * This union type will expand as more error types are supported
  * (e.g., 'throttling', 'invalidRequest').
  */
-export type GeminiErrorType = 'contextOverflow'
+export type GeminiErrorType = 'contextOverflow' | 'throttling'
 
 /**
  * Configuration for handling a specific error status.
@@ -32,6 +32,12 @@ export const ERROR_STATUS_MAP: Record<string, ErrorStatusConfig> = {
   INVALID_ARGUMENT: {
     type: 'contextOverflow',
     messagePatterns: new Set(['exceeds the maximum number of tokens']),
+  },
+  RESOURCE_EXHAUSTED: {
+    type: 'throttling',
+  },
+  UNAVAILABLE: {
+    type: 'throttling',
   },
 }
 

--- a/src/models/gemini/model.ts
+++ b/src/models/gemini/model.ts
@@ -17,7 +17,7 @@ import { Model } from '../model.js'
 import type { StreamOptions } from '../model.js'
 import type { Message } from '../../types/messages.js'
 import type { ModelStreamEvent } from '../streaming.js'
-import { ContextWindowOverflowError } from '../../errors.js'
+import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import type { GeminiModelConfig, GeminiModelOptions, GeminiStreamState } from './types.js'
 export type { GeminiModelConfig, GeminiModelOptions }
 import { classifyGeminiError } from './errors.js'
@@ -209,6 +209,10 @@ export class GeminiModel extends Model<GeminiModelConfig> {
 
       if (errorType === 'contextOverflow') {
         throw new ContextWindowOverflowError(error.message)
+      }
+
+      if (errorType === 'throttling') {
+        throw new ModelThrottledError(error.message, { cause: error })
       }
 
       throw error


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The Gemini model provider classifies API errors for contextOverflow but does not detect throttling/rate-limit errors. When the Gemini API returns RESOURCE_EXHAUSTED or UNAVAILABLE status codes, the error propagates as a generic Error instead of ModelThrottledError. This prevents users from leveraging AfterModelCallEvent.retry for throttle recovery — a pattern that already works with Bedrock, OpenAI, and Anthropic providers.

The Python SDK already handles this (mapping RESOURCE_EXHAUSTED and UNAVAILABLE to ModelThrottledException), so this brings the TypeScript SDK to parity.

Changes:

src/models/gemini/errors.ts — Added 'throttling' to the GeminiErrorType union and added RESOURCE_EXHAUSTED and UNAVAILABLE entries to ERROR_STATUS_MAP

src/models/gemini/model.ts — Imported ModelThrottledError and added handling for errorType === 'throttling' in the stream() catch block


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

Added 2 new test cases:

"throws ModelThrottledError for RESOURCE_EXHAUSTED status" — mocks a Gemini API error with RESOURCE_EXHAUSTED status and asserts ModelThrottledError is thrown

"throws ModelThrottledError for UNAVAILABLE status" — mocks a Gemini API error with UNAVAILABLE status and asserts ModelThrottledError is thrown

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
