### PR TITLE
feat(a2a): support custom ClientFactory in A2AAgent for authenticated requests

### DIFF
--- a/src/a2a/__tests__/a2a-agent.test.ts
+++ b/src/a2a/__tests__/a2a-agent.test.ts
@@ -190,6 +190,29 @@ describe('A2AAgent', () => {
       await agent.invoke('Hello')
       expect(mockGetAgentCard).toHaveBeenCalledOnce()
     })
+
+    it('uses custom clientFactory when provided', async () => {
+      const customSendMessageStream = vi.fn().mockReturnValue(mockStream(createMockTaskResponse()))
+      const customGetAgentCard = vi.fn().mockResolvedValue(mockAgentCard)
+      const customCreateFromUrl = vi.fn().mockResolvedValue({
+        sendMessageStream: customSendMessageStream,
+        getAgentCard: customGetAgentCard,
+      })
+      const customFactory = { createFromUrl: customCreateFromUrl }
+
+      const agent = new A2AAgent({
+        url: 'http://localhost:9000',
+        clientFactory: customFactory as never,
+      })
+
+      await agent.invoke('Hello')
+
+      expect(customCreateFromUrl).toHaveBeenCalledWith('http://localhost:9000', undefined)
+      expect(customGetAgentCard).toHaveBeenCalledOnce()
+      expect(customSendMessageStream).toHaveBeenCalledOnce()
+      // Default mock should not have been called
+      expect(mockSendMessageStream).not.toHaveBeenCalled()
+    })
   })
 
   describe('stream', () => {

--- a/src/a2a/a2a-agent.ts
+++ b/src/a2a/a2a-agent.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AgentCard, Part } from '@a2a-js/sdk'
-import type { Client as A2AClientSdk } from '@a2a-js/sdk/client'
+import type { Client as A2AClientSdk, ClientFactory as ClientFactoryType } from '@a2a-js/sdk/client'
 import { ClientFactory } from '@a2a-js/sdk/client'
 import type { InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
 import { AgentResult } from '../types/agent.js'
@@ -31,6 +31,8 @@ export interface A2AAgentConfig {
   name?: string
   /** Optional description. If not provided, populated from the agent card after connection. */
   description?: string
+  /** Optional custom A2A ClientFactory for authenticating requests (e.g. SigV4, bearer token). */
+  clientFactory?: ClientFactoryType
 }
 
 /**
@@ -170,7 +172,7 @@ export class A2AAgent implements InvokableAgent {
 
     logExperimentalWarning()
 
-    const factory = new ClientFactory()
+    const factory = this._config.clientFactory ?? new ClientFactory()
     const client = await factory.createFromUrl(this._config.url, this._config.agentCardPath)
     this._agentCard = await client.getAgentCard()
     if (this.name === undefined && this._agentCard?.name) {


### PR DESCRIPTION
## Motivation

The `A2AAgent` currently always creates a default `ClientFactory` internally, providing no way to customize how HTTP requests are made to the remote A2A server. This prevents users from authenticating requests with mechanisms like SigV4 signing or bearer tokens, which is required when invoking A2A agents on services like [Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html).

The Python SDK already supports this by accepting a custom A2A client factory in its `A2AAgent` class.

Resolves: #802

## Public API Changes

`A2AAgentConfig` now accepts an optional `clientFactory` parameter:

```typescript
// Before: no way to authenticate requests
const agent = new A2AAgent({ url: "http://localhost:9000" })

// After: pass a custom ClientFactory for authenticated requests
const sigv4Fetch = ...
const a2aClientFactory = new ClientFactory(
  ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
    transports: [new JsonRpcTransportFactory({ fetchImpl: sigv4Fetch })],
    cardResolver: new DefaultAgentCardResolver({ fetchImpl: sigv4Fetch }),
  }),
)

const agent = new A2AAgent({
  url: "http://localhost:9000",
  clientFactory: a2aClientFactory,
})
```

When no `clientFactory` is provided, the default `ClientFactory` is used — fully backward compatible.

## Use Cases

- **SigV4 authentication**: Sign requests when invoking A2A agents on Bedrock AgentCore
- **Bearer token authentication**: Pass JWT or other bearer tokens for authenticated endpoints
- **Custom transport**: Provide any custom fetch implementation for specialized networking requirements