### PR TITLE
feat: add graph+session manager integration + tests

### DIFF
--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { MockSnapshotStorage } from '../../__fixtures__/mock-storage-provider.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { AfterNodeCallEvent, BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import { TextBlock, type ContentBlockData } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
 import { AgentNode, MultiAgentNode } from '../nodes.js'
 import { Graph } from '../graph.js'
+import { SessionManager } from '../../session/session-manager.js'
 
 function makeAgent(id: string, text = 'reply'): Agent {
   const model = new MockMessageModel().addTurn(new TextBlock(text))
@@ -614,6 +616,154 @@ describe('Graph', () => {
       // Simulates consumer break — should not hang waiting for node streams
       const result = await gen.return(undefined as never)
       expect(result.done).toBe(true)
+    })
+  })
+
+  describe('resume with session manager', () => {
+    function makeSessionManager(storage: MockSnapshotStorage): SessionManager {
+      return new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: storage },
+      })
+    }
+
+    it('resumes from the next ready node after a linear graph stops (A→B→C, A done, resumes at B)', async () => {
+      const storage = new MockSnapshotStorage()
+
+      const graph1 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          ['a', 'b'],
+          ['b', 'c'],
+        ],
+        maxSteps: 1,
+        plugins: [makeSessionManager(storage)],
+      })
+
+      await expect(graph1.invoke('start')).rejects.toThrow('max steps reached')
+
+      const graph2 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          ['a', 'b'],
+          ['b', 'c'],
+        ],
+        plugins: [makeSessionManager(storage)],
+      })
+
+      const result = await graph2.invoke('start')
+
+      expect(result.status).toBe(Status.COMPLETED)
+      const completedIds = result.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+      expect(completedIds).toStrictEqual(['a', 'b', 'c'])
+    })
+
+    it('resumes parallel branches independently (A→B, A→C, B done, C cancelled, resumes at C)', async () => {
+      const storage = new MockSnapshotStorage()
+
+      const graph1 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          ['a', 'b'],
+          ['a', 'c'],
+        ],
+        plugins: [makeSessionManager(storage)],
+        maxConcurrency: 1,
+      })
+
+      graph1.addHook(BeforeNodeCallEvent, (event: BeforeNodeCallEvent) => {
+        if (event.nodeId === 'c') event.cancel = 'simulated stop'
+      })
+
+      await graph1.invoke('start')
+
+      const graph2 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          ['a', 'b'],
+          ['a', 'c'],
+        ],
+        plugins: [makeSessionManager(storage)],
+      })
+
+      const result = await graph2.invoke('start')
+
+      const completedIds = result.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+      expect(completedIds).toContain('a')
+      expect(completedIds).toContain('b')
+      expect(completedIds).toContain('c')
+      // A and B should appear once each (not re-executed)
+      expect(completedIds.filter((id) => id === 'a')).toHaveLength(1)
+      expect(completedIds.filter((id) => id === 'b')).toHaveLength(1)
+    })
+
+    it('starts fresh when all nodes completed in the previous run', async () => {
+      const storage = new MockSnapshotStorage()
+
+      const graph1 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply')],
+        edges: [['a', 'b']],
+        plugins: [makeSessionManager(storage)],
+      })
+
+      const result1 = await graph1.invoke('start')
+      expect(result1.status).toBe(Status.COMPLETED)
+
+      const graph2 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply')],
+        edges: [['a', 'b']],
+        plugins: [makeSessionManager(storage)],
+      })
+
+      const result2 = await graph2.invoke('start')
+
+      expect(result2.status).toBe(Status.COMPLETED)
+      // A should appear twice — once from restored state, once from fresh execution
+      const aCount = result2.results.filter((r) => r.nodeId === 'a' && r.status === Status.COMPLETED).length
+      expect(aCount).toBe(2)
+    })
+
+    it('respects conditional edges on resume', async () => {
+      const storage = new MockSnapshotStorage()
+
+      // A → B (always), A → C (condition: false)
+      // First run: A completes, B completes, C blocked by condition
+      // maxSteps=2 allows A and B but graph completes normally since C is blocked
+      const graph1 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          { source: 'a', target: 'b', handler: () => true },
+          { source: 'a', target: 'c', handler: () => false },
+        ],
+        plugins: [makeSessionManager(storage)],
+      })
+
+      const result1 = await graph1.invoke('start')
+      expect(result1.results.map((r) => r.nodeId)).toStrictEqual(['a', 'b'])
+
+      // Resume: C should still be blocked by the false condition
+      const graph2 = new Graph({
+        id: 'my-graph',
+        nodes: [makeAgent('a', 'a-reply'), makeAgent('b', 'b-reply'), makeAgent('c', 'c-reply')],
+        edges: [
+          { source: 'a', target: 'b', handler: () => true },
+          { source: 'a', target: 'c', handler: () => false },
+        ],
+        plugins: [makeSessionManager(storage)],
+      })
+
+      const result2 = await graph2.invoke('start')
+
+      // C should not appear — condition still blocks it
+      const completedIds = result2.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+      expect(completedIds).not.toContain('c')
     })
   })
 })

--- a/src/multiagent/__tests__/graph.test.ts
+++ b/src/multiagent/__tests__/graph.test.ts
@@ -627,6 +627,19 @@ describe('Graph', () => {
       })
     }
 
+    it('throws when sessionManager appears in both constructor arg and plugins', () => {
+      const sm = makeSessionManager(new MockSnapshotStorage())
+      expect(
+        () =>
+          new Graph({
+            nodes: [makeAgent('a')],
+            edges: [],
+            sessionManager: sm,
+            plugins: [sm],
+          })
+      ).toThrow('sessionManager was provided as both a constructor argument and in the plugins array')
+    })
+
     it('resumes from the next ready node after a linear graph stops (A→B→C, A done, resumes at B)', async () => {
       const storage = new MockSnapshotStorage()
 
@@ -638,7 +651,7 @@ describe('Graph', () => {
           ['b', 'c'],
         ],
         maxSteps: 1,
-        plugins: [makeSessionManager(storage)],
+        sessionManager: makeSessionManager(storage),
       })
 
       await expect(graph1.invoke('start')).rejects.toThrow('max steps reached')
@@ -650,7 +663,7 @@ describe('Graph', () => {
           ['a', 'b'],
           ['b', 'c'],
         ],
-        plugins: [makeSessionManager(storage)],
+        sessionManager: makeSessionManager(storage),
       })
 
       const result = await graph2.invoke('start')

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -548,11 +548,15 @@ export class Graph implements MultiAgent {
       }
     }
 
-    logger.debug(
-      `resume_targets=<${ready.map((n) => n.id).join(', ')}>, prior_steps=<${state.steps}> | resuming graph from restored state`
-    )
-    // Empty ready set means all nodes completed — start fresh
-    return ready.length > 0 ? ready : undefined
+    if (ready.length > 0) {
+      logger.debug(
+        `resume_targets=<${ready.map((n) => n.id).join(', ')}>, prior_steps=<${state.steps}> | resuming graph from restored state`
+      )
+      return ready
+    }
+
+    logger.debug('all nodes completed in restored state | starting fresh')
+    return undefined
   }
 
   /**

--- a/src/multiagent/graph.ts
+++ b/src/multiagent/graph.ts
@@ -3,10 +3,12 @@ import type { InvokableAgent } from '../types/agent.js'
 import type { MultiAgentInput } from './multiagent.js'
 import type { ContentBlock } from '../types/messages.js'
 import { TextBlock, contentBlockFromData } from '../types/messages.js'
+import { logger } from '../logging/logger.js'
 import { HookableEvent } from '../hooks/events.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
 import type { MultiAgentPlugin } from './plugins.js'
+import type { SessionManager } from '../session/session-manager.js'
 import { MultiAgentPluginRegistry } from './plugins.js'
 import type { NodeDefinition } from './nodes.js'
 import { AgentNode, MultiAgentNode, Node } from './nodes.js'
@@ -53,6 +55,8 @@ export interface GraphOptions extends GraphConfig {
   edges: EdgeDefinition[]
   /** Explicit source node IDs. If omitted, auto-detected from nodes with no incoming edges. */
   sources?: string[]
+  /** Session manager for saving and restoring graph sessions. */
+  sessionManager?: SessionManager
   /** Plugins for event-driven extensibility. */
   plugins?: MultiAgentPlugin[]
   /** Custom trace attributes to include on all spans. */
@@ -102,10 +106,11 @@ export class Graph implements MultiAgent {
   private readonly _hookRegistry: HookRegistryImplementation
   private readonly _sources: Node[]
   private readonly _tracer: Tracer
+  readonly sessionManager?: SessionManager | undefined
   private _initialized: boolean
 
   constructor(options: GraphOptions) {
-    const { id, nodes, edges, sources, plugins, traceAttributes, ...config } = options
+    const { id, nodes, edges, sources, sessionManager, plugins, traceAttributes, ...config } = options
 
     this.id = id ?? 'graph'
 
@@ -120,8 +125,17 @@ export class Graph implements MultiAgent {
     this._sources = this._resolveSources(sources)
     this._validateSources()
 
+    this.sessionManager = sessionManager
+
+    if (sessionManager && plugins?.some((p) => p.name === sessionManager.name)) {
+      throw new Error('sessionManager was provided as both a constructor argument and in the plugins array')
+    }
+
     this._hookRegistry = new HookRegistryImplementation()
-    this._pluginRegistry = new MultiAgentPluginRegistry(plugins)
+    this._pluginRegistry = new MultiAgentPluginRegistry([
+      ...(plugins ?? []),
+      ...(sessionManager ? [sessionManager] : []),
+    ])
     this._tracer = new Tracer(traceAttributes)
     this._initialized = false
   }
@@ -193,7 +207,6 @@ export class Graph implements MultiAgent {
     const state = new MultiAgentState({ nodeIds: [...this.nodes.keys()] })
 
     const queue = new Queue()
-    const targets = [...this._sources]
     const streams = new Map<string, Promise<void>>()
 
     const multiAgentSpan = this._tracer.startMultiAgentSpan({
@@ -202,7 +215,11 @@ export class Graph implements MultiAgent {
       input,
     })
 
+    // SessionManager (or plugins) may restore state.results here via the hook
     yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state })
+
+    // Resume: if state was restored, find nodes that are ready but haven't completed otherwise start from source nodes
+    const targets = (await this._findResumeTargets(state)) ?? [...this._sources]
 
     let caughtError: Error | undefined
     let result: MultiAgentResult | undefined
@@ -498,6 +515,57 @@ export class Graph implements MultiAgent {
     return [...blocks, ...deps]
   }
 
+  /**
+   * Finds nodes that should execute on resume from a restored {@link MultiAgentState}.
+   *
+   * Any node that did not complete is a candidate for re-execution, provided its
+   * dependencies are all COMPLETED and edge conditions are satisfied. This covers:
+   * - PENDING nodes that never started
+   * - EXECUTING/FAILED/CANCELLED nodes from the previous run
+   * - Source nodes (no incoming edges) that are not COMPLETED
+   *
+   * Works for all node types including {@link AgentNode} and {@link MultiAgentNode}
+   * (subgraphs/swarms). A `MultiAgentNode` that didn't complete will be re-executed
+   * from scratch — its inner orchestrator manages its own state independently.
+   *
+   * @returns Array of ready nodes, or `undefined` if state was not restored (fresh start)
+   */
+  private async _findResumeTargets(state: MultiAgentState): Promise<Node[] | undefined> {
+    // No completed nodes in state means fresh start (state was not restored)
+    const hasCompletedNodes = [...state.nodes.values()].some((ns) => ns.status === Status.COMPLETED)
+    if (!hasCompletedNodes) return undefined
+
+    const ready: Node[] = []
+    for (const [id, node] of this.nodes) {
+      if (state.node(id)?.status === Status.COMPLETED) continue
+
+      const incoming = this.edges.filter((e) => e.target.id === id)
+      if (incoming.length === 0) {
+        // Source node that hasn't completed
+        ready.push(node)
+      } else if (await this._allDependenciesSatisfied(incoming, state)) {
+        ready.push(node)
+      }
+    }
+
+    logger.debug(
+      `resume_targets=<${ready.map((n) => n.id).join(', ')}>, prior_steps=<${state.steps}> | resuming graph from restored state`
+    )
+    // Empty ready set means all nodes completed — start fresh
+    return ready.length > 0 ? ready : undefined
+  }
+
+  /**
+   * Checks whether all incoming edges have completed sources with satisfied conditions.
+   */
+  private async _allDependenciesSatisfied(incoming: Edge[], state: MultiAgentState): Promise<boolean> {
+    for (const edge of incoming) {
+      if (state.node(edge.source.id)?.status !== Status.COMPLETED) return false
+      if (!(await edge.handler(state))) return false
+    }
+    return true
+  }
+
   private _checkSteps(state: MultiAgentState): void {
     if (state.steps >= this.config.maxSteps) {
       throw new Error(`steps=<${state.steps}> | max steps reached`)
@@ -528,15 +596,10 @@ export class Graph implements MultiAgent {
       // skip if the target is already running or queued
       if (streams.has(edge.target.id) || targets.some((n) => n.id === edge.target.id)) continue
 
-      const deps = this.edges.filter((e) => e.target.id === edge.target.id)
-
-      // skip if any source node has not completed
-      if (deps.some((e) => state.node(e.source.id)?.status !== Status.COMPLETED)) continue
-
-      // skip if any edge handler rejects the transition
-      if (!(await Promise.all(deps.map((e) => e.handler(state)))).every(Boolean)) continue
-
-      ready.push(edge.target)
+      const incoming = this.edges.filter((e) => e.target.id === edge.target.id)
+      if (await this._allDependenciesSatisfied(incoming, state)) {
+        ready.push(edge.target)
+      }
     }
 
     return ready

--- a/test/integ/multiagent/session-manager.test.node.ts
+++ b/test/integ/multiagent/session-manager.test.node.ts
@@ -2,7 +2,6 @@
  * Integration tests for multi-agent session management (Swarm resume).
  * Node-only: uses FileStorage which requires fs.
  *
- * TODO: Add Graph resume tests once Graph resume is implemented.
  */
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
 import { promises as fs } from 'fs'
@@ -10,7 +9,15 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { v7 as uuidv7 } from 'uuid'
 import { Agent } from '$/sdk/agent/agent.js'
-import { Swarm, Status } from '$/sdk/multiagent/index.js'
+import {
+  Swarm,
+  Status,
+  Graph,
+  BeforeNodeCallEvent,
+  BeforeMultiAgentInvocationEvent,
+  MultiAgentState,
+} from '$/sdk/multiagent/index.js'
+import type { EdgeDefinition } from '$/sdk/multiagent/index.js'
 import { SessionManager } from '$/sdk/session/session-manager.js'
 import { FileStorage } from '$/sdk/session/file-storage.js'
 import { bedrock } from '../__fixtures__/model-providers.js'
@@ -86,5 +93,246 @@ describe.skipIf(bedrock.skip)('Multi-Agent Session Management - Swarm', () => {
 
     const text = result.content.find((b) => b.type === 'textBlock')
     expect(text?.text).toMatch(/Everest/i)
+  })
+})
+
+// ─── Graph Resume ────────────────────────────────────────────────────────────
+describe.skipIf(bedrock.skip)('Multi-Agent Session Management - Graph', () => {
+  const createModel = (maxTokens = 1024) => bedrock.createModel({ maxTokens })
+  let tempDir: string
+
+  beforeAll(async () => {
+    tempDir = join(tmpdir(), `strands-graph-session-integ-${Date.now()}`)
+    await fs.mkdir(tempDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Graph topology (parallel branches + sub-graph):
+   *
+   *   researcher ──→ analyst ──→ reporter
+   *       │                         ↑
+   *       └──→ sub-graph ───────────┘
+   *             (drafter → reviewer)
+   *
+   * - `researcher` is the source node.
+   * - `analyst` and `sub-graph` run in parallel after researcher completes.
+   * - `reporter` waits for both analyst AND sub-graph (AND-join).
+   * - `sub-graph` is a nested Graph with two nodes: drafter → reviewer.
+   *
+   * First run: researcher and analyst complete, sub-graph is cancelled via hook.
+   * Resume: sub-graph executes (dep researcher=COMPLETED), then reporter fires
+   *         (deps analyst=COMPLETED, sub-graph=COMPLETED).
+   *
+   * This tests:
+   * - sessionManager constructor arg (not plugins)
+   * - parallel execution (default maxConcurrency)
+   * - sub-graph (MultiAgentNode) resume
+   * - AND-join dependency resolution across resume boundary
+   * - cross-boundary data flow (reporter receives outputs from both runs)
+   */
+  it('resumes graph with parallel branches and sub-graph across session boundary', async () => {
+    const sessionId = uuidv7()
+    const graphId = 'resume-subgraph'
+
+    function makeAgent(id: string, prompt: string) {
+      return new Agent({ model: createModel(), printer: false, id, systemPrompt: prompt })
+    }
+
+    function createSubGraph() {
+      return new Graph({
+        id: 'sub-graph',
+        nodes: [
+          makeAgent('drafter', 'You are a drafter. Write a one-sentence draft about the topic.'),
+          makeAgent(
+            'reviewer',
+            'You are a reviewer. Improve the draft in one sentence. Mention "Everest" if the topic is about mountains.'
+          ),
+        ],
+        edges: [['drafter', 'reviewer']],
+      })
+    }
+
+    function createNodes() {
+      return [
+        makeAgent('researcher', 'You are a researcher. State the topic of the question in one sentence.'),
+        makeAgent('analyst', 'You are an analyst. Add one key fact about the topic from the researcher.'),
+        createSubGraph(),
+        makeAgent(
+          'reporter',
+          'You are a reporter. Combine all inputs into a final two-sentence summary. Mention "Everest" if the topic is about mountains.'
+        ),
+      ]
+    }
+
+    const edges: [string, string][] = [
+      ['researcher', 'analyst'],
+      ['researcher', 'sub-graph'],
+      ['analyst', 'reporter'],
+      ['sub-graph', 'reporter'],
+    ]
+
+    // ── Run 1: cancel sub-graph so only researcher + analyst complete ──
+    const graph1 = new Graph({
+      id: graphId,
+      nodes: createNodes(),
+      edges,
+      sessionManager: makeSessionManager(sessionId, tempDir),
+    })
+
+    graph1.addHook(BeforeNodeCallEvent, (event) => {
+      if (event.nodeId === 'sub-graph') {
+        event.cancel = 'simulated crash'
+      }
+    })
+
+    const result1 = await graph1.invoke('What is the tallest mountain in the world?')
+
+    const completedRun1 = result1.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+    expect(completedRun1).toContain('researcher')
+    expect(completedRun1).toContain('analyst')
+    expect(completedRun1).not.toContain('sub-graph')
+    expect(completedRun1).not.toContain('reporter')
+
+    // Verify sessionManager property is accessible
+    expect(graph1.sessionManager).toBeDefined()
+
+    // ── Run 2: fresh Graph + SessionManager, no cancel hook ──
+    const graph2 = new Graph({
+      id: graphId,
+      nodes: createNodes(),
+      edges,
+      sessionManager: makeSessionManager(sessionId, tempDir),
+    })
+
+    const result2 = await graph2.invoke('What is the tallest mountain in the world?')
+
+    const completedRun2 = result2.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+
+    // Sub-graph and reporter should now be completed
+    expect(completedRun2).toContain('sub-graph')
+    expect(completedRun2).toContain('reporter')
+
+    // Researcher and analyst should not be re-executed (exactly one COMPLETED each)
+    expect(completedRun2.filter((id) => id === 'researcher')).toHaveLength(1)
+    expect(completedRun2.filter((id) => id === 'analyst')).toHaveLength(1)
+
+    // All completed nodes produced content
+    for (const nodeResult of result2.results.filter((r) => r.status === Status.COMPLETED)) {
+      expect(nodeResult.content.length).toBeGreaterThan(0)
+    }
+
+    // Reporter is the terminus — verify it received data from both branches
+    // (analyst from run 1, sub-graph from run 2) by checking for topic-relevant content
+    const reporterText = result2.results
+      .filter((r) => r.nodeId === 'reporter' && r.status === Status.COMPLETED)
+      .flatMap((r) => r.content)
+      .find((b) => b.type === 'textBlock')?.text
+    expect(reporterText).toBeTruthy()
+    expect(reporterText).toMatch(/Everest|mountain|tallest/i)
+  })
+
+  /**
+   * Graph topology with conditional edge:
+   *
+   *   researcher ──→ writer  (conditional: only if app state has 'approved' flag)
+   *       │              ↑
+   *       └──→ analyst ──┘  (unconditional)
+   *
+   * - `researcher` and `analyst` are sources (no incoming edges).
+   * - `writer` has an AND-join: needs both researcher and analyst COMPLETED,
+   *   AND the researcher→writer conditional edge handler to return true.
+   *
+   * Run 1: researcher and analyst both complete normally. But the conditional
+   *   edge handler checks `state.app.get('approved')` which is not set, so
+   *   _findReady evaluates the handler → false → writer is blocked.
+   *   All deps are COMPLETED but the handler rejects the transition.
+   *
+   * Run 2 (resume): state is restored (researcher=COMPLETED, analyst=COMPLETED,
+   *   writer=PENDING). A BeforeMultiAgentInvocationEvent hook sets approved=true.
+   *   _findResumeTargets evaluates the handler via _allDependenciesSatisfied
+   *   → true → writer is ready and executes.
+   *
+   * This directly tests that _findResumeTargets evaluates edge handlers,
+   * not just source node statuses.
+   */
+  it('resumes with conditional edge handlers evaluated correctly', async () => {
+    const sessionId = uuidv7()
+    const graphId = 'resume-conditional'
+
+    function makeAgent(id: string, prompt: string) {
+      return new Agent({ model: createModel(), printer: false, id, systemPrompt: prompt })
+    }
+
+    function createNodes() {
+      return [
+        makeAgent('researcher', 'You are a researcher. State one fact about the topic.'),
+        makeAgent('analyst', 'You are an analyst. Add one supporting detail about the topic.'),
+        makeAgent(
+          'writer',
+          'You are a writer. Write a polished one-sentence answer. Mention "Everest" if the topic is about mountains.'
+        ),
+      ]
+    }
+
+    const edges: EdgeDefinition[] = [
+      {
+        source: 'researcher',
+        target: 'writer',
+        handler: (state: MultiAgentState) => state.app.get('approved') === true,
+      },
+      ['analyst', 'writer'],
+    ]
+
+    // ── Run 1: no approval flag → writer blocked by handler despite all deps COMPLETED ──
+    const graph1 = new Graph({
+      id: graphId,
+      nodes: createNodes(),
+      edges,
+      sessionManager: makeSessionManager(sessionId, tempDir),
+    })
+
+    const result1 = await graph1.invoke('What is the tallest mountain?')
+
+    const completedRun1 = result1.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+    expect(completedRun1).toContain('researcher')
+    expect(completedRun1).toContain('analyst')
+    // Writer should NOT have run — both deps are COMPLETED but the handler returned false
+    expect(completedRun1).not.toContain('writer')
+
+    // ── Run 2: set approval flag before resume so handler passes ──
+    const graph2 = new Graph({
+      id: graphId,
+      nodes: createNodes(),
+      edges,
+      sessionManager: makeSessionManager(sessionId, tempDir),
+    })
+
+    // Initialize first so the session manager's restore hook is registered,
+    // then add our hook — hooks run in registration order, so restore happens
+    // before we set the flag.
+    await graph2.initialize()
+    graph2.addHook(BeforeMultiAgentInvocationEvent, (event) => {
+      event.state.app.set('approved', true)
+    })
+
+    const result2 = await graph2.invoke('What is the tallest mountain?')
+
+    const completedRun2 = result2.results.filter((r) => r.status === Status.COMPLETED).map((r) => r.nodeId)
+    expect(completedRun2).toContain('writer')
+
+    // Researcher and analyst should not be re-executed
+    expect(completedRun2.filter((id) => id === 'researcher')).toHaveLength(1)
+    expect(completedRun2.filter((id) => id === 'analyst')).toHaveLength(1)
+
+    const writerText = result2.results
+      .filter((r) => r.nodeId === 'writer' && r.status === Status.COMPLETED)
+      .flatMap((r) => r.content)
+      .find((b) => b.type === 'textBlock')?.text
+    expect(writerText).toBeTruthy()
+    expect(writerText).toMatch(/Everest|mountain|tallest/i)
   })
 })

--- a/test/integ/multiagent/session-manager.test.node.ts
+++ b/test/integ/multiagent/session-manager.test.node.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for multi-agent session management (Swarm resume).
+ * Integration tests for multi-agent session management (Swarm and Graph resume).
  * Node-only: uses FileStorage which requires fs.
  *
  */


### PR DESCRIPTION
## Description

Adds Graph resume support via SessionManager, bringing Graph to parity with Swarm's existing session management capabilities.

### Changes

**`src/multiagent/graph.ts`**
- Added `sessionManager` as a first-class constructor option on `GraphOptions` (matching Swarm's API), with duplicate-detection guard that throws if the same session manager appears in both `sessionManager` and `plugins`.
- Added `_findResumeTargets()` — on resume, identifies nodes that are ready to execute based on restored state. Any non-COMPLETED node whose dependencies are all COMPLETED (with edge handlers satisfied) becomes a resume target. Returns `undefined` for fresh starts (no restored state or all nodes already completed).
- Extracted `_allDependenciesSatisfied()` to share dependency-checking logic between `_findReady()` and `_findResumeTargets()`. This also fixes a subtle behavioral difference: the old `_findReady` evaluated edge handlers in parallel via `Promise.all`, while the new shared method evaluates sequentially with short-circuit, which is safer for handlers with side effects.
- Refactored `_findReady()` to use `_allDependenciesSatisfied()`, eliminating duplicated dependency-check logic.

**`src/multiagent/__tests__/graph.test.ts`**
- Added `resume with session manager` test suite covering:
  - Linear graph resume (A→B→C, A completes, maxSteps stops, resumes at B)
  - Parallel branch resume (A→B, A→C, C cancelled, resumes at C)
  - Fresh start when all nodes already completed
  - Conditional edge handlers respected on resume (handler returns false → node stays blocked)

**`test/integ/multiagent/session-manager.test.node.ts`**
- Added Graph resume integration tests alongside existing Swarm tests:
  - Parallel branches + sub-graph resume: tests `sessionManager` constructor arg, `MultiAgentNode` resume, AND-join across resume boundary, cross-boundary data flow
  - Conditional edge handler resume: tests that `_findResumeTargets` evaluates edge handlers (not just node statuses), with a `BeforeMultiAgentInvocationEvent` hook modifying `state.app` to flip the handler result between runs

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

### Unit tests
4 new tests in `src/multiagent/__tests__/graph.test.ts` covering resume scenarios with `MockSnapshotStorage`.

### Integration tests
2 new tests in `test/integ/multiagent/session-manager.test.node.ts` using real Bedrock models and `FileStorage` to verify end-to-end resume across process boundaries.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
