### PR TITLE
fix: migrate MultiagentPlugin to be an interface

### DIFF
--- a/src/multiagent/plugins.ts
+++ b/src/multiagent/plugins.ts
@@ -1,7 +1,7 @@
 /**
  * Plugin interface and registry for extending multi-agent orchestrator functionality.
  *
- * This module defines the MultiAgentPlugin abstract class and MultiAgentPluginRegistry,
+ * This module defines the MultiAgentPlugin interface and MultiAgentPluginRegistry,
  * which provide a composable way to add behavior to multi-agent orchestrators (e.g. Swarm, Graph)
  * through hook registration and custom initialization.
  */
@@ -9,19 +9,20 @@
 import type { MultiAgent } from './multiagent.js'
 
 /**
- * Abstract base class for plugins that extend multi-agent orchestrator functionality.
+ * Interface for objects that extend multi-agent orchestrator functionality.
  *
- * MultiAgentPlugins provide a composable way to add behavior to orchestrators
- * by registering hook callbacks in their `initMultiAgent` method.
+ * Plugins provide a composable way to add behavior to orchestrators by registering
+ * hook callbacks in their `initMultiAgent` method. Each plugin must have a unique name
+ * for identification, logging, and duplicate prevention.
  *
  * @example
  * ```typescript
- * class LoggingPlugin extends MultiAgentPlugin {
+ * class LoggingPlugin implements MultiAgentPlugin {
  *   get name(): string {
  *     return 'logging-plugin'
  *   }
  *
- *   override initMultiAgent(orchestrator: MultiAgent): void {
+ *   initMultiAgent(orchestrator: MultiAgent): void {
  *     orchestrator.addHook(BeforeNodeCallEvent, (event) => {
  *       console.log(`Node ${event.nodeId} starting`)
  *     })
@@ -35,21 +36,21 @@ import type { MultiAgent } from './multiagent.js'
  * })
  * ```
  */
-export abstract class MultiAgentPlugin {
+export interface MultiAgentPlugin {
   /**
    * A stable string identifier for the plugin.
    * Used for logging, duplicate detection, and plugin management.
    */
-  abstract readonly name: string
+  readonly name: string
 
   /**
    * Initialize the plugin with the orchestrator instance.
    *
-   * Override this method to register hooks and perform custom initialization.
+   * Implement this method to register hooks and perform custom initialization.
    *
    * @param orchestrator - The orchestrator this plugin is being attached to
    */
-  abstract initMultiAgent(orchestrator: MultiAgent): void | Promise<void>
+  initMultiAgent(orchestrator: MultiAgent): void | Promise<void>
 }
 
 /**

--- a/src/multiagent/plugins.ts
+++ b/src/multiagent/plugins.ts
@@ -9,11 +9,10 @@
 import type { MultiAgent } from './multiagent.js'
 
 /**
- * Interface for objects that extend multi-agent orchestrator functionality.
+ * Interface for objects that implement multi-agent orchestrator plugin functionality.
  *
- * Plugins provide a composable way to add behavior to orchestrators by registering
- * hook callbacks in their `initMultiAgent` method. Each plugin must have a unique name
- * for identification, logging, and duplicate prevention.
+ * MultiAgentPlugins provide a composable way to add behavior to orchestrators
+ * by registering hook callbacks in their `initMultiAgent` method.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Description

Changes `MultiAgentPlugin` from an `abstract class` to an `interface`, aligning it with the existing `Plugin` pattern used for single-agent plugins.

### Motivation

`MultiAgentPlugin` was defined as an `abstract class` but had zero concrete methods — it was effectively an interface. This created an inconsistency with `Plugin` (which is an `interface`) and forced consumers to use `implements` anyway (since TypeScript only allows single inheritance with `extends`). For example, `SessionManager` already declares `implements Plugin, MultiAgentPlugin` — this worked due to structural typing but was semantically incorrect for an abstract class.

### Related PR
https://github.com/strands-agents/sdk-typescript/pull/654


## Related Issues

N/A

## Documentation PR

N/A — no user-facing API change (consumers already used `implements`).

## Type of Change

Refactor (non-breaking)

## Testing

- [x] I ran `npm run check`
- [x] All 1834 unit tests pass across 67 test files, no type errors

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
