### PR TITLE
feat: enable session manager in multiagent (P0, resume logic will be in separate PR)

### DIFF
--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -745,11 +745,10 @@ describe('SessionManager — multi-agent', () => {
   })
 
   describe('AfterMultiAgentInvocationEvent handling', () => {
-    it('saves snapshot when saveLatestOn is invocation', async () => {
+    it('saves snapshot when multiagentSaveLatestOn is invocation (default)', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',
         storage: { snapshot: storage },
-        saveLatestOn: 'invocation',
       })
       sessionManager.initMultiAgent(orchestrator)
 
@@ -763,35 +762,14 @@ describe('SessionManager — multi-agent', () => {
       expect(snapshot?.scope).toBe('multiAgent')
     })
 
-    it('does not save when saveLatestOn is trigger', async () => {
+    it('saves snapshot independently of agent saveLatestOn setting', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',
         storage: { snapshot: storage },
         saveLatestOn: 'trigger',
+        multiAgentSaveLatestOn: 'invocation',
       })
       sessionManager.initMultiAgent(orchestrator)
-
-      const state = new MultiAgentState({ nodeIds: ['a'] })
-      await invokeOrchestratorHook(orchestrator, new AfterMultiAgentInvocationEvent({ orchestrator, state }))
-
-      const snapshot = await storage.loadSnapshot({
-        location: { sessionId: 'test-session', scope: 'multiAgent', scopeId: 'test-graph' },
-      })
-      expect(snapshot).toBeNull()
-    })
-
-    it('warns and saves on invocation when saveLatestOn is message (fallback)', async () => {
-      const warnSpy = vi.spyOn(logger, 'warn')
-      sessionManager = new SessionManager({
-        sessionId: 'test-session',
-        storage: { snapshot: storage },
-        saveLatestOn: 'message',
-      })
-      sessionManager.initMultiAgent(orchestrator)
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("saveLatestOn 'message' has no multi-agent equivalent")
-      )
 
       const state = new MultiAgentState({ nodeIds: ['a'] })
       await invokeOrchestratorHook(orchestrator, new AfterMultiAgentInvocationEvent({ orchestrator, state }))
@@ -800,7 +778,6 @@ describe('SessionManager — multi-agent', () => {
         location: { sessionId: 'test-session', scope: 'multiAgent', scopeId: 'test-graph' },
       })
       expect(snapshot).not.toBeNull()
-      warnSpy.mockRestore()
     })
   })
 

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -5,7 +5,7 @@
 
 // Core types
 export { SessionManager } from './session-manager.js'
-export type { SessionManagerConfig, SaveLatestStrategy } from './session-manager.js'
+export type { SessionManagerConfig, SaveLatestStrategy, MultiAgentSaveLatestStrategy } from './session-manager.js'
 export type { SnapshotManifest, SnapshotTriggerCallback, SnapshotTriggerParams } from './types.js'
 
 // Storage layer

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -35,6 +35,16 @@ import type { Swarm } from '../multiagent/swarm.js'
  */
 export type SaveLatestStrategy = 'message' | 'invocation' | 'trigger'
 
+/**
+ * Controls when `snapshot_latest` is saved for multi-agent orchestrators.
+ *
+ * Currently only `'invocation'` is supported. Additional strategies may be added
+ * in future releases as multi-agent persistence patterns evolve.
+ *
+ * - `'invocation'`: after every orchestrator invocation completes (default)
+ */
+export type MultiAgentSaveLatestStrategy = 'invocation'
+
 export interface SessionManagerConfig {
   /** Pluggable storage backends for snapshot persistence. Defaults to FileStorage in Node.js; required in browser environments. */
   storage: {
@@ -46,6 +56,8 @@ export interface SessionManagerConfig {
   saveLatestOn?: SaveLatestStrategy
   /** Callback invoked after each invocation to decide whether to create an immutable snapshot. */
   snapshotTrigger?: SnapshotTriggerCallback
+  /** When to save snapshot_latest for multi-agent orchestrators. Default: `'invocation'` (after each orchestrator invocation completes). See {@link MultiAgentSaveLatestStrategy} for details. */
+  multiAgentSaveLatestOn?: MultiAgentSaveLatestStrategy
 }
 
 /**
@@ -71,6 +83,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _storage: { snapshot: SnapshotStorage }
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
+  private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
   private _multiAgentRestoredIds = new Set<string>()
 
   /**
@@ -84,6 +97,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     this._sessionId = validateIdentifier(config.sessionId ?? 'default-session')
     this._storage = { snapshot: config.storage.snapshot }
     this._saveLatestOn = config.saveLatestOn ?? 'invocation'
+    this._multiAgentSaveLatestOn = config.multiAgentSaveLatestOn ?? 'invocation'
     this._snapshotTrigger = config.snapshotTrigger
   }
 
@@ -225,13 +239,6 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   /** Initializes the multi-agent plugin by registering orchestrator lifecycle hooks. */
   public initMultiAgent(orchestrator: MultiAgent): void {
-    if (this._saveLatestOn === 'message') {
-      logger.warn(
-        `orchestrator_id=<${orchestrator.id}>, session_id=<${this._sessionId}> | ` +
-          `saveLatestOn 'message' has no multi-agent equivalent; falling back to 'invocation'`
-      )
-    }
-
     orchestrator.addHook(BeforeMultiAgentInvocationEvent, async (event) => {
       await this._onBeforeMultiAgentInvocation(event)
     })
@@ -258,7 +265,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   /** Saves latest orchestrator snapshot after invocation completes. */
   private async _onAfterMultiAgentInvocation(event: AfterMultiAgentInvocationEvent): Promise<void> {
-    if (this._saveLatestOn === 'invocation' || this._saveLatestOn === 'message') {
+    if (this._multiAgentSaveLatestOn === 'invocation') {
       await this.saveSnapshot({
         target: event.orchestrator as Graph | Swarm,
         state: event.state,


### PR DESCRIPTION
## Description

Adds multi-agent snapshot support to `SessionManager`, enabling Graph and Swarm orchestrators to save and restore execution state via the existing plugin and hook system.

### What it does

- **Save**: After each orchestrator invocation (`AfterMultiAgentInvocationEvent`), `SessionManager` takes a snapshot of the `MultiAgentState` (node statuses, results, steps, app state) and persists it to storage.
- **Restore**: On the first orchestrator invocation (`BeforeMultiAgentInvocationEvent`), `SessionManager` loads the latest snapshot from storage and restores it into the event's state via `loadMultiAgentSnapshot()` (with full scope, schema version, and orchestrator ID validation). A `_multiAgentRestoredIds` set keyed by orchestrator ID ensures this only happens once per orchestrator.

### How it works

The `SessionManager` now implements `MultiAgentPlugin` in addition to `Plugin`. This PR wires it into Graph/Swarm by:

1. Registering hooks in `initMultiAgent()` — same pattern as the existing agent plugin (`initAgent`).
2. On `BeforeMultiAgentInvocationEvent`, loading the snapshot from storage and restoring it into `event.state` via the validated `loadMultiAgentSnapshot()` path. A `_multiAgentRestoredIds` set ensures the load-and-restore happens only on the first invocation per orchestrator, then no-ops on subsequent ones.
3. On `AfterMultiAgentInvocationEvent`, saving the current `MultiAgentState` snapshot to storage (controlled by `multiAgentSaveLatestOn`).

All restore logic lives entirely in `SessionManager` — Graph and Swarm are unchanged.

### Usage

```typescript
const session = new SessionManager({
  sessionId: 'my-session',
  storage: { snapshot: new FileStorage() },
})

const graph = new Graph({
  id: 'my-graph',
  nodes: [researcher, writer, editor],
  edges: [['researcher', 'writer'], ['writer', 'editor']],
  plugins: [session],
})

// First invocation — snapshot saved automatically after completion
await graph.invoke('Write about AI')

// Second invocation — state restored from snapshot before first node executes
await graph.invoke('Continue')
```

### Design notes

- **No changes to Graph or Swarm.** All restore logic is in `SessionManager` via hooks. The orchestrators don't need a `loadState()` method — the plugin mutates `event.state` in-place during `BeforeMultiAgentInvocationEvent`.
- **Per-orchestrator restore guard.** Uses `Set<string>` keyed by orchestrator ID (not a single boolean), so a shared `SessionManager` across multiple orchestrators restores each one independently.
- **Validated restore path.** The hook handler uses `loadMultiAgentSnapshot()` which validates snapshot scope, schema version, and orchestrator ID — consistent with the public `restoreSnapshot()` method.
- **Separate save strategy.** Introduced `MultiAgentSaveLatestStrategy` and `multiAgentSaveLatestOn` config, decoupled from the agent-scoped `saveLatestOn`. Currently only `'invocation'` is supported; additional strategies may be added as multi-agent persistence patterns evolve.
- **This PR does not implement resume logic.** The snapshot correctly captures partial execution state (e.g., researcher=COMPLETED, writer=COMPLETED, editor=CANCELLED), but `_stream()` does not yet skip completed nodes on restore — it re-executes from scratch. Resume (skip-completed-nodes, swarm position tracking) is tracked as a separate follow-up.
- **Scope isolation** between agent and multi-agent snapshots is maintained via separate `SnapshotLocation` scopes (`agent` vs `multiAgent`).
- **Hook ordering note**: User hooks registered before `initialize()` run before plugin hooks. A user's `BeforeMultiAgentInvocationEvent` hook sees pre-restore state, but since the state object is mutated in-place, execution is correct regardless.

### Files changed

| File | Change |
|------|--------|
| `session-manager.ts` | Implements `MultiAgentPlugin`; added `initMultiAgent`, `_multiAgentRestoredIds` guard (per-orchestrator), `_onBeforeMultiAgentInvocation` (validated load + restore via `loadMultiAgentSnapshot`), `_onAfterMultiAgentInvocation` (save), multi-agent overloads for `saveSnapshot`/`restoreSnapshot`, `MultiAgentSaveLatestStrategy` type, `multiAgentSaveLatestOn` config |
| `session/index.ts` | Re-exported `MultiAgentSaveLatestStrategy` |
| `session-manager.test.ts` | Added multi-agent test suite: hook registration, per-orchestrator restore guard (two orchestrators sharing one SessionManager), state restore with field-level assertions, no-op when no snapshot, consumes-once semantics, `multiAgentSaveLatestOn` independence from agent `saveLatestOn`, scope isolation, save with/without state |

## Related Issues

Follow-up work:
- Implement resume logic: skip completed/cancelled nodes on restore, swarm position tracking, stale `startTime`/duplicate results handling

## Documentation PR

N/A — no public API surface changes for end users yet. Documentation will be added when resume logic is implemented.

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- [x] All unit tests pass (40 session-manager tests), no type errors, clean build
- [x] End-to-end integration tested with real Bedrock model: 3-node Graph (researcher → writer → editor), cancelled editor mid-execution, verified snapshot captures partial state to FileStorage, verified restore loads correct node statuses and content via `BeforeNodeCallEvent` observation

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
