### PR TITLE
fix: prevent invocation lock leak when consumer breaks from stream

### DIFF
--- a/src/agent/__tests__/agent.test.ts
+++ b/src/agent/__tests__/agent.test.ts
@@ -181,7 +181,7 @@ describe('Agent', () => {
     })
 
     describe('hook error cleanup', () => {
-      it('fires AfterInvocationEvent when consumer breaks from stream', async () => {
+      it('fires AfterInvocationEvent when consumer breaks from stream and allows reinvocation', async () => {
         const model = new MockMessageModel()
           .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
           .addTurn({ type: 'textBlock', text: 'Done' })
@@ -208,6 +208,10 @@ describe('Agent', () => {
         }
 
         expect(afterInvocationCallback).toHaveBeenCalledOnce()
+
+        const result = await agent.invoke('Test again')
+        expect(result.stopReason).toBe('endTurn')
+        expect(result.lastMessage.content[0]).toEqual(new TextBlock('Done'))
       })
     })
   })

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -490,7 +490,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     args: InvokeArgs,
     options?: InvokeOptions
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
-    this.acquireLock()
+    using _lock = this.acquireLock()
 
     // Create AbortController for this invocation and compose with external signal
     this._abortController = new AbortController()
@@ -502,6 +502,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Delegate to _stream and process events through printer and hooks
     const streamGenerator = this._stream(args, options)
+    let caughtError: Error | undefined
     try {
       let result = await streamGenerator.next()
 
@@ -513,20 +514,21 @@ export class Agent implements LocalAgent, InvokableAgent {
       yield await this._invokeCallbacks(new AgentResultEvent({ agent: this, result: result.value }))
 
       return result.value
+    } catch (error) {
+      caughtError = error as Error
+      throw error
     } finally {
-      // Release the invocation lock before any yields. The drain loop below
-      // yields events, and when for-await-of breaks, .return() only consumes
-      // one yield — any subsequent yield orphans the generator. Releasing the
-      // lock first ensures the agent can always be reinvoked.
-      this._isInvoking = false
-
-      // Drain remaining events from _stream() BEFORE clearing the abort
-      // signals, so that _stream's finally block can still inspect
-      // cancellation state and append a cancel message when needed.
+      // Drain _stream() so cleanup hooks and printer still fire.
+      // Yield only on error (consumer may still be iterating); on a consumer
+      // break, yielding would suspend the generator and leak the lock.
       let result = await streamGenerator.return(undefined as never)
       while (!result.done) {
         try {
-          yield await this._invokeCallbacks(result.value)
+          if (caughtError) {
+            yield await this._invokeCallbacks(result.value)
+          } else {
+            await this._invokeCallbacks(result.value)
+          }
         } catch (error) {
           logger.warn(`event_type=<${result.value.type}>, error=<${error}> | error invoking callbacks during cleanup`)
         }


### PR DESCRIPTION
## Description

When a consumer breaks out of `for-await-of` on `agent.stream()`, the runtime calls `.return()` on the generator. The `finally` block in `stream()` drains remaining events from the inner `_stream()` generator by yielding them. However, with no consumer to resume the generator, it suspends permanently at that `yield`, preventing scope exit. The `using _lock` disposable never runs, leaving `_isInvoking` stuck at `true`. Any subsequent call to `invoke()` or `stream()` throws `ConcurrentInvocationError`.

The fix tracks whether `finally` was entered via an exception (where the consumer may still be iterating and should receive drain events) or via `.return()` (consumer left). Drain events are only yielded in the error case; otherwise callbacks are invoked without yielding so the generator completes and the lock releases normally.

## Related Issues

None

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Extended the existing "fires AfterInvocationEvent when consumer breaks from stream" test to also verify the agent is reinvokable after the break. Without the fix, this assertion fails with `ConcurrentInvocationError`.

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.