### PR TITLE
feat: expose metrics/usage on message metadata

### DIFF
--- a/src/models/__tests__/model.test.ts
+++ b/src/models/__tests__/model.test.ts
@@ -78,6 +78,9 @@ describe('Model', () => {
             type: 'message',
             role: 'assistant',
             content: [{ type: 'textBlock', text: 'Hello' }],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {
@@ -153,6 +156,9 @@ describe('Model', () => {
               { type: 'textBlock', text: 'First' },
               { type: 'textBlock', text: 'Second' },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {
@@ -214,6 +220,9 @@ describe('Model', () => {
                 input: { location: 'Paris' },
               },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 8, totalTokens: 18 },
+            },
           },
           stopReason: 'toolUse',
           metadata: {
@@ -269,6 +278,9 @@ describe('Model', () => {
                 input: {},
               },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 8, totalTokens: 18 },
+            },
           },
           stopReason: 'toolUse',
           metadata: {
@@ -377,6 +389,9 @@ describe('Model', () => {
                 signature: 'sig1',
               },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {
@@ -425,6 +440,9 @@ describe('Model', () => {
                 redactedContent: new Uint8Array(0),
               },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {
@@ -473,6 +491,9 @@ describe('Model', () => {
                 text: 'Thinking',
               },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {
@@ -541,6 +562,9 @@ describe('Model', () => {
               { type: 'toolUseBlock', toolUseId: 'tool1', name: 'get_weather', input: { city: 'Paris' } },
               { type: 'reasoningBlock', text: 'Reasoning', signature: 'sig1' },
             ],
+            metadata: {
+              usage: { inputTokens: 10, outputTokens: 15, totalTokens: 25 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {
@@ -594,6 +618,10 @@ describe('Model', () => {
             type: 'message',
             role: 'assistant',
             content: [{ type: 'textBlock', text: 'Hello' }],
+            metadata: {
+              usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+              metrics: { latencyMs: 100 },
+            },
           },
           stopReason: 'endTurn',
           metadata: {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,6 +1,7 @@
 import {
   type ContentBlock,
   Message,
+  type MessageMetadata,
   ReasoningBlock,
   type Role,
   type StopReason,
@@ -383,6 +384,19 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       if (!stoppedMessage || !finalStopReason) {
         // If we exit the loop without completing a message or stop reason, throw an error
         throw new ModelError('Stream ended without completing a message')
+      }
+
+      // Attach metadata after redaction so it applies to the final message.
+      const messageMetadata: MessageMetadata = {
+        ...(metadata?.usage !== undefined && { usage: metadata.usage }),
+        ...(metadata?.metrics !== undefined && { metrics: metadata.metrics }),
+      }
+      if (Object.keys(messageMetadata).length > 0) {
+        stoppedMessage = new Message({
+          role: stoppedMessage.role,
+          content: stoppedMessage.content,
+          metadata: messageMetadata,
+        })
       }
 
       // Handle stop reason

--- a/src/types/__tests__/messages.test.ts
+++ b/src/types/__tests__/messages.test.ts
@@ -29,6 +29,89 @@ describe('Message', () => {
   })
 })
 
+describe('Message metadata', () => {
+  test('creates message without metadata', () => {
+    const message = new Message({ role: 'user', content: [new TextBlock('test')] })
+    expect(message.metadata).toBeUndefined()
+  })
+
+  test('creates message with metadata', () => {
+    const metadata = {
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      metrics: { latencyMs: 100 },
+    }
+    const message = new Message({ role: 'assistant', content: [new TextBlock('hello')], metadata })
+    expect(message.metadata).toStrictEqual(metadata)
+  })
+
+  test('creates message with custom metadata', () => {
+    const metadata = {
+      custom: { source: 'summarization', originalTurns: [5, 6, 7] },
+    }
+    const message = new Message({ role: 'assistant', content: [new TextBlock('summary')], metadata })
+    expect(message.metadata).toStrictEqual(metadata)
+  })
+
+  test('toJSON includes metadata when present', () => {
+    const metadata = {
+      usage: { inputTokens: 42, outputTokens: 10, totalTokens: 52 },
+      metrics: { latencyMs: 200 },
+    }
+    const message = new Message({ role: 'assistant', content: [new TextBlock('test')], metadata })
+    const json = message.toJSON()
+    expect(json.metadata).toStrictEqual(metadata)
+  })
+
+  test('toJSON omits metadata when not present', () => {
+    const message = new Message({ role: 'user', content: [new TextBlock('test')] })
+    const json = message.toJSON()
+    expect('metadata' in json).toBe(false)
+  })
+
+  test('fromMessageData preserves metadata', () => {
+    const data: MessageData = {
+      role: 'assistant',
+      content: [{ text: 'hello' }],
+      metadata: {
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        metrics: { latencyMs: 100 },
+      },
+    }
+    const message = Message.fromMessageData(data)
+    expect(message.metadata).toStrictEqual(data.metadata)
+  })
+
+  test('fromMessageData works without metadata', () => {
+    const data: MessageData = {
+      role: 'user',
+      content: [{ text: 'hello' }],
+    }
+    const message = Message.fromMessageData(data)
+    expect(message.metadata).toBeUndefined()
+  })
+
+  test('round-trips metadata through toJSON/fromJSON', () => {
+    const metadata = {
+      usage: { inputTokens: 42, outputTokens: 10, totalTokens: 52 },
+      metrics: { latencyMs: 200 },
+      custom: { source: 'test' },
+    }
+    const original = new Message({ role: 'assistant', content: [new TextBlock('test')], metadata })
+    const restored = Message.fromJSON(original.toJSON())
+    expect(restored.metadata).toStrictEqual(metadata)
+  })
+
+  test('round-trips metadata through JSON.stringify/parse', () => {
+    const metadata = {
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    }
+    const original = new Message({ role: 'assistant', content: [new TextBlock('test')], metadata })
+    const jsonString = JSON.stringify(original)
+    const restored = Message.fromJSON(JSON.parse(jsonString))
+    expect(restored.metadata).toStrictEqual(metadata)
+  })
+})
+
 describe('TextBlock', () => {
   test('creates text block with text', () => {
     const block = new TextBlock('hello')

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -4,6 +4,7 @@ import type { ImageBlockData, VideoBlockData, DocumentBlockData } from './media.
 import { ImageBlock, VideoBlock, DocumentBlock, encodeBase64, decodeBase64 } from './media.js'
 import type { CitationsBlockData } from './citations.js'
 import { CitationsBlock } from './citations.js'
+import type { Usage, Metrics } from '../models/streaming.js'
 
 /**
  * Message types and content blocks for conversational AI interactions.
@@ -12,6 +13,21 @@ import { CitationsBlock } from './citations.js'
  * for objects, while corresponding classes extend those interfaces with additional
  * functionality and type discrimination.
  */
+
+/**
+ * Optional metadata attached to a message.
+ *
+ * Not sent to model providers — model providers construct their own message format
+ * from `role` and `content` only. Persisted alongside the message in session storage.
+ */
+export interface MessageMetadata {
+  /** Token usage information from the model response. */
+  usage?: Usage
+  /** Performance metrics from the model response. */
+  metrics?: Metrics
+  /** Arbitrary user/framework metadata (e.g. compression provenance). */
+  custom?: Record<string, JSONValue>
+}
 
 /**
  * Data for a message.
@@ -26,6 +42,11 @@ export interface MessageData {
    * Array of content blocks that make up this message.
    */
   content: ContentBlockData[]
+
+  /**
+   * Optional metadata, not sent to model providers.
+   */
+  metadata?: MessageMetadata
 }
 
 /**
@@ -48,9 +69,17 @@ export class Message implements JSONSerializable<MessageData> {
    */
   readonly content: ContentBlock[]
 
-  constructor(data: { role: Role; content: ContentBlock[] }) {
+  /**
+   * Optional metadata, not sent to model providers.
+   */
+  readonly metadata?: MessageMetadata
+
+  constructor(data: { role: Role; content: ContentBlock[]; metadata?: MessageMetadata }) {
     this.role = data.role
     this.content = data.content
+    if (data.metadata !== undefined) {
+      this.metadata = data.metadata
+    }
   }
 
   /**
@@ -62,6 +91,7 @@ export class Message implements JSONSerializable<MessageData> {
     return new Message({
       role: data.role,
       content: contentBlocks,
+      ...(data.metadata !== undefined && { metadata: data.metadata }),
     })
   }
 
@@ -73,6 +103,7 @@ export class Message implements JSONSerializable<MessageData> {
     return {
       role: this.role,
       content: this.content.map((block) => block.toJSON() as ContentBlockData),
+      ...(this.metadata !== undefined && { metadata: this.metadata }),
     }
   }
 


### PR DESCRIPTION
## Description

Adds an optional `metadata` field to `Message` that carries per-message `usage`, `metrics`, and arbitrary `custom` data from model responses. This is a foundational piece for the context management roadmap — downstream features like proactive compression, smart truncation, and per-message cost analysis need this information attached directly to messages.

**What it does:**
- Adds `MessageMetadata` interface with optional `usage`, `metrics`, and `custom` fields
- Adds optional `metadata` to `MessageData` interface and `Message` class
- Populates `metadata` on assistant messages in `streamAggregated` after stream processing, before `AfterModelCallEvent` fires (so all hook consumers see consistent state)
- Metadata is not sent to model providers — providers construct their own message format from `role` and `content` only
- Metadata round-trips through `toJSON()`/`fromJSON()` for session persistence

**API surface note:** `MessageData` and `Message` are public types, so the optional `metadata` field is a visible (but backward-compatible) addition. `MessageMetadata` itself is not exported from the package root — users can reference it via `Message['metadata']` if needed.

TypeScript replica of [strands-agents/sdk-python#2125](https://github.com/strands-agents/sdk-python/pull/2125).

## Related Issues

Closes #1532

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?
- Added 8 unit tests for `MessageMetadata` in `messages.test.ts`: construction with/without metadata, `toJSON()` inclusion/omission, `fromMessageData()` preservation, and full round-trip through `JSON.stringify`/`parse`
- Updated 9 existing assertions in `model.test.ts` to account for `metadata` presence on assistant messages
- All existing tests pass
- [x] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.