### PR TITLE
fix(bedrock): disable thinking when tool_choice forces tool use

### DIFF
--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -3948,4 +3948,44 @@ describe('BedrockModel', () => {
       })
     })
   })
+
+  describe('thinking with forced tool choice', () => {
+    const mockConverseStreamCommand = vi.mocked(ConverseStreamCommand)
+
+    const provider = new BedrockModel({
+      modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+      additionalRequestFields: {
+        thinking: { type: 'enabled', budget_tokens: 5000 },
+        some_other_field: 'value',
+      },
+    })
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+    const toolSpecs = [{ name: 'test_tool', description: 'test' }]
+
+    it.each([
+      { name: 'any', toolChoice: { any: {} } },
+      { name: 'tool', toolChoice: { tool: { name: 'test_tool' } } },
+    ])('strips thinking from additional request fields when tool choice is $name', ({ toolChoice }) => {
+      collectIterator(provider.stream(messages, { toolSpecs, toolChoice }))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: { some_other_field: 'value' },
+        })
+      )
+    })
+
+    it('preserves thinking when tool choice is auto', () => {
+      collectIterator(provider.stream(messages, { toolSpecs, toolChoice: { auto: {} } }))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: { type: 'enabled', budget_tokens: 5000 },
+            some_other_field: 'value',
+          },
+        })
+      )
+    })
+  })
 })

--- a/src/models/__tests__/bedrock.test.ts
+++ b/src/models/__tests__/bedrock.test.ts
@@ -3987,5 +3987,35 @@ describe('BedrockModel', () => {
         })
       )
     })
+
+    it('preserves thinking when no tool choice is provided', () => {
+      collectIterator(provider.stream(messages, { toolSpecs }))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: { type: 'enabled', budget_tokens: 5000 },
+            some_other_field: 'value',
+          },
+        })
+      )
+    })
+
+    it('omits additionalModelRequestFields when thinking is the only field and tool choice forces tool use', () => {
+      const thinkingOnlyProvider = new BedrockModel({
+        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        additionalRequestFields: {
+          thinking: { type: 'enabled', budget_tokens: 5000 },
+        },
+      })
+
+      collectIterator(thinkingOnlyProvider.stream(messages, { toolSpecs, toolChoice: { any: {} } }))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({
+          additionalModelRequestFields: expect.anything(),
+        })
+      )
+    })
   })
 })

--- a/src/models/bedrock.ts
+++ b/src/models/bedrock.ts
@@ -604,8 +604,9 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     }
 
     // Add additional request fields
-    if (this._config.additionalRequestFields) {
-      request.additionalModelRequestFields = this._config.additionalRequestFields
+    const additionalRequestFields = this._getAdditionalRequestFields(options)
+    if (additionalRequestFields) {
+      request.additionalModelRequestFields = additionalRequestFields
     }
 
     // Add additional response field paths
@@ -631,6 +632,30 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     }
 
     return request
+  }
+
+  /**
+   * Get additional request fields, adjusted for compatibility with the current stream options.
+   *
+   * Certain additional request fields are incompatible with specific API options. For example,
+   * Bedrock does not allow thinking mode when tool_choice forces tool use.
+   *
+   * @param options - The stream options for the current request
+   * @returns The additional request fields, or undefined if none
+   */
+  private _getAdditionalRequestFields(options?: StreamOptions): JSONValue | undefined {
+    const fields = this._config.additionalRequestFields as Record<string, JSONValue> | undefined
+    if (!fields || !('thinking' in fields)) {
+      return fields
+    }
+
+    const toolChoice = options?.toolChoice
+    if (!toolChoice || 'auto' in toolChoice) {
+      return fields
+    }
+
+    const { thinking: _, ...rest } = fields
+    return Object.keys(rest).length > 0 ? rest : undefined
   }
 
   /**


### PR DESCRIPTION
## Description

When using `structuredOutputSchema` with extended thinking enabled via `additionalRequestFields`, the agent loop can hit a Bedrock API error: "Thinking may not be enabled when tool_choice forces tool use." This happens because the SDK forces `toolChoice` to coerce the model into calling the structured output tool, but `thinking` remains in the request fields.

This adds a `_getAdditionalRequestFields` helper to `BedrockModel` that strips the `thinking` key from `additionalRequestFields` when `toolChoice` forces tool use (`any` or `tool` variants). Thinking is preserved for `auto` and unset tool choice. This mirrors the approach taken in the Python SDK (strands-agents/sdk-python#1495).

## Related Issues

Resolves #793

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Unit tests covering forced tool choice with `any` and `tool` variants, plus a negative test confirming thinking is preserved with `auto`
- Manually verified against Bedrock: without the fix, `ValidationException`; with the fix, successful response

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.