### PR TITLE
feat(tools): add fromJsonSchema helper for FunctionTool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,8 +114,8 @@ export type { InvokableTool, ToolContext, ToolStreamEventData, ToolStreamGenerat
 export { Tool, ToolStreamEvent } from './tools/tool.js'
 
 // FunctionTool implementation
-export { FunctionTool } from './tools/function-tool.js'
-export type { FunctionToolConfig, FunctionToolCallback } from './tools/function-tool.js'
+export { FunctionTool, fromJsonSchema } from './tools/function-tool.js'
+export type { FunctionToolConfig, FunctionToolCallback, FromJsonSchemaConfig } from './tools/function-tool.js'
 
 // ZodTool implementation
 export { ZodTool } from './tools/zod-tool.js'

--- a/src/tools/__tests__/tool.test.ts
+++ b/src/tools/__tests__/tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { FunctionTool } from '../function-tool.js'
+import { FunctionTool, fromJsonSchema } from '../function-tool.js'
 import { Tool, ToolStreamEvent } from '../tool.js'
 import type { ToolContext } from '../tool.js'
 import type { JSONValue } from '../../types/json.js'
@@ -8,6 +8,31 @@ import { createMockContext } from '../../__fixtures__/tool-helpers.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 
 describe('FunctionTool', () => {
+  describe('fromJsonSchema', () => {
+    it('matches constructor with inputSchema', () => {
+      const schema = {
+        type: 'object' as const,
+        properties: { id: { type: 'string' as const } },
+        required: ['id'],
+      }
+      const viaHelper = fromJsonSchema({
+        name: 'lookup',
+        description: 'Looks up by id',
+        schema,
+        callback: (input) => (input as { id: string }).id,
+      })
+      const viaCtor = new FunctionTool({
+        name: 'lookup',
+        description: 'Looks up by id',
+        inputSchema: schema,
+        callback: (input) => (input as { id: string }).id,
+      })
+      expect(viaHelper.name).toBe(viaCtor.name)
+      expect(viaHelper.description).toBe(viaCtor.description)
+      expect(viaHelper.toolSpec).toEqual(viaCtor.toolSpec)
+    })
+  })
+
   describe('properties', () => {
     it('has a non-empty toolName', () => {
       const tool = new FunctionTool({

--- a/src/tools/function-tool.ts
+++ b/src/tools/function-tool.ts
@@ -369,3 +369,31 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
     }
   }
 }
+
+/**
+ * Same shape as {@link FunctionToolConfig} but uses `schema` instead of `inputSchema`
+ * for call sites that already model tools as JSON Schema objects.
+ */
+export interface FromJsonSchemaConfig {
+  /** The unique name of the tool */
+  name: string
+  /** Human-readable description of the tool's purpose */
+  description: string
+  /** JSON Schema defining the expected input structure */
+  schema: JSONSchema
+  /** Function that implements the tool logic */
+  callback: FunctionToolCallback
+}
+
+/**
+ * Builds a {@link FunctionTool} from a JSON Schema definition (no Zod).
+ * Prefer this when tool definitions already use a `schema` field.
+ */
+export function fromJsonSchema(config: FromJsonSchemaConfig): FunctionTool {
+  return new FunctionTool({
+    name: config.name,
+    description: config.description,
+    inputSchema: config.schema,
+    callback: config.callback,
+  })
+}


### PR DESCRIPTION
## Description

Adds **`fromJsonSchema()`**, a small factory for building a **`FunctionTool`** when your tool definitions already use a **`schema`** field instead of **`inputSchema`**. It maps `schema` → `inputSchema` and delegates to the existing constructor, so behavior matches **`new FunctionTool({ … })`** exactly.

Also introduces **`FromJsonSchemaConfig`** and exports **`fromJsonSchema`** and **`FromJsonSchemaConfig`** from the package entry point.

Unit test asserts parity with the constructor for `name`, `description`, and `toolSpec`.

## Type of change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Other (please describe)

## Testing

- [x] `npm run check` (with Node **v20.19.6**; Vitest/Rolldown require **≥ 20.19** per engine fields)

## Checklist

- [x] I have read the CONTRIBUTING document  
- [x] I have added tests that prove the feature works  
- [ ] I have updated the documentation accordingly (JSDoc on the new API; shout if you want README/examples too)  
- [ ] I have added an example to the documentation, or no new docs are needed  
- [x] My changes generate no new warnings (`npm run check`)  
- [x] Any dependent changes have been merged and published  

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---
