### PR TITLE
fix: A2AAgent lazy init skips empty string name and description from agent card

### DIFF
--- a/src/a2a/__tests__/a2a-agent.test.ts
+++ b/src/a2a/__tests__/a2a-agent.test.ts
@@ -127,6 +127,15 @@ describe('A2AAgent', () => {
       expect(agent.name).toBe('Custom Name')
       expect(agent.description).toBe('Custom description')
     })
+
+    it('populates empty string description from agent card', async () => {
+      mockGetAgentCard.mockResolvedValue({ ...mockAgentCard, description: '' })
+      const agent = new A2AAgent({ url: 'http://localhost:9000' })
+
+      await agent.invoke('Hello')
+
+      expect(agent.description).toBe('')
+    })
   })
 
   describe('invoke', () => {

--- a/src/a2a/a2a-agent.ts
+++ b/src/a2a/a2a-agent.ts
@@ -173,10 +173,10 @@ export class A2AAgent implements InvokableAgent {
     const factory = new ClientFactory()
     const client = await factory.createFromUrl(this._config.url, this._config.agentCardPath)
     this._agentCard = await client.getAgentCard()
-    if (this.name === undefined && this._agentCard?.name) {
+    if (this.name === undefined && this._agentCard?.name !== undefined) {
       ;(this as { name?: string }).name = this._agentCard.name
     }
-    if (this.description === undefined && this._agentCard?.description) {
+    if (this.description === undefined && this._agentCard?.description !== undefined) {
       ;(this as { description?: string }).description = this._agentCard.description
     }
     this._client = client


### PR DESCRIPTION
## Description

`A2AAgent._getClient()` uses truthiness checks for `this._agentCard?.name` and `this._agentCard?.description`. When the server returns an empty string for either field, the check treats it as falsy and the client skips the assignment, leaving the value as `undefined`.

Changed both checks to use `!== undefined` so empty strings from the agent card are preserved.

## Related Issues

N/A (found during bug bash)

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

Added a test verifying that an empty string description from the agent card is populated on the client.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.