### PR TITLE
fix: remove top level telemetry export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,9 +228,6 @@ export type { SessionStorage, SnapshotStorage, SnapshotLocation } from './sessio
 export { FileStorage } from './session/file-storage.js'
 export type { Scope, Snapshot } from './agent/snapshot.js'
 
-// Telemetry
-export * as telemetry from './telemetry/index.js'
-
 // Local Traces
 export { AgentTrace } from './telemetry/tracer.js'
 


### PR DESCRIPTION
## Description
- Fixes telemetry top level exported readded during rebase in https://github.com/strands-agents/sdk-typescript/commit/895a677bac9b3ab90e55f41606c579a1917ef516#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80

## Related Issues

N/A

## Documentation PR

N/A
## Type of Change

Bug fix


## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
