### PR TITLE
feat/added Agent retry strategy in parity with pythonSDK(#472)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,8 @@ function sdkRules(options) {
       globals: {
         console: 'readonly',
         process: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
       },
     },
     plugins: {

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -61,6 +61,7 @@ import {
 import { StructuredOutputTool, STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
 import { AgentAsTool } from './agent-as-tool.js'
 import type { AgentAsToolOptions } from './agent-as-tool.js'
+import { ModelRetryStrategy, type RetryStrategyConfig } from '../event-loop/retry.js'
 
 import type { z } from 'zod'
 import { SessionManager } from '../session/session-manager.js'
@@ -162,6 +163,14 @@ export type AgentConfig = {
    * Optional unique identifier for the agent. Defaults to "agent".
    */
   id?: string
+  /**
+   * Retry strategy for handling model throttling.
+   *
+   * - Omit (default): Uses default RetryStrategyConfig.
+   * - Pass a RetryStrategyConfig object: Uses your custom configuration.
+   * - Pass null: Disables retries entirely.
+   */
+  retryStrategy?: RetryStrategyConfig | null
 }
 
 /** Default name assigned to agents when none is provided. */
@@ -234,6 +243,8 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _tracer: Tracer
   /** Meter instance for accumulating loop metrics during invocation. */
   private _meter: Meter
+  /** The default retry strategy config for handling model throttling */
+  public readonly _defaultRetryStrategyConfig: RetryStrategyConfig | null
 
   /**
    * Creates an instance of the Agent.
@@ -261,6 +272,12 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Initialize hooks registry
     this._hooksRegistry = new HookRegistryImplementation()
+
+    if (config?.retryStrategy === undefined) {
+      this._defaultRetryStrategyConfig = {}
+    } else {
+      this._defaultRetryStrategyConfig = config.retryStrategy
+    }
 
     // Initialize plugin registry with all plugins to be initialized during initialize()
     this._pluginRegistry = new PluginRegistry([
@@ -500,6 +517,17 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     await this.initialize()
 
+    const retryConfig = options?.retryStrategy ?? this._defaultRetryStrategyConfig
+    const retryHooksCleanup: (() => void)[] = []
+
+    if (retryConfig !== null) {
+      const retryStrategy = new ModelRetryStrategy(retryConfig)
+      retryHooksCleanup.push(this.addHook(AfterModelCallEvent, retryStrategy.handleAfterModelCall.bind(retryStrategy)))
+      retryHooksCleanup.push(
+        this.addHook(AfterInvocationEvent, retryStrategy.handleAfterInvocation.bind(retryStrategy))
+      )
+    }
+
     // Delegate to _stream and process events through printer and hooks
     const streamGenerator = this._stream(args, options)
     let caughtError: Error | undefined
@@ -534,6 +562,9 @@ export class Agent implements LocalAgent, InvokableAgent {
         }
         result = await streamGenerator.next()
       }
+
+      // Cleanup dynamically bound hooks for this invocation
+      retryHooksCleanup.forEach((cleanup) => cleanup())
 
       // Reset controller and signal for next invocation
       this._abortController = new AbortController()

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -517,7 +517,9 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     await this.initialize()
 
-    const retryConfig = options?.retryStrategy ?? this._defaultRetryStrategyConfig
+    const retryConfig = options?.retryStrategy
+      ? { ...this._defaultRetryStrategyConfig, ...options.retryStrategy }
+      : this._defaultRetryStrategyConfig
     const retryHooksCleanup: (() => void)[] = []
 
     if (retryConfig !== null) {
@@ -917,89 +919,91 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *_invokeModel(
     toolChoice?: ToolChoice
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
-    const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
-    const streamOptions: StreamOptions = { toolSpecs }
-    if (this.systemPrompt !== undefined) {
-      streamOptions.systemPrompt = this.systemPrompt
-    }
+    while (true) {
+      const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
+      const streamOptions: StreamOptions = { toolSpecs }
+      if (this.systemPrompt !== undefined) {
+        streamOptions.systemPrompt = this.systemPrompt
+      }
 
-    // Add tool choice if provided
-    if (toolChoice) {
-      streamOptions.toolChoice = toolChoice
-    }
+      // Add tool choice if provided
+      if (toolChoice) {
+        streamOptions.toolChoice = toolChoice
+      }
 
-    yield new BeforeModelCallEvent({ agent: this, model: this.model })
+      yield new BeforeModelCallEvent({ agent: this, model: this.model })
 
-    // Start model span within loop span context
-    const modelId = this.model.modelId
-    const modelSpan = this._tracer.startModelInvokeSpan({
-      messages: this.messages,
-      ...(modelId && { modelId }),
-      ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
-    })
-
-    try {
-      const result = yield* this._streamFromModel(this.messages, streamOptions)
-
-      // Accumulate token usage and model latency metrics
-      this._meter.updateCycle(result.metadata)
-
-      // End model span with usage
-      const usage = result.metadata?.usage
-      const metrics = result.metadata?.metrics
-      this._tracer.endModelInvokeSpan(modelSpan, {
-        output: result.message,
-        stopReason: result.stopReason,
-        ...(usage && { usage }),
-        ...(metrics && { metrics }),
+      // Start model span within loop span context
+      const modelId = this.model.modelId
+      const modelSpan = this._tracer.startModelInvokeSpan({
+        messages: this.messages,
+        ...(modelId && { modelId }),
+        ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
       })
 
-      yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
+      try {
+        const result = yield* this._streamFromModel(this.messages, streamOptions)
 
-      // Handle user content redaction if guardrails blocked input
-      if (result.redaction?.userMessage) {
-        this._redactLastMessage(result.redaction.userMessage)
-      }
+        // Accumulate token usage and model latency metrics
+        this._meter.updateCycle(result.metadata)
 
-      const stopData: ModelStopData = {
-        message: result.message,
-        stopReason: result.stopReason,
-        ...(result.redaction && { redaction: result.redaction }),
-      }
+        // End model span with usage
+        const usage = result.metadata?.usage
+        const metrics = result.metadata?.metrics
+        this._tracer.endModelInvokeSpan(modelSpan, {
+          output: result.message,
+          stopReason: result.stopReason,
+          ...(usage && { usage }),
+          ...(metrics && { metrics }),
+        })
 
-      const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, stopData })
-      yield afterModelCallEvent
+        yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
 
-      if (afterModelCallEvent.retry) {
-        return yield* this._invokeModel(toolChoice)
-      }
+        // Handle user content redaction if guardrails blocked input
+        if (result.redaction?.userMessage) {
+          this._redactLastMessage(result.redaction.userMessage)
+        }
 
-      return result
-    } catch (error) {
-      const modelError = normalizeError(error)
+        const stopData: ModelStopData = {
+          message: result.message,
+          stopReason: result.stopReason,
+          ...(result.redaction && { redaction: result.redaction }),
+        }
 
-      // End model span with error
-      this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
+        const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, stopData })
+        yield afterModelCallEvent
 
-      // Create error event
-      const errorEvent = new AfterModelCallEvent({ agent: this, model: this.model, error: modelError })
+        if (afterModelCallEvent.retry) {
+          continue
+        }
 
-      // Yield error event - stream will invoke hooks
-      yield errorEvent
+        return result
+      } catch (error) {
+        const modelError = normalizeError(error)
 
-      // Let CancelledError propagate directly — no retry
-      // (we emit the AfterModelCall because we already emitted Before and we guarentee the pair)
-      if (error instanceof CancelledError) {
+        // End model span with error
+        this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
+
+        // Create error event
+        const errorEvent = new AfterModelCallEvent({ agent: this, model: this.model, error: modelError })
+
+        // Yield error event - stream will invoke hooks
+        yield errorEvent
+
+        // Let CancelledError propagate directly — no retry
+        // (we emit the AfterModelCall because we already emitted Before and we guarentee the pair)
+        if (error instanceof CancelledError) {
+          throw error
+        }
+
+        // After yielding, hooks have been invoked and may have set retry
+        if (errorEvent.retry) {
+          continue
+        }
+
+        // Re-throw error
         throw error
       }
-
-      // After yielding, hooks have been invoked and may have set retry
-      if (errorEvent.retry) {
-        return yield* this._invokeModel(toolChoice)
-      }
-
-      // Re-throw error
-      throw error
     }
   }
 

--- a/src/event-loop/__tests__/retry.test.ts
+++ b/src/event-loop/__tests__/retry.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ModelRetryStrategy, ExponentialBackoff } from '../retry.js'
+import { AfterModelCallEvent, AfterInvocationEvent } from '../../hooks/events.js'
+import { ModelThrottledError } from '../../errors.js'
+import type { LocalAgent } from '../../types/agent.js'
+import { Message, TextBlock } from '../../types/messages.js'
+
+class CustomNetworkError extends Error {
+  constructor(message?: string) {
+    super(message)
+    this.name = 'CustomNetworkError'
+  }
+}
+
+describe('ModelRetryStrategy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const mockAgent = {} as LocalAgent
+  const mockModel = {} as any
+
+  describe('constructor', () => {
+    it('sets default values', () => {
+      const strategy = new ModelRetryStrategy()
+      expect(strategy['_maxAttempts']).toBe(6)
+      expect(strategy['_backoff'].initialDelay).toBe(1000)
+      expect(strategy['_backoff'].maxDelay).toBe(30000)
+      expect(strategy['_retryOn']).toEqual(['ModelThrottledError'])
+    })
+
+    it('accepts custom values', () => {
+      const strategy = new ModelRetryStrategy({
+        maxAttempts: 10,
+        backoff: new ExponentialBackoff({ initialDelay: 500, maxDelay: 10000 }),
+        retryOn: ['ModelThrottledError', 'CustomNetworkError'],
+      })
+      expect(strategy['_maxAttempts']).toBe(10)
+      expect(strategy['_backoff'].initialDelay).toBe(500)
+      expect(strategy['_backoff'].maxDelay).toBe(10000)
+      expect(strategy['_retryOn']).toContain('CustomNetworkError')
+    })
+
+    it('accepts maxAttempts=1 for no retries', () => {
+      const strategy = new ModelRetryStrategy({ maxAttempts: 1 })
+      expect(strategy['_maxAttempts']).toBe(1)
+    })
+  })
+
+  describe('_calculateDelay', () => {
+    it('returns initialDelay * 2^attempt for small attempt numbers', () => {
+      const strategy = new ModelRetryStrategy({
+        backoff: new ExponentialBackoff({ initialDelay: 4000, maxDelay: 240000 }),
+      })
+      expect(strategy._calculateDelay(0)).toBe(4000)
+      expect(strategy._calculateDelay(1)).toBe(8000)
+      expect(strategy._calculateDelay(2)).toBe(16000)
+      expect(strategy._calculateDelay(3)).toBe(32000)
+    })
+
+    it('returns maxDelay when the calculated value exceeds it', () => {
+      const strategy = new ModelRetryStrategy({
+        backoff: new ExponentialBackoff({ initialDelay: 4000, maxDelay: 60000 }),
+      })
+      expect(strategy._calculateDelay(0)).toBe(4000)
+      expect(strategy._calculateDelay(4)).toBe(60000) // 4000 * 2^4 = 64000 > 60000
+      expect(strategy._calculateDelay(5)).toBe(60000)
+    })
+  })
+
+  describe('handleAfterModelCall', () => {
+    it('does not set retry when event.retry is already true', async () => {
+      const strategy = new ModelRetryStrategy()
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new ModelThrottledError('test'),
+      })
+      event.retry = true
+
+      await strategy.handleAfterModelCall(event)
+      expect(strategy['_currentAttempt']).toBe(0)
+    })
+
+    it('resets state and does not retry on success (stopData present)', async () => {
+      const strategy = new ModelRetryStrategy()
+      strategy['_currentAttempt'] = 2
+
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        stopData: {
+          stopReason: 'end_turn',
+          message: new Message({ role: 'assistant', content: [new TextBlock('test')] }),
+        },
+      })
+
+      await strategy.handleAfterModelCall(event)
+      expect(strategy['_currentAttempt']).toBe(0)
+      expect(event.retry).toBeUndefined()
+    })
+
+    it('resets state and does not retry when no error', async () => {
+      const strategy = new ModelRetryStrategy()
+      strategy['_currentAttempt'] = 2
+
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+      })
+
+      await strategy.handleAfterModelCall(event)
+      expect(strategy['_currentAttempt']).toBe(0)
+      expect(event.retry).toBeUndefined()
+    })
+
+    it('does not retry on unlisted exceptions', async () => {
+      const strategy = new ModelRetryStrategy()
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new Error('Different error'),
+      })
+
+      await strategy.handleAfterModelCall(event)
+      expect(strategy['_currentAttempt']).toBe(0)
+      expect(event.retry).toBeUndefined()
+    })
+
+    it('retries on CustomNetworkError if listed in retryOn config', async () => {
+      const strategy = new ModelRetryStrategy({
+        backoff: new ExponentialBackoff({ initialDelay: 1000 }),
+        retryOn: ['CustomNetworkError'],
+      })
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new CustomNetworkError('socket hang up'),
+      })
+
+      const promise = strategy.handleAfterModelCall(event)
+      expect(strategy['_currentAttempt']).toBe(1)
+      await vi.advanceTimersByTimeAsync(1000)
+      await promise
+      expect(event.retry).toBe(true)
+    })
+
+    it('sets retry=true and sleeps on ModelThrottledError', async () => {
+      const strategy = new ModelRetryStrategy({ backoff: new ExponentialBackoff({ initialDelay: 4000 }) })
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new ModelThrottledError('throttle'),
+      })
+
+      const promise = strategy.handleAfterModelCall(event)
+
+      expect(strategy['_currentAttempt']).toBe(1)
+
+      // Advance timers by 4 seconds
+      await vi.advanceTimersByTimeAsync(4000)
+      await promise
+
+      expect(event.retry).toBe(true)
+    })
+
+    it('increments attempt and doubles delay on subsequent retries', async () => {
+      const strategy = new ModelRetryStrategy({ backoff: new ExponentialBackoff({ initialDelay: 4000 }) })
+
+      // Attempt 1 (0 -> 1)
+      const event1 = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new ModelThrottledError('throttle'),
+      })
+      const promise1 = strategy.handleAfterModelCall(event1)
+      expect(strategy['_currentAttempt']).toBe(1)
+      await vi.advanceTimersByTimeAsync(4000)
+      await promise1
+      expect(event1.retry).toBe(true)
+
+      // Attempt 2 (1 -> 2)
+      const event2 = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new ModelThrottledError('throttle'),
+      })
+      const promise2 = strategy.handleAfterModelCall(event2)
+      expect(strategy['_currentAttempt']).toBe(2)
+      await vi.advanceTimersByTimeAsync(8000)
+      await promise2
+      expect(event2.retry).toBe(true)
+    })
+
+    it('does not retry when max attempts are reached', async () => {
+      const strategy = new ModelRetryStrategy({ maxAttempts: 2 })
+      strategy['_currentAttempt'] = 1 // Already tried once (1 failed -> attempt=1. The second failure leads attempt=2)
+
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        error: new ModelThrottledError('throttle'),
+      })
+      await strategy.handleAfterModelCall(event)
+
+      // Hits maxAttempts
+      expect(strategy['_currentAttempt']).toBe(2)
+      expect(event.retry).toBeUndefined() // No retry requested
+    })
+  })
+
+  describe('handleAfterInvocation', () => {
+    it('resets currentAttempt to 0', async () => {
+      const strategy = new ModelRetryStrategy()
+      strategy['_currentAttempt'] = 3
+
+      await strategy.handleAfterInvocation(new AfterInvocationEvent({ agent: mockAgent }))
+
+      expect(strategy['_currentAttempt']).toBe(0)
+    })
+  })
+})

--- a/src/event-loop/retry.ts
+++ b/src/event-loop/retry.ts
@@ -1,0 +1,103 @@
+import { AfterModelCallEvent, AfterInvocationEvent } from '../hooks/events.js'
+import { logger } from '../logging/logger.js'
+
+export class ExponentialBackoff {
+  public initialDelay: number
+  public maxDelay: number
+
+  constructor({
+    initialDelay = 1000,
+    maxDelay = 30000,
+  }: {
+    initialDelay?: number
+    maxDelay?: number
+  } = {}) {
+    this.initialDelay = initialDelay
+    this.maxDelay = maxDelay
+  }
+}
+
+export interface RetryStrategyConfig {
+  maxAttempts?: number
+  backoff?: ExponentialBackoff
+  retryOn?: string[]
+}
+
+const DEFAULT_MAX_ATTEMPTS = 6
+const DEFAULT_RETRY_ON = ['ModelThrottledError']
+
+/**
+ * Underlying strategy instance that evaluates responses and applies backoff sleeps per Python SDK internal architecture.
+ */
+export class ModelRetryStrategy {
+  private readonly _maxAttempts: number
+  private readonly _backoff: ExponentialBackoff
+  private readonly _retryOn: string[]
+  private _currentAttempt: number = 0
+
+  constructor(config?: RetryStrategyConfig) {
+    this._maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+    this._backoff = config?.backoff ?? new ExponentialBackoff()
+    this._retryOn = config?.retryOn ?? DEFAULT_RETRY_ON
+  }
+
+  /**
+   * Calculate retry delay using exponential backoff.
+   * Formula: initialDelay * (2 ^ attempt), capped at maxDelay.
+   *
+   * @internal
+   */
+  _calculateDelay(attempt: number): number {
+    const delay = this._backoff.initialDelay * Math.pow(2, attempt)
+    return Math.min(delay, this._backoff.maxDelay)
+  }
+
+  private _resetRetryState(): void {
+    this._currentAttempt = 0
+  }
+
+  public async handleAfterModelCall(event: AfterModelCallEvent): Promise<void> {
+    const delay = this._calculateDelay(this._currentAttempt)
+
+    if (event.retry) {
+      return
+    }
+
+    if (event.stopData != null) {
+      this._resetRetryState()
+      return
+    }
+
+    if (event.error == null) {
+      this._resetRetryState()
+      return
+    }
+
+    // Only retry if the error name matches an entry in retryOn
+    if (!this._retryOn.includes(event.error.name)) {
+      this._resetRetryState()
+      return
+    }
+
+    this._currentAttempt += 1
+
+    if (this._currentAttempt >= this._maxAttempts) {
+      logger.debug('max retry attempts reached, not retrying')
+      return
+    }
+
+    logger.debug(
+      `delay=<${delay}>, attempt=<${this._currentAttempt}>, max_attempts=<${this._maxAttempts}> | model throttled, retrying API call`
+    )
+    await sleep(delay)
+    event.retry = true
+  }
+
+  public async handleAfterInvocation(_event: AfterInvocationEvent): Promise<void> {
+    this._resetRetryState()
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,10 @@
 // Agent class
 export { Agent } from './agent/agent.js'
 
+// Retry Strategy
+export { ModelRetryStrategy, ExponentialBackoff } from './event-loop/retry.js'
+export type { RetryStrategyConfig } from './event-loop/retry.js'
+
 // App state
 export { StateStore } from './state-store.js'
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -24,6 +24,7 @@ import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hoo
 import type { ToolRegistry } from '../registry/tool-registry.js'
 import type { z } from 'zod'
 import { AgentMetrics } from '../telemetry/meter.js'
+import type { RetryStrategyConfig } from '../event-loop/retry.js'
 
 /**
  * Arguments for invoking an agent.
@@ -73,6 +74,11 @@ export interface InvokeOptions {
    * ```
    */
   cancelSignal?: AbortSignal
+
+  /**
+   * Retry strategy to override the agent-level configuration for this specific invocation.
+   */
+  retryStrategy?: RetryStrategyConfig | null
 }
 
 /**

--- a/src/vended-tools/bash/bash.ts
+++ b/src/vended-tools/bash/bash.ts
@@ -88,7 +88,7 @@ class BashSession {
     const effectiveTimeout = timeout ?? this._timeout
     let stdoutData = ''
     let stderrData = ''
-    // eslint-disable-next-line no-undef
+
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null
     let isTimedOut = false
 
@@ -138,7 +138,6 @@ class BashSession {
       // Does NOT stop the process, preserving session state between calls.
       const cleanup = (): void => {
         if (timeoutHandle !== null) {
-          // eslint-disable-next-line no-undef
           clearTimeout(timeoutHandle)
           timeoutHandle = null
         }
@@ -152,7 +151,7 @@ class BashSession {
       }
 
       // Set up timeout
-      // eslint-disable-next-line no-undef
+
       timeoutHandle = setTimeout(() => {
         isTimedOut = true
         cleanup()


### PR DESCRIPTION
## Description
This PR introduces a robust model retry strategy with exponential backoff, achieving full architectural parity with the Python SDK while adhering to TypeScript idioms in response to #472.

**Specific Codebase Changes:**
* **Added `ExponentialBackoff` & `RetryStrategyConfig`:** Created the core configuration types and delay math in `src/event-loop/retry.ts` strictly matching the issue's proposed API.
* **Added `ModelRetryStrategy`:** Abstracted the attempt counting, math, and timeout execution into an independent class that connects specifically to `.retry` mutation flags inside the `AfterModelCallEvent` and `AfterInvocationEvent` hook pipeline.
* **Global & Local Configuration Support:** Added `retryStrategy` to `AgentConfig`. Added `retryStrategy` to `InvokeOptions` (in `src/types/agent.ts`) to enable per-invocation overrides. Updated `Agent.stream()` to execute a safe deep-merge of configuration options at runtime.
* **Removed Recursion Risk in `agent.ts`:** Refactored the core `_invokeModel` generator method. Replaced the legacy `return yield* this._invokeModel()` recursive approach with a flat, safe `while (true)` loop to prevent stack overflow/memory leaks during heavy API throttling.
* **Linter & Formatting Standardization:** Formally added Javascript standard timers (`setTimeout`, `clearTimeout`) to the workspace allowed globals in `eslint.config.js`, resolving cross-environment `no-undef` warnings cleanly without using `globalThis` hacks. Removed trailing `eslint-disable` tags from `bash.ts` and formatted the repository.
* **Tests:** Added full vitest coverage for delay logic, config handling, and exact model-retry behavior boundaries in `src/event-loop/__tests__/retry.test.ts`.

## Related Issues
Closes #472

## Documentation PR
To be created

## Type of Change
New feature

## Testing
How have you tested the change?

- [x] Tested fallback logic behavior, math, and parameter parsing locally via Node.js scratch scripts against a mock throttled layout.
- [x] Unit test suites passed completely asserting all delay algorithms.
- [x] I ran `npm run check` (vitest, type-check, format, and lint).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly 
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
