### PR TITLE
feat: prevent self-handoffs in Swarm

### DIFF
--- a/src/multiagent/__tests__/nodes.test.ts
+++ b/src/multiagent/__tests__/nodes.test.ts
@@ -152,7 +152,7 @@ describe('AgentNode', () => {
       expect(agent.appState.getAll()).toStrictEqual(stateBefore)
     })
 
-    it('passes structuredOutputSchema from state to the agent', async () => {
+    it('passes structuredOutputSchema from options to the agent', async () => {
       const schema = z.object({ agentName: z.string().optional(), message: z.string() })
 
       const model = new MockMessageModel()
@@ -166,9 +166,9 @@ describe('AgentNode', () => {
 
       agent = new Agent({ model, printer: false, id: 'schema-agent' })
       node = new AgentNode({ agent })
-      state = new MultiAgentState({ nodeIds: ['schema-agent'], structuredOutputSchema: schema })
+      state = new MultiAgentState({ nodeIds: ['schema-agent'] })
 
-      const { result } = await collectGenerator(node.stream('test', state))
+      const { result } = await collectGenerator(node.stream('test', state, { structuredOutputSchema: schema }))
 
       expect(result.structuredOutput).toStrictEqual({ message: 'hello' })
     })

--- a/src/multiagent/__tests__/swarm.test.ts
+++ b/src/multiagent/__tests__/swarm.test.ts
@@ -177,6 +177,30 @@ describe('Swarm', () => {
       expect(texts).toContainEqual(expect.stringContaining(JSON.stringify(contextData, null, 2)))
     })
 
+    it('excludes current agent from handoff schema', async () => {
+      const agentA = createHandoffAgent('a', { agentId: 'b', message: 'go to b' })
+      const agentB = createFinalAgent('b', 'done')
+      const streamSpyA = vi.spyOn(agentA, 'stream')
+      const streamSpyB = vi.spyOn(agentB, 'stream')
+
+      const swarm = new Swarm({
+        nodes: [agentA, agentB],
+        start: 'a',
+      })
+
+      await swarm.invoke('start')
+
+      // Agent A's handoff schema allows B but rejects A
+      const schemaA = streamSpyA.mock.calls[0]![1]!.structuredOutputSchema!
+      expect(schemaA.parse({ agentId: 'b', message: 'ok' })).toStrictEqual({ agentId: 'b', message: 'ok' })
+      expect(() => schemaA.parse({ agentId: 'a', message: 'ok' })).toThrow()
+
+      // Agent B's handoff schema allows A but rejects B
+      const schemaB = streamSpyB.mock.calls[0]![1]!.structuredOutputSchema!
+      expect(schemaB.parse({ agentId: 'a', message: 'ok' })).toStrictEqual({ agentId: 'a', message: 'ok' })
+      expect(() => schemaB.parse({ agentId: 'b', message: 'ok' })).toThrow()
+    })
+
     it('throws when maxSteps is exceeded', async () => {
       const swarm = new Swarm({
         nodes: [createHandoffAgent('a', { agentId: 'b', message: 'to b' }), createFinalAgent('b', 'done')],

--- a/src/multiagent/index.ts
+++ b/src/multiagent/index.ts
@@ -6,7 +6,14 @@ export { MultiAgentState, NodeState, Status, NodeResult, MultiAgentResult } from
 export type { NodeResultUpdate, ResultStatus } from './state.js'
 
 export { Node, AgentNode, MultiAgentNode } from './nodes.js'
-export type { NodeConfig, AgentNodeOptions, MultiAgentNodeOptions, NodeDefinition, NodeType } from './nodes.js'
+export type {
+  NodeConfig,
+  NodeInputOptions,
+  AgentNodeOptions,
+  MultiAgentNodeOptions,
+  NodeDefinition,
+  NodeType,
+} from './nodes.js'
 
 export {
   MultiAgentInitializedEvent,

--- a/src/multiagent/nodes.ts
+++ b/src/multiagent/nodes.ts
@@ -8,6 +8,7 @@ import { NodeResult, Status } from './state.js'
 import type { MultiAgentState, NodeResultUpdate } from './state.js'
 import type { MultiAgent } from './multiagent.js'
 import { logger } from '../logging/logger.js'
+import type { z } from 'zod'
 
 /**
  * Known node type identifiers with extensibility for custom nodes.
@@ -22,6 +23,16 @@ export interface NodeConfig {
    * Optional description of what this node does.
    */
   description?: string
+}
+
+/**
+ * Per-invocation options passed from the orchestrator to a node.
+ */
+export interface NodeInputOptions {
+  /**
+   * Structured output schema for this node invocation.
+   */
+  structuredOutputSchema?: z.ZodSchema
 }
 
 /**
@@ -51,13 +62,15 @@ export abstract class Node {
    * Execute the node. Handles duration measurement, error capture,
    * and delegates to handle() for node-specific logic.
    *
-   * @param args - Input to pass to the node (string or content blocks)
+   * @param input - Input to pass to the node (string or content blocks)
    * @param state - The current multi-agent state
+   * @param options - Per-invocation options from the orchestrator
    * @returns Async generator yielding streaming events and returning a NodeResult
    */
   async *stream(
-    args: MultiAgentInput,
-    state: MultiAgentState
+    input: MultiAgentInput,
+    state: MultiAgentState,
+    options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResult, undefined> {
     const nodeState = state.node(this.id)!
     nodeState.status = Status.EXECUTING
@@ -65,7 +78,7 @@ export abstract class Node {
 
     let result: NodeResult
     try {
-      const update = yield* this.handle(args, state)
+      const update = yield* this.handle(input, state, options)
       result = new NodeResult({
         nodeId: this.id,
         status: Status.COMPLETED,
@@ -93,13 +106,15 @@ export abstract class Node {
   /**
    * Node-specific execution logic implemented by subclasses.
    *
-   * @param args - Input to process (string or content blocks)
+   * @param input - Input to process (string or content blocks)
    * @param state - The current multi-agent state
+   * @param options - Per-invocation options from the orchestrator
    * @returns Async generator yielding streaming events and returning a partial result
    */
   abstract handle(
-    args: MultiAgentInput,
-    state: MultiAgentState
+    input: MultiAgentInput,
+    state: MultiAgentState,
+    options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined>
 }
 
@@ -140,23 +155,25 @@ export class AgentNode extends Node {
    * Executes the wrapped agent, yielding each agent streaming event
    * wrapped in a {@link NodeStreamUpdateEvent}.
    *
-   * @param args - Input to pass to the agent
+   * @param input - Input to pass to the agent
    * @param state - The current multi-agent state
+   * @param options - Per-invocation options from the orchestrator
    * @returns Async generator yielding streaming events and returning the agent's content blocks
    */
   async *handle(
-    args: MultiAgentInput,
-    state: MultiAgentState
+    input: MultiAgentInput,
+    state: MultiAgentState,
+    options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
     // Only Agent instances support snapshot/restore for state isolation
     const snapshot =
       this._agent instanceof Agent ? takeSnapshot(this._agent, { include: ['messages', 'state'] }) : undefined
     try {
-      const options: InvokeOptions = {
-        ...(state.structuredOutputSchema && { structuredOutputSchema: state.structuredOutputSchema }),
+      const invokeOptions: InvokeOptions = {
+        ...(options?.structuredOutputSchema && { structuredOutputSchema: options.structuredOutputSchema }),
       }
 
-      const gen = this._agent.stream(args, options)
+      const gen = this._agent.stream(input, invokeOptions)
       let next = await gen.next()
       while (!next.done) {
         yield new NodeStreamUpdateEvent({
@@ -217,15 +234,17 @@ export class MultiAgentNode extends Node {
    * pass through as-is; all other events are wrapped in a new
    * {@link NodeStreamUpdateEvent} tagged with this node's identity.
    *
-   * @param args - Input to pass to the orchestrator
-   * @param _state - The current multi-agent state (unused)
+   * @param input - Input to pass to the orchestrator
+   * @param state - The current multi-agent state
+   * @param _options - Per-invocation options (unused by orchestrator nodes)
    * @returns Async generator yielding streaming events and returning the orchestrator's content
    */
   async *handle(
-    args: MultiAgentInput,
-    state: MultiAgentState
+    input: MultiAgentInput,
+    state: MultiAgentState,
+    _options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
-    const gen = this._orchestrator.stream(args)
+    const gen = this._orchestrator.stream(input)
     let next = await gen.next()
     while (!next.done) {
       const event = next.value

--- a/src/multiagent/state.ts
+++ b/src/multiagent/state.ts
@@ -140,16 +140,13 @@ export class MultiAgentState {
   readonly results: NodeResult[]
   /** App-level key-value state accessible from hooks, edge handlers, and custom nodes. */
   readonly app: StateStore
-  /** Structured output schema to apply to node invocations. */
-  readonly structuredOutputSchema?: z.ZodSchema
   private readonly _nodes: Map<string, NodeState>
 
-  constructor(data?: { nodeIds?: string[]; structuredOutputSchema?: z.ZodSchema }) {
+  constructor(data?: { nodeIds?: string[] }) {
     this.startTime = Date.now()
     this.steps = 0
     this.results = []
     this.app = new StateStore()
-    if (data?.structuredOutputSchema) this.structuredOutputSchema = data.structuredOutputSchema
     this._nodes = new Map()
     for (const id of data?.nodeIds ?? []) {
       this._nodes.set(id, new NodeState())

--- a/src/multiagent/swarm.ts
+++ b/src/multiagent/swarm.ts
@@ -103,7 +103,6 @@ export class Swarm implements MultiAgent {
   private readonly _pluginRegistry: MultiAgentPluginRegistry
   private readonly _hookRegistry: HookRegistryImplementation
   readonly start: AgentNode
-  private readonly _handoffSchema: z.ZodType<HandoffResult>
   private _initialized: boolean
 
   constructor(options: SwarmOptions) {
@@ -118,8 +117,6 @@ export class Swarm implements MultiAgent {
 
     this.nodes = this._resolveNodes(nodes)
     this.start = this._resolveStart(start)
-
-    this._handoffSchema = this._buildHandoffSchema()
 
     this._hookRegistry = new HookRegistryImplementation()
     this._pluginRegistry = new MultiAgentPluginRegistry(plugins)
@@ -188,7 +185,6 @@ export class Swarm implements MultiAgent {
   private async *_stream(input: MultiAgentInput): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
     const state = new MultiAgentState({
       nodeIds: [...this.nodes.keys()],
-      structuredOutputSchema: this._handoffSchema,
     })
 
     yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state })
@@ -238,6 +234,7 @@ export class Swarm implements MultiAgent {
     handoff?: HandoffResult
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResult, undefined> {
     const nodeState = state.node(node.id)!
+    const handoffSchema = this._buildHandoffSchema(node.id)
 
     const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id })
     yield beforeEvent
@@ -255,7 +252,7 @@ export class Swarm implements MultiAgent {
     const nodeInput = this._resolveNodeInput(input, handoff)
 
     try {
-      const gen = node.stream(nodeInput, state)
+      const gen = node.stream(nodeInput, state, { structuredOutputSchema: handoffSchema })
       let next = await gen.next()
       while (!next.done) {
         yield next.value
@@ -331,9 +328,9 @@ export class Swarm implements MultiAgent {
     }
   }
 
-  private _buildHandoffSchema(): z.ZodType<HandoffResult> {
-    const agentIds = [...this.nodes.keys()]
-    const agentDescriptions = agentIds
+  private _buildHandoffSchema(nodeId: string): z.ZodType<HandoffResult> {
+    const handoffIds = [...this.nodes.keys()].filter((id) => id !== nodeId)
+    const handoffDescriptions = handoffIds
       .map((id) => {
         const desc = this.nodes.get(id)!.config.description
         return desc ? `- ${id}: ${desc}` : `- ${id}`
@@ -342,12 +339,15 @@ export class Swarm implements MultiAgent {
 
     return z
       .object({
-        agentId: z
-          .enum(agentIds as [string, ...string[]])
-          .optional()
-          .describe(
-            `Target agent to hand off to. Omit to end the conversation.\n\nAvailable agents:\n${agentDescriptions}`
-          ),
+        agentId:
+          handoffIds.length > 0
+            ? z
+                .enum(handoffIds as [string, ...string[]])
+                .optional()
+                .describe(
+                  `Target agent to hand off to. Omit to end the conversation.\n\nAvailable agents:\n${handoffDescriptions}`
+                )
+            : z.never().optional().describe('No other agents available. Omit this field to end the conversation.'),
         message: z.string().describe('Instructions for the next agent, or the final response if no handoff.'),
         context: z.record(z.string(), z.unknown()).optional().describe('Structured data to pass to the next agent.'),
       })


### PR DESCRIPTION
## Description

Swarm agents can currently hand off to themselves, creating infinite loops. This change prevents that by building a per-node handoff schema that excludes the currently executing agent from the list of valid handoff targets. The model never sees itself as an option.

The implementation introduces `NodeInputOptions` as a way for orchestrators to pass per-invocation configuration (like structured output schemas) to nodes without polluting shared state. The Swarm builds the handoff schema inside `_streamNode` and passes it through `NodeInputOptions` to the agent.

Removing `structuredOutputSchema` from `MultiAgentState` is a breaking change. Since the SDK is in preview, this is acceptable. The field was configuration, not state, and storing it in shared mutable state would cause correctness issues with parallel node execution.

For single-node swarms (no valid handoff targets), the schema uses `z.never().optional()` so the model can only produce a final response.

Resolves: https://github.com/strands-agents/sdk-typescript/pull/692

## Related Issues

- https://github.com/strands-agents/sdk-typescript/pull/692

## Documentation PR

No documentation updates required. This is an internal behavioral change with no new public API surface beyond the `NodeInputOptions` type export.

## Type of Change

Breaking change

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- [x] Integration tests pass against `global.anthropic.claude-sonnet-4-6` via Bedrock

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.