### PR TITLE
refactor: rename OpenAIModel to OpenAIChatModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ const agent = new Agent({ model })
 
 ```typescript
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 
 // Automatically uses process.env.OPENAI_API_KEY and defaults to gpt-4o
-const model = new OpenAIModel()
+const model = new OpenAIChatModel()
 
 const agent = new Agent({ model })
 ```

--- a/examples/mcp/src/index.ts
+++ b/examples/mcp/src/index.ts
@@ -1,5 +1,5 @@
 import { Agent, McpClient } from '@strands-agents/sdk'
-import { OpenAIModel } from '../../../dist/src/models/openai.js'
+import { OpenAIChatModel } from '../../../dist/src/models/openai-chat.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
       "types": "./dist/src/models/anthropic.d.ts",
       "default": "./dist/src/models/anthropic.js"
     },
-    "./openai": {
-      "types": "./dist/src/models/openai.d.ts",
-      "default": "./dist/src/models/openai.js"
+    "./openai-chat": {
+      "types": "./dist/src/models/openai-chat.d.ts",
+      "default": "./dist/src/models/openai-chat.js"
     },
     "./bedrock": {
       "types": "./dist/src/models/bedrock.d.ts",

--- a/src/models/__tests__/openai-chat.test.ts
+++ b/src/models/__tests__/openai-chat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import OpenAI from 'openai'
 import { isNode } from '../../__fixtures__/environment.js'
-import { OpenAIModel } from '../openai.js'
+import { OpenAIChatModel } from '../openai-chat.js'
 import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
 import { Message, TextBlock, ToolUseBlock, ToolResultBlock, GuardContentBlock } from '../../types/messages.js'
@@ -31,7 +31,7 @@ vi.mock('openai', () => {
   }
 })
 
-describe('OpenAIModel', () => {
+describe('OpenAIChatModel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
@@ -68,14 +68,14 @@ describe('OpenAIModel', () => {
 
   describe('constructor', () => {
     it('creates an instance with required modelId', () => {
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', apiKey: 'sk-test' })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', apiKey: 'sk-test' })
       const config = provider.getConfig()
       expect(config.modelId).toBe('gpt-4o')
     })
 
     it('uses custom model ID', () => {
       const customModelId = 'gpt-3.5-turbo'
-      const provider = new OpenAIModel({ modelId: customModelId, apiKey: 'sk-test' })
+      const provider = new OpenAIChatModel({ modelId: customModelId, apiKey: 'sk-test' })
       expect(provider.getConfig()).toStrictEqual({
         modelId: customModelId,
       })
@@ -83,7 +83,7 @@ describe('OpenAIModel', () => {
 
     it('uses API key from constructor parameter', () => {
       const apiKey = 'sk-explicit'
-      new OpenAIModel({ modelId: 'gpt-4o', apiKey })
+      new OpenAIChatModel({ modelId: 'gpt-4o', apiKey })
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
           apiKey: apiKey,
@@ -95,7 +95,7 @@ describe('OpenAIModel', () => {
     if (isNode) {
       it('uses API key from environment variable', () => {
         vi.stubEnv('OPENAI_API_KEY', 'sk-from-env')
-        new OpenAIModel({ modelId: 'gpt-4o' })
+        new OpenAIChatModel({ modelId: 'gpt-4o' })
         // OpenAI client should be called without explicit apiKey (uses env var internally)
         expect(OpenAI).toHaveBeenCalled()
       })
@@ -106,7 +106,7 @@ describe('OpenAIModel', () => {
         vi.stubEnv('OPENAI_API_KEY', 'sk-from-env')
       }
       const explicitKey = 'sk-explicit'
-      new OpenAIModel({ modelId: 'gpt-4o', apiKey: explicitKey })
+      new OpenAIChatModel({ modelId: 'gpt-4o', apiKey: explicitKey })
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
           apiKey: explicitKey,
@@ -118,14 +118,14 @@ describe('OpenAIModel', () => {
       if (isNode) {
         vi.stubEnv('OPENAI_API_KEY', '')
       }
-      expect(() => new OpenAIModel({ modelId: 'gpt-4o' })).toThrow(
+      expect(() => new OpenAIChatModel({ modelId: 'gpt-4o' })).toThrow(
         "OpenAI API key is required. Provide it via the 'apiKey' option (string or function) or set the OPENAI_API_KEY environment variable."
       )
     })
 
     it('uses custom client configuration', () => {
       const timeout = 30000
-      new OpenAIModel({ modelId: 'gpt-4o', apiKey: 'sk-test', clientConfig: { timeout } })
+      new OpenAIChatModel({ modelId: 'gpt-4o', apiKey: 'sk-test', clientConfig: { timeout } })
       expect(OpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
           timeout: timeout,
@@ -136,7 +136,7 @@ describe('OpenAIModel', () => {
     it('uses provided client instance', () => {
       vi.clearAllMocks()
       const mockClient = {} as OpenAI
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       // Should not create a new OpenAI client
       expect(OpenAI).not.toHaveBeenCalled()
       expect(provider).toBeDefined()
@@ -145,7 +145,7 @@ describe('OpenAIModel', () => {
     it('provided client takes precedence over apiKey and clientConfig', () => {
       vi.clearAllMocks()
       const mockClient = {} as OpenAI
-      new OpenAIModel({
+      new OpenAIChatModel({
         modelId: 'gpt-4o',
         apiKey: 'sk-test',
         client: mockClient,
@@ -161,12 +161,12 @@ describe('OpenAIModel', () => {
         vi.stubEnv('OPENAI_API_KEY', '')
       }
       const mockClient = {} as OpenAI
-      expect(() => new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })).not.toThrow()
+      expect(() => new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })).not.toThrow()
     })
 
     it('accepts function-based API key', () => {
       const apiKeyFn = vi.fn(async () => 'sk-dynamic')
-      new OpenAIModel({
+      new OpenAIChatModel({
         modelId: 'gpt-4o',
         apiKey: apiKeyFn,
       })
@@ -183,7 +183,7 @@ describe('OpenAIModel', () => {
         return 'sk-async-key'
       }
 
-      new OpenAIModel({
+      new OpenAIChatModel({
         modelId: 'gpt-4o',
         apiKey: apiKeyFn,
       })
@@ -198,7 +198,7 @@ describe('OpenAIModel', () => {
 
   describe('updateConfig', () => {
     it('merges new config with existing config', () => {
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', apiKey: 'sk-test', temperature: 0.5 })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', apiKey: 'sk-test', temperature: 0.5 })
       provider.updateConfig({ modelId: 'gpt-4o', temperature: 0.8, maxTokens: 2048 })
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'gpt-4o',
@@ -208,7 +208,7 @@ describe('OpenAIModel', () => {
     })
 
     it('preserves fields not included in the update', () => {
-      const provider = new OpenAIModel({
+      const provider = new OpenAIChatModel({
         apiKey: 'sk-test',
         modelId: 'gpt-3.5-turbo',
         temperature: 0.5,
@@ -225,7 +225,7 @@ describe('OpenAIModel', () => {
 
   describe('getConfig', () => {
     it('returns the current configuration', () => {
-      const provider = new OpenAIModel({
+      const provider = new OpenAIChatModel({
         modelId: 'gpt-4o',
         apiKey: 'sk-test',
         maxTokens: 1024,
@@ -243,7 +243,7 @@ describe('OpenAIModel', () => {
     describe('validation', () => {
       it('throws error when messages array is empty', async () => {
         const mockClient = createMockClient(async function* () {})
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
 
         await expect(async () => {
           await collectIterator(provider.stream([]))
@@ -259,7 +259,7 @@ describe('OpenAIModel', () => {
             choices: [{ finish_reason: 'stop', delta: {}, index: 0 }],
           }
         })
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
         // System prompt that's only whitespace should not be sent
@@ -272,7 +272,7 @@ describe('OpenAIModel', () => {
 
       it('throws error for streaming with n > 1', async () => {
         const mockClient = createMockClient(async function* () {})
-        const provider = new OpenAIModel({
+        const provider = new OpenAIChatModel({
           modelId: 'gpt-4o',
           client: mockClient,
           params: { n: 2 },
@@ -288,7 +288,7 @@ describe('OpenAIModel', () => {
 
       it('throws error for tool spec without name or description', async () => {
         const mockClient = createMockClient(async function* () {})
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
         await expect(async () => {
@@ -302,7 +302,7 @@ describe('OpenAIModel', () => {
 
       it('throws error for empty tool result content', async () => {
         const mockClient = createMockClient(async function* () {})
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
         const messages = [
           new Message({
             role: 'user',
@@ -332,7 +332,7 @@ describe('OpenAIModel', () => {
             choices: [{ finish_reason: 'stop', delta: {}, index: 0 }],
           }
         })
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
         const messages = [
           new Message({ role: 'user', content: [new TextBlock('Run tool')] }),
           new Message({
@@ -367,7 +367,7 @@ describe('OpenAIModel', () => {
 
       it('throws error for circular reference in tool input', async () => {
         const mockClient = createMockClient(async function* () {})
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
 
         const circular: any = { a: 1 }
         circular.self = circular
@@ -411,7 +411,7 @@ describe('OpenAIModel', () => {
           }
         })
 
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
         const events = await collectIterator(provider.stream(messages))
@@ -451,7 +451,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -482,7 +482,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -515,7 +515,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -539,7 +539,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       // Suppress console.warn for this test
@@ -601,7 +601,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Calculate 2+2')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -680,7 +680,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -719,7 +719,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       // Suppress console.warn for this test
@@ -767,7 +767,7 @@ describe('OpenAIModel', () => {
         yield { choices: [{ finish_reason: 'tool_calls', delta: {}, index: 0 }] }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -811,7 +811,7 @@ describe('OpenAIModel', () => {
         yield { choices: [{ finish_reason: 'tool_calls', delta: {}, index: 0 }] }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Calculate 2+2')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -854,7 +854,7 @@ describe('OpenAIModel', () => {
           }
         })
 
-        const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+        const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
         const events = await collectIterator(provider.stream(messages))
@@ -875,7 +875,7 @@ describe('OpenAIModel', () => {
         }
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       const events = await collectIterator(provider.stream(messages))
@@ -911,7 +911,7 @@ describe('OpenAIModel', () => {
         },
       } as any
 
-      const provider = new OpenAIModel({
+      const provider = new OpenAIChatModel({
         modelId: 'gpt-4o',
         client: mockClient,
         temperature: 0.7,
@@ -968,7 +968,7 @@ describe('OpenAIModel', () => {
     it('formats array system prompt with text blocks only', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       await collectIterator(
@@ -991,7 +991,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       collectIterator(
@@ -1022,7 +1022,7 @@ describe('OpenAIModel', () => {
     it('handles empty array system prompt', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       await collectIterator(
@@ -1039,7 +1039,7 @@ describe('OpenAIModel', () => {
     it('formats array system prompt with single text block', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       await collectIterator(
@@ -1059,7 +1059,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       await collectIterator(
@@ -1096,7 +1096,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       await collectIterator(
@@ -1134,7 +1134,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
       await collectIterator(
@@ -1169,7 +1169,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [
         new Message({
           role: 'user',
@@ -1212,7 +1212,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const imageBytes = new Uint8Array([1, 2, 3, 4])
       const messages = [
         new Message({
@@ -1249,7 +1249,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [
         new Message({
           role: 'user',
@@ -1283,7 +1283,7 @@ describe('OpenAIModel', () => {
     it('formats image block in user message as image_url with base64', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const imageBytes = new Uint8Array([72, 101, 108, 108, 111])
       const messages = [
         new Message({
@@ -1310,7 +1310,7 @@ describe('OpenAIModel', () => {
     it('formats image block in user message with URL source', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [
         new Message({
           role: 'user',
@@ -1330,7 +1330,7 @@ describe('OpenAIModel', () => {
     it('formats document block with bytes source as file in user message', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const docBytes = new Uint8Array([1, 2, 3])
       const messages = [
         new Message({
@@ -1351,7 +1351,7 @@ describe('OpenAIModel', () => {
     it('splits image from tool result into separate user message', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const imageBytes = new Uint8Array([72, 101, 108, 108, 111])
       const messages = [
         new Message({
@@ -1389,7 +1389,7 @@ describe('OpenAIModel', () => {
     it('injects placeholder text when tool result contains only images', async () => {
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [
         new Message({
           role: 'user',
@@ -1413,7 +1413,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [
         new Message({
           role: 'user',
@@ -1442,7 +1442,7 @@ describe('OpenAIModel', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const captured: { request: any } = { request: null }
       const mockClient = createMockClientWithCapture(captured)
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [
         new Message({
           role: 'user',
@@ -1482,7 +1482,7 @@ describe('OpenAIModel', () => {
         },
       } as any
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1503,7 +1503,7 @@ describe('OpenAIModel', () => {
         },
       } as any
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1531,7 +1531,7 @@ describe('OpenAIModel', () => {
         },
       } as any
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1552,7 +1552,7 @@ describe('OpenAIModel', () => {
         },
       } as any
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1570,7 +1570,7 @@ describe('OpenAIModel', () => {
         throw new Error('Network connection lost')
       })
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1594,7 +1594,7 @@ describe('OpenAIModel', () => {
         },
       } as unknown as OpenAI
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1618,7 +1618,7 @@ describe('OpenAIModel', () => {
         },
       } as unknown as OpenAI
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1639,7 +1639,7 @@ describe('OpenAIModel', () => {
         },
       } as unknown as OpenAI
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1660,7 +1660,7 @@ describe('OpenAIModel', () => {
         },
       } as unknown as OpenAI
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       await expect(async () => {
@@ -1684,7 +1684,7 @@ describe('OpenAIModel', () => {
         },
       } as unknown as OpenAI
 
-      const provider = new OpenAIModel({ modelId: 'gpt-4o', client: mockClient })
+      const provider = new OpenAIChatModel({ modelId: 'gpt-4o', client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
       try {

--- a/src/models/openai-chat.ts
+++ b/src/models/openai-chat.ts
@@ -80,7 +80,7 @@ type OpenAIChatChoice = {
  * }
  * ```
  */
-export interface OpenAIModelConfig extends BaseModelConfig {
+export interface OpenAIChatModelConfig extends BaseModelConfig {
   /**
    * OpenAI model identifier (e.g., gpt-4o, gpt-3.5-turbo).
    */
@@ -138,7 +138,7 @@ export interface OpenAIModelConfig extends BaseModelConfig {
 /**
  * Options interface for creating an OpenAIModel instance.
  */
-export interface OpenAIModelOptions extends OpenAIModelConfig {
+export interface OpenAIChatModelOptions extends OpenAIChatModelConfig {
   /**
    * OpenAI API key (falls back to OPENAI_API_KEY environment variable).
    *
@@ -187,8 +187,8 @@ export interface OpenAIModelOptions extends OpenAIModelConfig {
  * }
  * ```
  */
-export class OpenAIModel extends Model<OpenAIModelConfig> {
-  private _config: OpenAIModelConfig
+export class OpenAIChatModel extends Model<OpenAIChatModelConfig> {
+  private _config: OpenAIChatModelConfig
   private _client: OpenAI
 
   /**
@@ -231,7 +231,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
    * })
    * ```
    */
-  constructor(options?: OpenAIModelOptions) {
+  constructor(options?: OpenAIChatModelOptions) {
     super()
     const { apiKey, client, clientConfig, ...modelConfig } = options || {}
 
@@ -277,7 +277,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
    * })
    * ```
    */
-  updateConfig(modelConfig: OpenAIModelConfig): void {
+  updateConfig(modelConfig: OpenAIChatModelConfig): void {
     this._config = { ...this._config, ...modelConfig }
   }
 
@@ -292,7 +292,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
    * console.log(config.modelId)
    * ```
    */
-  getConfig(): OpenAIModelConfig {
+  getConfig(): OpenAIChatModelConfig {
     return this._config
   }
 

--- a/test/integ/__fixtures__/model-providers.ts
+++ b/test/integ/__fixtures__/model-providers.ts
@@ -4,7 +4,7 @@
 
 import { inject } from 'vitest'
 import { BedrockModel, type BedrockModelOptions } from '$/sdk/models/bedrock.js'
-import { OpenAIModel, type OpenAIModelOptions } from '$/sdk/models/openai.js'
+import { OpenAIChatModel, type OpenAIChatModelOptions } from '$/sdk/models/openai-chat.js'
 import { AnthropicModel, type AnthropicModelOptions } from '$/sdk/models/anthropic.js'
 import { GeminiModel, type GeminiModelOptions } from '$/sdk/models/gemini/model.js'
 
@@ -61,7 +61,7 @@ export const bedrock = {
 }
 
 export const openai = {
-  name: 'OpenAIModel',
+  name: 'OpenAIChatModel',
   supports: {
     reasoning: false,
     tools: true,
@@ -80,12 +80,12 @@ export const openai = {
   get skip() {
     return inject('provider-openai').shouldSkip
   },
-  createModel: (config: OpenAIModelOptions = {}): OpenAIModel => {
+  createModel: (config: OpenAIChatModelOptions = {}): OpenAIChatModel => {
     const apiKey = inject('provider-openai')?.apiKey
     if (!apiKey) {
       throw new Error('No OpenAI apiKey provided')
     }
-    return new OpenAIModel({
+    return new OpenAIChatModel({
       ...config,
       apiKey,
       clientConfig: { ...(config.clientConfig ?? {}), dangerouslyAllowBrowser: true },

--- a/test/integ/models/openai-chat.test.ts
+++ b/test/integ/models/openai-chat.test.ts
@@ -6,7 +6,7 @@ import { collectIterator } from '$/sdk/__fixtures__/model-test-helpers.js'
 
 import { openai } from '../__fixtures__/model-providers.js'
 
-describe.skipIf(openai.skip)('OpenAIModel Integration Tests', () => {
+describe.skipIf(openai.skip)('OpenAIChatModel Integration Tests', () => {
   describe('Configuration', () => {
     it.concurrent('respects maxTokens configuration', async () => {
       const provider = openai.createModel({


### PR DESCRIPTION
## Description

The TypeScript SDK currently names its OpenAI Chat Completions provider `OpenAIModel`, which is ambiguous since OpenAI offers multiple API surfaces (Chat Completions and Responses). This rename to `OpenAIChatModel` makes the provider name explicit about which API it wraps, aligning with how the class is actually implemented and leaving room for future OpenAI providers.

This is a breaking change to the public API. The file, class, config interface, options interface, and package.json export path are all renamed:

- `openai.ts` -> `openai-chat.ts`
- `OpenAIModel` -> `OpenAIChatModel`
- `OpenAIModelConfig` -> `OpenAIChatModelConfig`
- `OpenAIModelOptions` -> `OpenAIChatModelOptions`
- Export path: `@strands-agents/sdk/openai` -> `@strands-agents/sdk/openai-chat`

## Public API Changes

```typescript
// Before
import { OpenAIModel } from '@strands-agents/sdk/openai'

const model = new OpenAIModel({
  modelId: 'gpt-4o',
  apiKey: 'sk-...'
})

// After
import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'

const model = new OpenAIChatModel({
  modelId: 'gpt-4o',
  apiKey: 'sk-...'
})
```

All existing functionality is preserved. Only the names and import path have changed.

## Breaking Changes

Users importing from `@strands-agents/sdk/openai` will need to update their import path to `@strands-agents/sdk/openai-chat` and rename `OpenAIModel` to `OpenAIChatModel`.

### Migration

```typescript
// Before
import { OpenAIModel } from '@strands-agents/sdk/openai'
const model = new OpenAIModel({ modelId: 'gpt-4o', apiKey: 'sk-...' })

// After
import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
const model = new OpenAIChatModel({ modelId: 'gpt-4o', apiKey: 'sk-...' })
```

## Related Issues

## Documentation PR

strands-agents/docs#680

## Type of Change

Breaking change

## Testing

All 1611 existing unit tests pass. No new tests needed since this is a pure rename with no behavioral changes.

- [x] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.