### PR TITLE
fix: handle type-discriminator format in contentBlockFromData

### DIFF
--- a/src/types/__tests__/messages.test.ts
+++ b/src/types/__tests__/messages.test.ts
@@ -330,6 +330,52 @@ describe('Message.fromMessageData', () => {
     } as unknown as MessageData
     expect(() => Message.fromMessageData(messageData)).toThrow('Unknown ContentBlockData type')
   })
+  it('handles ToolUseBlock data with type discriminator instead of nested wrapper (issue #533)', () => {
+    // When content blocks are spread ({...block}) or stored by ORMs that flatten
+    // the nested structure, the data has {type: 'toolUseBlock', name, toolUseId, input}
+    // instead of {toolUse: {name, toolUseId, input}}
+    const messageData = {
+      role: 'assistant' as const,
+      content: [
+        { type: 'toolUseBlock', name: 'greet', toolUseId: 'tu_123', input: { name: 'Alice' } },
+      ],
+    } as unknown as MessageData
+    const message = Message.fromMessageData(messageData)
+    expect(message.content).toHaveLength(1)
+    expect(message.content[0].type).toBe('toolUseBlock')
+    const block = message.content[0] as ToolUseBlock
+    expect(block.name).toBe('greet')
+    expect(block.toolUseId).toBe('tu_123')
+    expect(block.input).toEqual({ name: 'Alice' })
+  })
+
+  it('handles TextBlock data with type discriminator instead of nested wrapper', () => {
+    const messageData = {
+      role: 'user' as const,
+      content: [
+        { type: 'textBlock', text: 'hello' },
+      ],
+    } as unknown as MessageData
+    const message = Message.fromMessageData(messageData)
+    expect(message.content).toHaveLength(1)
+    expect(message.content[0].type).toBe('textBlock')
+    expect((message.content[0] as TextBlock).text).toBe('hello')
+  })
+
+  it('handles ToolResultBlock data with type discriminator instead of nested wrapper', () => {
+    const messageData = {
+      role: 'user' as const,
+      content: [
+        { type: 'toolResultBlock', toolUseId: 'tu_123', content: [], status: 'success' },
+      ],
+    } as unknown as MessageData
+    const message = Message.fromMessageData(messageData)
+    expect(message.content).toHaveLength(1)
+    expect(message.content[0].type).toBe('toolResultBlock')
+    const block = message.content[0] as ToolResultBlock
+    expect(block.toolUseId).toBe('tu_123')
+  })
+
 })
 
 describe('systemPromptFromData', () => {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -883,6 +883,26 @@ export function contentBlockFromData(data: ContentBlockData): ContentBlock {
   } else if ('citations' in data) {
     return CitationsBlock.fromJSON(data)
   } else {
+    // Fallback: handle data with a type discriminator instead of nested wrappers.
+    // This occurs when content blocks are spread ({...block}) or stored by ORMs
+    // that flatten the nested structure produced by toJSON().
+    const typed = data as Record<string, unknown>
+    if (typed.type === 'toolUseBlock' && typeof typed.name === 'string' && typeof typed.toolUseId === 'string') {
+      return new ToolUseBlock({
+        name: typed.name,
+        toolUseId: typed.toolUseId,
+        input: typed.input as JSONValue,
+        ...(typed.reasoningSignature !== undefined && { reasoningSignature: typed.reasoningSignature as string }),
+      })
+    } else if (typed.type === 'textBlock' && typeof typed.text === 'string') {
+      return new TextBlock(typed.text)
+    } else if (typed.type === 'toolResultBlock' && typeof typed.toolUseId === 'string') {
+      return new ToolResultBlock({
+        toolUseId: typed.toolUseId,
+        content: Array.isArray(typed.content) ? (typed.content as ToolResultContent[]) : [],
+        status: (typed.status as 'success' | 'error') ?? 'success',
+      })
+    }
     throw new Error('Unknown ContentBlockData type')
   }
 }


### PR DESCRIPTION
## Problem

Fixes #533

When content blocks are stored in a database (e.g., for session persistence) and then loaded back, the data may have a flat shape with a `type` discriminator:

```json
{"type": "toolUseBlock", "name": "greet", "toolUseId": "tu_123", "input": {}}
```

instead of the nested wrapper format that `contentBlockFromData` expects:

```json
{"toolUse": {"name": "greet", "toolUseId": "tu_123", "input": {}}}
```

This happens when blocks are spread (`{...block}`) or when ORMs/storage layers flatten the nested structure.

## Solution

Added fallback handling in `contentBlockFromData` that checks for the `type` discriminator when the nested wrapper keys aren't found. Supports `toolUseBlock`, `textBlock`, and `toolResultBlock` — the most common block types encountered in session storage.

## Tests

Added 3 tests verifying round-trip deserialization from type-discriminator format:
- ToolUseBlock with type discriminator
- TextBlock with type discriminator  
- ToolResultBlock with type discriminator

All 66 tests pass.