### PR TITLE
feat: add contextWindowLimit to BaseModelConfig

### DIFF
--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -264,6 +264,14 @@ describe('BedrockModel', () => {
         temperature: 0.5,
       })
     })
+
+    it('includes contextWindowLimit in config when provided', () => {
+      const provider = new BedrockModel({
+        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        contextWindowLimit: 200_000,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(200_000)
+    })
   })
 
   describe('updateConfig', () => {

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -270,7 +270,10 @@ describe('BedrockModel', () => {
         modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
         contextWindowLimit: 200_000,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(200_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        contextWindowLimit: 200_000,
+      })
     })
   })
 

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -140,7 +140,10 @@ describe('GoogleModel', () => {
         modelId: 'gemini-2.5-flash',
         contextWindowLimit: 1_048_576,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'gemini-2.5-flash',
+        contextWindowLimit: 1_048_576,
+      })
     })
   })
 

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -133,6 +133,15 @@ describe('GoogleModel', () => {
         params: { maxOutputTokens: 1024, temperature: 0.7 },
       })
     })
+
+    it('includes contextWindowLimit in config when provided', () => {
+      const provider = new GoogleModel({
+        apiKey: 'test-key',
+        modelId: 'gemini-2.5-flash',
+        contextWindowLimit: 1_048_576,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+    })
   })
 
   describe('stream', () => {

--- a/strands-ts/src/models/__tests__/openai.test.ts
+++ b/strands-ts/src/models/__tests__/openai.test.ts
@@ -242,6 +242,16 @@ describe('OpenAIModel', () => {
         temperature: 0.7,
       })
     })
+
+    it('includes contextWindowLimit in config when provided', () => {
+      const provider = new OpenAIModel({
+        api: 'chat',
+        modelId: 'gpt-4o',
+        apiKey: 'sk-test',
+        contextWindowLimit: 128_000,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(128_000)
+    })
   })
 
   describe('stream', () => {

--- a/strands-ts/src/models/__tests__/openai.test.ts
+++ b/strands-ts/src/models/__tests__/openai.test.ts
@@ -250,7 +250,10 @@ describe('OpenAIModel', () => {
         apiKey: 'sk-test',
         contextWindowLimit: 128_000,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(128_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'gpt-4o',
+        contextWindowLimit: 128_000,
+      })
     })
   })
 

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -92,6 +92,13 @@ export interface BaseModelConfig {
    * @see Provider-specific documentation for details
    */
   topP?: number
+
+  /**
+   * Maximum context window size in tokens for the model.
+   *
+   * This value represents the total token capacity shared between input and output.
+   */
+  contextWindowLimit?: number
 }
 
 /**


### PR DESCRIPTION
## Description
Adds `contextWindowLimit` as an optional property on `BaseModelConfig`. This exposes the model's maximum token capacity (shared between input and output) so that conversation managers can implement  proactive context compression — triggering reduction before the model rejects a request, rather than after.                                                                                             
                                                                                                                                                                                                      
```typescript                                                                                                                                                                                           
const model = new BedrockModel({                                                                                                                                                                        
  modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',                                                                                                                                                   
  contextWindowLimit: 200_000,                                                                                                                                                                          
})                                                                                                                                                                                                      
                                                                                                                                                                                                      
// ConversationManager reads it to check thresholds:                                                                                                                                                    
const limit = model.getConfig().contextWindowLimit                                                                                                                                                      
```
                                                                                                                                                                                
Per-provider lookup tables that auto-populate this value from model ID will be added in a follow-up.                                                                                                    
                                                                                                      
## Related Issues

- strands-agents/sdk-python#1295                                                                                                                                                                        
- strands-agents/docs#758  

## Documentation PR

docs will accompany the proactive context compression feature.                  


## Type of Change

New feature                                                                                                                                                                                             


## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
                                                                                                                                                                                                      
- [x] I have read the CONTRIBUTING document                                                                                                                                                             
- [x] I have added any necessary tests that prove my fix is effective or my feature works                                                                                                               
- [ ] I have updated the documentation accordingly                                                                                                                                                      
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed                                                                                        
- [x] My changes generate no new warnings                                                                                                                                                               
- [x] Any dependent changes have been merged and published    

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
