### PR TITLE
fix: add newline after printing agent response

### DIFF
--- a/src/agent/__tests__/printer.test.ts
+++ b/src/agent/__tests__/printer.test.ts
@@ -20,7 +20,7 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('Hello world')
+      expect(allOutput).toBe('Hello world\n')
     })
 
     it('prints reasoning content wrapped in tags', async () => {
@@ -35,7 +35,7 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('\n💭 Reasoning:\n   Let me think\n')
+      expect(allOutput).toBe('\n💭 Reasoning:\n   Let me think\n\n')
     })
 
     it('prints text and reasoning together', async () => {
@@ -53,7 +53,7 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('Answer: \n💭 Reasoning:\n   thinking\n')
+      expect(allOutput).toBe('Answer: \n💭 Reasoning:\n   thinking\n\n')
     })
 
     it('handles newlines in reasoning content', async () => {
@@ -76,7 +76,7 @@ describe('AgentPrinter', () => {
    First line
    Second line
    Third line
-`
+\n`
       expect(allOutput).toBe(expected)
     })
 
@@ -104,7 +104,7 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('\n🔧 Tool #1: calc\n✓ Tool completed\nResult: 4')
+      expect(allOutput).toBe('\n🔧 Tool #1: calc\n✓ Tool completed\nResult: 4\n')
     })
 
     it('prints tool error', async () => {
@@ -131,7 +131,7 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('\n🔧 Tool #1: bad_tool\n✗ Tool failed\nError handled')
+      expect(allOutput).toBe('\n🔧 Tool #1: bad_tool\n✗ Tool failed\nError handled\n')
     })
 
     it('prints comprehensive scenario with all output types', async () => {
@@ -195,7 +195,7 @@ The calculation succeeded.
 All done. 
 💭 Reasoning:
    Task completed successfully
-`
+\n`
 
       expect(allOutput).toBe(expected)
     })

--- a/src/agent/printer.ts
+++ b/src/agent/printer.ts
@@ -79,6 +79,10 @@ export class AgentPrinter implements Printer {
         this.handleToolResult(event)
         break
 
+      case 'agentResultEvent':
+        this.write('\n')
+        break
+
       // Ignore other event types
       default:
         break


### PR DESCRIPTION
## Description
Print newline after printing agent output

Before, if the agent printed its outptut to the terminal, the terminal could overwrite the line. Adding a newline at the end prevents this from happening

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
