### PR TITLE
fix: standardize log messages to follow structured logging format

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1053,7 +1053,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       } else if (lastMessage) {
         // Unexpected state: redaction requested but last message is not from user
         logger.warn(
-          `role=<${lastMessage.role}> | received input redaction but last message is not from user | redaction skipped.`
+          `role=<${lastMessage.role}> | received input redaction but last message is not from user | redaction skipped`
         )
       }
     }

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -3599,7 +3599,7 @@ describe('BedrockModel', () => {
         collectIterator(provider.stream(messages))
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          "Image format 'gif' not supported by Bedrock guardrails, skipping guardContent wrap"
+          'image_format=<gif> | format not supported by bedrock guardrails | skipping guardContent wrap'
         )
         expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
           expect.objectContaining({
@@ -3646,7 +3646,7 @@ describe('BedrockModel', () => {
         collectIterator(provider.stream(messages))
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          "Image format 'webp' not supported by Bedrock guardrails, skipping guardContent wrap"
+          'image_format=<webp> | format not supported by bedrock guardrails | skipping guardContent wrap'
         )
         expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
           expect.objectContaining({
@@ -3697,7 +3697,7 @@ describe('BedrockModel', () => {
         collectIterator(provider.stream(messages))
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'Image source must be bytes for Bedrock guardrails, skipping guardContent wrap'
+          'source_type=<non-bytes> | image source must be bytes for bedrock guardrails | skipping guardContent wrap'
         )
         expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
           expect.objectContaining({
@@ -3748,7 +3748,7 @@ describe('BedrockModel', () => {
 
         // URL sources return undefined in _formatMediaSource, resulting in source: undefined
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'Ignoring imageSourceUrl content block as its not supported by bedrock'
+          'source_type=<imageSourceUrl> | not supported by bedrock | skipping'
         )
         // The image block still appears but with undefined source (Bedrock will reject this)
         expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(

--- a/src/models/__tests__/openai.test.ts
+++ b/src/models/__tests__/openai.test.ts
@@ -1197,7 +1197,7 @@ describe('OpenAIModel', () => {
 
       // Verify warning was logged
       expect(warnSpy).toHaveBeenCalledWith(
-        'OpenAI ChatCompletions API does not support content type: guardContentBlock.'
+        'block_type=<guardContentBlock> | unsupported content type in openai user message | skipping'
       )
 
       // Verify guard content filtered out
@@ -1240,7 +1240,7 @@ describe('OpenAIModel', () => {
 
       // Verify warning was logged
       expect(warnSpy).toHaveBeenCalledWith(
-        'OpenAI ChatCompletions API does not support content type: guardContentBlock.'
+        'block_type=<guardContentBlock> | unsupported content type in openai user message | skipping'
       )
 
       // Verify guard content filtered out
@@ -1275,7 +1275,7 @@ describe('OpenAIModel', () => {
 
       // Verify warning was logged
       expect(warnSpy).toHaveBeenCalledWith(
-        'OpenAI ChatCompletions API does not support content type: guardContentBlock.'
+        'block_type=<guardContentBlock> | unsupported content type in openai user message | skipping'
       )
 
       // Verify no user message added (only guard content)

--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -242,7 +242,9 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
 
             if (cacheControl) i++
           } else if (block.type === 'guardContentBlock') {
-            logger.warn('guardContentBlock is not supported in Anthropic system prompt')
+            logger.warn(
+              'block_type=<guardContentBlock> | guard content not supported in anthropic system prompt | skipping'
+            )
           }
         }
         if (systemBlocks.length > 0) request.system = systemBlocks
@@ -357,7 +359,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
             },
           }
         }
-        logger.warn('Anthropic provider requires image bytes. URLs not fully supported.')
+        logger.warn('source_type=<imageSourceUrl> | anthropic requires image bytes | url sources not fully supported')
         return undefined
       }
 
@@ -384,7 +386,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
             if (typeof TextDecoder !== 'undefined') {
               textContent = new TextDecoder().decode(docBlock.source.bytes)
             } else {
-              logger.warn(`Cannot decode bytes for ${docBlock.format} document: TextDecoder missing.`)
+              logger.warn(`format=<${docBlock.format}> | cannot decode document bytes | TextDecoder not available`)
             }
           }
 
@@ -475,7 +477,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       case 'tool_use':
         return 'toolUse'
       default:
-        logger.warn(`Unknown stop reason: ${anthropicReason}`)
+        logger.warn(`stop_reason=<${anthropicReason}> | unknown anthropic stop reason`)
         return anthropicReason
     }
   }

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -736,13 +736,17 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
       // Bedrock guardrails only support png/jpeg formats
       if (format !== 'png' && format !== 'jpeg') {
-        logger.warn(`Image format '${format}' not supported by Bedrock guardrails, skipping guardContent wrap`)
+        logger.warn(
+          `image_format=<${format}> | format not supported by bedrock guardrails | skipping guardContent wrap`
+        )
         return formattedBlock
       }
 
       // Bedrock guardrails only support bytes source (not S3 or URL)
       if (!('bytes' in imageBlock.source)) {
-        logger.warn('Image source must be bytes for Bedrock guardrails, skipping guardContent wrap')
+        logger.warn(
+          'source_type=<non-bytes> | image source must be bytes for bedrock guardrails | skipping guardContent wrap'
+        )
         return formattedBlock
       }
 
@@ -988,7 +992,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
             },
           }
         }
-        logger.warn('Ignoring imageSourceUrl content block as its not supported by bedrock')
+        logger.warn('source_type=<imageSourceUrl> | not supported by bedrock | skipping')
         return
 
       case 'imageSourceS3Location':

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -336,7 +336,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
               yield block
             } catch (e: unknown) {
               if (e instanceof SyntaxError) {
-                logger.error('Unable to parse JSON string.', e)
+                logger.error('unable to parse JSON string', e)
                 throw e
               }
             }

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -636,7 +636,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                   case 'documentSourceText': {
                     // Text documents can be added directly
                     logger.warn(
-                      'OpenAI does not support text document sources directly. Converting this text document to string content.'
+                      'source_type=<documentSourceText> | openai does not support text document sources directly | converting to string content'
                     )
                     contentParts.push({
                       type: 'text',
@@ -658,7 +658,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                   }
                   default: {
                     logger.warn(
-                      `OpenAI ChatCompletions API only supports text content in user messages. Skipping document block type: ${docBlock.source.type}.`
+                      `source_type=<${docBlock.source.type}> | openai only supports text content in user messages | skipping document block`
                     )
                     break
                   }
@@ -666,7 +666,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                 break
               }
               default: {
-                logger.warn(`OpenAI ChatCompletions API does not support content type: ${block.type}.`)
+                logger.warn(`block_type=<${block.type}> | unsupported content type in openai user message | skipping`)
                 break
               }
             }
@@ -764,14 +764,16 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
             }
             case 'reasoningBlock': {
               if (block.text) {
-                logger.warn('Reasoning blocks are not supported by OpenAI Chat Completions API. Converting to text.')
+                logger.warn(
+                  'block_type=<reasoningBlock> | reasoning blocks not supported by openai | converting to text'
+                )
                 textParts.push(block.text)
               }
               break
             }
             default: {
               logger.warn(
-                `OpenAI ChatCompletions API does not support ${block.type} content in assistant messages. Skipping this block.`
+                `block_type=<${block.type}> | unsupported content type in openai assistant message | skipping`
               )
             }
           }

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -38,7 +38,7 @@ if (typeof globalThis.process?.getBuiltinModule === 'function') {
       DefaultTracerProvider = req('@opentelemetry/sdk-trace-node').NodeTracerProvider
     }
   } catch {
-    logger.info('sdk-trace-node not available; using BasicTracerProvider without async context propagation')
+    logger.info('sdk-trace-node not available | using BasicTracerProvider without async context propagation')
   }
 }
 


### PR DESCRIPTION
## Description

Several log messages across model providers (Anthropic, Bedrock, OpenAI), the base model, agent, and telemetry modules were not following the structured logging format defined in AGENTS.md.

This PR updates all non-conforming log messages to use the standard format: `field=<value> | human readable message`, with lowercase text, no punctuation, and pipe separators between statements.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.