### PR TITLE
feat: mark LocalAgent interface as internal-only

### DIFF
--- a/src/__fixtures__/tool-helpers.ts
+++ b/src/__fixtures__/tool-helpers.ts
@@ -9,6 +9,7 @@ import type { JSONValue } from '../types/json.js'
 import { StateStore } from '../state-store.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
 import type { PlainToolResultBlock } from './slim-types.js'
+import type { LocalAgent } from '../types/agent.js'
 
 /**
  * Helper to create a mock ToolContext for testing.
@@ -29,7 +30,7 @@ export function createMockContext(
       messages: [],
       toolRegistry: new ToolRegistry(),
       addHook: () => () => {},
-    },
+    } as unknown as LocalAgent,
   }
 }
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -5,6 +5,7 @@ import {
   type InvokeArgs,
   type InvokeOptions,
   type LocalAgent,
+  type localAgentSymbol,
 } from '../types/agent.js'
 import { BedrockModel } from '../models/bedrock.js'
 import {
@@ -167,6 +168,9 @@ const DEFAULT_AGENT_ID = 'agent'
  * and invoking the core decision-making loop.
  */
 export class Agent implements LocalAgent, InvokableAgent {
+  /** @internal */
+  declare readonly [localAgentSymbol]: true
+
   /**
    * The conversation history of messages between user and assistant.
    */

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -87,10 +87,25 @@ export interface InvokableAgent {
 }
 
 /**
+ * Branded symbol that prevents external implementations of {@link LocalAgent}.
+ *
+ * @internal
+ */
+export declare const localAgentSymbol: unique symbol
+
+/**
  * Interface for agents with locally accessible state, messages, tools, and hooks.
- * Used by ToolContext and hook events that need access to agent internals.
+ *
+ * This interface is exported for typing purposes only (e.g. in {@link ToolContext},
+ * hook events, and {@link Plugin.initAgent}). The Strands SDK is responsible for
+ * providing all implementations. External code should not implement this interface.
+ *
+ * @internal Not for external implementation. Use the {@link Agent} class instead.
  */
 export interface LocalAgent {
+  /** @internal Prevents external implementations of this interface. */
+  readonly [localAgentSymbol]: true
+
   /**
    * The unique identifier of the agent instance.
    */


### PR DESCRIPTION
## Description

`LocalAgent` is exported for typing purposes (used in `ToolContext`, `Plugin.initAgent`, and hook events), but it is not intended for external implementation. The Strands SDK is responsible for all `LocalAgent` implementations. This PR adds a branded unique symbol (`localAgentSymbol`) to the interface that prevents external code from implementing it, while keeping it usable as a type annotation.

## Motivation

TypeScript uses structural typing, so any object matching the `LocalAgent` shape could satisfy the interface. This is undesirable because `LocalAgent` exposes agent internals that only the SDK should manage. By adding an unexported unique symbol as a required property, external consumers are structurally locked out of implementing the interface while still being able to use it for type annotations in tools and plugins.

## Public API Changes

No breaking changes. `LocalAgent` remains exported as a type from the SDK entry point. The symbol is not exported, so consumers cannot reference it. Existing code that uses `LocalAgent` as a type annotation (e.g. in `Plugin.initAgent` or `ToolContext`) continues to work unchanged.

## Type of Change

Other: Internal API hardening

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- Temporarily removed the `declare` from `Agent` and confirmed type-check fails with `Property [localAgentSymbol] is missing`
- Restored it and confirmed type-check passes

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.