### PR TITLE
fix: allow pre-release versions in NPM publish workflow

### DIFF
--- a/.github/workflows/npm-publish-on-release.yml
+++ b/.github/workflows/npm-publish-on-release.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Validate version
       run: |
-        if [[ ${{ steps.version.outputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ ${{ steps.version.outputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "Valid version format"
             exit 0
         else


### PR DESCRIPTION
## Description

The NPM publish workflow's version validation regex only accepted stable semver (`X.Y.Z`), causing the release job to fail immediately for any pre-release tag like `v1.0.0-rc.0`. The regex now accepts an optional pre-release suffix (`-rc.0`, `-beta.1`, etc.) while still rejecting malformed tags.

Example failure: https://github.com/strands-agents/sdk-typescript/actions/runs/23560079868/job/68598759456

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Validated both `1.0.0` and `1.0.0-rc.0` against the updated regex in bash — both match as expected.

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
