### PR TITLE
fix(tool): added function replacer for notebook_tool replace

### DIFF
--- a/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -195,6 +195,22 @@ describe('notebook tool', () => {
       expect(notebooks!.default).toBe('# Todo List\n\n[x] Task 1\n[x] Task 2\n[x] Task 3')
     })
 
+    it('preserves dollar sign patterns in newStr literally', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { default: 'const value = getPrice()' })
+      const result = await notebook.invoke(
+        {
+          mode: 'write',
+          oldStr: 'getPrice()',
+          newStr: '$& is not $1 or $$',
+        },
+        context
+      )
+      expect(result).toBe("Replaced text in notebook 'default'")
+      const notebooks = state.get<NotebookState>('notebooks')
+      expect(notebooks!.default).toBe('const value = $& is not $1 or $$')
+    })
+
     it('throws error if old string not found', async () => {
       const { state, context } = createFreshContext()
       state.set('notebooks', { default: '# Todo List\n\n[ ] Task 1\n[ ] Task 2\n[x] Task 3' })

--- a/src/vended-tools/notebook/notebook.ts
+++ b/src/vended-tools/notebook/notebook.ts
@@ -202,7 +202,7 @@ function handleWrite(
       throw new Error(`String '${oldStr}' not found in notebook '${name}'`)
     }
 
-    notebooks[name] = notebooks[name]!.replace(oldStr, newStr)
+    notebooks[name] = notebooks[name]!.replace(oldStr, () => newStr)
     return `Replaced text in notebook '${name}'`
   }
 


### PR DESCRIPTION
## Description
Similar to the fix of this PR: https://github.com/strands-agents/sdk-typescript/pull/688

Added function replacement which bypasses all `$-pattern` processing to prevent content injection.

## Documentation PR

N/A

## Type of Change

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
