### PR TITLE
feat: enhance SlidingWindowConversationManager to support requireUserMessageStart

### DIFF
--- a/src/agent/__tests__/agent.test.ts
+++ b/src/agent/__tests__/agent.test.ts
@@ -21,6 +21,7 @@ import {
 import { AgentPrinter } from '../printer.js'
 import { BeforeInvocationEvent, BeforeToolsEvent } from '../../hooks/events.js'
 import { BedrockModel } from '../../models/bedrock.js'
+import { SlidingWindowConversationManager } from '../../conversation-manager/sliding-window-conversation-manager.js'
 import { StructuredOutputError } from '../../errors.js'
 import { expectLoopMetrics } from '../../__fixtures__/metrics-helpers.js'
 import { expectAgentResult } from '../../__fixtures__/agent-helpers.js'
@@ -1120,6 +1121,22 @@ describe('Agent', () => {
 
         expect(agent.model).toBe(explicitModel)
         expect(agent.model.getConfig().modelId).toBe('explicit-model-id')
+      })
+    })
+
+    describe('default conversation manager', () => {
+      it('enables requireUserMessageStart for Bedrock models', () => {
+        const agent = new Agent()
+
+        expect((agent as any)._conversationManager).toBeInstanceOf(SlidingWindowConversationManager)
+        expect((agent as any)._conversationManager._requireUserMessageStart).toBe(true)
+      })
+
+      it('does not enable requireUserMessageStart for non-Bedrock models', () => {
+        const agent = new Agent({ model: new MockMessageModel() })
+
+        expect((agent as any)._conversationManager).toBeInstanceOf(SlidingWindowConversationManager)
+        expect((agent as any)._conversationManager._requireUserMessageStart).toBe(false)
       })
     })
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -224,7 +224,6 @@ export class Agent implements LocalAgent, InvokableAgent {
     // Initialize public fields
     this.messages = (config?.messages ?? []).map((msg) => (msg instanceof Message ? msg : Message.fromMessageData(msg)))
     this.appState = new StateStore(config?.appState)
-    this._conversationManager = config?.conversationManager ?? new SlidingWindowConversationManager({ windowSize: 40 })
     this.name = config?.name ?? DEFAULT_AGENT_NAME
     this.id = config?.id ?? DEFAULT_AGENT_ID
     if (config?.description !== undefined) this.description = config.description
@@ -234,6 +233,13 @@ export class Agent implements LocalAgent, InvokableAgent {
     } else {
       this.model = config?.model ?? new BedrockModel()
     }
+
+    this._conversationManager =
+      config?.conversationManager ??
+      new SlidingWindowConversationManager({
+        windowSize: 40,
+        requireUserMessageStart: this.model instanceof BedrockModel,
+      })
 
     const { tools, mcpClients } = flattenTools(config?.tools ?? [])
     this._toolRegistry = new ToolRegistry(tools)

--- a/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -46,6 +46,16 @@ describe('SlidingWindowConversationManager', () => {
       const manager = new SlidingWindowConversationManager({ shouldTruncateResults: false })
       expect((manager as any)._shouldTruncateResults).toBe(false)
     })
+
+    it('sets default requireUserMessageStart to false', () => {
+      const manager = new SlidingWindowConversationManager()
+      expect((manager as any)._requireUserMessageStart).toBe(false)
+    })
+
+    it('accepts custom requireUserMessageStart', () => {
+      const manager = new SlidingWindowConversationManager({ requireUserMessageStart: true })
+      expect((manager as any)._requireUserMessageStart).toBe(true)
+    })
   })
 
   describe('reduce', () => {
@@ -426,6 +436,21 @@ describe('SlidingWindowConversationManager', () => {
   })
 
   describe('reduceContext - tool pair validation', () => {
+    it('skips assistant trim points when requireUserMessageStart is true', async () => {
+      const manager = new SlidingWindowConversationManager({ windowSize: 2, requireUserMessageStart: true })
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
+        new Message({ role: 'user', content: [new TextBlock('Message 2')] }),
+      ]
+      const mockAgent = createMockAgent({ messages })
+
+      await triggerContextOverflow(manager, mockAgent, new ContextWindowOverflowError('Context overflow'))
+
+      expect(mockAgent.messages).toHaveLength(1)
+      expect(mockAgent.messages[0]).toStrictEqual(new Message({ role: 'user', content: [new TextBlock('Message 2')] }))
+    })
+
     it('does not trim at index where oldest message is toolResult', async () => {
       const manager = new SlidingWindowConversationManager({ windowSize: 2, shouldTruncateResults: false })
       const messages = [

--- a/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -26,6 +26,12 @@ export type SlidingWindowConversationManagerConfig = {
    * Defaults to true.
    */
   shouldTruncateResults?: boolean
+
+  /**
+   * Whether reduced histories must begin with a user message.
+   * Defaults to false.
+   */
+  requireUserMessageStart?: boolean
 }
 
 /**
@@ -43,6 +49,7 @@ export type SlidingWindowConversationManagerConfig = {
 export class SlidingWindowConversationManager extends ConversationManager {
   private readonly _windowSize: number
   private readonly _shouldTruncateResults: boolean
+  private readonly _requireUserMessageStart: boolean
 
   /**
    * Unique identifier for this conversation manager.
@@ -58,6 +65,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
     super()
     this._windowSize = config?.windowSize ?? 40
     this._shouldTruncateResults = config?.shouldTruncateResults ?? true
+    this._requireUserMessageStart = config?.requireUserMessageStart ?? false
   }
 
   /**
@@ -139,6 +147,11 @@ export class SlidingWindowConversationManager extends ConversationManager {
       const oldestMessage = messages[trimIndex]
       if (!oldestMessage) {
         break
+      }
+
+      if (this._requireUserMessageStart && oldestMessage.role !== 'user') {
+        trimIndex++
+        continue
       }
 
       // Check if oldest message would be a toolResult (invalid - needs preceding toolUse)


### PR DESCRIPTION
## Description
This is a fix to https://github.com/strands-agents/sdk-typescript/issues/727 without breaking any existing behavior by enforcing the fix via a `requireUserMessageStart` configuration that defaults to false.

## Public API Change
```ts
 // Before
  const conversationManager = new SlidingWindowConversationManager({
    windowSize: 40,
    shouldTruncateResults: true,
  })

  // After
  const conversationManager = new SlidingWindowConversationManager({
    windowSize: 40,
    shouldTruncateResults: true,
    requireUserMessageStart: true,
  })
```

## Related Issues

#727

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix
New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
