### PR TITLE
fix: fix self-loop node is incorrectly treated as a target in auto detection

### DIFF
--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -476,7 +476,6 @@ describe('Graph', () => {
             },
           },
         ],
-        sources: ['a'],
       })
 
       const result = await graph.invoke('go')

--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -135,6 +135,15 @@ describe('Graph', () => {
       ).toThrow('node_id=<island1> | unreachable from any source node')
     })
 
+    it('auto-detects source when only edge is a self-loop', () => {
+      const graph = new Graph({
+        nodes: [makeAgent('refiner', 'refiner-reply'), makeAgent('formatter', 'formatter-reply')],
+        edges: [{ source: 'refiner', target: 'refiner', handler: () => false }, ['refiner', 'formatter']],
+      })
+
+      expect(graph.nodes.size).toBe(2)
+    })
+
     it('throws when explicit source references unknown node', () => {
       expect(
         () =>
@@ -484,6 +493,18 @@ describe('Graph', () => {
       expect(result.results).toHaveLength(2)
       expect(result.results.map((r) => r.nodeId)).toStrictEqual(['a', 'a'])
       expect(visits).toBe(2)
+    })
+
+    it('auto-detects self-loop node as source and executes full graph', async () => {
+      const graph = new Graph({
+        nodes: [makeAgent('refiner', 'refined'), makeAgent('formatter', 'formatted')],
+        edges: [{ source: 'refiner', target: 'refiner', handler: () => false }, ['refiner', 'formatter']],
+      })
+
+      const result = await graph.invoke('go')
+
+      expect(result.status).toBe(Status.COMPLETED)
+      expect(result.results.map((r) => r.nodeId)).toStrictEqual(['refiner', 'formatter'])
     })
   })
 

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -51,7 +51,27 @@ export interface GraphOptions extends GraphConfig {
   nodes: NodeDefinition[]
   /** Edge definitions describing connections between nodes. */
   edges: EdgeDefinition[]
-  /** Explicit source node IDs. If omitted, auto-detected from nodes with no incoming edges. */
+  /**
+   * Explicit source (entry point) node IDs.
+   *
+   * If omitted, sources are auto-detected as nodes with no incoming edges from
+   * other nodes (self-loop edges are ignored during detection). For graphs with
+   * cycles or complex topologies, prefer setting this explicitly to make entry
+   * points clear and avoid relying on heuristic detection.
+   *
+   * @example
+   * ```typescript
+   * // Recommended for cyclic graphs
+   * const graph = new Graph({
+   *   nodes: [refiner, formatter],
+   *   edges: [
+   *     { source: 'refiner', target: 'refiner', handler: shouldLoop },
+   *     ['refiner', 'formatter'],
+   *   ],
+   *   sources: ['refiner'],
+   * })
+   * ```
+   */
   sources?: string[]
   /** Plugins for event-driven extensibility. */
   plugins?: MultiAgentPlugin[]
@@ -63,9 +83,12 @@ export interface GraphOptions extends GraphConfig {
  * Directed graph orchestration pattern.
  *
  * Agents execute as nodes in a dependency graph, with edges defining execution order
- * and optional conditions controlling routing. Source nodes (those with no incoming edges)
- * run first, and downstream nodes execute once all their dependencies complete. Parallel
- * execution is supported up to a configurable concurrency limit.
+ * and optional conditions controlling routing. Source nodes (entry points) run first,
+ * and downstream nodes execute once all their dependencies complete. Parallel execution
+ * is supported up to a configurable concurrency limit.
+ *
+ * Source nodes are auto-detected as nodes with no incoming edges from other nodes
+ * (self-loops are ignored). For graphs with cycles, prefer setting `sources` explicitly.
  *
  * Key design choices vs the Python SDK:
  * - Construction uses a declarative options object rather than a mutable GraphBuilder.
@@ -442,6 +465,18 @@ export class Graph implements MultiAgent {
     return edges
   }
 
+  /**
+   * Resolves source (entry point) nodes for the graph.
+   *
+   * When explicit source IDs are provided, validates and returns those nodes.
+   * Otherwise, auto-detects sources as nodes with no incoming edges from other
+   * nodes. Self-loop edges (where source === target) are excluded from this
+   * detection so that a node with only a self-loop is still recognized as a
+   * source.
+   *
+   * For graphs with cycles, prefer passing explicit source IDs to avoid
+   * relying on heuristic detection.
+   */
   private _resolveSources(sourceIds?: string[]): Node[] {
     if (sourceIds) {
       const sources: Node[] = []
@@ -455,14 +490,16 @@ export class Graph implements MultiAgent {
       return sources
     }
 
-    const targetIds = new Set(this.edges.map((e) => e.target.id))
+    // Self-loop edges are excluded: a node whose only incoming edge is from
+    // itself has no external dependencies and should be treated as a source.
+    const targetIds = new Set(this.edges.filter((e) => e.source.id !== e.target.id).map((e) => e.target.id))
     return [...this.nodes.values()].filter((node) => !targetIds.has(node.id))
   }
 
   /**
    * Identifies terminus nodes and returns their combined content.
    * A terminus node is where an execution path ended: completed with no
-   * downstream progress, or failed/cancelled.
+   * downstream progress, or failed/canceled.
    */
   private _resolveContent(state: MultiAgentState): ContentBlock[] {
     for (const [id, ns] of state.nodes.entries()) {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Fix _resolveSources to exclude self-loop edges when auto-detecting source (entry point) nodes.

Previously, the auto-detection built a targetIds set from all edges, including self-loops. A node with a self-loop edge (A → A) appeared in targetIds and was incorrectly excluded as a source, even if it had no other incoming edges. For a graph like [refiner→refiner, refiner→formatter], both nodes end up in targetIds, resulting in zero sources and a "graph has no source nodes" error at construction time.

The fix filters out self-loop edges (source.id === target.id) before computing the target set:
```
// Before
const targetIds = new Set(this.edges.map((e) => e.target.id))

// After
const targetIds = new Set(this.edges.filter((e) => e.source.id !== e.target.id).map((e) => e.target.id))

```

Additionally, JSDoc on sources, _resolveSources, and the Graph class has been updated to document the self-loop behavior and recommend explicit sources for graphs with cycles.

The existing unit test ("re-executes node in a cycle when conditional edge allows re-entry") previously worked around this bug by passing sources: ['a'] explicitly — that workaround has been removed to validate auto-detection now works correctly.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
