### PR TITLE
fix: guarantee after-events fire during hook errors and stream cleanup

### DIFF
--- a/src/agent/__tests__/agent.test.ts
+++ b/src/agent/__tests__/agent.test.ts
@@ -19,7 +19,13 @@ import {
   DocumentBlock,
 } from '../../index.js'
 import { AgentPrinter } from '../printer.js'
-import { BeforeInvocationEvent, BeforeToolsEvent } from '../../hooks/events.js'
+import {
+  AfterInvocationEvent,
+  AfterToolCallEvent,
+  AfterToolsEvent,
+  BeforeInvocationEvent,
+  BeforeToolsEvent,
+} from '../../hooks/events.js'
 import { BedrockModel } from '../../models/bedrock.js'
 import { StructuredOutputError } from '../../errors.js'
 import { expectLoopMetrics } from '../../__fixtures__/metrics-helpers.js'
@@ -171,6 +177,37 @@ describe('Agent', () => {
         await expect(async () => {
           await collectGenerator(agent.stream('Test'))
         }).rejects.toThrow(MaxTokensError)
+      })
+    })
+
+    describe('hook error cleanup', () => {
+      it('fires AfterInvocationEvent when consumer breaks from stream', async () => {
+        const model = new MockMessageModel()
+          .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+          .addTurn({ type: 'textBlock', text: 'Done' })
+
+        const tool = createMockTool(
+          'testTool',
+          () =>
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success' as const,
+              content: [new TextBlock('ok')],
+            })
+        )
+
+        const agent = new Agent({ model, tools: [tool], printer: false })
+
+        const afterInvocationCallback = vi.fn()
+        agent.addHook(AfterInvocationEvent, afterInvocationCallback)
+
+        for await (const event of agent.stream('Test')) {
+          if (event.type === 'beforeToolsEvent') {
+            break
+          }
+        }
+
+        expect(afterInvocationCallback).toHaveBeenCalledOnce()
       })
     })
   })
@@ -499,6 +536,107 @@ describe('Agent', () => {
           latencyMs: expect.any(Number),
         })
         expect(meter.metrics.toolMetrics).toStrictEqual({})
+      })
+    })
+
+    describe('hook error cleanup', () => {
+      it('fires AfterInvocationEvent when a mid-stream hook throws', async () => {
+        const model = new MockMessageModel()
+          .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+          .addTurn({ type: 'textBlock', text: 'Done' })
+
+        const tool = createMockTool(
+          'testTool',
+          () =>
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success' as const,
+              content: [new TextBlock('ok')],
+            })
+        )
+
+        const agent = new Agent({ model, tools: [tool], printer: false })
+
+        agent.addHook(AfterToolCallEvent, () => {
+          throw new Error('hook error')
+        })
+
+        const afterInvocationCallback = vi.fn()
+        agent.addHook(AfterInvocationEvent, afterInvocationCallback)
+
+        await expect(agent.invoke('Test')).rejects.toThrow('hook error')
+        expect(afterInvocationCallback).toHaveBeenCalledOnce()
+      })
+
+      it('fires AfterToolsEvent when a mid-stream hook throws', async () => {
+        const model = new MockMessageModel()
+          .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+          .addTurn({ type: 'textBlock', text: 'Done' })
+
+        const tool = createMockTool(
+          'testTool',
+          () =>
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success' as const,
+              content: [new TextBlock('ok')],
+            })
+        )
+
+        const agent = new Agent({ model, tools: [tool], printer: false })
+
+        agent.addHook(AfterToolCallEvent, () => {
+          throw new Error('hook error')
+        })
+
+        const afterToolsCallback = vi.fn()
+        agent.addHook(AfterToolsEvent, afterToolsCallback)
+
+        await expect(agent.invoke('Test')).rejects.toThrow('hook error')
+        expect(afterToolsCallback).toHaveBeenCalledOnce()
+      })
+
+      it('does not fire AfterInvocationEvent when BeforeInvocationEvent hook throws', async () => {
+        const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+        const agent = new Agent({ model, printer: false })
+
+        agent.addHook(BeforeInvocationEvent, () => {
+          throw new Error('before hook error')
+        })
+
+        const afterInvocationCallback = vi.fn()
+        agent.addHook(AfterInvocationEvent, afterInvocationCallback)
+
+        await expect(agent.invoke('Test')).rejects.toThrow('before hook error')
+        expect(afterInvocationCallback).not.toHaveBeenCalled()
+      })
+
+      it('does not fire AfterToolsEvent when BeforeToolsEvent hook throws', async () => {
+        const model = new MockMessageModel()
+          .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+          .addTurn({ type: 'textBlock', text: 'Done' })
+
+        const tool = createMockTool(
+          'testTool',
+          () =>
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success' as const,
+              content: [new TextBlock('ok')],
+            })
+        )
+
+        const agent = new Agent({ model, tools: [tool], printer: false })
+
+        agent.addHook(BeforeToolsEvent, () => {
+          throw new Error('before tools hook error')
+        })
+
+        const afterToolsCallback = vi.fn()
+        agent.addHook(AfterToolsEvent, afterToolsCallback)
+
+        await expect(agent.invoke('Test')).rejects.toThrow('before tools hook error')
+        expect(afterToolsCallback).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -414,29 +414,44 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Delegate to _stream and process events through printer and hooks
     const streamGenerator = this._stream(args, options)
-    let result = await streamGenerator.next()
+    try {
+      let result = await streamGenerator.next()
 
-    while (!result.done) {
-      const event = result.value
-
-      // Invoke hook callbacks for hookable events (all current events are hookable;
-      // the guard exists for future StreamEvent subclasses that may not be)
-      if (event instanceof HookableEvent) {
-        await this._hooksRegistry.invokeCallbacks(event)
+      while (!result.done) {
+        yield await this._invokeCallbacks(result.value)
+        result = await streamGenerator.next()
       }
 
-      this._printer?.processEvent(event)
-      yield event
-      result = await streamGenerator.next()
+      yield await this._invokeCallbacks(new AgentResultEvent({ agent: this, result: result.value }))
+
+      return result.value
+    } finally {
+      // Drain remaining events from _stream() so cleanup events (after events
+      // from finally blocks) still get their hooks and printer invoked.
+      let result = await streamGenerator.return(undefined as never)
+      while (!result.done) {
+        try {
+          yield await this._invokeCallbacks(result.value)
+        } catch (error) {
+          logger.warn(`event_type=<${result.value.type}>, error=<${error}> | error invoking callbacks during cleanup`)
+        }
+        result = await streamGenerator.next()
+      }
     }
+  }
 
-    // Yield final result as last event
-    const agentResultEvent = new AgentResultEvent({ agent: this, result: result.value })
-    await this._hooksRegistry.invokeCallbacks(agentResultEvent)
-    this._printer?.processEvent(agentResultEvent)
-    yield agentResultEvent
-
-    return result.value
+  /**
+   * Invokes hook callbacks and printer for a stream event.
+   *
+   * @param event - The event to process
+   * @returns The event after processing
+   */
+  private async _invokeCallbacks(event: AgentStreamEvent): Promise<AgentStreamEvent> {
+    if (event instanceof HookableEvent) {
+      await this._hooksRegistry.invokeCallbacks(event)
+    }
+    this._printer?.processEvent(event)
+    return event
   }
 
   /**
@@ -815,52 +830,52 @@ export class Agent implements LocalAgent, InvokableAgent {
     const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
     yield beforeToolsEvent
 
-    // Extract tool use blocks from assistant message
-    const toolUseBlocks = assistantMessage.content.filter(
-      (block): block is ToolUseBlock => block.type === 'toolUseBlock'
-    )
-
-    if (toolUseBlocks.length === 0) {
-      // No tool use blocks found even though stopReason is toolUse
-      throw new Error('Model indicated toolUse but no tool use blocks found in message')
-    }
-
-    // Cancel all tools if hook requested it
-    if (beforeToolsEvent.cancel) {
-      const cancelMessage = cancelToolMessage(beforeToolsEvent.cancel)
-      const toolResultBlocks = toolUseBlocks.map(
-        (block) =>
-          new ToolResultBlock({
-            toolUseId: block.toolUseId,
-            status: 'error',
-            content: [new TextBlock(cancelMessage)],
-          })
-      )
-      for (const result of toolResultBlocks) {
-        yield new ToolResultEvent({ agent: this, result })
-      }
-      const toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
-      return toolResultMessage
-    }
-
     const toolResultBlocks: ToolResultBlock[] = []
+    let toolResultMessage: Message
 
-    for (const toolUseBlock of toolUseBlocks) {
-      const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
-      toolResultBlocks.push(toolResultBlock)
+    try {
+      // Extract tool use blocks from assistant message
+      const toolUseBlocks = assistantMessage.content.filter(
+        (block): block is ToolUseBlock => block.type === 'toolUseBlock'
+      )
 
-      // Yield the tool result event as it's created
-      yield new ToolResultEvent({ agent: this, result: toolResultBlock })
+      if (toolUseBlocks.length === 0) {
+        // No tool use blocks found even though stopReason is toolUse
+        throw new Error('Model indicated toolUse but no tool use blocks found in message')
+      }
+
+      // Cancel all tools if hook requested it
+      if (beforeToolsEvent.cancel) {
+        const cancelMessage = cancelToolMessage(beforeToolsEvent.cancel)
+        const cancelBlocks = toolUseBlocks.map(
+          (block) =>
+            new ToolResultBlock({
+              toolUseId: block.toolUseId,
+              status: 'error',
+              content: [new TextBlock(cancelMessage)],
+            })
+        )
+        for (const result of cancelBlocks) {
+          yield new ToolResultEvent({ agent: this, result })
+        }
+        toolResultBlocks.push(...cancelBlocks)
+      } else {
+        for (const toolUseBlock of toolUseBlocks) {
+          const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
+          toolResultBlocks.push(toolResultBlock)
+
+          // Yield the tool result event as it's created
+          yield new ToolResultEvent({ agent: this, result: toolResultBlock })
+        }
+      }
+    } finally {
+      toolResultMessage = new Message({
+        role: 'user',
+        content: toolResultBlocks,
+      })
+
+      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
     }
-
-    // Create user message with tool results
-    const toolResultMessage: Message = new Message({
-      role: 'user',
-      content: toolResultBlocks,
-    })
-
-    yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
 
     return toolResultMessage
   }


### PR DESCRIPTION
## Description

When a hook throws mid-execution or a consumer breaks out of a stream loop, "after" events (`AfterToolsEvent`, `AfterInvocationEvent`) were not guaranteed to fire. This meant hook consumers relying on cleanup or teardown logic in after-event callbacks could miss those callbacks entirely.

This change wraps the event processing in `stream()` and tool execution in `executeTools()` with try/finally blocks so that:

- `AfterToolsEvent` always fires when `BeforeToolsEvent` has fired, even if a tool-phase hook throws
- `AfterInvocationEvent` always fires when `BeforeInvocationEvent` has fired, even if an error occurs mid-stream
- Breaking out of a `for await` stream loop triggers generator cleanup that drains remaining after-events through hooks and the printer

A new `_invokeCallbacks` helper consolidates hook invocation and printer processing for stream events.

## Related Issues

N/A (internal consistency improvement)

## Documentation PR

N/A (no public API changes)

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

New tests cover:
- `AfterInvocationEvent` fires when a mid-stream hook throws
- `AfterToolsEvent` fires when a mid-stream hook throws
- `AfterInvocationEvent` fires when consumer breaks from stream
- `AfterInvocationEvent` does not fire when `BeforeInvocationEvent` hook throws
- `AfterToolsEvent` does not fire when `BeforeToolsEvent` hook throws

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.