### PR TITLE
docs: update AGENTS.md and CONTRIBUTING.md for strands-ts workspace layout

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,9 @@
 echo "Running pre-commit checks..."
 
+# Build (required for integ type-check: workspace symlink resolves to dist/)
+echo "Building..."
+npm run build || { echo "Build failed. Commit aborted."; exit 1; }
+
 # Run tests
 echo "Running tests..."
 npm run test:coverage || { echo "Tests failed. Commit aborted."; exit 1; }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,8 +186,7 @@ sdk-typescript/
 │       └── esm-module/
 │
 ├── .github/                      # GitHub Actions workflows
-│   ├── workflows/
-│   └── agent-sops/
+│   └── workflows/
 │
 ├── .husky/                       # Git hooks (pre-commit checks)
 │
@@ -259,6 +258,7 @@ See [PR.md](docs/PR.md) for the complete guidance and template.
 ### 4. Quality Gates
 
 Pre-commit hooks automatically run:
+- Build (via npm run build, required for workspace type resolution)
 - Unit tests (via npm test)
 - Linting (via npm run lint)
 - Format checking (via npm run format:check)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,162 +14,186 @@ This document provides guidance specifically for AI agents working on the Strand
 
 ## Directory Structure
 
+The repo is an npm workspace monorepo. The root `package.json` delegates all build/test/lint commands to the `strands-ts` workspace package.
+
 ```
 sdk-typescript/
-├── src/                          # Source code (all production code)
-│   ├── __tests__/                # Unit tests for root-level source files
-│   │   ├── errors.test.ts        # Tests for error classes
-│   │   ├── index.test.ts         # Tests for main entry point
-│   │   └── app-state.test.ts     # Tests for app state
+├── strands-ts/                   # SDK workspace package
+│   ├── src/                      # All production code
+│   │   ├── __fixtures__/         # Shared test fixtures (mocks, helpers)
+│   │   ├── __tests__/            # Unit tests for root-level source files
+│   │   │
+│   │   ├── a2a/                  # Agent-to-agent protocol
+│   │   │   ├── __tests__/
+│   │   │   ├── a2a-agent.ts      # A2A agent client
+│   │   │   ├── adapters.ts       # Strands/A2A type converters
+│   │   │   ├── events.ts         # A2A streaming events
+│   │   │   ├── executor.ts       # A2A executor
+│   │   │   ├── express-server.ts # Express-based A2A server
+│   │   │   ├── server.ts         # A2A server base
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── agent/                # Agent loop and streaming
+│   │   │   ├── __tests__/
+│   │   │   ├── agent.ts          # Core agent implementation
+│   │   │   ├── agent-as-tool.ts  # Wrap agent as a tool
+│   │   │   ├── printer.ts        # Agent output printing
+│   │   │   └── snapshot.ts       # Agent state snapshots
+│   │   │
+│   │   ├── conversation-manager/ # Conversation history strategies
+│   │   │   ├── __tests__/
+│   │   │   ├── conversation-manager.ts
+│   │   │   ├── null-conversation-manager.ts
+│   │   │   ├── sliding-window-conversation-manager.ts
+│   │   │   ├── summarizing-conversation-manager.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── hooks/                # Hooks system for extensibility
+│   │   │   ├── __tests__/
+│   │   │   ├── events.ts
+│   │   │   ├── registry.ts
+│   │   │   ├── types.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── logging/              # Structured logging
+│   │   │   ├── __tests__/
+│   │   │   ├── logger.ts
+│   │   │   ├── types.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── models/               # Model provider implementations
+│   │   │   ├── __tests__/
+│   │   │   ├── google/           # Google Gemini provider
+│   │   │   ├── anthropic.ts      # Anthropic Claude
+│   │   │   ├── bedrock.ts        # AWS Bedrock
+│   │   │   ├── openai.ts         # OpenAI
+│   │   │   ├── vercel.ts         # Vercel AI SDK
+│   │   │   ├── model.ts          # Base model interface
+│   │   │   └── streaming.ts      # Streaming event types
+│   │   │
+│   │   ├── multiagent/           # Multi-agent orchestration
+│   │   │   ├── __tests__/
+│   │   │   ├── graph.ts          # Graph orchestrator (DAG)
+│   │   │   ├── swarm.ts          # Swarm orchestrator (handoff)
+│   │   │   ├── multiagent.ts     # Base multi-agent class
+│   │   │   ├── nodes.ts          # Node types
+│   │   │   ├── state.ts          # State management
+│   │   │   ├── events.ts         # Streaming events
+│   │   │   ├── edge.ts           # Edge definitions
+│   │   │   ├── queue.ts          # Execution queue
+│   │   │   ├── snapshot.ts       # Multi-agent snapshots
+│   │   │   ├── plugins.ts        # Multi-agent plugins
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── plugins/              # Plugin system
+│   │   │   ├── __tests__/
+│   │   │   ├── plugin.ts
+│   │   │   ├── registry.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── registry/             # Tool registry
+│   │   │   ├── __tests__/
+│   │   │   └── tool-registry.ts
+│   │   │
+│   │   ├── session/              # Session management
+│   │   │   ├── __tests__/
+│   │   │   ├── session-manager.ts
+│   │   │   ├── storage.ts        # Storage interface
+│   │   │   ├── file-storage.ts   # File-based storage
+│   │   │   ├── s3-storage.ts     # S3 storage
+│   │   │   ├── types.ts
+│   │   │   ├── validation.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── telemetry/            # OpenTelemetry tracing and metrics
+│   │   │   ├── __tests__/
+│   │   │   ├── tracer.ts
+│   │   │   ├── meter.ts
+│   │   │   ├── config.ts
+│   │   │   ├── json.ts
+│   │   │   ├── types.ts
+│   │   │   ├── utils.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── tools/                # Tool definitions and types
+│   │   │   ├── __tests__/
+│   │   │   ├── function-tool.ts
+│   │   │   ├── mcp-tool.ts
+│   │   │   ├── noop-tool.ts
+│   │   │   ├── structured-output-tool.ts
+│   │   │   ├── tool-factory.ts
+│   │   │   ├── tool.ts
+│   │   │   ├── zod-tool.ts
+│   │   │   ├── zod-utils.ts
+│   │   │   └── types.ts
+│   │   │
+│   │   ├── types/                # Core type definitions
+│   │   │   ├── __tests__/
+│   │   │   ├── agent.ts
+│   │   │   ├── citations.ts
+│   │   │   ├── json.ts
+│   │   │   ├── media.ts
+│   │   │   ├── messages.ts
+│   │   │   ├── serializable.ts
+│   │   │   ├── snapshot.ts
+│   │   │   └── validation.ts
+│   │   │
+│   │   ├── vended-plugins/       # Optional vended plugins
+│   │   │   └── skills/           # AgentSkills plugin
+│   │   │
+│   │   ├── vended-tools/         # Optional vended tools
+│   │   │   ├── bash/
+│   │   │   ├── file-editor/
+│   │   │   ├── http-request/
+│   │   │   └── notebook/
+│   │   │
+│   │   ├── errors.ts             # Custom error classes
+│   │   ├── index.ts              # Main SDK entry point
+│   │   ├── mcp.ts                # MCP client implementation
+│   │   ├── mime.ts               # MIME type utilities
+│   │   └── state-store.ts        # State store implementation
 │   │
-│   ├── agent/                    # Agent loop and streaming
-│   │   ├── __tests__/            # Unit tests for agent loop
-│   │   │   ├── agent.test.ts     # Tests for agent implementation
-│   │   │   └── printer.test.ts   # Tests for printer
-│   │   ├── agent.ts              # Core agent implementation
-│   │   ├── printer.ts            # Agent output printing
-│   │   └── streaming.ts          # Agent streaming event types
+│   ├── test/                     # Tests outside of source
+│   │   ├── integ/                # Integration tests
+│   │   │   ├── a2a/
+│   │   │   ├── conversation-manager/
+│   │   │   ├── mcp/
+│   │   │   ├── models/
+│   │   │   ├── multiagent/
+│   │   │   ├── skills/
+│   │   │   ├── tools/
+│   │   │   ├── agent.test.ts
+│   │   │   └── ...
+│   │   └── packages/             # Package compatibility tests (CJS/ESM)
 │   │
-│   ├── conversation-manager/ # Conversation management implementations
-│   │   ├── __tests__/        # Unit tests for conversation managers
-│   │   │   ├── conversation-manager.test.ts
-│   │   │   ├── null-conversation-manager.test.ts
-│   │   │   ├── sliding-window-conversation-manager.test.ts
-│   │   │   └── summarizing-conversation-manager.test.ts
-│   │   ├── conversation-manager.ts        # Abstract base class
-│   │   ├── null-conversation-manager.ts   # No-op implementation
-│   │   ├── sliding-window-conversation-manager.ts  # Sliding window strategy
-│   │   ├── summarizing-conversation-manager.ts     # Summarization-based strategy
-│   │   └── index.ts          # Public exports
+│   ├── examples/                 # Example applications
+│   │   ├── agents-as-tools/
+│   │   ├── browser-agent/
+│   │   ├── first-agent/
+│   │   ├── graph/
+│   │   ├── mcp/
+│   │   ├── swarm/
+│   │   └── telemetry/
 │   │
-│   ├── hooks/                    # Hooks system for extensibility
-│   │   ├── __tests__/            # Unit tests for hooks
-│   │   │   ├── events.test.ts    # Tests for hook events
-│   │   │   └── registry.test.ts  # Tests for HookRegistry
-│   │   ├── events.ts             # HookEvent base class and concrete events
-│   │   ├── registry.ts           # HookRegistry implementation
-│   │   ├── types.ts              # Hook-related type definitions
-│   │   └── index.ts              # Public exports for hooks
-│   │
-│   ├── plugins/                  # Plugin system for agent extensibility
-│   │   ├── __tests__/            # Unit tests for plugins
-│   │   │   ├── plugin.test.ts    # Tests for Plugin abstract class
-│   │   │   └── registry.test.ts  # Tests for PluginRegistry
-│   │   ├── plugin.ts             # Plugin abstract base class
-│   │   ├── registry.ts           # PluginRegistry implementation
-│   │   └── index.ts              # Public exports for plugins
-│   │
-│   ├── models/                   # Model provider implementations
-│   │   ├── __tests__/            # Unit tests for model providers
-│   │   │   └── bedrock.test.ts   # Tests for Bedrock model provider
-│   │   ├── bedrock.ts            # AWS Bedrock model provider
-│   │   ├── model.ts              # Base model provider interface
-│   │   └── streaming.ts          # Streaming event types
-│   │
-│   ├── tools/                    # Tool definitions and types
-│   │   ├── __tests__/            # Unit tests for tools
-│   │   │   ├── registry.test.ts  # Tests for ToolRegistry
-│   │   │   ├── tool.test.ts      # Tests for FunctionTool
-│   │   │   └── structured-output-tool.test.ts  # Tests for StructuredOutputTool
-│   │   ├── function-tool.ts      # FunctionTool implementation
-│   │   ├── mcp-tool.ts           # MCP tool wrapper
-│   │   ├── structured-output-tool.ts  # Structured output validation tool
-│   │   ├── registry.ts           # ToolRegistry implementation
-│   │   ├── tool.ts               # Tool interface
-│   │   ├── zod-utils.ts          # Zod to JSON Schema conversion
-│   │   └── types.ts              # Tool-related type definitions
-│   │
-│   ├── multiagent/               # Multi-agent orchestration patterns
-│   │   ├── __tests__/            # Unit tests for multi-agent
-│   │   │   ├── graph.test.ts     # Tests for Graph orchestrator
-│   │   │   ├── swarm.test.ts     # Tests for Swarm orchestrator
-│   │   │   ├── nodes.test.ts     # Tests for Node types
-│   │   │   ├── events.test.ts    # Tests for multi-agent events
-│   │   │   └── queue.test.ts     # Tests for execution queue
-│   │   ├── base.ts               # MultiAgentBase interface
-│   │   ├── graph.ts              # Graph orchestrator (DAG execution)
-│   │   ├── swarm.ts              # Swarm orchestrator (handoff-based)
-│   │   ├── nodes.ts              # Node types (AgentNode, MultiAgentNode)
-│   │   ├── state.ts              # MultiAgentState, NodeResult, Status
-│   │   ├── events.ts             # Multi-agent streaming events
-│   │   ├── edge.ts               # Graph edge definitions
-│   │   ├── queue.ts              # Node execution queue
-│   │   └── index.ts              # Public exports
-│   │
-│   ├── types/                    # Core type definitions
-│   │   ├── json.ts               # JSON schema and value types
-│   │   └── messages.ts           # Message and content block types
-│   │
-│   ├── __tests__/                # Unit tests for root-level source files
-│   │   ├── errors.test.ts        # Tests for error classes
-│   │   ├── index.test.ts         # Tests for main entry point
-│   │   └── mcp.test.ts           # Tests for MCP integration
-│   │
-│   ├── vended-plugins/            # Optional vended plugins (not part of core SDK)
-│   │   └── skills/               # AgentSkills plugin for progressive skill disclosure
-│   │       ├── __tests__/        # Unit tests for skills plugin
-│   │       │   ├── agent-skills.test.node.ts  # Tests for AgentSkillsPlugin
-│   │       │   └── skill.test.node.ts         # Tests for Skill data model
-│   │       ├── agent-skills.ts   # AgentSkillsPlugin implementation
-│   │       ├── skill.ts          # Skill data model and loading utilities
-│   │       └── index.ts          # Public exports for skills plugin
-│   │
-│   ├── mcp.ts                    # MCP client implementation
-│   ├── errors.ts                 # Custom error classes
-│   ├── app-state.ts              # App state implementation
-│   └── index.ts                  # Main SDK entry point (single export point)
+│   ├── package.json              # SDK package config and dependencies
+│   ├── tsconfig.base.json        # TypeScript configuration
+│   ├── vitest.config.ts          # Testing configuration
+│   └── eslint.config.js          # Linting configuration
 │
-├── vended-tools/                 # Optional vended tools (not part of core SDK)
-│   ├── notebook/                 # Notebook tool for managing text notebooks
-│   │   ├── __tests__/            # Unit tests for notebook tool
-│   │   │   └── notebook.test.ts
-│   │   ├── notebook.ts           # Notebook implementation
-│   │   ├── types.ts              # Notebook type definitions
-│   │   ├── index.ts              # Public exports for notebook tool
-│   │   └── README.md             # Notebook tool documentation
-│   └── README.md                 # Vended tools overview
-│
-├── test/integ/                  # Integration tests (separate from source)
-│   ├── multiagent/               # Multi-agent integration tests
-│   │   ├── graph.test.ts         # Graph orchestrator integration tests
-│   │   └── swarm.test.ts         # Swarm orchestrator integration tests
-│   ├── skills/                   # Skills plugin integration tests
-│   │   └── agent-skills.test.node.ts  # End-to-end skill activation tests
-│   ├── bedrock.test.ts           # Bedrock integration tests (requires AWS credentials)
-│   ├── hooks.test.ts             # Hooks integration tests
-│   └── registry.test.ts          # ToolRegistry integration tests
-│
-├── examples/                     # Example applications
-│   ├── first-agent/              # Basic agent usage example
-│   ├── graph/                    # Graph multi-agent orchestration example
-│   ├── mcp/                      # MCP integration examples
-│   ├── swarm/                    # Swarm multi-agent orchestration example
-│   └── telemetry/                # OpenTelemetry integration example
+├── test/                         # Root-level package compatibility tests
+│   └── packages/
+│       ├── cjs-module/
+│       └── esm-module/
 │
 ├── .github/                      # GitHub Actions workflows
-│   ├── workflows/                # CI/CD workflows
-│   │   ├── pr-and-push.yml       # Triggers test/lint on PR and push
-│   │   ├── test-lint.yml         # Unit tests and linting
-│   │   └── integration-test.yml  # Secure integration tests with AWS
-│   └── agent-sops/               # Agent system prompts
+│   ├── workflows/
+│   └── agent-sops/
 │
-├── .project/                     # Project management (tasks, tracking)
-│   ├── tasks/                    # Active tasks
-│   ├── tasks/completed/          # Completed tasks
-│   ├── project-overview.md       # Project goals and roadmap
-│   └── task-registry.md          # Task dependencies
+├── .husky/                       # Git hooks (pre-commit checks)
 │
-├── dist/                         # Compiled output (generated, not in git)
-├── coverage/                     # Test coverage reports (generated)
-├── node_modules/                 # Dependencies (generated)
-│
-├── package.json                  # Project configuration and dependencies
-├── tsconfig.json                 # TypeScript compiler configuration
-├── vitest.config.ts              # Testing configuration (with unit/integ projects)
-├── eslint.config.js              # Linting configuration
+├── package.json                  # Root workspace config (delegates to strands-ts)
 ├── .prettierrc                   # Code formatting configuration
 ├── .gitignore                    # Git ignore rules
-├── .husky/                       # Git hooks (pre-commit checks)
 │
 ├── AGENTS.md                     # This file (agent guidance)
 ├── CONTRIBUTING.md               # Human contributor guidelines
@@ -178,22 +202,27 @@ sdk-typescript/
 
 ### Directory Purposes
 
-- **`src/`**: All production code lives here with co-located unit tests
-- **`src/__tests__/`**: Unit tests for root-level source files
-- **`src/agent/`**: Agent loop coordination, streaming event types, output printing, and conversation management
-- **`src/agent/conversation-manager/`**: Conversation history management strategies
-- **`src/hooks/`**: Hooks system for event-driven extensibility
-- **`src/plugins/`**: Plugin system for extending agent functionality
-- **`src/models/`**: Model provider implementations (Bedrock, OpenAI, future providers)
-- **`src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas
-- **`src/multiagent/`**: Multi-agent orchestration patterns (Graph for DAG execution, Swarm for handoff-based routing)
-- **`src/types/`**: Core type definitions used across the SDK
-- **`src/vended-plugins/`**: Optional vended plugins (not part of core SDK, independently importable)
-- **`src/vended-plugins/skills/`**: AgentSkills plugin — progressive skill disclosure via SKILL.md files (AgentSkills.io spec)
-- **`src/vended-tools/`**: Optional vended tools (not part of core SDK, independently importable)
-- **`test/integ/`**: Integration tests (tests public API and external integrations)
+- **`strands-ts/`**: The SDK workspace package containing all source, tests, and examples
+- **`strands-ts/src/`**: All production code with co-located unit tests
+- **`strands-ts/src/__fixtures__/`**: Shared test fixtures (mock models, helpers)
+- **`strands-ts/src/a2a/`**: Agent-to-agent protocol (A2A client, server, adapters)
+- **`strands-ts/src/agent/`**: Agent loop coordination, output printing, snapshots
+- **`strands-ts/src/conversation-manager/`**: Conversation history management strategies
+- **`strands-ts/src/hooks/`**: Hooks system for event-driven extensibility
+- **`strands-ts/src/logging/`**: Structured logging utilities
+- **`strands-ts/src/models/`**: Model provider implementations (Bedrock, Anthropic, OpenAI, Google, Vercel)
+- **`strands-ts/src/multiagent/`**: Multi-agent orchestration patterns (Graph for DAG execution, Swarm for handoff-based routing)
+- **`strands-ts/src/plugins/`**: Plugin system for extending agent functionality
+- **`strands-ts/src/registry/`**: Tool registry implementation
+- **`strands-ts/src/session/`**: Session management (file, S3, custom storage)
+- **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
+- **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas
+- **`strands-ts/src/types/`**: Core type definitions used across the SDK
+- **`strands-ts/src/vended-plugins/`**: Optional vended plugins (not part of core SDK, independently importable)
+- **`strands-ts/src/vended-tools/`**: Optional vended tools (bash, file-editor, http-request, notebook)
+- **`strands-ts/test/integ/`**: Integration tests (tests public API and external integrations)
+- **`strands-ts/examples/`**: Example applications
 - **`.github/workflows/`**: CI/CD automation and quality gates
-- **`.project/`**: Task management and project tracking
 
 **IMPORTANT**: After making changes that affect the directory structure (adding new directories, moving files, or adding significant new files), you MUST update this directory structure section to reflect the current state of the repository.
 
@@ -319,7 +348,7 @@ import { something } from 'external-package'
 
 **For source files**:
 ```
-src/
+strands-ts/src/
 ├── module.ts              # Source file
 └── __tests__/
     └── module.test.ts     # Unit tests co-located
@@ -360,7 +389,7 @@ export async function* mainFunction() {
 
 **For integration tests**:
 ```
-test/integ/
+strands-ts/test/integ/
 └── feature.test.ts        # Tests public API
 ```
 
@@ -669,7 +698,7 @@ export interface CitationSourceContent {
 - Use `type` alias (not `interface`) so it can be expanded to a union later
 - Each variant's field is **required** within that variant
 - Use object-key discrimination (`'text' in source`) to narrow variants at runtime
-- See `DocumentSourceData` in `src/types/media.ts` and `CitationLocation` in `src/types/citations.ts` for reference implementations
+- See `DocumentSourceData` in `strands-ts/src/types/media.ts` and `CitationLocation` in `strands-ts/src/types/citations.ts` for reference implementations
 
 ### Error Handling
 
@@ -744,7 +773,7 @@ When adding or modifying dependencies, you **MUST** follow the guidelines in [do
 
 **Don't**:
 - Use `any` type (enforced by ESLint)
-- Put unit tests in separate `tests/` directory (use `src/**/__tests__/**`)
+- Put unit tests in separate `tests/` directory (use `strands-ts/src/**/__tests__/**`)
 - Skip documentation for exported functions
 - Use semicolons (Prettier will remove them)
 - Commit without running pre-commit hooks
@@ -823,7 +852,8 @@ When responding to PR feedback:
 - **docs/TESTING.md**: Comprehensive testing guidelines (MUST follow when writing tests)
 - **docs/PR.md**: Pull request guidelines and template
 - **README.md**: Public-facing documentation, links to strandsagents.com
-- **package.json**: Defines all npm scripts referenced in documentation
+- **package.json**: Root workspace config that delegates to strands-ts
+- **strands-ts/package.json**: SDK package config, dependencies, and npm scripts
 
 ## Additional Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,11 +180,6 @@ sdk-typescript/
 │   ├── vitest.config.ts          # Testing configuration
 │   └── eslint.config.js          # Linting configuration
 │
-├── test/                         # Root-level package compatibility tests
-│   └── packages/
-│       ├── cjs-module/
-│       └── esm-module/
-│
 ├── .github/                      # GitHub Actions workflows
 │   └── workflows/
 │

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,16 @@ When proposing solutions or reviewing code, we reference these principles to gui
    npm ci
    ```
 
+   This also installs git hooks (via husky) that automatically run tests, linting, formatting checks, and type checking before each commit.
+
    > **Note**: Use `npm ci` for installing dependencies. Use `npm install` only when intentionally adding or updating dependencies. See [Dependency Guidelines](docs/DEPENDENCIES.md) for details.
 
 2. Install Playwright browsers for browser testing:
-
    ```bash
    npm run test:browser:install
    ```
 
-3. Verify your setup by running the test suite:
+3. Verify your setup:
    ```bash
    npm test
    npm run lint
@@ -50,44 +51,34 @@ When proposing solutions or reviewing code, we reference these principles to gui
    npm run type-check
    ```
 
-4. Install git hooks for automatic quality checks:
-   ```bash
-   npm run prepare
-   ```
-
-This will set up pre-commit hooks that automatically run tests, linting, formatting checks, and type checking before each commit.
+The repo is an npm workspace. The SDK source lives in `strands-ts/`, and the root `package.json` proxies common commands (`test`, `lint`, `format:check`, `type-check`, `build`) into that workspace. For commands that aren't proxied at root (like `test:integ` or `test:watch`), run them from `strands-ts/` directly.
 
 ## Testing Instructions and Best Practices
 
 ### Running Tests
 
+Common commands work from the repo root:
+
 ```bash
-# Run unit tests only (Node.js environment)
-npm test
+npm test                          # Unit tests (Node.js)
+npm run test:coverage             # Unit tests with coverage (required: 80%+)
+npm run test:all:coverage         # All environments with coverage
+```
 
-# Run unit tests for a single file
-npm test -- src/models/__tests__/openai.test.ts
+For the full set of test commands, run from `strands-ts/`:
 
-# Run tests with coverage (required: 80%+)
-npm run test:coverage
+```bash
+cd strands-ts
 
-# Run tests in watch mode during development
-npm run test:watch
-
-# Run only integration tests
-npm run test:integ
-
-# Run integ tests for a single file
-npm run test:integ -- test/integ/openai.test.ts
-
-# Run browser tests (Chromium)
-npm run test:browser
-
-# Run tests in all environments (Node.js + Browser)
-npm run test:all
-
-# Run tests in all environments with coverage
-npm run test:all:coverage
+npm test                                              # Unit tests (Node.js)
+npm test -- src/models/__tests__/openai.test.ts       # Single unit test file
+npm run test:watch                                    # Watch mode
+npm run test:coverage                                 # Unit tests with coverage
+npm run test:browser                                  # Unit tests in browser (Chromium)
+npm run test:all                                      # Unit tests in all environments
+npm run test:all:coverage                             # All environments with coverage
+npm run test:integ                                    # Integration tests
+npm run test:integ -- test/integ/models/openai.test.ts  # Single integ test file
 ```
 
 ### Test Requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ When proposing solutions or reviewing code, we reference these principles to gui
    npm ci
    ```
 
-   This also installs git hooks (via husky) that automatically run tests, linting, formatting checks, and type checking before each commit.
+   This also installs git hooks (via husky) that automatically build the SDK, run tests, linting, formatting checks, and type checking before each commit.
 
    > **Note**: Use `npm ci` for installing dependencies. Use `npm install` only when intentionally adding or updating dependencies. See [Dependency Guidelines](docs/DEPENDENCIES.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Both patterns support streaming via `.stream()` for real-time access to handoff 
 For detailed guidance, tutorials, and concept overviews, please visit:
 
 - **[Official Documentation](https://strandsagents.com/)**: Comprehensive guides and tutorials
-- **[API Reference](https://strandsagents.com/latest/documentation/docs/api-reference/typescript/)**: Complete API documentation
+- **[API Reference](https://strandsagents.com/docs/api/typescript/)**: Complete API documentation
 - **[Examples](./strands-ts/examples/)**: Sample applications
   - **[First Agent](./strands-ts/examples/first-agent/)**: Basic Node.js agent
   - **[MCP](./strands-ts/examples/mcp/)**: MCP integration example

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -77,7 +77,7 @@
   },
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
-    "check": "npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
+    "check": "npm run build && npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
     "check:browser-bundle": "esbuild src/index.ts --bundle --platform=browser --format=esm --packages=external --outfile=/dev/null",
     "clean": "rm -rf node_modules dist",
     "lock:refresh": "rm -rf node_modules && npm install --ignore-scripts --os=linux --os=darwin --os=win32 --cpu=x64 --cpu=arm64 --cpu=wasm32",


### PR DESCRIPTION
## Description

Updates documentation for the workspace restructure and fixes a regression where `npm run check` fails on a clean install.

## Motivation

The monorepo restructure (PR #827) moved the SDK into `strands-ts/` as a workspace package. This caused two issues:

1. AGENTS.md and CONTRIBUTING.md referenced the old flat layout (`src/`, `test/integ/`, etc. at repo root), giving contributors incorrect paths.
2. `npm run check` fails on a clean install because integration tests import from `@strands-agents/sdk`, which resolves via the workspace symlink to `strands-ts/`. The package's `exports` map points to `dist/src/index.d.ts`, so `type-check` requires `dist/` to exist.

Before the restructure, the repo had `prepare: "npm run build && husky"`, so `npm install` always produced `dist/` as a side effect. The restructure changed this to just `prepare: "husky"`, so a clean install no longer leaves `dist/` populated and `type-check` fails.

## Type of Change

Bug fix
Documentation update

## Changes

strands-ts/package.json:
- Added `npm run build` as the first step in the `check` script so `dist/` is populated before `type-check` runs against the integ tsconfig

AGENTS.md:
- Rewrote directory structure tree for the `strands-ts/` workspace layout
- Updated directory purposes, file organization patterns, and path references
- Added missing modules (a2a, logging, registry, session, telemetry, new model providers, additional vended-tools)

CONTRIBUTING.md:
- Reorganized setup and test command sections for the workspace layout
- Split test commands into "common from root" and "full set from strands-ts/"
- Fixed stale integ test example path

README.md:
- Fixed API Reference link to `strandsagents.com/docs/api/typescript/`

## Testing

Verified on a clean clone:
- `npm run check` fails on commit `563d941` (the restructure) without the build fix
- `npm run check` passes on the commit before the restructure (`8823825`)
- `npm run build && npm run type-check` passes on `563d941`, confirming the fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published