### PR TITLE
fix: use logger instead of console log that bypass logging system

### DIFF
--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -736,13 +736,13 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
       // Bedrock guardrails only support png/jpeg formats
       if (format !== 'png' && format !== 'jpeg') {
-        console.warn(`Image format '${format}' not supported by Bedrock guardrails, skipping guardContent wrap`)
+        logger.warn(`Image format '${format}' not supported by Bedrock guardrails, skipping guardContent wrap`)
         return formattedBlock
       }
 
       // Bedrock guardrails only support bytes source (not S3 or URL)
       if (!('bytes' in imageBlock.source)) {
-        console.warn('Image source must be bytes for Bedrock guardrails, skipping guardContent wrap')
+        logger.warn('Image source must be bytes for Bedrock guardrails, skipping guardContent wrap')
         return formattedBlock
       }
 
@@ -988,7 +988,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
             },
           }
         }
-        console.warn('Ignoring imageSourceUrl content block as its not supported by bedrock')
+        logger.warn('Ignoring imageSourceUrl content block as its not supported by bedrock')
         return
 
       case 'imageSourceS3Location':

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -206,7 +206,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       case 'modelRedactionEvent':
         return new ModelRedactionEvent(event_data)
       default:
-        throw new Error(`Unsupported event type: ${event_data}`)
+        throw new Error(`Unsupported event type: ${(event_data as { type: string }).type}`)
     }
   }
 

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -610,7 +610,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                   }
                   case 'documentSourceText': {
                     // Text documents can be added directly
-                    console.warn(
+                    logger.warn(
                       'OpenAI does not support text document sources directly. Converting this text document to string content.'
                     )
                     contentParts.push({
@@ -632,7 +632,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                     break
                   }
                   default: {
-                    console.warn(
+                    logger.warn(
                       `OpenAI ChatCompletions API only supports text content in user messages. Skipping document block type: ${docBlock.source.type}.`
                     )
                     break
@@ -641,7 +641,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                 break
               }
               default: {
-                console.warn(`OpenAI ChatCompletions API does not support content type: ${block.type}.`)
+                logger.warn(`OpenAI ChatCompletions API does not support content type: ${block.type}.`)
                 break
               }
             }
@@ -739,13 +739,13 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
             }
             case 'reasoningBlock': {
               if (block.text) {
-                console.warn('Reasoning blocks are not supported by OpenAI Chat Completions API. Converting to text.')
+                logger.warn('Reasoning blocks are not supported by OpenAI Chat Completions API. Converting to text.')
                 textParts.push(block.text)
               }
               break
             }
             default: {
-              console.warn(
+              logger.warn(
                 `OpenAI ChatCompletions API does not support ${block.type} content in assistant messages. Skipping this block.`
               )
             }


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

This PR fixes logging consistency issues across model providers by replacing direct console.warn calls with the SDK's logger.warn abstraction, and improves error message clarity in the model event converter.

Changes:

bedrock.ts : Replaced 3 console.warn calls with logger.warn (unsupported image formats, image source types)

openai.ts : Replaced 5 console.warn calls with logger.warn (unsupported content types, document sources, reasoning blocks)

model.ts : Fixed _convert_to_class_event error message that was printing [object Object] instead of the actual event type

Why this matters: Direct console.warn calls bypass the configureLogging() abstraction. Users who inject a custom logger (e.g., Pino, Winston) expect all SDK warnings to route through their logger — these calls were going directly to console instead.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
