### PR TITLE
docs: remove preview status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,3 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information on reporting security issues.
 
----
-
-## ⚠️ Preview Status
-
-Strands Agents is currently in public preview. During this period:
-- APIs may change as we refine the SDK
-- We welcome feedback and contributions


### PR DESCRIPTION
## Description

The SDK is no longer in preview. This removes the "⚠️ Preview Status" section from the README to reflect that the project has graduated to general availability.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.