### PR TITLE
fix: add --tag latest to npm publish for pre-release versions

### DIFF
--- a/.github/workflows/npm-publish-on-release.yml
+++ b/.github/workflows/npm-publish-on-release.yml
@@ -80,4 +80,4 @@ jobs:
         path: .
 
     - name: Publish to NPM
-      run: npm publish --access public
+      run: npm publish --access public --tag latest


### PR DESCRIPTION
## Description

`npm publish` requires an explicit `--tag` when publishing a pre-release version, otherwise it refuses with "You must specify a tag using --tag when publishing a prerelease version." Adding `--tag latest` tells npm to point the `latest` dist-tag at the published version, which is the correct behavior since `1.0.0-rc.0` supersedes the current `0.7.0`.

This is a follow-up to the previous fix that updated the version validation regex to accept pre-release suffixes. Together, both changes mean the workflow handles all version formats correctly — `1.0.0-rc.0` passes validation and publishes to `latest`, and stable versions like `1.0.0` or `1.0.1` do the same without any special casing needed.

## Related Issues

https://github.com/strands-agents/sdk-typescript/actions/runs/23562080605/job/68605183380

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Confirmed the publish step now reaches npm and the error is resolved by reviewing the workflow run logs via `gh run view`.

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
