### PR TITLE
feat(a2a): add clientFactory to A2AAgent for auth support

### DIFF
--- a/src/a2a/__tests__/a2a-agent.test.ts
+++ b/src/a2a/__tests__/a2a-agent.test.ts
@@ -29,17 +29,8 @@ vi.mock('@a2a-js/sdk/client', () => {
     }
   }
 
-  const mockCreateFrom = vi.fn().mockImplementation((_original: unknown, overrides: unknown) => ({
-    transports: [],
-    ...(overrides as Record<string, unknown>),
-  }))
-
   return {
     ClientFactory: MockClientFactory,
-    ClientFactoryOptions: {
-      default: { transports: [] },
-      createFrom: mockCreateFrom,
-    },
   }
 })
 
@@ -148,48 +139,34 @@ describe('A2AAgent', () => {
     })
   })
 
-  describe('clientFactoryOptions', () => {
-    it('creates ClientFactory with no arguments when clientFactoryOptions is not provided', async () => {
+  describe('clientFactory', () => {
+    it('creates a default ClientFactory when clientFactory is not provided', async () => {
       const agent = new A2AAgent({ url: 'http://localhost:9000' })
 
       await agent.invoke('Hello')
 
+      // Default factory created with no arguments
       expect(clientFactoryConstructorArgs).toHaveLength(1)
       expect(clientFactoryConstructorArgs[0]).toHaveLength(0)
     })
 
-    it('creates ClientFactory with merged options when clientFactoryOptions is provided', async () => {
-      const { ClientFactoryOptions } = await import('@a2a-js/sdk/client')
-      const customOptions = {
-        clientConfig: { interceptors: [] },
-      }
+    it('uses the provided ClientFactory instead of creating a new one', async () => {
+      const { ClientFactory } = await import('@a2a-js/sdk/client')
+      const customFactory = new ClientFactory()
+
+      // Reset tracking after factory construction
+      clientFactoryConstructorArgs.length = 0
+
       const agent = new A2AAgent({
         url: 'http://localhost:9000',
-        clientFactoryOptions: customOptions,
+        clientFactory: customFactory,
       })
 
       await agent.invoke('Hello')
 
-      expect(ClientFactoryOptions.createFrom).toHaveBeenCalledWith(ClientFactoryOptions.default, customOptions)
-      expect(clientFactoryConstructorArgs).toHaveLength(1)
-      expect(clientFactoryConstructorArgs[0]![0]).toEqual(
-        expect.objectContaining({ clientConfig: { interceptors: [] } })
-      )
-    })
-
-    it('passes custom cardResolver through to ClientFactory', async () => {
-      const { ClientFactoryOptions } = await import('@a2a-js/sdk/client')
-      const mockResolver = { resolve: vi.fn() }
-      const agent = new A2AAgent({
-        url: 'http://localhost:9000',
-        clientFactoryOptions: { cardResolver: mockResolver },
-      })
-
-      await agent.invoke('Hello')
-
-      expect(ClientFactoryOptions.createFrom).toHaveBeenCalledWith(ClientFactoryOptions.default, {
-        cardResolver: mockResolver,
-      })
+      // No new factory created — the provided one is used directly
+      expect(clientFactoryConstructorArgs).toHaveLength(0)
+      expect(mockCreateFromUrl).toHaveBeenCalledWith('http://localhost:9000', undefined)
     })
 
     it('passes agentCardPath to createFromUrl', async () => {
@@ -200,6 +177,23 @@ describe('A2AAgent', () => {
 
       await agent.invoke('Hello')
 
+      expect(mockCreateFromUrl).toHaveBeenCalledWith('http://localhost:9000', '/custom/card.json')
+    })
+
+    it('passes agentCardPath to createFromUrl with custom factory', async () => {
+      const { ClientFactory } = await import('@a2a-js/sdk/client')
+      const customFactory = new ClientFactory()
+      clientFactoryConstructorArgs.length = 0
+
+      const agent = new A2AAgent({
+        url: 'http://localhost:9000',
+        agentCardPath: '/custom/card.json',
+        clientFactory: customFactory,
+      })
+
+      await agent.invoke('Hello')
+
+      expect(clientFactoryConstructorArgs).toHaveLength(0)
       expect(mockCreateFromUrl).toHaveBeenCalledWith('http://localhost:9000', '/custom/card.json')
     })
   })

--- a/src/a2a/__tests__/a2a-agent.test.ts
+++ b/src/a2a/__tests__/a2a-agent.test.ts
@@ -14,20 +14,34 @@ import type { InvokeArgs } from '../../types/agent.js'
 // Mock the A2A SDK client
 const mockSendMessageStream = vi.fn()
 const mockGetAgentCard = vi.fn()
+const mockCreateFromUrl = vi.fn()
 
-vi.mock('@a2a-js/sdk/client', () => ({
-  ClientFactory: class MockClientFactory {
-    async createFromUrl(): Promise<{
-      sendMessageStream: typeof mockSendMessageStream
-      getAgentCard: typeof mockGetAgentCard
-    }> {
-      return {
-        sendMessageStream: mockSendMessageStream,
-        getAgentCard: mockGetAgentCard,
-      }
+// Track ClientFactory constructor calls
+const clientFactoryConstructorArgs: unknown[][] = []
+
+vi.mock('@a2a-js/sdk/client', () => {
+  class MockClientFactory {
+    constructor(...args: unknown[]) {
+      clientFactoryConstructorArgs.push(args)
     }
-  },
-}))
+    async createFromUrl(...args: unknown[]) {
+      return mockCreateFromUrl(...args)
+    }
+  }
+
+  const mockCreateFrom = vi.fn().mockImplementation((_original: unknown, overrides: unknown) => ({
+    transports: [],
+    ...(overrides as Record<string, unknown>),
+  }))
+
+  return {
+    ClientFactory: MockClientFactory,
+    ClientFactoryOptions: {
+      default: { transports: [] },
+      createFrom: mockCreateFrom,
+    },
+  }
+})
 
 const mockAgentCard: AgentCard = {
   name: 'Remote Agent',
@@ -77,8 +91,13 @@ async function collectStream(
 describe('A2AAgent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clientFactoryConstructorArgs.length = 0
     mockGetAgentCard.mockResolvedValue(mockAgentCard)
     mockSendMessageStream.mockReturnValue(mockStream(createMockTaskResponse()))
+    mockCreateFromUrl.mockResolvedValue({
+      sendMessageStream: mockSendMessageStream,
+      getAgentCard: mockGetAgentCard,
+    })
   })
 
   describe('identity properties', () => {
@@ -126,6 +145,62 @@ describe('A2AAgent', () => {
 
       expect(agent.name).toBe('Custom Name')
       expect(agent.description).toBe('Custom description')
+    })
+  })
+
+  describe('clientFactoryOptions', () => {
+    it('creates ClientFactory with no arguments when clientFactoryOptions is not provided', async () => {
+      const agent = new A2AAgent({ url: 'http://localhost:9000' })
+
+      await agent.invoke('Hello')
+
+      expect(clientFactoryConstructorArgs).toHaveLength(1)
+      expect(clientFactoryConstructorArgs[0]).toHaveLength(0)
+    })
+
+    it('creates ClientFactory with merged options when clientFactoryOptions is provided', async () => {
+      const { ClientFactoryOptions } = await import('@a2a-js/sdk/client')
+      const customOptions = {
+        clientConfig: { interceptors: [] },
+      }
+      const agent = new A2AAgent({
+        url: 'http://localhost:9000',
+        clientFactoryOptions: customOptions,
+      })
+
+      await agent.invoke('Hello')
+
+      expect(ClientFactoryOptions.createFrom).toHaveBeenCalledWith(ClientFactoryOptions.default, customOptions)
+      expect(clientFactoryConstructorArgs).toHaveLength(1)
+      expect(clientFactoryConstructorArgs[0]![0]).toEqual(
+        expect.objectContaining({ clientConfig: { interceptors: [] } })
+      )
+    })
+
+    it('passes custom cardResolver through to ClientFactory', async () => {
+      const { ClientFactoryOptions } = await import('@a2a-js/sdk/client')
+      const mockResolver = { resolve: vi.fn() }
+      const agent = new A2AAgent({
+        url: 'http://localhost:9000',
+        clientFactoryOptions: { cardResolver: mockResolver },
+      })
+
+      await agent.invoke('Hello')
+
+      expect(ClientFactoryOptions.createFrom).toHaveBeenCalledWith(ClientFactoryOptions.default, {
+        cardResolver: mockResolver,
+      })
+    })
+
+    it('passes agentCardPath to createFromUrl', async () => {
+      const agent = new A2AAgent({
+        url: 'http://localhost:9000',
+        agentCardPath: '/custom/card.json',
+      })
+
+      await agent.invoke('Hello')
+
+      expect(mockCreateFromUrl).toHaveBeenCalledWith('http://localhost:9000', '/custom/card.json')
     })
   })
 
@@ -243,14 +318,12 @@ describe('A2AAgent', () => {
       const agent = new A2AAgent({ url: 'http://localhost:9000' })
       const { events } = await collectStream(agent.stream('Hello'))
 
-      // 3 A2AStreamUpdateEvents + 1 A2AResultEvent
       expect(events).toHaveLength(4)
       expect(events[0]).toBeInstanceOf(A2AStreamUpdateEvent)
       expect(events[1]).toBeInstanceOf(A2AStreamUpdateEvent)
       expect(events[2]).toBeInstanceOf(A2AStreamUpdateEvent)
       expect(events[3]).toBeInstanceOf(A2AResultEvent)
 
-      // Final result built from last complete event (status-update with completed state)
       const resultEvent = events[3] as A2AResultEvent
       expect((resultEvent.result.lastMessage.content[0] as TextBlock).text).toBe('Final answer')
     })
@@ -306,7 +379,7 @@ describe('A2AAgent', () => {
       const agent = new A2AAgent({ url: 'http://localhost:9000' })
       const { events, result } = await collectStream(agent.stream('Hello'))
 
-      expect(events).toHaveLength(1) // only A2AResultEvent
+      expect(events).toHaveLength(1)
       expect(events[0]).toBeInstanceOf(A2AResultEvent)
       expect((result as { lastMessage: Message }).lastMessage.content[0]).toBeInstanceOf(TextBlock)
       expect(((result as { lastMessage: Message }).lastMessage.content[0] as TextBlock).text).toBe('')
@@ -339,7 +412,12 @@ describe('A2AAgent', () => {
 describe('response text extraction via invoke', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clientFactoryConstructorArgs.length = 0
     mockGetAgentCard.mockResolvedValue(mockAgentCard)
+    mockCreateFromUrl.mockResolvedValue({
+      sendMessageStream: mockSendMessageStream,
+      getAgentCard: mockGetAgentCard,
+    })
   })
 
   it('joins multiple text parts from Task artifacts', async () => {

--- a/src/a2a/a2a-agent.ts
+++ b/src/a2a/a2a-agent.ts
@@ -9,7 +9,7 @@
 
 import type { AgentCard, Part } from '@a2a-js/sdk'
 import type { Client as A2AClientSdk } from '@a2a-js/sdk/client'
-import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client'
+import { ClientFactory } from '@a2a-js/sdk/client'
 import type { InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
 import { AgentResult } from '../types/agent.js'
 import { Message, TextBlock, type ContentBlock, type ContentBlockData, type MessageData } from '../types/messages.js'
@@ -32,27 +32,29 @@ export interface A2AAgentConfig {
   /** Optional description. If not provided, populated from the agent card after connection. */
   description?: string
   /**
-   * Options passed to the underlying A2A SDK {@link ClientFactory}.
+   * Pre-configured {@link ClientFactory} for the underlying A2A SDK.
    *
    * Use this to configure authentication, custom transports, interceptors,
-   * or a custom agent card resolver. Partial options are merged with the SDK
-   * defaults via `ClientFactoryOptions.createFrom`.
+   * or a custom agent card resolver. When not provided, a default
+   * `ClientFactory` is created with no authentication.
    *
    * @example
    * ```typescript
-   * import { DefaultAgentCardResolver, createAuthenticatingFetchWithRetry } from '@a2a-js/sdk/client'
+   * import { ClientFactory, ClientFactoryOptions, DefaultAgentCardResolver, createAuthenticatingFetchWithRetry } from '@a2a-js/sdk/client'
+   *
+   * const factory = new ClientFactory(ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+   *   cardResolver: new DefaultAgentCardResolver({
+   *     fetchImpl: createAuthenticatingFetchWithRetry(fetch, myAuthHandler),
+   *   }),
+   * }))
    *
    * const agent = new A2AAgent({
    *   url: 'https://protected-agent.example.com',
-   *   clientFactoryOptions: {
-   *     cardResolver: new DefaultAgentCardResolver({
-   *       fetchImpl: createAuthenticatingFetchWithRetry(fetch, myAuthHandler),
-   *     }),
-   *   },
+   *   clientFactory: factory,
    * })
    * ```
    */
-  clientFactoryOptions?: Partial<ClientFactoryOptions>
+  clientFactory?: ClientFactory
 }
 
 /**
@@ -192,10 +194,7 @@ export class A2AAgent implements InvokableAgent {
 
     logExperimentalWarning()
 
-    const factoryOptions = this._config.clientFactoryOptions
-    const factory = factoryOptions
-      ? new ClientFactory(ClientFactoryOptions.createFrom(ClientFactoryOptions.default, factoryOptions))
-      : new ClientFactory()
+    const factory = this._config.clientFactory ?? new ClientFactory()
     const client = await factory.createFromUrl(this._config.url, this._config.agentCardPath)
     this._agentCard = await client.getAgentCard()
     if (this.name === undefined && this._agentCard?.name) {

--- a/src/a2a/a2a-agent.ts
+++ b/src/a2a/a2a-agent.ts
@@ -9,7 +9,7 @@
 
 import type { AgentCard, Part } from '@a2a-js/sdk'
 import type { Client as A2AClientSdk } from '@a2a-js/sdk/client'
-import { ClientFactory } from '@a2a-js/sdk/client'
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client'
 import type { InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
 import { AgentResult } from '../types/agent.js'
 import { Message, TextBlock, type ContentBlock, type ContentBlockData, type MessageData } from '../types/messages.js'
@@ -31,6 +31,28 @@ export interface A2AAgentConfig {
   name?: string
   /** Optional description. If not provided, populated from the agent card after connection. */
   description?: string
+  /**
+   * Options passed to the underlying A2A SDK {@link ClientFactory}.
+   *
+   * Use this to configure authentication, custom transports, interceptors,
+   * or a custom agent card resolver. Partial options are merged with the SDK
+   * defaults via `ClientFactoryOptions.createFrom`.
+   *
+   * @example
+   * ```typescript
+   * import { DefaultAgentCardResolver, createAuthenticatingFetchWithRetry } from '@a2a-js/sdk/client'
+   *
+   * const agent = new A2AAgent({
+   *   url: 'https://protected-agent.example.com',
+   *   clientFactoryOptions: {
+   *     cardResolver: new DefaultAgentCardResolver({
+   *       fetchImpl: createAuthenticatingFetchWithRetry(fetch, myAuthHandler),
+   *     }),
+   *   },
+   * })
+   * ```
+   */
+  clientFactoryOptions?: Partial<ClientFactoryOptions>
 }
 
 /**
@@ -170,7 +192,10 @@ export class A2AAgent implements InvokableAgent {
 
     logExperimentalWarning()
 
-    const factory = new ClientFactory()
+    const factoryOptions = this._config.clientFactoryOptions
+    const factory = factoryOptions
+      ? new ClientFactory(ClientFactoryOptions.createFrom(ClientFactoryOptions.default, factoryOptions))
+      : new ClientFactory()
     const client = await factory.createFromUrl(this._config.url, this._config.agentCardPath)
     this._agentCard = await client.getAgentCard()
     if (this.name === undefined && this._agentCard?.name) {


### PR DESCRIPTION
## Summary

Add `clientFactory?: ClientFactory` to `A2AAgentConfig` to allow passing a pre-configured A2A SDK `ClientFactory` for authentication, custom transports, interceptors, and agent card resolution.

## Problem

`A2AAgent` creates a bare `new ClientFactory()` with no options, which means agent card resolution and message sending use plain unauthenticated `fetch` calls. This causes **403 errors** when connecting to protected endpoints (SigV4, OAuth, bearer tokens).

This is the same auth bug fixed in the Python SDK via [PR #2103](https://github.com/strands-agents/sdk-python/pull/2103).

## Solution

Accept an optional `clientFactory?: ClientFactory` — a pre-configured factory instance. The factory already handles card resolution (`createFromUrl`) and client creation, so we just use it directly.

When not provided, a default `new ClientFactory()` is created (existing behavior).

## Usage

```typescript
import { A2AAgent } from '@strands-agents/sdk/a2a'
import { ClientFactory, ClientFactoryOptions, DefaultAgentCardResolver, createAuthenticatingFetchWithRetry } from '@a2a-js/sdk/client'

const factory = new ClientFactory(ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
  cardResolver: new DefaultAgentCardResolver({
    fetchImpl: createAuthenticatingFetchWithRetry(fetch, myAuthHandler),
  }),
}))

const agent = new A2AAgent({
  url: 'https://protected-agent.example.com',
  clientFactory: factory,
})
```

## Changes

| File | Change |
|------|--------|
| `src/a2a/a2a-agent.ts` | Replace `clientFactoryOptions` with `clientFactory: ClientFactory`, simplify `_getClient()` to `this._config.clientFactory ?? new ClientFactory()` |
| `src/a2a/__tests__/a2a-agent.test.ts` | Update tests: verify provided factory is used directly (no extra construction), agentCardPath works with custom factory |

## Key Design Decision

We accept a `ClientFactory` instance instead of `Partial<ClientFactoryOptions>` because:
- The factory already handles everything (card resolution + client creation)
- Users configure auth/transports/interceptors on *their* factory — we just use it
- Simpler API, no need to re-expose SDK options through our config
- Factory is reusable across multiple `A2AAgent` instances

## Testing

- ✅ **32 tests** pass (4 factory-specific + 28 existing)
- ✅ TypeScript build clean (zero errors in src/a2a/)
- ✅ ESLint clean
- ✅ Prettier formatted

## Related

- Python SDK equivalent: https://github.com/strands-agents/sdk-python/pull/2103
- Tracking issue: https://github.com/agent-of-mkmeral/strands-coder-private/issues/10