### PR TITLE
feat: add bounded retry and error type to agent

### DIFF
--- a/src/agent/__tests__/agent.hook.test.ts
+++ b/src/agent/__tests__/agent.hook.test.ts
@@ -17,6 +17,7 @@ import { MockPlugin } from '../../__fixtures__/mock-plugin.js'
 import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { ModelRetryLimitError } from '../../errors.js'
 
 describe('Agent Hooks Integration', () => {
   let mockPlugin: MockPlugin
@@ -393,6 +394,73 @@ describe('Agent Hooks Integration', () => {
 
       expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'Second response after retry' })
       expect(callCount).toBe(2)
+    })
+
+    it('throws ModelRetryLimitError when error retry hook always retries', async () => {
+      // Model that always fails
+      const turns = Array.from({ length: 10 }, () => new Error('always fails'))
+      const model = new MockMessageModel()
+      for (const t of turns) model.addTurn(t)
+
+      const agent = new Agent({ model, maxModelRetries: 3 })
+      agent.addHook(AfterModelCallEvent, (event: AfterModelCallEvent) => {
+        if (event.error) {
+          event.retry = true
+        }
+      })
+
+      await expect(agent.invoke('Test')).rejects.toThrow(ModelRetryLimitError)
+    })
+
+    it('throws ModelRetryLimitError when success retry hook always retries', async () => {
+      const turns = Array.from({ length: 10 }, () => ({ type: 'textBlock' as const, text: 'response' }))
+      const model = new MockMessageModel()
+      for (const t of turns) model.addTurn(t)
+
+      const agent = new Agent({ model, maxModelRetries: 2 })
+      agent.addHook(AfterModelCallEvent, (event: AfterModelCallEvent) => {
+        event.retry = true
+      })
+
+      await expect(agent.invoke('Test')).rejects.toThrow(ModelRetryLimitError)
+    })
+
+    it('respects custom maxModelRetries value', async () => {
+      let callCount = 0
+      const turns = Array.from({ length: 10 }, () => new Error('fail'))
+      const model = new MockMessageModel()
+      for (const t of turns) model.addTurn(t)
+
+      const agent = new Agent({ model, maxModelRetries: 4 })
+      agent.addHook(AfterModelCallEvent, (event: AfterModelCallEvent) => {
+        callCount++
+        if (event.error) {
+          event.retry = true
+        }
+      })
+
+      await expect(agent.invoke('Test')).rejects.toThrow(ModelRetryLimitError)
+      // 1 initial + 4 retries = 5 calls
+      expect(callCount).toBe(5)
+    })
+
+    it('uses default maxModelRetries of 5', async () => {
+      let callCount = 0
+      const turns = Array.from({ length: 10 }, () => new Error('fail'))
+      const model = new MockMessageModel()
+      for (const t of turns) model.addTurn(t)
+
+      const agent = new Agent({ model })
+      agent.addHook(AfterModelCallEvent, (event: AfterModelCallEvent) => {
+        callCount++
+        if (event.error) {
+          event.retry = true
+        }
+      })
+
+      await expect(agent.invoke('Test')).rejects.toThrow(ModelRetryLimitError)
+      // 1 initial + 5 retries = 6 calls
+      expect(callCount).toBe(6)
     })
   })
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -24,7 +24,7 @@ import { McpClient } from '../mcp.js'
 import { type Tool, type ToolContext } from '../tools/tool.js'
 import type { ToolChoice } from '../tools/types.js'
 import { systemPromptFromData } from '../types/messages.js'
-import { normalizeError, ConcurrentInvocationError, MaxTokensError } from '../errors.js'
+import { normalizeError, ConcurrentInvocationError, MaxTokensError, ModelRetryLimitError } from '../errors.js'
 import { Model } from '../models/model.js'
 import type { BaseModelConfig, StreamAggregatedResult, StreamOptions } from '../models/model.js'
 import { isModelStreamEvent } from '../models/streaming.js'
@@ -153,6 +153,11 @@ export type AgentConfig = {
    * Optional unique identifier for the agent. Defaults to "agent".
    */
   id?: string
+  /**
+   * Maximum number of times hooks can retry a model call via AfterModelCallEvent.retry.
+   * Prevents infinite recursion from buggy retry hooks. Defaults to 5.
+   */
+  maxModelRetries?: number
 }
 
 /** Default name assigned to agents when none is provided. */
@@ -211,6 +216,8 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _isInvoking: boolean = false
   private _printer?: Printer
   private _structuredOutputSchema?: z.ZodSchema | undefined
+  /** Maximum number of hook-driven model retries before throwing. */
+  private readonly _maxModelRetries: number
   /** Tracer instance for creating and managing OpenTelemetry spans. */
   private _tracer: Tracer
   /** Meter instance for accumulating loop metrics during invocation. */
@@ -261,6 +268,9 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Store structured output schema
     this._structuredOutputSchema = config?.structuredOutputSchema
+
+    // Store max model retries (default 5)
+    this._maxModelRetries = config?.maxModelRetries ?? 5
 
     // Initialize tracer - OTEL returns no-op tracer if not configured
     this._tracer = new Tracer(config?.traceAttributes)
@@ -670,83 +680,89 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *invokeModel(
     forcedToolChoice?: ToolChoice
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
-    const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
-    const streamOptions: StreamOptions = { toolSpecs }
-    if (this.systemPrompt !== undefined) {
-      streamOptions.systemPrompt = this.systemPrompt
-    }
+    for (let attempt = 0; ; attempt++) {
+      if (attempt > this._maxModelRetries) {
+        throw new ModelRetryLimitError(this._maxModelRetries)
+      }
 
-    // Add tool choice if provided (for structured output forcing)
-    if (forcedToolChoice) {
-      streamOptions.toolChoice = forcedToolChoice
-    }
+      const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
+      const streamOptions: StreamOptions = { toolSpecs }
+      if (this.systemPrompt !== undefined) {
+        streamOptions.systemPrompt = this.systemPrompt
+      }
 
-    yield new BeforeModelCallEvent({ agent: this })
+      // Add tool choice if provided (for structured output forcing)
+      if (forcedToolChoice) {
+        streamOptions.toolChoice = forcedToolChoice
+      }
 
-    // Start model span within loop span context
-    const modelId = this.model.modelId
-    const modelSpan = this._tracer.startModelInvokeSpan({
-      messages: this.messages,
-      ...(modelId && { modelId }),
-      ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
-    })
+      yield new BeforeModelCallEvent({ agent: this })
 
-    try {
-      const result = yield* this._streamFromModel(this.messages, streamOptions)
-
-      // Accumulate token usage and model latency metrics
-      this._meter.updateCycle(result.metadata)
-
-      // End model span with usage
-      const usage = result.metadata?.usage
-      const metrics = result.metadata?.metrics
-      this._tracer.endModelInvokeSpan(modelSpan, {
-        output: result.message,
-        stopReason: result.stopReason,
-        ...(usage && { usage }),
-        ...(metrics && { metrics }),
+      // Start model span within loop span context
+      const modelId = this.model.modelId
+      const modelSpan = this._tracer.startModelInvokeSpan({
+        messages: this.messages,
+        ...(modelId && { modelId }),
+        ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
       })
 
-      yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
+      try {
+        const result = yield* this._streamFromModel(this.messages, streamOptions)
 
-      // Handle user content redaction if guardrails blocked input
-      if (result.redaction?.userMessage) {
-        this._redactLastMessage(result.redaction.userMessage)
+        // Accumulate token usage and model latency metrics
+        this._meter.updateCycle(result.metadata)
+
+        // End model span with usage
+        const usage = result.metadata?.usage
+        const metrics = result.metadata?.metrics
+        this._tracer.endModelInvokeSpan(modelSpan, {
+          output: result.message,
+          stopReason: result.stopReason,
+          ...(usage && { usage }),
+          ...(metrics && { metrics }),
+        })
+
+        yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
+
+        // Handle user content redaction if guardrails blocked input
+        if (result.redaction?.userMessage) {
+          this._redactLastMessage(result.redaction.userMessage)
+        }
+
+        const stopData: ModelStopData = {
+          message: result.message,
+          stopReason: result.stopReason,
+          ...(result.redaction && { redaction: result.redaction }),
+        }
+
+        const afterModelCallEvent = new AfterModelCallEvent({ agent: this, stopData })
+        yield afterModelCallEvent
+
+        if (afterModelCallEvent.retry) {
+          continue
+        }
+
+        return result
+      } catch (error) {
+        const modelError = normalizeError(error)
+
+        // End model span with error
+        this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
+
+        // Create error event
+        const errorEvent = new AfterModelCallEvent({ agent: this, error: modelError })
+
+        // Yield error event - stream will invoke hooks
+        yield errorEvent
+
+        // After yielding, hooks have been invoked and may have set retry
+        if (errorEvent.retry) {
+          continue
+        }
+
+        // Re-throw error
+        throw error
       }
-
-      const stopData: ModelStopData = {
-        message: result.message,
-        stopReason: result.stopReason,
-        ...(result.redaction && { redaction: result.redaction }),
-      }
-
-      const afterModelCallEvent = new AfterModelCallEvent({ agent: this, stopData })
-      yield afterModelCallEvent
-
-      if (afterModelCallEvent.retry) {
-        return yield* this.invokeModel(forcedToolChoice)
-      }
-
-      return result
-    } catch (error) {
-      const modelError = normalizeError(error)
-
-      // End model span with error
-      this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
-
-      // Create error event
-      const errorEvent = new AfterModelCallEvent({ agent: this, error: modelError })
-
-      // Yield error event - stream will invoke hooks
-      yield errorEvent
-
-      // After yielding, hooks have been invoked and may have set retry
-      if (errorEvent.retry) {
-        return yield* this.invokeModel(forcedToolChoice)
-      }
-
-      // Re-throw error
-      throw error
     }
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -172,3 +172,17 @@ export class ToolValidationError extends Error {
     this.name = 'ToolValidationError'
   }
 }
+
+/**
+ * Error thrown when the model retry limit is exceeded.
+ *
+ * This error indicates that hooks requested more retries than the configured
+ * maximum via `AfterModelCallEvent.retry`. This prevents infinite recursion
+ * from buggy retry hooks.
+ */
+export class ModelRetryLimitError extends ModelError {
+  constructor(maxRetries: number) {
+    super(`Model retry limit (${maxRetries}) exceeded. Configure maxModelRetries in AgentConfig to adjust.`)
+    this.name = 'ModelRetryLimitError'
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
   JsonValidationError,
   ConcurrentInvocationError,
   ModelThrottledError,
+  ModelRetryLimitError,
   ToolValidationError,
 } from './errors.js'
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

invokeModel used recursive return yield* this.invokeModel(forcedToolChoice) when AfterModelCallEvent.retry was set to true by a hook. There was no retry counter or depth limit, so a hook that always sets retry = true (e.g., a buggy throttle-retry hook) would cause infinite recursion and a stack overflow.

The Python SDK handles this differently — it uses an iterative while True loop with continue for retries, and ships a default ModelRetryStrategy with max_attempts=6 as a safety net. JavaScript's call stack is smaller than Python's default recursion limit (1000), making the crash more likely and less informative.

This PR:

Converts the recursive retry in invokeModel to an iterative for loop with continue, matching the Python SDK's pattern

Adds a configurable maxModelRetries option to AgentConfig (default: 5)

Introduces ModelRetryLimitError (extends ModelError) thrown when the limit is exceeded

Exports ModelRetryLimitError from the SDK entry point

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?
unit testing

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
