### PR TITLE
fix(multiagent): evaluate all incoming edge handlers in Graph._findReady

### DIFF
--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -299,6 +299,18 @@ describe('Graph', () => {
       expect(result.results.map((r) => r.nodeId)).toStrictEqual(['a', 'b'])
     })
 
+    it('evaluates conditional edges on join node (A -> C false, B -> C)', async () => {
+      const graph = new Graph({
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [{ source: 'a', target: 'c', handler: () => false }, ['b', 'c']],
+      })
+
+      const result = await graph.invoke('start')
+
+      expect(result.status).toBe(Status.COMPLETED)
+      expect(result.results.map((r) => r.nodeId).sort()).toStrictEqual(['a', 'b'])
+    })
+
     it('passes task + dependency content to downstream nodes', async () => {
       const agentB = makeAgent('b')
       const streamSpy = vi.spyOn(agentB, 'stream')

--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -311,6 +311,21 @@ describe('Graph', () => {
       expect(result.results.map((r) => r.nodeId).sort()).toStrictEqual(['a', 'b'])
     })
 
+    it('evaluates conditional edges on join node (A -> C true, B -> C true)', async () => {
+      const graph = new Graph({
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          { source: 'a', target: 'c', handler: () => true },
+          { source: 'b', target: 'c', handler: () => true },
+        ],
+      })
+
+      const result = await graph.invoke('start')
+
+      expect(result.status).toBe(Status.COMPLETED)
+      expect(result.results.map((r) => r.nodeId).sort()).toStrictEqual(['a', 'b', 'c'])
+    })
+
     it('passes task + dependency content to downstream nodes', async () => {
       const agentB = makeAgent('b')
       const streamSpy = vi.spyOn(agentB, 'stream')

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -506,7 +506,7 @@ export class Graph implements MultiAgent {
 
   /**
    * Finds downstream nodes that are ready to execute after a node completes.
-   * A target is ready when all its incoming edge sources are COMPLETED.
+   * A target is ready when all its incoming edge sources are COMPLETED and all edge handlers return true.
    */
   private async _findReady(
     node: Node,
@@ -519,14 +519,17 @@ export class Graph implements MultiAgent {
     const ready: Node[] = []
 
     for (const edge of this.edges.filter((e) => e.source.id === node.id)) {
-      if (!(await edge.handler(state))) continue
-
       if (streams.has(edge.target.id) || targets.some((n) => n.id === edge.target.id)) continue
 
       const deps = this.edges.filter((e) => e.target.id === edge.target.id)
-      if (deps.every((e) => state.node(e.source.id)?.status === Status.COMPLETED)) {
-        ready.push(edge.target)
-      }
+
+      // skip if any source node has not completed
+      if (deps.some((e) => state.node(e.source.id)?.status !== Status.COMPLETED)) continue
+
+      // skip if any edge handler rejects the transition
+      if (!(await Promise.all(deps.map((e) => e.handler(state)))).every(Boolean)) continue
+
+      ready.push(edge.target)
     }
 
     return ready

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -507,6 +507,12 @@ export class Graph implements MultiAgent {
   /**
    * Finds downstream nodes that are ready to execute after a node completes.
    * A target is ready when all its incoming edge sources are COMPLETED and all edge handlers return true.
+   *
+   * @param node - The node that just completed execution.
+   * @param state - Current multi-agent execution state.
+   * @param streams - Map of node IDs to their in-flight execution promises.
+   * @param targets - Nodes already queued for execution.
+   * @returns Nodes that are ready to execute.
    */
   private async _findReady(
     node: Node,
@@ -519,6 +525,7 @@ export class Graph implements MultiAgent {
     const ready: Node[] = []
 
     for (const edge of this.edges.filter((e) => e.source.id === node.id)) {
+      // skip if the target is already running or queued
       if (streams.has(edge.target.id) || targets.some((n) => n.id === edge.target.id)) continue
 
       const deps = this.edges.filter((e) => e.target.id === edge.target.id)


### PR DESCRIPTION
## Description

`Graph._findReady` evaluates the edge handler only for the edge originating from the just-completed node. For join nodes with multiple incoming edges, the handlers on other incoming edges are never checked. This means a conditional edge returning `false` from an earlier source is ignored when a later source completes and schedules the target.

The fix replaces the status-only dependency check with a two-step gate: first verify all source nodes have COMPLETED, then run all incoming edge handlers in parallel and require every one to return `true` before scheduling the target.

Resolves: #803

## Related Issues

#803

## Type of Change

Bug fix

## Testing

- Added test: `evaluates conditional edges on join node (A -> C false, B -> C)` confirming C is not executed when one incoming edge handler returns false
- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.