### PR TITLE
fix(snapshot): correctly restore null systemPrompt in loadSnapshot

### DIFF
--- a/src/agent/__tests__/snapshot.test.ts
+++ b/src/agent/__tests__/snapshot.test.ts
@@ -199,7 +199,7 @@ describe('Snapshot API', () => {
       expect(agent.systemPrompt).toBe('Restored system prompt')
     })
 
-    it('leaves systemPrompt unchanged when snapshot has null systemPrompt', () => {
+    it('clears systemPrompt when snapshot has null systemPrompt (agent had no system prompt at snapshot time)', () => {
       agent.systemPrompt = 'Original prompt'
 
       const snapshot: Snapshot = {
@@ -212,8 +212,57 @@ describe('Snapshot API', () => {
 
       loadSnapshot(agent, snapshot)
 
-      // systemPrompt should remain unchanged since snapshot had null
+      // null in snapshot means the agent had no system prompt — should be cleared
+      expect(agent.systemPrompt).toBeUndefined()
+    })
+
+    it('leaves systemPrompt unchanged when systemPrompt key is absent from snapshot', () => {
+      agent.systemPrompt = 'Original prompt'
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: '1.0',
+        createdAt: createTimestamp(),
+        data: { messages: [] }, // systemPrompt key not present at all
+        appData: {},
+      }
+
+      loadSnapshot(agent, snapshot)
+
+      // absent key means field was not snapshotted — agent prompt should be untouched
       expect(agent.systemPrompt).toBe('Original prompt')
+    })
+
+    it('leaves messages unchanged when messages key is absent from snapshot', () => {
+      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Existing')] }))
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: '1.0',
+        createdAt: createTimestamp(),
+        data: { state: { key: 'val' } }, // messages key not present
+        appData: {},
+      }
+
+      loadSnapshot(agent, snapshot)
+
+      expect(agent.messages).toHaveLength(1)
+    })
+
+    it('leaves state unchanged when state key is absent from snapshot', () => {
+      agent.appState.set('existing', 'value')
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: '1.0',
+        createdAt: createTimestamp(),
+        data: { messages: [] }, // state key not present
+        appData: {},
+      }
+
+      loadSnapshot(agent, snapshot)
+
+      expect(agent.appState.get('existing')).toBe('value')
     })
   })
 

--- a/src/agent/snapshot.ts
+++ b/src/agent/snapshot.ts
@@ -167,22 +167,27 @@ export function loadSnapshot(agent: Agent, snapshot: Snapshot): void {
     )
   }
 
-  const { messages, state, systemPrompt } = snapshot.data
-
-  if (messages !== undefined) {
+  if ('messages' in snapshot.data) {
+    const messages = snapshot.data.messages
     agent.messages.length = 0
     for (const msgData of messages as unknown as MessageData[]) {
       agent.messages.push(Message.fromJSON(msgData))
     }
   }
 
-  if (state !== undefined) {
-    loadStateSerializable(agent.appState, state)
+  if ('state' in snapshot.data) {
+    loadStateSerializable(agent.appState, snapshot.data.state)
   }
 
-  // Only restore systemPrompt if explicitly present and non-null in the snapshot
-  if (systemPrompt !== undefined && systemPrompt !== null) {
-    agent.systemPrompt = systemPromptFromData(systemPrompt as SystemPromptData)
+  // Use key-presence check to distinguish "field absent" (leave unchanged) from
+  // "field present as null" (agent had no system prompt — clear it).
+  if ('systemPrompt' in snapshot.data) {
+    const systemPrompt = snapshot.data.systemPrompt
+    if (systemPrompt !== null) {
+      agent.systemPrompt = systemPromptFromData(systemPrompt as SystemPromptData)
+    } else {
+      delete agent.systemPrompt
+    }
   }
 }
 


### PR DESCRIPTION
## Description

`loadSnapshot` used destructuring to pull `systemPrompt` out of `snapshot.data`, which conflated two semantically distinct cases:

- Key **absent** from `snapshot.data` — the field wasn't included in the snapshot; the agent's current system prompt should be left unchanged.
- Key **present as `null`** — the snapshot was taken from an agent with no system prompt; the agent's system prompt should be cleared.

Because destructuring produces `undefined` for both an absent key and a `null` value (after the `!== null` guard), restoring a snapshot with `systemPrompt: null` was silently a no-op instead of clearing the prompt.

The fix replaces destructuring with explicit `'key' in snapshot.data` checks — the same pattern the Python SDK already uses correctly:

```python
if "system_prompt" in data:
    self.system_prompt = data["system_prompt"]  # None clears the prompt
```

The same key-presence pattern is applied to `messages` and `state` for consistency. `delete agent.systemPrompt` is used to clear the property (rather than assigning `undefined`) to satisfy `exactOptionalPropertyTypes`.

## Related Issues

N/A

## Documentation PR

Not needed, bug fix

## Type of Change

Bug fix

## Testing

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
