### PR TITLE
fix: handle empty Bedrock stream response (messageStop without messageStart)

### DIFF
--- a/src/models/__tests__/model.test.ts
+++ b/src/models/__tests__/model.test.ts
@@ -638,6 +638,94 @@ describe('Model', () => {
       })
     })
 
+    describe('when modelMessageStopEvent arrives without modelMessageStartEvent', () => {
+      it('creates assistant message with empty content instead of throwing', async () => {
+        const provider = new TestModelProvider(async function* () {
+          // Bedrock may return messageStop without messageStart when the model
+          // produces an empty response (e.g., after certain tool results)
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+          yield {
+            type: 'modelMetadataEvent',
+            usage: { inputTokens: 100, outputTokens: 0, totalTokens: 100 },
+          }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(result.message.role).toBe('assistant')
+        expect(result.message.content).toEqual([])
+        expect(result.stopReason).toBe('endTurn')
+        expect(result.metadata).toEqual({
+          type: 'modelMetadataEvent',
+          usage: { inputTokens: 100, outputTokens: 0, totalTokens: 100 },
+        })
+      })
+
+      it('preserves content blocks accumulated before messageStop without messageStart', async () => {
+        const provider = new TestModelProvider(async function* () {
+          // Edge case: content blocks arrive but messageStart was missed/skipped
+          yield { type: 'modelContentBlockStartEvent' }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'textDelta', text: 'partial' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { items, result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(result.message.role).toBe('assistant')
+        expect(result.message.content).toHaveLength(1)
+        expect(result.message.content[0]!.type).toBe('textBlock')
+        expect(result.stopReason).toBe('endTurn')
+
+        // Content block should still be yielded
+        const contentBlocks = items.filter((i: any) => i.type === 'textBlock')
+        expect(contentBlocks).toHaveLength(1)
+      })
+
+      it('handles toolUse stopReason without messageStart', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' }
+          yield {
+            type: 'modelMetadataEvent',
+            usage: { inputTokens: 50, outputTokens: 0, totalTokens: 50 },
+          }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(result.message.role).toBe('assistant')
+        expect(result.message.content).toEqual([])
+        expect(result.stopReason).toBe('toolUse')
+      })
+    })
+
+    describe('when stream is completely empty', () => {
+      it('throws ModelError when no events are received', async () => {
+        const provider = new TestModelProvider(async function* () {
+          // Completely empty stream — no events at all
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        try {
+          await collectGenerator(provider.streamAggregated(messages))
+          expect.fail('Expected error to be thrown')
+        } catch (error) {
+          expect(error).toBeInstanceOf(ModelError)
+          expect((error as ModelError).message).toBe('Stream ended without completing a message')
+        }
+      })
+    })
+
     describe('when stream() throws an error', () => {
       it('wraps non-ModelError errors in ModelError with original as cause', async () => {
         const originalError = new Error('API connection failed')

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -344,14 +344,15 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
           }
 
           case 'modelMessageStopEvent':
-            // Store message and stop reason
-            if (messageRole) {
-              stoppedMessage = new Message({
-                role: messageRole,
-                content: [...contentBlocks],
-              })
-              finalStopReason = event.stopReason!
-            }
+            // Store message and stop reason.
+            // Bedrock may return messageStop without messageStart when the model
+            // produces an empty response (e.g., after certain tool results).
+            // In that case, default to 'assistant' role with empty content.
+            stoppedMessage = new Message({
+              role: messageRole ?? 'assistant',
+              content: [...contentBlocks],
+            })
+            finalStopReason = event.stopReason!
             break
 
           case 'modelMetadataEvent':


### PR DESCRIPTION
## Problem

When using AWS Bedrock Converse API, the model may return a `modelMessageStopEvent` without a preceding `modelMessageStartEvent`. This happens when the model produces an empty response — for example, after processing certain tool results (like `ask_clarifying_questions`) where the model determines it has nothing to add.

The current code throws `ModelError('Stream ended without completing a message')` because `stoppedMessage` is null (set only when `messageRole` is truthy, which requires `modelMessageStartEvent`).

This is valid Bedrock behavior — the Converse API spec allows `messageStop` events with a stop reason even when no content blocks were produced.

## Fix

In `src/models/model.ts`, the `modelMessageStopEvent` handler now defaults to `'assistant'` role when `modelMessageStartEvent` was not received:

```typescript
// Before
if (messageRole) {
  stoppedMessage = new Message({ role: messageRole, content: [...contentBlocks] })
  finalStopReason = event.stopReason!
}

// After
stoppedMessage = new Message({ role: messageRole ?? 'assistant', content: [...contentBlocks] })
finalStopReason = event.stopReason!
```

The `contentBlocks` array will be empty in this case, which is the correct representation of an empty model response.

## Test plan

Added 4 new test cases in `src/models/__tests__/model.test.ts`:

- **messageStop without messageStart** → creates assistant message with empty content
- **content blocks before messageStop without messageStart** → preserves accumulated blocks
- **toolUse stopReason without messageStart** → handled correctly
- **completely empty stream** → still throws `ModelError` (no events at all = real error)

All 1617 tests pass. Coverage on `model.ts` branch coverage improved (87.09% → 90.32%).

## Reproduction

This issue was discovered in a production conversational search application using Bedrock Converse API with Claude Sonnet 4.6 and 13 tools. The model consistently returns empty responses after `ask_clarifying_questions` tool results, causing the agent loop to crash.

## Checklist

- [x] Tests added
- [x] All existing tests pass (1617/1617)
- [x] Pre-commit hooks pass (lint, format, type-check)
- [x] No breaking changes — empty responses that previously threw now return a valid empty Message