### PR TITLE
feat: add Sandbox abstraction for agent code execution environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,14 @@ sdk-typescript/
 │   │   │   ├── snapshot.ts
 │   │   │   └── validation.ts
 │   │   │
+│   │   ├── sandbox/              # Sandbox abstraction for code execution
+│   │   │   ├── __tests__/
+│   │   │   ├── base.ts           # Sandbox ABC, types (ExecutionResult, FileInfo, etc.)
+│   │   │   ├── host.ts           # HostSandbox — native Node.js execution (default)
+│   │   │   ├── shell-based.ts    # ShellBasedSandbox — shell-based for remote environments
+│   │   │   ├── noop.ts           # NoOpSandbox — disables sandbox functionality
+│   │   │   └── index.ts
+│   │   │
 │   │   ├── vended-plugins/       # Optional vended plugins
 │   │   │   └── skills/           # AgentSkills plugin
 │   │   │
@@ -256,6 +264,7 @@ sdk-typescript/
 - **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
 - **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas
 - **`strands-ts/src/types/`**: Core type definitions used across the SDK
+- **`strands-ts/src/sandbox/`**: Sandbox abstraction for agent code/command execution and filesystem access
 - **`strands-ts/src/vended-plugins/`**: Optional vended plugins (not part of core SDK, independently importable)
 - **`strands-ts/src/vended-tools/`**: Optional vended tools (bash, file-editor, http-request, notebook)
 - **`strands-ts/test/integ/`**: Integration tests (tests public API and external integrations)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "strands",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strands",
+      "version": "0.0.0",
       "workspaces": [
         "strands-dev",
         "strands-ts",

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1,3 +1,5 @@
+import { Sandbox } from '../sandbox/base.js'
+import { HostSandbox } from '../sandbox/host.js'
 import {
   AgentResult,
   type AgentStreamEvent,
@@ -145,6 +147,12 @@ export type AgentConfig = {
    */
   sessionManager?: SessionManager
   /**
+   * Sandbox for code execution and filesystem access.
+   * Defaults to HostSandbox when not specified.
+   * Pass NoOpSandbox to disable sandbox functionality.
+   */
+  sandbox?: Sandbox
+  /**
    * Custom trace attributes to include in all spans.
    * These attributes are merged with standard attributes in telemetry spans.
    * Telemetry must be enabled globally via telemetry.setupTracer() for these to take effect.
@@ -219,6 +227,10 @@ export class Agent implements LocalAgent, InvokableAgent {
    * The session manager for saving and restoring agent sessions, if configured.
    */
   public readonly sessionManager?: SessionManager | undefined
+  /**
+   * The sandbox for code execution and filesystem access.
+   */
+  public readonly sandbox: Sandbox
 
   private readonly _hooksRegistry: HookRegistryImplementation
   private readonly _pluginRegistry: PluginRegistry
@@ -248,6 +260,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     this.id = config?.id ?? DEFAULT_AGENT_ID
     if (config?.description !== undefined) this.description = config.description
     this.sessionManager = config?.sessionManager
+    this.sandbox = config?.sandbox ?? new HostSandbox()
 
     if (typeof config?.model === 'string') {
       this.model = new BedrockModel({ modelId: config.model })

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -250,7 +250,7 @@ export { Graph } from './multiagent/index.js'
 export { Swarm } from './multiagent/index.js'
 
 // Sandbox
-export { Sandbox, HostSandbox, NoOpSandbox } from './sandbox/index.js'
+export { Sandbox, HostSandbox, ShellBasedSandbox, NoOpSandbox } from './sandbox/index.js'
 export type {
   ExecutionResult,
   ExecuteOptions,

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -248,3 +248,15 @@ export { AgentMetrics } from './telemetry/meter.js'
 // Multi-agent orchestration
 export { Graph } from './multiagent/index.js'
 export { Swarm } from './multiagent/index.js'
+
+// Sandbox
+export { Sandbox, HostSandbox, NoOpSandbox } from './sandbox/index.js'
+export type {
+  ExecutionResult,
+  ExecuteOptions,
+  FileInfo,
+  OutputFile,
+  StreamChunk,
+  StreamType,
+  HostSandboxConfig,
+} from './sandbox/index.js'

--- a/strands-ts/src/sandbox/__tests__/base.test.ts
+++ b/strands-ts/src/sandbox/__tests__/base.test.ts
@@ -1,0 +1,112 @@
+import { Buffer } from 'buffer'
+import { describe, it, expect } from 'vitest'
+import { Sandbox } from '../base.js'
+import type { ExecutionResult, ExecuteOptions, FileInfo, StreamChunk } from '../base.js'
+
+class ConcreteSandbox extends Sandbox {
+  async *executeStreaming(
+    command: string,
+    _options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    yield { data: `out:${command}\n`, streamType: 'stdout' }
+    yield { exitCode: 0, stdout: `out:${command}\n`, stderr: '', outputFiles: [] }
+  }
+
+  async *executeCodeStreaming(
+    code: string,
+    language: string,
+    _options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    yield { data: `${language}:${code}\n`, streamType: 'stdout' }
+    yield { exitCode: 0, stdout: `${language}:${code}\n`, stderr: '', outputFiles: [] }
+  }
+
+  async readFile(_path: string): Promise<Uint8Array> {
+    return new Uint8Array(Buffer.from('file content'))
+  }
+
+  async writeFile(_path: string, _content: Uint8Array): Promise<void> {
+    // noop
+  }
+
+  async removeFile(_path: string): Promise<void> {
+    // noop
+  }
+
+  async listFiles(_path: string): Promise<FileInfo[]> {
+    return [{ name: 'test.txt', isDir: false, size: 100 }]
+  }
+}
+
+describe('Sandbox', () => {
+  describe('abstract contract', () => {
+    it('can be instantiated via a concrete subclass', () => {
+      const sandbox = new ConcreteSandbox()
+      expect(sandbox).toBeInstanceOf(Sandbox)
+    })
+
+    it('requires all abstract methods to be implemented', () => {
+      const sandbox = new ConcreteSandbox()
+      expect(typeof sandbox.executeStreaming).toBe('function')
+      expect(typeof sandbox.executeCodeStreaming).toBe('function')
+      expect(typeof sandbox.readFile).toBe('function')
+      expect(typeof sandbox.writeFile).toBe('function')
+      expect(typeof sandbox.removeFile).toBe('function')
+      expect(typeof sandbox.listFiles).toBe('function')
+    })
+  })
+
+  describe('execute (non-streaming)', () => {
+    it('consumes the stream and returns ExecutionResult', async () => {
+      const sandbox = new ConcreteSandbox()
+      const result = await sandbox.execute('hello')
+      expect(result).toStrictEqual({
+        exitCode: 0,
+        stdout: 'out:hello\n',
+        stderr: '',
+        outputFiles: [],
+      })
+    })
+  })
+
+  describe('executeCode (non-streaming)', () => {
+    it('consumes the stream and returns ExecutionResult', async () => {
+      const sandbox = new ConcreteSandbox()
+      const result = await sandbox.executeCode('print(1)', 'python')
+      expect(result).toStrictEqual({
+        exitCode: 0,
+        stdout: 'python:print(1)\n',
+        stderr: '',
+        outputFiles: [],
+      })
+    })
+  })
+
+  describe('readText', () => {
+    it('decodes bytes to a string', async () => {
+      const sandbox = new ConcreteSandbox()
+      const text = await sandbox.readText('test.txt')
+      expect(text).toBe('file content')
+    })
+  })
+
+  describe('writeText', () => {
+    it('encodes a string to bytes and calls writeFile', async () => {
+      const sandbox = new ConcreteSandbox()
+      await sandbox.writeText('test.txt', 'hello world')
+    })
+  })
+
+  describe('streaming methods', () => {
+    it('yields StreamChunks followed by ExecutionResult', async () => {
+      const sandbox = new ConcreteSandbox()
+      const chunks: (StreamChunk | ExecutionResult)[] = []
+      for await (const chunk of sandbox.executeStreaming('test')) {
+        chunks.push(chunk)
+      }
+      expect(chunks).toHaveLength(2)
+      expect(chunks[0]).toStrictEqual({ data: 'out:test\n', streamType: 'stdout' })
+      expect(chunks[1]).toStrictEqual({ exitCode: 0, stdout: 'out:test\n', stderr: '', outputFiles: [] })
+    })
+  })
+})

--- a/strands-ts/src/sandbox/__tests__/host.test.ts
+++ b/strands-ts/src/sandbox/__tests__/host.test.ts
@@ -1,0 +1,199 @@
+import { Buffer } from 'buffer'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { rmSync } from 'node:fs'
+import { HostSandbox } from '../host.js'
+import type { StreamChunk, ExecutionResult } from '../base.js'
+import { Sandbox } from '../base.js'
+
+describe('HostSandbox', () => {
+  let workDir: string
+  let sandbox: HostSandbox
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'sandbox-test-'))
+    sandbox = new HostSandbox({ workingDir: workDir })
+  })
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  describe('constructor', () => {
+    it('extends Sandbox', () => {
+      expect(sandbox).toBeInstanceOf(Sandbox)
+    })
+
+    it('uses provided workingDir', () => {
+      expect(sandbox.workingDir).toBe(workDir)
+    })
+
+    it('defaults to process.cwd() when no config', () => {
+      const defaultSandbox = new HostSandbox()
+      expect(defaultSandbox.workingDir).toBe(process.cwd())
+    })
+  })
+
+  describe('execute', () => {
+    it('runs a shell command and returns stdout', async () => {
+      const result = await sandbox.execute('echo hello')
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.trim()).toBe('hello')
+      expect(result.stderr).toBe('')
+    })
+
+    it('captures stderr', async () => {
+      const result = await sandbox.execute('echo error >&2')
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr.trim()).toBe('error')
+    })
+
+    it('returns non-zero exit code on failure', async () => {
+      const result = await sandbox.execute('exit 42')
+      expect(result.exitCode).toBe(42)
+    })
+
+    it('uses sandbox working directory', async () => {
+      const result = await sandbox.execute('pwd')
+      expect(result.stdout.trim()).toBe(workDir)
+    })
+
+    it('uses cwd option when provided', async () => {
+      const subDir = join(workDir, 'subdir')
+      mkdirSync(subDir)
+      const result = await sandbox.execute('pwd', { cwd: subDir })
+      expect(result.stdout.trim()).toBe(subDir)
+    })
+  })
+
+  describe('executeStreaming', () => {
+    it('yields StreamChunks then ExecutionResult', async () => {
+      const chunks: (StreamChunk | ExecutionResult)[] = []
+      for await (const chunk of sandbox.executeStreaming('echo hello')) {
+        chunks.push(chunk)
+      }
+
+      const streamChunks = chunks.filter((c): c is StreamChunk => 'streamType' in c)
+      const results = chunks.filter((c): c is ExecutionResult => 'exitCode' in c)
+
+      expect(streamChunks.length).toBeGreaterThan(0)
+      expect(results).toHaveLength(1)
+      expect(results[0]!.exitCode).toBe(0)
+      expect(results[0]!.stdout.trim()).toBe('hello')
+    })
+
+    it('distinguishes stdout and stderr', async () => {
+      const chunks: StreamChunk[] = []
+      for await (const chunk of sandbox.executeStreaming('echo out && echo err >&2')) {
+        if ('streamType' in chunk) {
+          chunks.push(chunk)
+        }
+      }
+
+      const stdoutChunks = chunks.filter((c) => c.streamType === 'stdout')
+      const stderrChunks = chunks.filter((c) => c.streamType === 'stderr')
+
+      expect(stdoutChunks.length).toBeGreaterThan(0)
+      expect(stderrChunks.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('executeCode', () => {
+    it('runs code and returns result', async () => {
+      const result = await sandbox.executeCode('print("hello from python")', 'python3')
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.trim()).toBe('hello from python')
+    })
+
+    it('rejects unsafe language names', async () => {
+      await expect(sandbox.executeCode('code', 'python; rm -rf /')).rejects.toThrow(
+        'language parameter contains unsafe characters'
+      )
+    })
+
+    it('returns exit code 127 for missing interpreter', async () => {
+      const result = await sandbox.executeCode('code', 'nonexistent_lang_xyz')
+      expect(result.exitCode).toBe(127)
+      expect(result.stderr).toContain('Language interpreter not found')
+    })
+  })
+
+  describe('file operations', () => {
+    it('writes and reads a file', async () => {
+      const content = Buffer.from('hello world')
+      await sandbox.writeFile('test.txt', new Uint8Array(content))
+      const read = await sandbox.readFile('test.txt')
+      expect(Buffer.from(read).toString()).toBe('hello world')
+    })
+
+    it('writes and reads text', async () => {
+      await sandbox.writeText('test.txt', 'hello text')
+      const text = await sandbox.readText('test.txt')
+      expect(text).toBe('hello text')
+    })
+
+    it('creates parent directories on write', async () => {
+      await sandbox.writeFile('deep/nested/dir/test.txt', new Uint8Array(Buffer.from('deep')))
+      const read = await sandbox.readFile('deep/nested/dir/test.txt')
+      expect(Buffer.from(read).toString()).toBe('deep')
+    })
+
+    it('removes a file', async () => {
+      await sandbox.writeFile('removeme.txt', new Uint8Array(Buffer.from('delete this')))
+      await sandbox.removeFile('removeme.txt')
+      await expect(sandbox.readFile('removeme.txt')).rejects.toThrow()
+    })
+
+    it('throws on reading nonexistent file', async () => {
+      await expect(sandbox.readFile('nonexistent.txt')).rejects.toThrow()
+    })
+
+    it('handles binary data roundtrip', async () => {
+      const bytes = new Uint8Array([0, 1, 127, 128, 255])
+      await sandbox.writeFile('binary.bin', bytes)
+      const read = await sandbox.readFile('binary.bin')
+      expect(Array.from(read)).toStrictEqual([0, 1, 127, 128, 255])
+    })
+  })
+
+  describe('listFiles', () => {
+    it('lists files with metadata', async () => {
+      writeFileSync(join(workDir, 'a.txt'), 'content')
+      mkdirSync(join(workDir, 'subdir'))
+
+      const files = await sandbox.listFiles('.')
+      const fileNames = files.map((f) => f.name)
+
+      expect(fileNames).toContain('a.txt')
+      expect(fileNames).toContain('subdir')
+
+      const fileEntry = files.find((f) => f.name === 'a.txt')
+      expect(fileEntry!.isDir).toBe(false)
+      expect(fileEntry!.size).toBeGreaterThan(0)
+
+      const dirEntry = files.find((f) => f.name === 'subdir')
+      expect(dirEntry!.isDir).toBe(true)
+    })
+
+    it('returns sorted results', async () => {
+      writeFileSync(join(workDir, 'c.txt'), '')
+      writeFileSync(join(workDir, 'a.txt'), '')
+      writeFileSync(join(workDir, 'b.txt'), '')
+
+      const files = await sandbox.listFiles('.')
+      const names = files.map((f) => f.name)
+      expect(names).toStrictEqual([...names].sort())
+    })
+
+    it('includes hidden files', async () => {
+      writeFileSync(join(workDir, '.hidden'), '')
+      writeFileSync(join(workDir, 'visible.txt'), '')
+
+      const files = await sandbox.listFiles('.')
+      const names = files.map((f) => f.name)
+      expect(names).toContain('.hidden')
+    })
+  })
+})

--- a/strands-ts/src/sandbox/__tests__/noop.test.ts
+++ b/strands-ts/src/sandbox/__tests__/noop.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { NoOpSandbox } from '../noop.js'
+import { Sandbox } from '../base.js'
+
+describe('NoOpSandbox', () => {
+  const sandbox = new NoOpSandbox()
+
+  it('extends Sandbox', () => {
+    expect(sandbox).toBeInstanceOf(Sandbox)
+  })
+
+  it('throws on executeStreaming', async () => {
+    const gen = sandbox.executeStreaming('echo hello')
+    await expect(gen.next()).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on executeCodeStreaming', async () => {
+    const gen = sandbox.executeCodeStreaming('print(1)', 'python')
+    await expect(gen.next()).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on execute', async () => {
+    await expect(sandbox.execute('echo hello')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on executeCode', async () => {
+    await expect(sandbox.executeCode('print(1)', 'python')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on readFile', async () => {
+    await expect(sandbox.readFile('test.txt')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on writeFile', async () => {
+    await expect(sandbox.writeFile('test.txt', new Uint8Array())).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on removeFile', async () => {
+    await expect(sandbox.removeFile('test.txt')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on listFiles', async () => {
+    await expect(sandbox.listFiles('.')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on readText', async () => {
+    await expect(sandbox.readText('test.txt')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+
+  it('throws on writeText', async () => {
+    await expect(sandbox.writeText('test.txt', 'content')).rejects.toThrow('Sandbox is disabled (NoOpSandbox)')
+  })
+})

--- a/strands-ts/src/sandbox/__tests__/shell-based.test.ts
+++ b/strands-ts/src/sandbox/__tests__/shell-based.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ShellBasedSandbox } from '../shell-based.js'
+import type { ExecutionResult, ExecuteOptions, StreamChunk } from '../base.js'
+import { Sandbox } from '../base.js'
+
+/**
+ * Concrete test subclass that implements only executeStreaming.
+ * Records commands for assertion.
+ */
+class TestShellSandbox extends ShellBasedSandbox {
+  readonly commands: string[] = []
+  exitCode = 0
+  stdout = ''
+  stderr = ''
+
+  async *executeStreaming(
+    command: string,
+    _options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    this.commands.push(command)
+    yield { data: this.stdout, streamType: 'stdout' }
+    yield { exitCode: this.exitCode, stdout: this.stdout, stderr: this.stderr, outputFiles: [] }
+  }
+}
+
+describe('ShellBasedSandbox', () => {
+  describe('class hierarchy', () => {
+    it('extends Sandbox', () => {
+      const sandbox = new TestShellSandbox()
+      expect(sandbox).toBeInstanceOf(Sandbox)
+      expect(sandbox).toBeInstanceOf(ShellBasedSandbox)
+    })
+  })
+
+  describe('executeCodeStreaming', () => {
+    it('delegates to executeStreaming with shell-quoted command', async () => {
+      const sandbox = new TestShellSandbox()
+      sandbox.stdout = 'hello\n'
+
+      const chunks: (StreamChunk | ExecutionResult)[] = []
+      for await (const chunk of sandbox.executeCodeStreaming('print("hello")', 'python')) {
+        chunks.push(chunk)
+      }
+
+      expect(sandbox.commands).toHaveLength(1)
+      expect(sandbox.commands[0]).toContain("'python'")
+      expect(sandbox.commands[0]).toContain('-c')
+    })
+
+    it('passes options through to executeStreaming', async () => {
+      const sandbox = new TestShellSandbox()
+      const executeSpy = vi.spyOn(sandbox, 'executeStreaming')
+
+      const chunks: (StreamChunk | ExecutionResult)[] = []
+      for await (const chunk of sandbox.executeCodeStreaming('code', 'node', { timeout: 30, cwd: '/tmp' })) {
+        chunks.push(chunk)
+      }
+
+      expect(executeSpy).toHaveBeenCalledWith(expect.any(String), { timeout: 30, cwd: '/tmp' })
+    })
+  })
+
+  describe('readFile', () => {
+    it('uses base64 encoding for safe binary transport', async () => {
+      const sandbox = new TestShellSandbox()
+      // base64 of "hello world"
+      sandbox.stdout = 'aGVsbG8gd29ybGQ=\n'
+
+      const data = await sandbox.readFile('/tmp/test.txt')
+      const text = new TextDecoder().decode(data)
+      expect(text).toBe('hello world')
+      expect(sandbox.commands[0]).toContain('base64')
+      expect(sandbox.commands[0]).toContain("'/tmp/test.txt'")
+    })
+
+    it('throws on non-zero exit code', async () => {
+      const sandbox = new TestShellSandbox()
+      sandbox.exitCode = 1
+      sandbox.stderr = 'No such file'
+
+      await expect(sandbox.readFile('/nope')).rejects.toThrow('No such file')
+    })
+  })
+
+  describe('writeFile', () => {
+    it('uses base64 encoding and mkdir -p', async () => {
+      const sandbox = new TestShellSandbox()
+      const content = new TextEncoder().encode('hello')
+
+      await sandbox.writeFile('/tmp/dir/file.txt', content)
+
+      expect(sandbox.commands[0]).toContain('mkdir -p')
+      expect(sandbox.commands[0]).toContain('base64 -d')
+    })
+
+    it('throws on non-zero exit code', async () => {
+      const sandbox = new TestShellSandbox()
+      sandbox.exitCode = 1
+      sandbox.stderr = 'Permission denied'
+
+      await expect(sandbox.writeFile('/nope', new Uint8Array([1]))).rejects.toThrow('Permission denied')
+    })
+  })
+
+  describe('removeFile', () => {
+    it('uses rm with shell-quoted path', async () => {
+      const sandbox = new TestShellSandbox()
+      await sandbox.removeFile('/tmp/file.txt')
+      expect(sandbox.commands[0]).toBe("rm '/tmp/file.txt'")
+    })
+
+    it('throws on non-zero exit code', async () => {
+      const sandbox = new TestShellSandbox()
+      sandbox.exitCode = 1
+      sandbox.stderr = 'No such file'
+
+      await expect(sandbox.removeFile('/nope')).rejects.toThrow('No such file')
+    })
+  })
+
+  describe('listFiles', () => {
+    it('parses ls -1aF output into FileInfo entries', async () => {
+      const sandbox = new TestShellSandbox()
+      sandbox.stdout = '.\n..\nfile.txt\ndir/\nscript.sh*\nlink@\n'
+
+      const entries = await sandbox.listFiles('/tmp')
+      expect(entries).toStrictEqual([
+        { name: 'file.txt', isDir: false },
+        { name: 'dir', isDir: true },
+        { name: 'script.sh', isDir: false },
+        { name: 'link', isDir: false },
+      ])
+    })
+
+    it('throws on non-zero exit code', async () => {
+      const sandbox = new TestShellSandbox()
+      sandbox.exitCode = 1
+      sandbox.stderr = 'No such directory'
+
+      await expect(sandbox.listFiles('/nope')).rejects.toThrow('No such directory')
+    })
+  })
+})

--- a/strands-ts/src/sandbox/base.ts
+++ b/strands-ts/src/sandbox/base.ts
@@ -1,0 +1,308 @@
+/**
+ * Base sandbox interface for agent code execution environments.
+ *
+ * Defines the abstract `Sandbox` class and supporting types:
+ * - {@link ExecutionResult} — result of command/code execution
+ * - {@link FileInfo} — metadata about a file in the sandbox
+ * - {@link OutputFile} — a file produced as output by code execution
+ * - {@link StreamChunk} — a typed chunk of streaming output (stdout or stderr)
+ *
+ * Sandbox implementations provide the runtime context where tools execute code,
+ * run commands, and interact with a filesystem. Multiple tools share the same
+ * Sandbox instance, giving them a common working directory, environment variables,
+ * and filesystem.
+ *
+ * Class hierarchy:
+ * - `Sandbox`: All operations abstract. Implement for non-shell-based sandboxes.
+ * - `ShellBasedSandbox` (in shell-based.ts): Shell-based defaults for file operations.
+ * - `NoOpSandbox` (in noop.ts): Raises errors for all operations.
+ */
+
+/**
+ * Type of a streaming output chunk.
+ *
+ * - `"stdout"`: Standard output from the command or code.
+ * - `"stderr"`: Standard error from the command or code.
+ */
+export type StreamType = 'stdout' | 'stderr'
+
+/**
+ * A typed chunk of streaming output from command or code execution.
+ *
+ * Allows consumers to distinguish stdout from stderr during streaming,
+ * enabling richer UIs and more precise output handling.
+ */
+export interface StreamChunk {
+  /**
+   * The text content of the chunk.
+   */
+  data: string
+
+  /**
+   * Whether this chunk is from stdout or stderr.
+   */
+  streamType: StreamType
+}
+
+/**
+ * Metadata about a file or directory in a sandbox.
+ *
+ * Provides minimal structured information that lets tools distinguish
+ * files from directories and report sizes. Fields `isDir` and `size`
+ * are optional — implementations that cannot provide accurate data
+ * return `undefined` instead of lying.
+ */
+export interface FileInfo {
+  /**
+   * The file or directory name (not the full path).
+   */
+  name: string
+
+  /**
+   * Whether this entry is a directory. `undefined` if unknown.
+   */
+  isDir?: boolean
+
+  /**
+   * File size in bytes. `undefined` if unknown.
+   */
+  size?: number
+}
+
+/**
+ * A file produced as output by code execution.
+ *
+ * Used to carry binary artifacts (images, charts, PDFs, compiled files)
+ * from sandbox execution back to the agent. Tools can convert these
+ * to the SDK's media content types for the model.
+ */
+export interface OutputFile {
+  /**
+   * Filename (e.g., `"plot.png"`).
+   */
+  name: string
+
+  /**
+   * Raw file content as bytes.
+   */
+  content: Uint8Array
+
+  /**
+   * MIME type of the content (e.g., `"image/png"`).
+   */
+  mimeType: string
+}
+
+/**
+ * Result of code or command execution in a sandbox.
+ */
+export interface ExecutionResult {
+  /**
+   * The exit code of the command or code execution.
+   */
+  exitCode: number
+
+  /**
+   * Standard output captured from execution.
+   */
+  stdout: string
+
+  /**
+   * Standard error captured from execution.
+   */
+  stderr: string
+
+  /**
+   * Files produced by the execution (e.g., images, charts).
+   * Shell-based sandboxes typically return an empty list.
+   */
+  outputFiles: OutputFile[]
+}
+
+/**
+ * Abstract execution environment for agent tools.
+ *
+ * A Sandbox provides the runtime context where tools execute code,
+ * run commands, and interact with a filesystem. Multiple tools share
+ * the same Sandbox instance, giving them a common working directory,
+ * environment variables, and filesystem.
+ *
+ * The sandbox follows the SDK's streaming pattern: streaming methods
+ * (`executeStreaming`, `executeCodeStreaming`) are the abstract primitives
+ * that implementations must provide. Non-streaming convenience methods
+ * (`execute`, `executeCode`) consume the stream and return the final
+ * `ExecutionResult`.
+ *
+ * Streaming methods yield `StreamChunk` objects that carry both
+ * the text data and the stream type (stdout or stderr), followed by a
+ * final `ExecutionResult`.
+ *
+ * @example
+ * ```typescript
+ * import { HostSandbox } from '@strands-agents/sdk/sandbox'
+ *
+ * const sandbox = new HostSandbox({ workingDir: '/tmp/my-sandbox' })
+ * const result = await sandbox.execute('echo hello')
+ * console.log(result.stdout) // "hello\n"
+ * ```
+ */
+export abstract class Sandbox {
+  /**
+   * Execute a shell command, streaming output.
+   *
+   * Yields `StreamChunk` objects for stdout and stderr output
+   * as it arrives. The final yield is an `ExecutionResult` with
+   * the exit code and complete output.
+   *
+   * @param command - The shell command to execute.
+   * @param options - Execution options (timeout, cwd).
+   * @returns Async generator yielding StreamChunks then a final ExecutionResult.
+   */
+  abstract executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined>
+
+  /**
+   * Execute code in the sandbox, streaming output.
+   *
+   * @param code - The source code to execute.
+   * @param language - The programming language interpreter to use.
+   * @param options - Execution options (timeout, cwd).
+   * @returns Async generator yielding StreamChunks then a final ExecutionResult.
+   */
+  abstract executeCodeStreaming(
+    code: string,
+    language: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined>
+
+  /**
+   * Read a file from the sandbox filesystem.
+   *
+   * Returns raw bytes to support both text and binary files.
+   * Use {@link readText} for a convenience wrapper that decodes to a string.
+   *
+   * @param path - Path to the file to read.
+   * @returns The file contents as a Uint8Array.
+   */
+  abstract readFile(path: string): Promise<Uint8Array>
+
+  /**
+   * Write a file to the sandbox filesystem.
+   *
+   * Accepts raw bytes to support both text and binary content.
+   * Use {@link writeText} for a convenience wrapper that encodes a string.
+   *
+   * Implementations should create parent directories if they do not exist.
+   *
+   * @param path - Path to the file to write.
+   * @param content - The content to write as bytes.
+   */
+  abstract writeFile(path: string, content: Uint8Array): Promise<void>
+
+  /**
+   * Remove a file from the sandbox filesystem.
+   *
+   * @param path - Path to the file to remove.
+   */
+  abstract removeFile(path: string): Promise<void>
+
+  /**
+   * List files in a sandbox directory.
+   *
+   * Returns structured `FileInfo` entries with metadata.
+   *
+   * @param path - Path to the directory to list.
+   * @returns A list of FileInfo entries for the directory contents.
+   */
+  abstract listFiles(path: string): Promise<FileInfo[]>
+
+  /**
+   * Execute a shell command and return the result.
+   *
+   * Convenience wrapper that consumes `executeStreaming` and returns
+   * the final `ExecutionResult`. This is the common case — use
+   * `executeStreaming` when you need to process output as it arrives.
+   *
+   * @param command - The shell command to execute.
+   * @param options - Execution options (timeout, cwd).
+   * @returns The final ExecutionResult from execution.
+   */
+  async execute(command: string, options?: ExecuteOptions): Promise<ExecutionResult> {
+    let result: ExecutionResult | undefined
+    for await (const chunk of this.executeStreaming(command, options)) {
+      if ('exitCode' in chunk) {
+        result = chunk as ExecutionResult
+      }
+    }
+    if (!result) {
+      throw new Error('executeStreaming() did not yield an ExecutionResult')
+    }
+    return result
+  }
+
+  /**
+   * Execute code and return the result.
+   *
+   * Convenience wrapper that consumes `executeCodeStreaming` and returns
+   * the final `ExecutionResult`.
+   *
+   * @param code - The source code to execute.
+   * @param language - The programming language interpreter to use.
+   * @param options - Execution options (timeout, cwd).
+   * @returns The final ExecutionResult from execution.
+   */
+  async executeCode(code: string, language: string, options?: ExecuteOptions): Promise<ExecutionResult> {
+    let result: ExecutionResult | undefined
+    for await (const chunk of this.executeCodeStreaming(code, language, options)) {
+      if ('exitCode' in chunk) {
+        result = chunk as ExecutionResult
+      }
+    }
+    if (!result) {
+      throw new Error('executeCodeStreaming() did not yield an ExecutionResult')
+    }
+    return result
+  }
+
+  /**
+   * Read a text file from the sandbox filesystem.
+   *
+   * Convenience wrapper around `readFile` that decodes bytes to a string.
+   *
+   * @param path - Path to the file to read.
+   * @returns The file contents as a string.
+   */
+  async readText(path: string): Promise<string> {
+    const data = await this.readFile(path)
+    return new TextDecoder('utf-8').decode(data)
+  }
+
+  /**
+   * Write a text file to the sandbox filesystem.
+   *
+   * Convenience wrapper around `writeFile` that encodes a string to bytes.
+   *
+   * @param path - Path to the file to write.
+   * @param content - The text content to write.
+   */
+  async writeText(path: string, content: string): Promise<void> {
+    await this.writeFile(path, new TextEncoder().encode(content))
+  }
+}
+
+/**
+ * Options for command/code execution.
+ */
+export interface ExecuteOptions {
+  /**
+   * Maximum execution time in seconds. `undefined` means no timeout.
+   */
+  timeout?: number
+
+  /**
+   * Working directory for execution. `undefined` means use the sandbox's default.
+   */
+  cwd?: string
+}

--- a/strands-ts/src/sandbox/host.ts
+++ b/strands-ts/src/sandbox/host.ts
@@ -1,0 +1,251 @@
+import { Buffer } from 'buffer'
+/**
+ * Host sandbox implementation for host-process execution.
+ *
+ * Executes commands and code on the local host using Node.js `child_process`
+ * and native filesystem operations. Extends `Sandbox` directly — all file and
+ * code operations use proper Node.js methods instead of shell commands.
+ *
+ * This is the default sandbox used when no explicit sandbox is configured.
+ */
+
+import { spawn, execSync } from 'node:child_process'
+import { readFile, writeFile, unlink, readdir, stat, mkdir } from 'node:fs/promises'
+import { resolve, isAbsolute } from 'node:path'
+import { existsSync, mkdirSync } from 'node:fs'
+import { logger } from '../logging/logger.js'
+import type { ExecutionResult, ExecuteOptions, FileInfo, StreamChunk } from './base.js'
+import { Sandbox } from './base.js'
+
+/**
+ * Pattern for validating language/interpreter names.
+ * Allows alphanumeric characters, dots, hyphens, and underscores.
+ */
+const LANGUAGE_PATTERN = /^[a-zA-Z0-9._-]+$/
+
+/**
+ * Configuration for the HostSandbox.
+ */
+export interface HostSandboxConfig {
+  /**
+   * The working directory for command execution.
+   * Defaults to the current working directory.
+   */
+  workingDir?: string
+}
+
+/**
+ * Execute code and commands on the local host using native Node.js methods.
+ *
+ * Uses `child_process.spawn` for command execution and native `fs` methods
+ * for all file I/O.
+ *
+ * This sandbox extends `Sandbox` directly — it does **not** inherit from
+ * `ShellBasedSandbox`. All operations use proper, safe Node.js methods
+ * instead of piping through shell commands.
+ *
+ * @example
+ * ```typescript
+ * const sandbox = new HostSandbox({ workingDir: '/tmp/my-sandbox' })
+ * const result = await sandbox.execute('echo hello')
+ * console.log(result.stdout) // "hello\n"
+ * ```
+ */
+export class HostSandbox extends Sandbox {
+  private readonly _workingDir: string
+
+  /**
+   * Creates a new HostSandbox.
+   *
+   * @param config - Configuration options.
+   */
+  constructor(config?: HostSandboxConfig) {
+    super()
+    this._workingDir = config?.workingDir ?? process.cwd()
+  }
+
+  /**
+   * The working directory for this sandbox.
+   */
+  get workingDir(): string {
+    return this._workingDir
+  }
+
+  private _resolvePath(path: string): string {
+    if (isAbsolute(path)) {
+      return path
+    }
+    return resolve(this._workingDir, path)
+  }
+
+  private _ensureDir(dirPath: string): void {
+    if (!existsSync(dirPath)) {
+      mkdirSync(dirPath, { recursive: true })
+    }
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    const effectiveCwd = options?.cwd ?? this._workingDir
+    logger.debug(`command=<${command}>, timeout=<${options?.timeout}>, cwd=<${effectiveCwd}> | executing local command`)
+
+    this._ensureDir(effectiveCwd)
+
+    const { stdout, stderr, exitCode } = await this._spawnAndCollect(command, effectiveCwd, options?.timeout, true)
+
+    for (const chunk of stdout) {
+      yield { data: chunk, streamType: 'stdout' }
+    }
+    for (const chunk of stderr) {
+      yield { data: chunk, streamType: 'stderr' }
+    }
+
+    yield {
+      exitCode,
+      stdout: stdout.join(''),
+      stderr: stderr.join(''),
+      outputFiles: [],
+    }
+  }
+
+  async *executeCodeStreaming(
+    code: string,
+    language: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    if (!LANGUAGE_PATTERN.test(language)) {
+      throw new Error(`language parameter contains unsafe characters: ${language}`)
+    }
+
+    const effectiveCwd = options?.cwd ?? this._workingDir
+    logger.debug(
+      `language=<${language}>, timeout=<${options?.timeout}>, cwd=<${effectiveCwd}> | executing code locally`
+    )
+
+    this._ensureDir(effectiveCwd)
+
+    // Check if interpreter exists
+    try {
+      execSync(`which ${language}`, { stdio: 'pipe' })
+    } catch {
+      yield {
+        exitCode: 127,
+        stdout: '',
+        stderr: `Language interpreter not found: ${language}`,
+        outputFiles: [],
+      }
+      return
+    }
+
+    const { stdout, stderr, exitCode } = await this._spawnAndCollect(
+      `${language} -c ${this._shellQuote(code)}`,
+      effectiveCwd,
+      options?.timeout,
+      true
+    )
+
+    for (const chunk of stdout) {
+      yield { data: chunk, streamType: 'stdout' }
+    }
+    for (const chunk of stderr) {
+      yield { data: chunk, streamType: 'stderr' }
+    }
+
+    yield {
+      exitCode,
+      stdout: stdout.join(''),
+      stderr: stderr.join(''),
+      outputFiles: [],
+    }
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    const fullPath = this._resolvePath(path)
+    return new Uint8Array(await readFile(fullPath))
+  }
+
+  async writeFile(path: string, content: Uint8Array): Promise<void> {
+    const fullPath = this._resolvePath(path)
+    const dir = resolve(fullPath, '..')
+    await mkdir(dir, { recursive: true })
+    await writeFile(fullPath, content)
+  }
+
+  async removeFile(path: string): Promise<void> {
+    const fullPath = this._resolvePath(path)
+    await unlink(fullPath)
+  }
+
+  async listFiles(path: string): Promise<FileInfo[]> {
+    const fullPath = this._resolvePath(path)
+    const entries = await readdir(fullPath)
+    const results: FileInfo[] = []
+
+    for (const name of entries.sort()) {
+      const entryPath = resolve(fullPath, name)
+      try {
+        const s = await stat(entryPath)
+        results.push({
+          name,
+          isDir: s.isDirectory(),
+          size: s.size,
+        })
+      } catch {
+        // Broken symlink or stat failure — include with defaults
+        results.push({ name })
+      }
+    }
+
+    return results
+  }
+
+  private _shellQuote(s: string): string {
+    return `'${s.replace(/'/g, "'\\''")}'`
+  }
+
+  private async _spawnAndCollect(
+    command: string,
+    cwd: string,
+    timeout?: number,
+    shell = true
+  ): Promise<{ stdout: string[]; stderr: string[]; exitCode: number }> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(command, { cwd, shell, stdio: 'pipe' })
+
+      const stdoutChunks: string[] = []
+      const stderrChunks: string[] = []
+      let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined
+
+      if (timeout) {
+        timeoutId = globalThis.setTimeout(() => {
+          proc.kill('SIGKILL')
+          reject(new Error(`Command timed out after ${timeout} seconds`))
+        }, timeout * 1000)
+      }
+
+      proc.stdout.on('data', (data: Buffer) => {
+        stdoutChunks.push(data.toString())
+      })
+
+      proc.stderr.on('data', (data: Buffer) => {
+        stderrChunks.push(data.toString())
+      })
+
+      proc.on('close', (code) => {
+        if (timeoutId) globalThis.clearTimeout(timeoutId)
+        resolve({
+          stdout: stdoutChunks,
+          stderr: stderrChunks,
+          exitCode: code ?? 0,
+        })
+      })
+
+      proc.on('error', (err) => {
+        if (timeoutId) globalThis.clearTimeout(timeoutId)
+        reject(err)
+      })
+    })
+  }
+}

--- a/strands-ts/src/sandbox/index.ts
+++ b/strands-ts/src/sandbox/index.ts
@@ -8,6 +8,7 @@
  * Class hierarchy:
  * - `Sandbox` (abstract, all operations abstract + convenience helpers)
  *   - `HostSandbox` — native Node.js methods for host execution (default)
+ *   - `ShellBasedSandbox` — shell-based defaults for remote environments (Docker, SSH)
  *   - `NoOpSandbox` — no-op implementation that disables all functionality
  */
 
@@ -15,4 +16,5 @@ export { Sandbox } from './base.js'
 export type { ExecutionResult, ExecuteOptions, FileInfo, OutputFile, StreamChunk, StreamType } from './base.js'
 export { HostSandbox } from './host.js'
 export type { HostSandboxConfig } from './host.js'
+export { ShellBasedSandbox } from './shell-based.js'
 export { NoOpSandbox } from './noop.js'

--- a/strands-ts/src/sandbox/index.ts
+++ b/strands-ts/src/sandbox/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Sandbox abstraction for agent code execution environments.
+ *
+ * Provides the Sandbox interface that decouples tool logic from where code runs.
+ * Tools that need to execute code or access a filesystem receive a Sandbox
+ * instead of managing their own execution.
+ *
+ * Class hierarchy:
+ * - `Sandbox` (abstract, all operations abstract + convenience helpers)
+ *   - `HostSandbox` — native Node.js methods for host execution (default)
+ *   - `NoOpSandbox` — no-op implementation that disables all functionality
+ */
+
+export { Sandbox } from './base.js'
+export type { ExecutionResult, ExecuteOptions, FileInfo, OutputFile, StreamChunk, StreamType } from './base.js'
+export { HostSandbox } from './host.js'
+export type { HostSandboxConfig } from './host.js'
+export { NoOpSandbox } from './noop.js'

--- a/strands-ts/src/sandbox/noop.ts
+++ b/strands-ts/src/sandbox/noop.ts
@@ -1,0 +1,68 @@
+/**
+ * No-op sandbox implementation that disables all sandbox functionality.
+ *
+ * Use `NoOpSandbox` to explicitly disable sandbox features on an agent.
+ * All operations throw `Error` with a clear message.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { NoOpSandbox } from '@strands-agents/sdk/sandbox'
+ *
+ * const agent = new Agent({ sandbox: new NoOpSandbox() })
+ * ```
+ */
+
+import type { ExecutionResult, ExecuteOptions, FileInfo, StreamChunk } from './base.js'
+import { Sandbox } from './base.js'
+
+/**
+ * No-op sandbox that throws errors for all operations.
+ *
+ * Use this to explicitly disable sandbox functionality on an agent.
+ * Any tool that attempts to use the sandbox will get a clear error
+ * indicating that sandbox is disabled.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, NoOpSandbox } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ sandbox: new NoOpSandbox() })
+ * ```
+ */
+export class NoOpSandbox extends Sandbox {
+  async *executeStreaming(
+    _command: string,
+    _options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    throw new Error('Sandbox is disabled (NoOpSandbox). Cannot execute commands.')
+    // eslint-disable-next-line no-unreachable
+    yield undefined as never
+  }
+
+  async *executeCodeStreaming(
+    _code: string,
+    _language: string,
+    _options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    throw new Error('Sandbox is disabled (NoOpSandbox). Cannot execute code.')
+    // eslint-disable-next-line no-unreachable
+    yield undefined as never
+  }
+
+  async readFile(_path: string): Promise<Uint8Array> {
+    throw new Error('Sandbox is disabled (NoOpSandbox). Cannot read files.')
+  }
+
+  async writeFile(_path: string, _content: Uint8Array): Promise<void> {
+    throw new Error('Sandbox is disabled (NoOpSandbox). Cannot write files.')
+  }
+
+  async removeFile(_path: string): Promise<void> {
+    throw new Error('Sandbox is disabled (NoOpSandbox). Cannot remove files.')
+  }
+
+  async listFiles(_path: string): Promise<FileInfo[]> {
+    throw new Error('Sandbox is disabled (NoOpSandbox). Cannot list files.')
+  }
+}

--- a/strands-ts/src/sandbox/shell-based.ts
+++ b/strands-ts/src/sandbox/shell-based.ts
@@ -1,0 +1,166 @@
+/**
+ * Shell-based sandbox with default implementations for file and code operations.
+ *
+ * Defines the {@link ShellBasedSandbox} abstract class, which provides
+ * shell-command-based defaults for file operations (read, write, remove, list)
+ * and code execution. Subclasses only need to implement `executeStreaming()`.
+ *
+ * Use this for remote environments where only shell access is available
+ * (e.g., Docker containers, SSH connections). For local execution, use
+ * {@link HostSandbox} which uses native Node.js methods instead.
+ *
+ * Class hierarchy:
+ * - `Sandbox` (ABC, all abstract)
+ *   - `ShellBasedSandbox` (ABC, only `executeStreaming()` abstract — shell-based file ops + execute_code)
+ */
+
+import type { ExecutionResult, ExecuteOptions, FileInfo, StreamChunk } from './base.js'
+import { Sandbox } from './base.js'
+
+/**
+ * Shell-quote a string for safe use in shell commands.
+ *
+ * Wraps the string in single quotes and escapes embedded single quotes,
+ * equivalent to Python's `shlex.quote()`.
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Abstract sandbox that provides shell-based defaults for file and code operations.
+ *
+ * Subclasses only need to implement {@link executeStreaming}. The remaining
+ * operations — `executeCodeStreaming`, `readFile`, `writeFile`,
+ * `removeFile`, and `listFiles` — are implemented via shell commands
+ * piped through `executeStreaming()`.
+ *
+ * This class is intended for remote execution environments where only
+ * shell access is available (e.g., Docker containers, SSH connections).
+ * For local execution, use {@link HostSandbox} which uses native Node.js
+ * methods for better safety and reliability.
+ *
+ * Subclasses may override any method with a native implementation for
+ * better performance.
+ *
+ * @example
+ * ```typescript
+ * class DockerSandbox extends ShellBasedSandbox {
+ *   async *executeStreaming(command, options) {
+ *     // Run command in Docker container
+ *   }
+ * }
+ * ```
+ */
+export abstract class ShellBasedSandbox extends Sandbox {
+  /**
+   * Execute code in the sandbox, streaming output.
+   *
+   * The default implementation passes code to the language interpreter
+   * via `-c` with proper shell quoting. Both the `language` and
+   * `code` parameters are sanitized with shell quoting to prevent
+   * command injection.
+   *
+   * @param code - The source code to execute.
+   * @param language - The programming language interpreter to use
+   *   (e.g., `"python"`, `"node"`, `"ruby"`).
+   * @param options - Execution options (timeout, cwd).
+   * @returns Async generator yielding StreamChunks then a final ExecutionResult.
+   */
+  async *executeCodeStreaming(
+    code: string,
+    language: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    yield* this.executeStreaming(`${shellQuote(language)} -c ${shellQuote(code)}`, options)
+  }
+
+  /**
+   * Read a file from the sandbox filesystem as raw bytes.
+   *
+   * Uses `base64` to encode the file content for safe transport
+   * through the shell text layer, then decodes on the Node.js side.
+   * This preserves binary content (images, PDFs, compiled files)
+   * that would be corrupted by direct `cat` through a text pipe.
+   *
+   * @param path - Path to the file to read.
+   * @returns The file contents as a Uint8Array.
+   * @throws If the file does not exist or cannot be read.
+   */
+  async readFile(path: string): Promise<Uint8Array> {
+    const result = await this.execute(`base64 ${shellQuote(path)}`)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to read file: ${path}`)
+    }
+    const decoded = globalThis.atob(result.stdout.trim())
+    return Uint8Array.from(decoded, (c) => c.charCodeAt(0))
+  }
+
+  /**
+   * Write bytes to a file in the sandbox filesystem.
+   *
+   * Uses `base64` encoding to safely transport binary content through
+   * the shell text layer. Parent directories are created automatically
+   * via `mkdir -p`.
+   *
+   * @param path - Path to the file to write.
+   * @param content - The content to write as bytes.
+   * @throws If the file cannot be written.
+   */
+  async writeFile(path: string, content: Uint8Array): Promise<void> {
+    const binary = Array.from(content, (byte) => String.fromCharCode(byte)).join('')
+    const encoded = globalThis.btoa(binary)
+    const quotedPath = shellQuote(path)
+    const cmd = `mkdir -p "$(dirname ${quotedPath})" && printf '%s' ${shellQuote(encoded)} | base64 -d > ${quotedPath}`
+    const result = await this.execute(cmd)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to write file: ${path}`)
+    }
+  }
+
+  /**
+   * Remove a file from the sandbox filesystem.
+   *
+   * @param path - Path to the file to remove.
+   * @throws If the file does not exist.
+   */
+  async removeFile(path: string): Promise<void> {
+    const result = await this.execute(`rm ${shellQuote(path)}`)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to remove file: ${path}`)
+    }
+  }
+
+  /**
+   * List files in a sandbox directory with structured metadata.
+   *
+   * Uses `ls -1aF` to include hidden files (dotfiles) and identify
+   * directories. Returns {@link FileInfo} entries with name and isDir.
+   * Size is `undefined` for shell-based listing.
+   *
+   * @param path - Path to the directory to list.
+   * @returns A list of FileInfo entries.
+   * @throws If the directory does not exist.
+   */
+  async listFiles(path: string): Promise<FileInfo[]> {
+    const result = await this.execute(`ls -1aF ${shellQuote(path)}`)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to list files: ${path}`)
+    }
+
+    const entries: FileInfo[] = []
+    for (const line of result.stdout.trim().split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed === '.' || trimmed === '..' || trimmed === './' || trimmed === '../') {
+        continue
+      }
+      const isDir = trimmed.endsWith('/')
+      // Strip the type indicator from the name (ls -F appends / @ * = |)
+      const name = trimmed.replace(/[/@*=|]$/, '')
+      if (name) {
+        entries.push({ name, isDir })
+      }
+    }
+    return entries
+  }
+}

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -1,3 +1,4 @@
+import type { Sandbox } from '../sandbox/base.js'
 import type { StateStore } from '../state-store.js'
 import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason, SystemPrompt } from './messages.js'
 import type { AgentTrace } from '../telemetry/tracer.js'
@@ -155,6 +156,11 @@ export interface LocalAgent {
    * The tool registry for registering tools with the agent.
    */
   readonly toolRegistry: ToolRegistry
+
+  /**
+   * The sandbox for code execution and filesystem access.
+   */
+  readonly sandbox: Sandbox
 
   /**
    * The system prompt to pass to the model provider.

--- a/strands-ts/src/vended-plugins/skills/__tests__/sandbox-skills.test.node.ts
+++ b/strands-ts/src/vended-plugins/skills/__tests__/sandbox-skills.test.node.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Skill } from '../skill.js'
+import { AgentSkills } from '../agent-skills.js'
+import type { Sandbox } from '../../../sandbox/base.js'
+import type { FileInfo } from '../../../sandbox/base.js'
+import type { LocalAgent } from '../../../types/agent.js'
+import { StateStore } from '../../../state-store.js'
+import { ToolRegistry } from '../../../registry/tool-registry.js'
+
+const VALID_SKILL_MD = `---
+name: test-skill
+description: A test skill
+---
+# Instructions
+Do the thing.
+`
+
+function createMockSandbox(files: Record<string, string> = {}): Sandbox {
+  return {
+    readFile: vi.fn(async (path: string): Promise<Uint8Array> => {
+      const content = files[path]
+      if (content == null) throw new Error(`File not found: ${path}`)
+      return new TextEncoder().encode(content)
+    }),
+    readText: vi.fn(async (path: string): Promise<string> => {
+      const content = files[path]
+      if (content == null) throw new Error(`File not found: ${path}`)
+      return content
+    }),
+    writeFile: vi.fn(),
+    writeText: vi.fn(),
+    removeFile: vi.fn(),
+    listFiles: vi.fn(async (path: string): Promise<FileInfo[]> => {
+      const prefix = path.endsWith('/') ? path : `${path}/`
+      const children = new Set<string>()
+      for (const key of Object.keys(files)) {
+        if (key.startsWith(prefix)) {
+          const rest = key.slice(prefix.length)
+          const firstSegment = rest.split('/')[0]
+          if (firstSegment != null) children.add(firstSegment)
+        }
+      }
+      return Array.from(children).map((name) => {
+        const childPath = `${prefix}${name}`
+        const hasChildren = Object.keys(files).some((k) => k.startsWith(`${childPath}/`))
+        return { name, isDir: hasChildren }
+      })
+    }),
+    execute: vi.fn(),
+    executeCode: vi.fn(),
+    executeStreaming: vi.fn() as never,
+    executeCodeStreaming: vi.fn() as never,
+  } as unknown as Sandbox
+}
+
+function createMockAgent(sandbox: Sandbox): LocalAgent {
+  return {
+    id: 'test-agent',
+    sandbox,
+    appState: new StateStore(),
+    messages: [],
+    toolRegistry: new ToolRegistry(),
+    systemPrompt: 'test',
+    cancelSignal: new AbortController().signal,
+    addHook: vi.fn().mockReturnValue(() => {}),
+  } as unknown as LocalAgent
+}
+
+describe('Skill.fromSandbox', () => {
+  it('loads a skill from a sandbox directory', async () => {
+    const sandbox = createMockSandbox({
+      '/skills/my-skill/SKILL.md': VALID_SKILL_MD,
+    })
+
+    const skill = await Skill.fromSandbox(sandbox, '/skills/my-skill')
+    expect(skill.name).toBe('test-skill')
+    expect(skill.description).toBe('A test skill')
+    expect(skill.instructions).toContain('Do the thing.')
+  })
+
+  it('loads from a direct SKILL.md path', async () => {
+    const sandbox = createMockSandbox({
+      '/skills/my-skill/SKILL.md': VALID_SKILL_MD,
+    })
+
+    const skill = await Skill.fromSandbox(sandbox, '/skills/my-skill/SKILL.md')
+    expect(skill.name).toBe('test-skill')
+  })
+
+  it('falls back to lowercase skill.md', async () => {
+    const sandbox = createMockSandbox({
+      '/skills/my-skill/skill.md': VALID_SKILL_MD,
+    })
+
+    const skill = await Skill.fromSandbox(sandbox, '/skills/my-skill')
+    expect(skill.name).toBe('test-skill')
+  })
+
+  it('throws when no SKILL.md exists', async () => {
+    const sandbox = createMockSandbox({})
+    await expect(Skill.fromSandbox(sandbox, '/empty')).rejects.toThrow('no SKILL.md found')
+  })
+})
+
+describe('Skill.fromSandboxDirectory', () => {
+  it('loads multiple skills from subdirectories', async () => {
+    const sandbox = createMockSandbox({
+      '/skills/skill-a/SKILL.md': '---\nname: skill-a\ndescription: Skill A\n---\nInstructions for A',
+      '/skills/skill-b/SKILL.md': '---\nname: skill-b\ndescription: Skill B\n---\nInstructions for B',
+    })
+
+    const skills = await Skill.fromSandboxDirectory(sandbox, '/skills')
+    expect(skills).toHaveLength(2)
+    expect(skills.map((s) => s.name).sort()).toStrictEqual(['skill-a', 'skill-b'])
+  })
+
+  it('skips non-directory entries', async () => {
+    const sandbox = createMockSandbox({
+      '/skills/skill-a/SKILL.md': VALID_SKILL_MD,
+    })
+    // listFiles returns the file entry as non-dir
+    vi.mocked(sandbox.listFiles).mockResolvedValueOnce([
+      { name: 'skill-a', isDir: true },
+      { name: 'readme.txt', isDir: false },
+    ])
+
+    const skills = await Skill.fromSandboxDirectory(sandbox, '/skills')
+    expect(skills).toHaveLength(1)
+  })
+
+  it('returns empty array on listFiles failure', async () => {
+    const sandbox = createMockSandbox({})
+    vi.mocked(sandbox.listFiles).mockRejectedValueOnce(new Error('access denied'))
+
+    const skills = await Skill.fromSandboxDirectory(sandbox, '/nope')
+    expect(skills).toStrictEqual([])
+  })
+})
+
+describe('AgentSkills sandbox sources', () => {
+  it('resolves sandbox: prefixed sources during initAgent', async () => {
+    const sandbox = createMockSandbox({
+      '/home/skills/my-skill/SKILL.md': VALID_SKILL_MD,
+    })
+    const agent = createMockAgent(sandbox)
+
+    const plugin = new AgentSkills({
+      skills: ['sandbox:/home/skills/my-skill'],
+    })
+
+    await plugin.initAgent(agent)
+
+    const skills = await plugin.getAvailableSkills()
+    expect(skills).toHaveLength(1)
+    expect(skills[0]!.name).toBe('test-skill')
+  })
+
+  it('resolves sandbox directory sources', async () => {
+    const sandbox = createMockSandbox({
+      '/home/skills/skill-a/SKILL.md': '---\nname: skill-a\ndescription: A\n---\nDo A',
+      '/home/skills/skill-b/SKILL.md': '---\nname: skill-b\ndescription: B\n---\nDo B',
+    })
+    const agent = createMockAgent(sandbox)
+
+    const plugin = new AgentSkills({
+      skills: ['sandbox:/home/skills'],
+    })
+
+    await plugin.initAgent(agent)
+
+    const skills = await plugin.getAvailableSkills()
+    expect(skills).toHaveLength(2)
+  })
+
+  it('mixes filesystem and sandbox sources', async () => {
+    const localSkill = new Skill({ name: 'local-skill', description: 'local' })
+    const sandbox = createMockSandbox({
+      '/sandbox/skill/SKILL.md': '---\nname: sandbox-skill\ndescription: from sandbox\n---\nInstructions',
+    })
+    const agent = createMockAgent(sandbox)
+
+    const plugin = new AgentSkills({
+      skills: [localSkill, 'sandbox:/sandbox/skill'],
+    })
+
+    await plugin.initAgent(agent)
+
+    const skills = await plugin.getAvailableSkills()
+    expect(skills).toHaveLength(2)
+    expect(skills.map((s) => s.name).sort()).toStrictEqual(['local-skill', 'sandbox-skill'])
+  })
+
+  it('rejects sandbox sources in setAvailableSkills', () => {
+    const plugin = new AgentSkills({ skills: [] })
+    expect(() => plugin.setAvailableSkills(['sandbox:/nope'])).toThrow(
+      'Sandbox sources are not supported in setAvailableSkills'
+    )
+  })
+})

--- a/strands-ts/src/vended-plugins/skills/__tests__/sandbox-skills.test.node.ts
+++ b/strands-ts/src/vended-plugins/skills/__tests__/sandbox-skills.test.node.ts
@@ -53,9 +53,9 @@ function createMockSandbox(files: Record<string, string> = {}): Sandbox {
   } as unknown as Sandbox
 }
 
-function createMockAgent(sandbox: Sandbox): LocalAgent {
+function createMockAgent(sandbox: Sandbox, id = 'test-agent'): LocalAgent {
   return {
-    id: 'test-agent',
+    id,
     sandbox,
     appState: new StateStore(),
     messages: [],
@@ -150,7 +150,7 @@ describe('AgentSkills sandbox sources', () => {
 
     await plugin.initAgent(agent)
 
-    const skills = await plugin.getAvailableSkills()
+    const skills = await plugin.getAvailableSkills(agent)
     expect(skills).toHaveLength(1)
     expect(skills[0]!.name).toBe('test-skill')
   })
@@ -168,7 +168,7 @@ describe('AgentSkills sandbox sources', () => {
 
     await plugin.initAgent(agent)
 
-    const skills = await plugin.getAvailableSkills()
+    const skills = await plugin.getAvailableSkills(agent)
     expect(skills).toHaveLength(2)
   })
 
@@ -185,7 +185,7 @@ describe('AgentSkills sandbox sources', () => {
 
     await plugin.initAgent(agent)
 
-    const skills = await plugin.getAvailableSkills()
+    const skills = await plugin.getAvailableSkills(agent)
     expect(skills).toHaveLength(2)
     expect(skills.map((s) => s.name).sort()).toStrictEqual(['local-skill', 'sandbox-skill'])
   })
@@ -195,5 +195,148 @@ describe('AgentSkills sandbox sources', () => {
     expect(() => plugin.setAvailableSkills(['sandbox:/nope'])).toThrow(
       'Sandbox sources are not supported in setAvailableSkills'
     )
+  })
+})
+
+describe('AgentSkills per-agent skill isolation', () => {
+  it('two agents with different sandboxes get different skill catalogs', async () => {
+    const sandboxA = createMockSandbox({
+      '/skills/docker-skill/SKILL.md': '---\nname: docker-skill\ndescription: Docker skill\n---\nDocker instructions',
+    })
+    const sandboxB = createMockSandbox({
+      '/skills/s3-skill/SKILL.md': '---\nname: s3-skill\ndescription: S3 skill\n---\nS3 instructions',
+    })
+
+    const agentA = createMockAgent(sandboxA, 'agent-a')
+    const agentB = createMockAgent(sandboxB, 'agent-b')
+
+    const plugin = new AgentSkills({
+      skills: ['sandbox:/skills'],
+    })
+
+    await plugin.initAgent(agentA)
+    await plugin.initAgent(agentB)
+
+    // Agent A should only see docker-skill
+    const skillsA = await plugin.getAvailableSkills(agentA)
+    expect(skillsA).toHaveLength(1)
+    expect(skillsA[0]!.name).toBe('docker-skill')
+
+    // Agent B should only see s3-skill
+    const skillsB = await plugin.getAvailableSkills(agentB)
+    expect(skillsB).toHaveLength(1)
+    expect(skillsB[0]!.name).toBe('s3-skill')
+  })
+
+  it('shared base skills are present for all agents, sandbox skills are per-agent', async () => {
+    const baseSkill = new Skill({ name: 'shared-skill', description: 'shared' })
+
+    const sandboxA = createMockSandbox({
+      '/skills/skill-a/SKILL.md': '---\nname: skill-a\ndescription: A\n---\nA',
+    })
+    const sandboxB = createMockSandbox({
+      '/skills/skill-b/SKILL.md': '---\nname: skill-b\ndescription: B\n---\nB',
+    })
+
+    const agentA = createMockAgent(sandboxA, 'agent-a')
+    const agentB = createMockAgent(sandboxB, 'agent-b')
+
+    const plugin = new AgentSkills({
+      skills: [baseSkill, 'sandbox:/skills'],
+    })
+
+    await plugin.initAgent(agentA)
+    await plugin.initAgent(agentB)
+
+    // Agent A: shared + skill-a
+    const skillsA = await plugin.getAvailableSkills(agentA)
+    expect(skillsA.map((s) => s.name).sort()).toStrictEqual(['shared-skill', 'skill-a'])
+
+    // Agent B: shared + skill-b
+    const skillsB = await plugin.getAvailableSkills(agentB)
+    expect(skillsB.map((s) => s.name).sort()).toStrictEqual(['shared-skill', 'skill-b'])
+  })
+
+  it('overlapping skill names in different sandboxes do not cross-contaminate', async () => {
+    const sandboxA = createMockSandbox({
+      '/skills/common/SKILL.md': '---\nname: common\ndescription: Version A\n---\nInstructions A',
+    })
+    const sandboxB = createMockSandbox({
+      '/skills/common/SKILL.md': '---\nname: common\ndescription: Version B\n---\nInstructions B',
+    })
+
+    const agentA = createMockAgent(sandboxA, 'agent-a')
+    const agentB = createMockAgent(sandboxB, 'agent-b')
+
+    const plugin = new AgentSkills({
+      skills: ['sandbox:/skills'],
+    })
+
+    await plugin.initAgent(agentA)
+    await plugin.initAgent(agentB)
+
+    const skillsA = await plugin.getAvailableSkills(agentA)
+    const skillsB = await plugin.getAvailableSkills(agentB)
+
+    expect(skillsA).toHaveLength(1)
+    expect(skillsB).toHaveLength(1)
+
+    // Each agent should have ITS OWN version of the 'common' skill
+    expect(skillsA[0]!.description).toBe('Version A')
+    expect(skillsA[0]!.instructions).toContain('Instructions A')
+    expect(skillsB[0]!.description).toBe('Version B')
+    expect(skillsB[0]!.instructions).toContain('Instructions B')
+  })
+
+  it('getAvailableSkills without agent returns only base skills', async () => {
+    const baseSkill = new Skill({ name: 'base-skill', description: 'base' })
+    const sandbox = createMockSandbox({
+      '/skills/sandbox-skill/SKILL.md': '---\nname: sandbox-skill\ndescription: sandbox\n---\nInstructions',
+    })
+    const agent = createMockAgent(sandbox)
+
+    const plugin = new AgentSkills({
+      skills: [baseSkill, 'sandbox:/skills'],
+    })
+
+    // Before initAgent — only base skills
+    const beforeInit = await plugin.getAvailableSkills()
+    expect(beforeInit).toHaveLength(1)
+    expect(beforeInit[0]!.name).toBe('base-skill')
+
+    await plugin.initAgent(agent)
+
+    // With agent — base + sandbox
+    const withAgent = await plugin.getAvailableSkills(agent)
+    expect(withAgent).toHaveLength(2)
+
+    // Without agent — still only base
+    const withoutAgent = await plugin.getAvailableSkills()
+    expect(withoutAgent).toHaveLength(1)
+    expect(withoutAgent[0]!.name).toBe('base-skill')
+  })
+
+  it('setAvailableSkills resets per-agent caches', async () => {
+    const sandbox = createMockSandbox({
+      '/skills/sandbox-skill/SKILL.md': '---\nname: sandbox-skill\ndescription: sandbox\n---\nInstructions',
+    })
+    const agent = createMockAgent(sandbox)
+
+    const plugin = new AgentSkills({
+      skills: ['sandbox:/skills'],
+    })
+
+    await plugin.initAgent(agent)
+    const before = await plugin.getAvailableSkills(agent)
+    expect(before).toHaveLength(1)
+
+    // Replace all skills — should clear per-agent caches
+    const newSkill = new Skill({ name: 'new-skill', description: 'new' })
+    plugin.setAvailableSkills([newSkill])
+
+    // Agent's cache should be gone — falls back to new base skills
+    const after = await plugin.getAvailableSkills(agent)
+    expect(after).toHaveLength(1)
+    expect(after[0]!.name).toBe('new-skill')
   })
 })

--- a/strands-ts/src/vended-plugins/skills/agent-skills.ts
+++ b/strands-ts/src/vended-plugins/skills/agent-skills.ts
@@ -19,7 +19,7 @@ import type { LocalAgent } from '../../types/agent.js'
 import type { Tool } from '../../tools/tool.js'
 import type { ToolContext } from '../../tools/tool.js'
 
-/** A single skill source: filesystem path string, HTTPS URL string, or Skill instance. */
+/** A single skill source: filesystem path string, HTTPS URL string, `sandbox:/path` string, or Skill instance. */
 export type SkillSource = string | Skill
 
 /** Configuration for the AgentSkills plugin. */
@@ -30,6 +30,7 @@ export interface AgentSkillsConfig {
    * - A path to a skill directory (containing SKILL.md)
    * - A path to a parent directory (containing skill subdirectories)
    * - An `https://` URL pointing directly to raw SKILL.md content
+   * - A `sandbox:/path` URI to load from the agent's sandbox at init time
    */
   skills: SkillSource[]
 
@@ -46,6 +47,7 @@ export interface AgentSkillsConfig {
 const DEFAULT_STATE_KEY = 'agent_skills'
 const RESOURCE_DIRS = ['scripts', 'references', 'assets']
 const DEFAULT_MAX_RESOURCE_FILES = 20
+const SANDBOX_PREFIX = 'sandbox:'
 
 /**
  * Escape XML special characters in text content.
@@ -98,14 +100,17 @@ export class AgentSkills implements Plugin {
   private readonly _stateKey: string
   /** Resolves when all async skill sources (e.g. URLs) have been loaded. */
   private _ready: Promise<void>
+  /** Sandbox paths to resolve during initAgent(). */
+  private _sandboxSources: string[]
 
   constructor(config: AgentSkillsConfig) {
     this._strict = config.strict ?? false
     this._maxResourceFiles = config.maxResourceFiles ?? DEFAULT_MAX_RESOURCE_FILES
     this._stateKey = config.stateKey ?? DEFAULT_STATE_KEY
-    const { skills, ready } = this._resolveSkills(config.skills)
+    const { skills, ready, sandboxSources } = this._resolveSkills(config.skills)
     this._skills = skills
     this._ready = ready
+    this._sandboxSources = sandboxSources
   }
 
   /**
@@ -117,6 +122,11 @@ export class AgentSkills implements Plugin {
    */
   async initAgent(agent: LocalAgent): Promise<void> {
     await this._ready
+
+    // Resolve deferred sandbox sources using the agent's sandbox
+    if (this._sandboxSources.length > 0) {
+      await this._resolveSandboxSources(agent)
+    }
 
     if (this._skills.size === 0) {
       logger.warn('no skills were loaded, the agent will have no skills available')
@@ -157,9 +167,17 @@ export class AgentSkills implements Plugin {
    * next tool call or invocation.
    */
   setAvailableSkills(skills: SkillSource[]): void {
-    const { skills: resolved, ready } = this._resolveSkills(skills)
+    for (const source of skills) {
+      if (typeof source === 'string' && source.startsWith(SANDBOX_PREFIX)) {
+        throw new Error(
+          'Sandbox sources are not supported in setAvailableSkills(). Use sandbox sources in the AgentSkills constructor instead.'
+        )
+      }
+    }
+    const { skills: resolved, ready, sandboxSources } = this._resolveSkills(skills)
     this._skills = resolved
     this._ready = ready
+    this._sandboxSources = sandboxSources
   }
 
   /**
@@ -182,11 +200,20 @@ export class AgentSkills implements Plugin {
    * the background; the returned `ready` promise resolves when all URL
    * fetches have completed and the map has been updated.
    */
-  private _resolveSkills(sources: SkillSource[]): { skills: Map<string, Skill>; ready: Promise<void> } {
+  private _resolveSkills(sources: SkillSource[]): {
+    skills: Map<string, Skill>
+    ready: Promise<void>
+    sandboxSources: string[]
+  } {
     const resolved = new Map<string, Skill>()
     const asyncTasks: Promise<void>[] = []
+    const sandboxSources: string[] = []
 
     for (const source of sources) {
+      if (typeof source === 'string' && source.startsWith(SANDBOX_PREFIX)) {
+        sandboxSources.push(source.slice(SANDBOX_PREFIX.length))
+        continue
+      }
       if (source instanceof Skill) {
         if (resolved.has(source.name)) {
           logger.warn(`name=<${source.name}> | duplicate skill name, overwriting previous skill`)
@@ -263,7 +290,46 @@ export class AgentSkills implements Plugin {
       ready = Promise.resolve()
     }
 
-    return { skills: resolved, ready }
+    return { skills: resolved, ready, sandboxSources }
+  }
+
+  /**
+   * Resolve sandbox skill sources using the agent's sandbox.
+   *
+   * Each sandbox source path is treated as either a single skill directory
+   * (if it contains SKILL.md) or a parent directory of skill subdirectories.
+   */
+  private async _resolveSandboxSources(agent: LocalAgent): Promise<void> {
+    const { Skill } = await import('./skill.js')
+    const sandbox = agent.sandbox
+
+    for (const sandboxPath of this._sandboxSources) {
+      logger.debug(`sandbox_path=<${sandboxPath}> | resolving sandbox skill source`)
+
+      try {
+        // Try as a single skill directory first
+        const skill = await Skill.fromSandbox(sandbox, sandboxPath, { strict: this._strict })
+        if (this._skills.has(skill.name)) {
+          logger.warn(`name=<${skill.name}> | duplicate skill name, overwriting previous skill`)
+        }
+        this._skills.set(skill.name, skill)
+        logger.debug(`sandbox_path=<${sandboxPath}>, name=<${skill.name}> | loaded single skill from sandbox`)
+      } catch {
+        // Fall back to parent directory
+        try {
+          const skills = await Skill.fromSandboxDirectory(sandbox, sandboxPath, { strict: this._strict })
+          for (const skill of skills) {
+            if (this._skills.has(skill.name)) {
+              logger.warn(`name=<${skill.name}> | duplicate skill name, overwriting previous skill`)
+            }
+            this._skills.set(skill.name, skill)
+          }
+          logger.debug(`sandbox_path=<${sandboxPath}>, count=<${skills.length}> | loaded skills from sandbox directory`)
+        } catch (error) {
+          logger.warn(`sandbox_path=<${sandboxPath}> | failed to load sandbox skills: ${error}`)
+        }
+      }
+    }
   }
 
   /**

--- a/strands-ts/src/vended-plugins/skills/agent-skills.ts
+++ b/strands-ts/src/vended-plugins/skills/agent-skills.ts
@@ -4,6 +4,14 @@
  * This module provides the AgentSkills class that implements the Plugin
  * interface to add Agent Skills support. The plugin registers a tool for
  * activating skills and injects skill metadata into the system prompt.
+ *
+ * Sandbox skill sources (e.g., `"sandbox:/home/skills"`) are loaded
+ * asynchronously during `initAgent()` using the agent's sandbox instance,
+ * following the same deferred-loading pattern as the Python SDK.
+ *
+ * The skill catalog is maintained **per-agent** using a `WeakMap`,
+ * so a single plugin instance can be safely shared across multiple agents
+ * (even with different sandboxes) without skill cross-contamination.
  */
 
 import { readdirSync, statSync, existsSync } from 'fs'
@@ -71,7 +79,13 @@ function escapeXml(text: string): string {
  *
  * Skills can be provided as filesystem paths (to individual skill directories or
  * parent directories containing multiple skills), HTTPS URLs pointing to raw
- * SKILL.md content, or as pre-built `Skill` instances.
+ * SKILL.md content, `sandbox:/path` URIs that load from the agent's sandbox at
+ * init time, or as pre-built `Skill` instances.
+ *
+ * The skill catalog is stored **per-agent** so that a single plugin instance
+ * can be safely attached to multiple agents with different sandboxes.
+ * Synchronous sources (filesystem, URL, Skill instances) are shared as the
+ * base set; sandbox-resolved skills are added per-agent on top of that base.
  *
  * @example
  * ```typescript
@@ -83,17 +97,21 @@ function escapeXml(text: string): string {
  *   skills: ['./skills/pdf-processing', './skills/'],
  * })
  *
- * // Or provide Skill instances directly
- * const skill = new Skill({ name: 'my-skill', description: 'A custom skill', instructions: 'Do the thing' })
- * const plugin = new AgentSkills({ skills: [skill] })
+ * // Load from agent's sandbox (resolved at agent init)
+ * const plugin = new AgentSkills({ skills: ['sandbox:/home/skills'] })
  *
- * const agent = new Agent({ model, plugins: [plugin] })
+ * // Safe to share across multiple agents with different sandboxes
+ * const agent_a = new Agent({ model, sandbox: sandboxA, plugins: [plugin] })
+ * const agent_b = new Agent({ model, sandbox: sandboxB, plugins: [plugin] })
  * ```
  */
 export class AgentSkills implements Plugin {
   readonly name = 'strands:agent-skills'
 
-  private _skills: Map<string, Skill>
+  /** Base skills resolved synchronously (filesystem, URL, Skill instances). Shared across all agents. */
+  private _baseSkills: Map<string, Skill>
+  /** Per-agent skill catalogs (base + sandbox-resolved). Entries are cleaned up when agents are GC'd. */
+  private _agentSkills: WeakMap<LocalAgent, Map<string, Skill>>
   private readonly _maxResourceFiles: number
   /** When true, skill validation errors throw instead of logging warnings. */
   private readonly _strict: boolean
@@ -107,31 +125,60 @@ export class AgentSkills implements Plugin {
     this._strict = config.strict ?? false
     this._maxResourceFiles = config.maxResourceFiles ?? DEFAULT_MAX_RESOURCE_FILES
     this._stateKey = config.stateKey ?? DEFAULT_STATE_KEY
+    this._agentSkills = new WeakMap()
     const { skills, ready, sandboxSources } = this._resolveSkills(config.skills)
-    this._skills = skills
+    this._baseSkills = skills
     this._ready = ready
     this._sandboxSources = sandboxSources
   }
 
   /**
+   * Get the skill catalog for a specific agent.
+   *
+   * Returns the per-agent catalog if the agent has been initialized,
+   * otherwise falls back to the base (sync-resolved) skills.
+   */
+  private _getSkills(agent?: LocalAgent): Map<string, Skill> {
+    if (agent != null) {
+      const agentSkills = this._agentSkills.get(agent)
+      if (agentSkills != null) {
+        return agentSkills
+      }
+    }
+    return this._baseSkills
+  }
+
+  /**
    * Initialize the plugin with the agent instance.
    *
-   * Waits for any async skill sources (e.g. URLs) to finish loading, then
-   * registers a BeforeInvocationEvent hook that injects skill metadata
-   * into the system prompt before each invocation.
+   * Creates a per-agent skill catalog by copying the base skills and
+   * then resolving any sandbox sources using the agent's sandbox. This
+   * ensures each agent gets its own skill set without cross-contamination.
    */
   async initAgent(agent: LocalAgent): Promise<void> {
     await this._ready
 
-    // Resolve deferred sandbox sources using the agent's sandbox
+    // Start with a COPY of base skills for this agent
+    const agentSkills = new Map(this._baseSkills)
+
+    // Resolve deferred sandbox sources from THIS agent's sandbox
     if (this._sandboxSources.length > 0) {
-      await this._resolveSandboxSources(agent)
+      const sandboxSkills = await this._resolveSandboxSources(agent)
+      for (const [name, skill] of sandboxSkills) {
+        if (agentSkills.has(name)) {
+          logger.warn(`name=<${name}> | duplicate skill name, overwriting previous skill`)
+        }
+        agentSkills.set(name, skill)
+      }
     }
 
-    if (this._skills.size === 0) {
+    // Store per-agent catalog
+    this._agentSkills.set(agent, agentSkills)
+
+    if (agentSkills.size === 0) {
       logger.warn('no skills were loaded, the agent will have no skills available')
     }
-    logger.debug(`skill_count=<${this._skills.size}> | skills plugin initialized`)
+    logger.debug(`skill_count=<${agentSkills.size}> | skills plugin initialized for agent`)
 
     agent.addHook(BeforeInvocationEvent, async (event) => {
       await this._ready
@@ -148,10 +195,14 @@ export class AgentSkills implements Plugin {
 
   /**
    * Get the list of available skills.
+   *
+   * When called with an agent, returns that agent's full skill catalog
+   * (base + sandbox-resolved). Without an agent, returns only the base
+   * (sync-resolved) skills.
    */
-  async getAvailableSkills(): Promise<readonly Skill[]> {
+  async getAvailableSkills(agent?: LocalAgent): Promise<readonly Skill[]> {
     await this._ready
-    return [...this._skills.values()]
+    return [...this._getSkills(agent).values()]
   }
 
   /**
@@ -162,9 +213,13 @@ export class AgentSkills implements Plugin {
    * subdirectories, or an `https://` URL pointing directly to raw SKILL.md
    * content.
    *
-   * Note: this does not persist state or deactivate skills on any agent.
-   * Active skill state is managed per-agent and will be reconciled on the
-   * next tool call or invocation.
+   * Note: Sandbox sources (`"sandbox:/path"`) are NOT supported in
+   * `setAvailableSkills` because no agent context is available.
+   * Use sandbox sources in the `AgentSkills` constructor instead.
+   *
+   * Note: this replaces the base skill set. Per-agent caches from previous
+   * `initAgent()` calls are NOT automatically invalidated — new agents will
+   * pick up the updated base skills on their next `initAgent()`.
    */
   setAvailableSkills(skills: SkillSource[]): void {
     for (const source of skills) {
@@ -175,9 +230,11 @@ export class AgentSkills implements Plugin {
       }
     }
     const { skills: resolved, ready, sandboxSources } = this._resolveSkills(skills)
-    this._skills = resolved
+    this._baseSkills = resolved
     this._ready = ready
     this._sandboxSources = sandboxSources
+    // Reset per-agent caches — new WeakMap so existing entries can be GC'd
+    this._agentSkills = new WeakMap()
   }
 
   /**
@@ -199,6 +256,9 @@ export class AgentSkills implements Plugin {
    * immediately into the returned map. Async sources (URLs) are resolved in
    * the background; the returned `ready` promise resolves when all URL
    * fetches have completed and the map has been updated.
+   *
+   * Sandbox sources are separated out and returned in `sandboxSources` for
+   * deferred resolution during `initAgent()`.
    */
   private _resolveSkills(sources: SkillSource[]): {
     skills: Map<string, Skill>
@@ -298,10 +358,13 @@ export class AgentSkills implements Plugin {
    *
    * Each sandbox source path is treated as either a single skill directory
    * (if it contains SKILL.md) or a parent directory of skill subdirectories.
+   *
+   * Returns a new Map of resolved skills instead of mutating shared state.
    */
-  private async _resolveSandboxSources(agent: LocalAgent): Promise<void> {
+  private async _resolveSandboxSources(agent: LocalAgent): Promise<Map<string, Skill>> {
     const { Skill } = await import('./skill.js')
     const sandbox = agent.sandbox
+    const resolved = new Map<string, Skill>()
 
     for (const sandboxPath of this._sandboxSources) {
       logger.debug(`sandbox_path=<${sandboxPath}> | resolving sandbox skill source`)
@@ -309,20 +372,20 @@ export class AgentSkills implements Plugin {
       try {
         // Try as a single skill directory first
         const skill = await Skill.fromSandbox(sandbox, sandboxPath, { strict: this._strict })
-        if (this._skills.has(skill.name)) {
+        if (resolved.has(skill.name)) {
           logger.warn(`name=<${skill.name}> | duplicate skill name, overwriting previous skill`)
         }
-        this._skills.set(skill.name, skill)
+        resolved.set(skill.name, skill)
         logger.debug(`sandbox_path=<${sandboxPath}>, name=<${skill.name}> | loaded single skill from sandbox`)
       } catch {
         // Fall back to parent directory
         try {
           const skills = await Skill.fromSandboxDirectory(sandbox, sandboxPath, { strict: this._strict })
           for (const skill of skills) {
-            if (this._skills.has(skill.name)) {
+            if (resolved.has(skill.name)) {
               logger.warn(`name=<${skill.name}> | duplicate skill name, overwriting previous skill`)
             }
-            this._skills.set(skill.name, skill)
+            resolved.set(skill.name, skill)
           }
           logger.debug(`sandbox_path=<${sandboxPath}>, count=<${skills.length}> | loaded skills from sandbox directory`)
         } catch (error) {
@@ -330,6 +393,8 @@ export class AgentSkills implements Plugin {
         }
       }
     }
+
+    return resolved
   }
 
   /**
@@ -359,9 +424,10 @@ export class AgentSkills implements Plugin {
    * Handle skill activation from the tool callback.
    */
   private _activateSkill(skillName: string, context: ToolContext): string {
-    const found = this._skills.get(skillName)
+    const agentSkills = this._getSkills(context.agent)
+    const found = agentSkills.get(skillName)
     if (found == null) {
-      const available = [...this._skills.keys()].join(', ')
+      const available = [...agentSkills.keys()].join(', ')
       return `Skill '${skillName}' not found. Available skills: ${available}`
     }
 
@@ -412,7 +478,7 @@ export class AgentSkills implements Plugin {
    * across multiple agents safely.
    */
   private _injectSkillsXml(agent: LocalAgent): void {
-    const skillsXml = this._generateSkillsXml()
+    const skillsXml = this._generateSkillsXml(agent)
     const systemPrompt = agent.systemPrompt
 
     if (systemPrompt == null || typeof systemPrompt === 'string') {
@@ -456,25 +522,19 @@ export class AgentSkills implements Plugin {
   /**
    * Generate the XML block listing available skills for the system prompt.
    *
-   * @example Output with skills:
-   * ```xml
-   * <available_skills>
-   * <skill>
-   * <name>pdf-processing</name>
-   * <description>Extract text and tables from PDF files</description>
-   * <location>/path/to/pdf-processing/SKILL.md</location>
-   * </skill>
-   * </available_skills>
-   * ```
+   * When called with an agent, uses that agent's full skill catalog
+   * (base + sandbox-resolved). Without an agent, uses only the base skills.
    */
-  private _generateSkillsXml(): string {
-    if (this._skills.size === 0) {
+  private _generateSkillsXml(agent?: LocalAgent): string {
+    const skills = this._getSkills(agent)
+
+    if (skills.size === 0) {
       return '<available_skills>\nNo skills are currently available.\n</available_skills>'
     }
 
     const lines: string[] = ['<available_skills>']
 
-    for (const skill of this._skills.values()) {
+    for (const skill of skills.values()) {
       lines.push('<skill>')
       lines.push(`<name>${escapeXml(skill.name)}</name>`)
       lines.push(`<description>${escapeXml(skill.description)}</description>`)

--- a/strands-ts/src/vended-plugins/skills/skill.ts
+++ b/strands-ts/src/vended-plugins/skills/skill.ts
@@ -11,6 +11,7 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'fs'
 import { resolve, join, basename } from 'path'
 import { parse as parseYaml } from 'yaml'
 import { logger } from '../../logging/logger.js'
+import type { Sandbox } from '../../sandbox/base.js'
 
 const SKILL_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 const MAX_SKILL_NAME_LENGTH = 64
@@ -433,6 +434,108 @@ export class Skill {
     }
 
     logger.debug(`path=<${resolvedDir}>, count=<${skills.length}> | loaded skills from directory`)
+    return skills
+  }
+
+  /**
+   * Load a single skill from a sandbox filesystem.
+   *
+   * Reads a SKILL.md file from the sandbox and parses it into a Skill
+   * instance. The sandbox can be any implementation (host, Docker, cloud).
+   *
+   * @example
+   * ```typescript
+   * import { HostSandbox } from '@strands-agents/sdk/sandbox'
+   *
+   * const sandbox = new HostSandbox()
+   * const skill = await Skill.fromSandbox(sandbox, '/home/skills/my-skill')
+   * ```
+   *
+   * @param sandbox - The sandbox to read from.
+   * @param skillPath - Path to a skill directory or the SKILL.md file itself within the sandbox.
+   * @param options - Optional settings. When `strict` is true, throws on any validation issue.
+   * @returns A Promise resolving to a Skill instance populated from the sandbox SKILL.md file.
+   */
+  static async fromSandbox(sandbox: Sandbox, skillPath: string, options?: { strict?: boolean }): Promise<Skill> {
+    let skillMdPath: string | undefined
+
+    // Check if the path points directly to a SKILL.md file
+    const lowerPath = skillPath.toLowerCase()
+    if (lowerPath.endsWith('skill.md')) {
+      skillMdPath = skillPath
+    } else {
+      // Try to find SKILL.md in the directory
+      for (const name of ['SKILL.md', 'skill.md']) {
+        const candidate = skillPath.endsWith('/') ? `${skillPath}${name}` : `${skillPath}/${name}`
+        try {
+          await sandbox.readFile(candidate)
+          skillMdPath = candidate
+          break
+        } catch {
+          // File doesn't exist, try next
+        }
+      }
+    }
+
+    if (skillMdPath == null) {
+      throw new Error(`path=<${skillPath}> | no SKILL.md found in sandbox skill directory`)
+    }
+
+    logger.debug(`sandbox_path=<${skillMdPath}> | loading skill from sandbox`)
+
+    const content = await sandbox.readText(skillMdPath)
+    const skill = Skill.fromContent(content, options)
+
+    logger.debug(`name=<${skill.name}>, sandbox_path=<${skillMdPath}> | skill loaded from sandbox`)
+    return skill
+  }
+
+  /**
+   * Load all skills from a parent directory in a sandbox.
+   *
+   * Lists subdirectories in the given sandbox path and loads any that
+   * contain a SKILL.md file.
+   *
+   * @example
+   * ```typescript
+   * import { HostSandbox } from '@strands-agents/sdk/sandbox'
+   *
+   * const sandbox = new HostSandbox()
+   * const skills = await Skill.fromSandboxDirectory(sandbox, '/home/skills')
+   * ```
+   *
+   * @param sandbox - The sandbox to read from.
+   * @param skillsDir - Path to a parent directory containing skill subdirectories within the sandbox.
+   * @param options - Optional settings. When `strict` is true, throws on any validation issue.
+   * @returns A Promise resolving to a list of Skill instances loaded from the sandbox directory.
+   */
+  static async fromSandboxDirectory(
+    sandbox: Sandbox,
+    skillsDir: string,
+    options?: { strict?: boolean }
+  ): Promise<Skill[]> {
+    let entries
+    try {
+      entries = await sandbox.listFiles(skillsDir)
+    } catch (error) {
+      logger.warn(`sandbox_path=<${skillsDir}> | failed to list sandbox directory: ${error}`)
+      return []
+    }
+
+    const skills: Skill[] = []
+    for (const entry of entries) {
+      if (!entry.isDir) continue
+
+      const childPath = skillsDir.endsWith('/') ? `${skillsDir}${entry.name}` : `${skillsDir}/${entry.name}`
+      try {
+        const skill = await Skill.fromSandbox(sandbox, childPath, options)
+        skills.push(skill)
+      } catch (error) {
+        logger.debug(`sandbox_path=<${childPath}> | skipping directory: ${error}`)
+      }
+    }
+
+    logger.debug(`sandbox_path=<${skillsDir}>, count=<${skills.length}> | loaded skills from sandbox directory`)
     return skills
   }
 }

--- a/strands-ts/src/vended-tools/editor/__tests__/editor.test.ts
+++ b/strands-ts/src/vended-tools/editor/__tests__/editor.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { editor } from '../index.js'
+import type { ToolContext } from '../../../tools/tool.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import type { Sandbox, FileInfo } from '../../../sandbox/base.js'
+
+function createMockSandbox(overrides?: Partial<Sandbox>): Sandbox {
+  return {
+    executeStreaming: vi.fn(async function* () {}),
+
+    executeCodeStreaming: vi.fn(async function* () {}),
+    execute: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '', outputFiles: [] })),
+    executeCode: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '', outputFiles: [] })),
+    readFile: vi.fn(async () => new TextEncoder().encode('line1\nline2\nline3\n')),
+    writeFile: vi.fn(async () => {}),
+    removeFile: vi.fn(async () => {}),
+    listFiles: vi.fn(async () => {
+      throw new Error('ENOENT: not a directory')
+    }),
+    readText: vi.fn(async () => 'line1\nline2\nline3\n'),
+    writeText: vi.fn(async () => {}),
+    ...overrides,
+  } as unknown as Sandbox
+}
+
+function createTestContext(sandboxOverrides?: Partial<Sandbox>) {
+  const sandbox = createMockSandbox(sandboxOverrides)
+  const agent = createMockAgent({ extra: { sandbox } as Record<string, unknown> })
+  const context: ToolContext = { toolUse: { name: 'editor', toolUseId: 'test-id', input: {} }, agent }
+  return { context, sandbox, appState: agent.appState }
+}
+
+describe('editor tool', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('view command', () => {
+    it('views file content with line numbers', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke({ command: 'view', path: '/tmp/test.txt' }, context)
+      expect(result).toContain('cat -n')
+      expect(result).toContain('line1')
+    })
+
+    it('views file with line range', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('a\nb\nc\nd\ne\n')),
+      })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/test.txt', view_range: [2, 4] }, context)
+      expect(result).toContain('b')
+      expect(result).toContain('d')
+    })
+
+    it('views file with -1 end range', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('a\nb\nc\nd\ne')),
+      })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/test.txt', view_range: [3, -1] }, context)
+      expect(result).toContain('c')
+      expect(result).toContain('e')
+    })
+
+    it('lists directory contents', async () => {
+      const { context } = createTestContext({
+        listFiles: vi.fn(
+          async () =>
+            [
+              { name: 'file.ts', isDir: false },
+              { name: 'src', isDir: true },
+            ] satisfies FileInfo[]
+        ),
+      })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/project' }, context)
+      expect(result).toContain('file.ts')
+      expect(result).toContain('src/')
+    })
+
+    it('rejects view_range on directory', async () => {
+      const { context } = createTestContext({
+        listFiles: vi.fn(async () => [{ name: 'file.ts' }] satisfies FileInfo[]),
+      })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/project', view_range: [1, 5] }, context)
+      expect(result).toContain('Error')
+    })
+
+    it('returns error for non-existent file', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => {
+          throw new Error('ENOENT')
+        }),
+      })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/missing.txt' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('does not exist')
+    })
+
+    it('validates view_range bounds', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('a\nb\nc')),
+      })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/test.txt', view_range: [0, 2] }, context)
+      expect(result).toContain('Error')
+    })
+  })
+
+  describe('create command', () => {
+    it('creates a new file', async () => {
+      const { context, sandbox } = createTestContext({
+        readFile: vi.fn(async () => {
+          throw new Error('ENOENT')
+        }),
+      })
+      const result = await editor.invoke({ command: 'create', path: '/tmp/new.txt', file_text: 'hello' }, context)
+      expect(result).toContain('File created successfully')
+      expect(sandbox.writeFile).toHaveBeenCalled()
+    })
+
+    it('fails when file already exists', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke(
+        { command: 'create', path: '/tmp/existing.txt', file_text: 'content' },
+        context
+      )
+      expect(result).toContain('Error')
+      expect(result).toContain('already exists')
+    })
+
+    it('requires file_text parameter', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke({ command: 'create', path: '/tmp/new.txt' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('file_text')
+    })
+  })
+
+  describe('str_replace command', () => {
+    it('replaces unique string occurrence', async () => {
+      const { context, sandbox } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('hello world\n')),
+      })
+      const result = await editor.invoke(
+        { command: 'str_replace', path: '/tmp/test.txt', old_str: 'hello', new_str: 'goodbye' },
+        context
+      )
+      expect(result).toContain('has been edited')
+      expect(sandbox.writeFile).toHaveBeenCalled()
+    })
+
+    it('fails when old_str not found', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('hello world\n')),
+      })
+      const result = await editor.invoke(
+        { command: 'str_replace', path: '/tmp/test.txt', old_str: 'missing', new_str: 'x' },
+        context
+      )
+      expect(result).toContain('Error')
+      expect(result).toContain('did not appear')
+    })
+
+    it('fails when old_str has multiple occurrences', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('foo bar foo\n')),
+      })
+      const result = await editor.invoke(
+        { command: 'str_replace', path: '/tmp/test.txt', old_str: 'foo', new_str: 'baz' },
+        context
+      )
+      expect(result).toContain('Error')
+      expect(result).toContain('Multiple occurrences')
+    })
+
+    it('requires old_str parameter', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke({ command: 'str_replace', path: '/tmp/test.txt' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('old_str')
+    })
+  })
+
+  describe('insert command', () => {
+    it('inserts text at line number', async () => {
+      const { context, sandbox } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('line1\nline2\n')),
+      })
+      const result = await editor.invoke(
+        { command: 'insert', path: '/tmp/test.txt', insert_line: 1, new_str: 'inserted' },
+        context
+      )
+      expect(result).toContain('has been edited')
+      expect(sandbox.writeFile).toHaveBeenCalled()
+    })
+
+    it('validates insert_line bounds', async () => {
+      const { context } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('line1\nline2\n')),
+      })
+      const result = await editor.invoke(
+        { command: 'insert', path: '/tmp/test.txt', insert_line: 99, new_str: 'text' },
+        context
+      )
+      expect(result).toContain('Error')
+      expect(result).toContain('Invalid')
+    })
+
+    it('requires insert_line parameter', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke({ command: 'insert', path: '/tmp/test.txt', new_str: 'text' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('insert_line')
+    })
+  })
+
+  describe('undo_edit command', () => {
+    it('reverts last edit', async () => {
+      const { context, sandbox, appState } = createTestContext({
+        readFile: vi.fn(async () => new TextEncoder().encode('modified content')),
+      })
+      appState.set('_strands_editor_undo', { '/tmp/test.txt': 'original content' })
+      const result = await editor.invoke({ command: 'undo_edit', path: '/tmp/test.txt' }, context)
+      expect(result).toContain('Successfully reverted')
+      expect(sandbox.writeFile).toHaveBeenCalled()
+    })
+
+    it('returns error when no edit history', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke({ command: 'undo_edit', path: '/tmp/no-history.txt' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('No edit history')
+    })
+  })
+
+  describe('path validation', () => {
+    it('allows relative paths by default', async () => {
+      const { context } = createTestContext()
+      const result = await editor.invoke({ command: 'view', path: 'relative/path.txt' }, context)
+      expect(result).not.toContain('not an absolute path')
+    })
+
+    it('rejects relative paths when configured', async () => {
+      const { context, appState } = createTestContext()
+      appState.set('strands_editor_tool', { requireAbsolutePaths: true })
+      const result = await editor.invoke({ command: 'view', path: 'relative/path.txt' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('not an absolute path')
+    })
+
+    it('rejects path traversal when configured', async () => {
+      const { context, appState } = createTestContext()
+      appState.set('strands_editor_tool', { requireAbsolutePaths: true })
+      const result = await editor.invoke({ command: 'view', path: '/tmp/../etc/passwd' }, context)
+      expect(result).toContain('Error')
+      expect(result).toContain('Path traversal')
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws when no context provided', async () => {
+      await expect(editor.invoke({ command: 'view', path: '/tmp/test.txt' })).rejects.toThrow(
+        'Tool context is required'
+      )
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/editor/editor.ts
+++ b/strands-ts/src/vended-tools/editor/editor.ts
@@ -1,0 +1,434 @@
+/**
+ * Sandbox-aware file editor tool implementation.
+ *
+ * Provides view, create, str_replace, insert, and undo_edit operations on files
+ * in the agent's sandbox. The tool delegates all file I/O to the sandbox's
+ * `readFile`, `writeFile`, and `listFiles` methods.
+ *
+ * The tool shape matches Anthropic's `text_editor` built-in tool — 5 commands,
+ * 7 parameters. This means models trained on Anthropic's tool spec will work
+ * well with this tool out of the box.
+ *
+ * Configuration keys (set via `agent.appState.set('strands_editor_tool', {...})`):
+ * - `maxFileSize` (number): Maximum file size in bytes for read operations.
+ *   Default: 1048576 (1 MB).
+ * - `requireAbsolutePaths` (boolean): When true, rejects relative paths.
+ *   Default: false.
+ *
+ * @example
+ * ```typescript
+ * import { editor } from '@strands-agents/sdk/vended-tools/editor'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [editor] })
+ * await agent.invoke('View the contents of /tmp/example.ts')
+ * ```
+ */
+
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import type { Sandbox } from '../../sandbox/base.js'
+import type { ToolContext } from '../../tools/tool.js'
+import type { EditorToolConfig } from './types.js'
+
+/**
+ * State key for editor tool configuration in agent.appState.
+ */
+const STATE_KEY = 'strands_editor_tool'
+
+/**
+ * State key for undo history (internal).
+ */
+const UNDO_STATE_KEY = '_strands_editor_undo'
+
+/**
+ * Default maximum file size (1 MB).
+ */
+const DEFAULT_MAX_FILE_SIZE = 1_048_576
+
+/**
+ * Number of context lines to show around edits.
+ */
+const SNIPPET_LINES = 4
+
+/**
+ * Zod schema for editor input validation.
+ */
+const editorInputSchema = z.object({
+  command: z
+    .enum(['view', 'create', 'str_replace', 'insert', 'undo_edit'])
+    .describe('The operation to perform: view, create, str_replace, insert, or undo_edit'),
+  path: z.string().describe('Path to the file or directory'),
+  file_text: z.string().optional().describe('Content for new file (required for create command)'),
+  old_str: z
+    .string()
+    .optional()
+    .describe('Exact string to find and replace (required for str_replace). Must appear exactly once.'),
+  new_str: z.string().optional().describe('Replacement string (for str_replace and insert commands)'),
+  insert_line: z
+    .number()
+    .optional()
+    .describe('Line number where text should be inserted (0-indexed, required for insert)'),
+  view_range: z
+    .tuple([z.number(), z.number()])
+    .optional()
+    .describe('Line range to view [start, end]. 1-indexed. Use -1 for end of file.'),
+})
+
+/**
+ * Format file content with line numbers (cat -n style).
+ */
+function makeOutput(content: string, descriptor: string, initLine = 1): string {
+  const expanded = content.replace(/\t/g, '        ')
+  const lines = expanded.split('\n')
+  const numbered = lines.map((line, i) => {
+    const lineNum = i + initLine
+    return `${lineNum.toString().padStart(6)}  ${line}`
+  })
+  return `Here's the result of running \`cat -n\` on ${descriptor}:\n${numbered.join('\n')}\n`
+}
+
+/**
+ * Save file content for undo.
+ */
+function saveUndo(context: ToolContext, path: string, content: string): void {
+  const undoState = (context.agent.appState.get(UNDO_STATE_KEY) as Record<string, string>) ?? {}
+  undoState[path] = content
+  context.agent.appState.set(UNDO_STATE_KEY, undoState)
+}
+
+/**
+ * Get saved undo content for a file.
+ */
+function getUndo(context: ToolContext, path: string): string | undefined {
+  const undoState = (context.agent.appState.get(UNDO_STATE_KEY) as Record<string, string>) ?? {}
+  return undoState[path]
+}
+
+/**
+ * Escape special regex characters in a string.
+ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Handle the view command.
+ */
+async function handleView(
+  sandbox: Sandbox,
+  config: EditorToolConfig,
+  path: string,
+  viewRange?: [number, number]
+): Promise<string> {
+  // Check if path is a directory
+  try {
+    const entries = await sandbox.listFiles(path)
+    if (viewRange) {
+      return 'Error: The `view_range` parameter is not allowed when `path` points to a directory.'
+    }
+    const items = entries
+      .filter((e) => e.name !== '.' && e.name !== '..')
+      .map((e) => (e.isDir ? `${e.name}/` : e.name))
+      .sort()
+    return (
+      `Here's the files and directories up to 2 levels deep in ${path}, ` +
+      `excluding hidden items:\n${items.join('\n')}\n`
+    )
+  } catch {
+    // Not a directory, try as file
+  }
+
+  // Read file
+  const maxSize = config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE
+  let content: string
+  try {
+    const data = await sandbox.readFile(path)
+    content = new TextDecoder('utf-8').decode(data)
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ENOENT')) {
+      return `Error: The path ${path} does not exist. Please provide a valid path.`
+    }
+    if (error instanceof Error && error.message.includes('decode')) {
+      return `Error: The file ${path} is not a text file (cannot decode as UTF-8).`
+    }
+    return `Error: The path ${path} does not exist. Please provide a valid path.`
+  }
+
+  // Check size
+  if (new TextEncoder().encode(content).length > maxSize) {
+    return `Error: File size exceeds maximum allowed size (${maxSize} bytes).`
+  }
+
+  if (!viewRange) {
+    return makeOutput(content, path)
+  }
+
+  // Validate and apply view range
+  const lines = content.split('\n')
+  const nLines = lines.length
+  const [start, end] = viewRange
+
+  if (start < 1 || start > nLines) {
+    return `Error: Invalid \`view_range\`: [${start}, ${end}]. First element \`${start}\` should be within [1, ${nLines}].`
+  }
+  if (end !== -1 && end > nLines) {
+    return `Error: Invalid \`view_range\`: [${start}, ${end}]. Second element \`${end}\` should be <= ${nLines}.`
+  }
+  if (end !== -1 && end < start) {
+    return `Error: Invalid \`view_range\`: [${start}, ${end}]. Second element must be >= first element.`
+  }
+
+  const selected = end === -1 ? lines.slice(start - 1) : lines.slice(start - 1, end)
+  return makeOutput(selected.join('\n'), path, start)
+}
+
+/**
+ * Handle the create command.
+ */
+async function handleCreate(sandbox: Sandbox, context: ToolContext, path: string, fileText: string): Promise<string> {
+  // Check if file already exists
+  try {
+    await sandbox.readFile(path)
+    return `Error: File already exists at: ${path}. Cannot overwrite with \`create\`. Use \`str_replace\` to edit.`
+  } catch {
+    // File doesn't exist, good
+  }
+
+  await sandbox.writeFile(path, new TextEncoder().encode(fileText))
+  return `File created successfully at: ${path}`
+}
+
+/**
+ * Handle the str_replace command.
+ */
+async function handleStrReplace(
+  sandbox: Sandbox,
+  context: ToolContext,
+  config: EditorToolConfig,
+  path: string,
+  oldStr: string,
+  newStr: string
+): Promise<string> {
+  let content: string
+  try {
+    content = new TextDecoder('utf-8').decode(await sandbox.readFile(path))
+  } catch {
+    return `Error: The path ${path} does not exist.`
+  }
+
+  // Expand tabs for matching
+  content = content.replace(/\t/g, '        ')
+  const expandedOld = oldStr.replace(/\t/g, '        ')
+  const expandedNew = newStr.replace(/\t/g, '        ')
+
+  // Count occurrences — MUST be exactly 1
+  const matches = content.match(new RegExp(escapeRegExp(expandedOld), 'g'))
+  const count = matches ? matches.length : 0
+
+  if (count === 0) {
+    return `Error: No replacement was performed, old_str \`${oldStr}\` did not appear verbatim in ${path}.`
+  }
+
+  if (count > 1) {
+    const lines = content.split('\n')
+    const lineNums = lines.map((line, i) => (line.includes(expandedOld) ? i + 1 : -1)).filter((n) => n !== -1)
+    return (
+      `Error: No replacement was performed. Multiple occurrences (${count}) of old_str ` +
+      `in lines ${JSON.stringify(lineNums)}. Please ensure old_str is unique.`
+    )
+  }
+
+  // Save undo state
+  saveUndo(context, path, content)
+
+  // Perform replacement
+  const newContent = content.replace(expandedOld, () => expandedNew)
+
+  // Write back
+  await sandbox.writeFile(path, new TextEncoder().encode(newContent))
+
+  // Generate snippet around the change
+  const replaceIdx = content.indexOf(expandedOld)
+  const replaceLine = content.substring(0, replaceIdx).split('\n').length - 1
+  const insertedLines = expandedNew.split('\n').length
+  const originalLines = expandedOld.split('\n').length
+  const lineDiff = insertedLines - originalLines
+
+  const newLines = newContent.split('\n')
+  const snippetStart = Math.max(0, replaceLine - SNIPPET_LINES)
+  const snippetEnd = Math.min(newLines.length, replaceLine + SNIPPET_LINES + lineDiff + 1)
+  const snippet = newLines.slice(snippetStart, snippetEnd).join('\n')
+
+  return (
+    `The file ${path} has been edited. ` +
+    makeOutput(snippet, `a snippet of ${path}`, snippetStart + 1) +
+    'Review the changes and make sure they are as expected. Edit the file again if necessary.'
+  )
+}
+
+/**
+ * Handle the insert command.
+ */
+async function handleInsert(
+  sandbox: Sandbox,
+  context: ToolContext,
+  config: EditorToolConfig,
+  path: string,
+  insertLine: number,
+  newStr: string
+): Promise<string> {
+  let content: string
+  try {
+    content = new TextDecoder('utf-8').decode(await sandbox.readFile(path))
+  } catch {
+    return `Error: The path ${path} does not exist.`
+  }
+
+  // Expand tabs
+  content = content.replace(/\t/g, '        ')
+  const expandedNew = newStr.replace(/\t/g, '        ')
+
+  const lines = content.split('\n')
+  const nLines = lines.length
+
+  if (insertLine < 0 || insertLine > nLines) {
+    return `Error: Invalid \`insert_line\`: ${insertLine}. Should be within [0, ${nLines}].`
+  }
+
+  // Save undo state
+  saveUndo(context, path, content)
+
+  // Insert
+  const newStrLines = expandedNew.split('\n')
+  let newLines: string[]
+  if (content === '') {
+    newLines = newStrLines
+  } else {
+    newLines = [...lines.slice(0, insertLine), ...newStrLines, ...lines.slice(insertLine)]
+  }
+
+  const newContent = newLines.join('\n')
+  await sandbox.writeFile(path, new TextEncoder().encode(newContent))
+
+  // Generate snippet
+  const snippetStart = Math.max(0, insertLine - SNIPPET_LINES)
+  const snippetEnd = Math.min(newLines.length, insertLine + newStrLines.length + SNIPPET_LINES)
+  const snippet = newLines.slice(snippetStart, snippetEnd).join('\n')
+
+  return (
+    `The file ${path} has been edited. ` +
+    makeOutput(snippet, 'a snippet of the edited file', snippetStart + 1) +
+    'Review the changes and make sure they are as expected. Edit the file again if necessary.'
+  )
+}
+
+/**
+ * Handle the undo_edit command.
+ */
+async function handleUndo(sandbox: Sandbox, context: ToolContext, path: string): Promise<string> {
+  const previousContent = getUndo(context, path)
+  if (previousContent === undefined) {
+    return `Error: No edit history found for ${path}.`
+  }
+
+  // Read current content for future undo
+  let current = ''
+  try {
+    current = new TextDecoder('utf-8').decode(await sandbox.readFile(path))
+  } catch {
+    // File might have been deleted
+  }
+
+  // Write the previous content back
+  await sandbox.writeFile(path, new TextEncoder().encode(previousContent))
+
+  // Save current as new undo (so undo is toggleable)
+  saveUndo(context, path, current)
+
+  return `Successfully reverted last edit to ${path}.`
+}
+
+/**
+ * Sandbox-aware file editor for viewing, creating, and editing files.
+ *
+ * Unlike the legacy `fileEditor` tool that uses Node.js `fs` directly,
+ * this tool delegates all file I/O to `context.agent.sandbox`, making it
+ * work transparently with any sandbox implementation.
+ *
+ * Commands:
+ * - **view**: Display file contents with line numbers, or list directory contents.
+ * - **create**: Create a new file (fails if file exists).
+ * - **str_replace**: Replace a unique string occurrence in a file.
+ * - **insert**: Insert text at a specific line number.
+ * - **undo_edit**: Revert the last edit to a file.
+ *
+ * @example
+ * ```typescript
+ * import { editor } from '@strands-agents/sdk/vended-tools/editor'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [editor] })
+ * await agent.invoke('Create a file /tmp/hello.ts with a greeting function')
+ * ```
+ */
+export const editor = tool({
+  name: 'editor',
+  description:
+    "View, create, and edit files in the agent's sandbox. Supports view (with line ranges), " +
+    'create, str_replace (unique occurrence), insert (at line number), and undo_edit. ' +
+    'All file operations go through the sandbox.',
+  inputSchema: editorInputSchema,
+  callback: async (input, context?: ToolContext) => {
+    if (!context) {
+      throw new Error('Tool context is required for editor operations')
+    }
+
+    const config: EditorToolConfig = (context.agent.appState.get(STATE_KEY) as EditorToolConfig) ?? {}
+    const sandbox = context.agent.sandbox
+
+    // Path validation is opt-in
+    if (config.requireAbsolutePaths) {
+      if (!input.path.startsWith('/')) {
+        return `Error: The path ${input.path} is not an absolute path.`
+      }
+      if (input.path.includes('..')) {
+        return 'Error: Path traversal (..) is not allowed.'
+      }
+    }
+
+    try {
+      switch (input.command) {
+        case 'view':
+          return await handleView(sandbox, config, input.path, input.view_range)
+        case 'create':
+          if (input.file_text === undefined) {
+            return 'Error: Parameter `file_text` is required for command: create'
+          }
+          return await handleCreate(sandbox, context, input.path, input.file_text)
+        case 'str_replace':
+          if (input.old_str === undefined) {
+            return 'Error: Parameter `old_str` is required for command: str_replace'
+          }
+          return await handleStrReplace(sandbox, context, config, input.path, input.old_str, input.new_str ?? '')
+        case 'insert':
+          if (input.insert_line === undefined) {
+            return 'Error: Parameter `insert_line` is required for command: insert'
+          }
+          if (input.new_str === undefined) {
+            return 'Error: Parameter `new_str` is required for command: insert'
+          }
+          return await handleInsert(sandbox, context, config, input.path, input.insert_line, input.new_str)
+        case 'undo_edit':
+          return await handleUndo(sandbox, context, input.path)
+        default:
+          return `Error: Unknown command: ${input.command}`
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('NotImplementedError')) {
+        return `Error: Sandbox does not support this operation — ${error.message}`
+      }
+      return `Error: ${error instanceof Error ? error.message : String(error)}`
+    }
+  },
+})

--- a/strands-ts/src/vended-tools/editor/index.ts
+++ b/strands-ts/src/vended-tools/editor/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Sandbox-aware file editor tool for viewing, creating, and editing files.
+ *
+ * @example
+ * ```typescript
+ * import { editor } from '@strands-agents/sdk/vended-tools/editor'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [editor] })
+ * await agent.invoke('View the contents of /tmp/example.ts')
+ * ```
+ */
+
+export { editor } from './editor.js'
+export type { EditorToolConfig } from './types.js'

--- a/strands-ts/src/vended-tools/editor/types.ts
+++ b/strands-ts/src/vended-tools/editor/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Type definitions for the sandbox-aware editor tool.
+ */
+
+/**
+ * Configuration for the editor tool, stored in agent appState.
+ *
+ * Set via `agent.appState.set('strands_editor_tool', { maxFileSize: 2097152 })`.
+ */
+export interface EditorToolConfig {
+  /**
+   * Maximum file size in bytes for read operations.
+   * @defaultValue 1048576 (1 MB)
+   */
+  maxFileSize?: number
+
+  /**
+   * When true, rejects relative paths and paths containing `..`.
+   * When false, paths are passed through to the sandbox without validation.
+   * @defaultValue false
+   */
+  requireAbsolutePaths?: boolean
+}

--- a/strands-ts/src/vended-tools/python-repl/__tests__/python-repl.test.ts
+++ b/strands-ts/src/vended-tools/python-repl/__tests__/python-repl.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { pythonRepl } from '../index.js'
+import type { ToolContext } from '../../../tools/tool.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import type { ExecutionResult, StreamChunk, Sandbox } from '../../../sandbox/base.js'
+
+function createMockSandbox(overrides?: Partial<Sandbox>): Sandbox {
+  return {
+    executeStreaming: vi.fn(async function* () {}),
+    executeCodeStreaming: vi.fn(async function* () {
+      yield { data: 'hello\n', streamType: 'stdout' } satisfies StreamChunk
+      yield { exitCode: 0, stdout: 'hello\n', stderr: '', outputFiles: [] } satisfies ExecutionResult
+    }),
+    execute: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '', outputFiles: [] })),
+    executeCode: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '', outputFiles: [] })),
+    readFile: vi.fn(async () => new Uint8Array()),
+    writeFile: vi.fn(async () => {}),
+    removeFile: vi.fn(async () => {}),
+    listFiles: vi.fn(async () => []),
+    readText: vi.fn(async () => ''),
+    writeText: vi.fn(async () => {}),
+    ...overrides,
+  } as unknown as Sandbox
+}
+
+function createTestContext(sandboxOverrides?: Partial<Sandbox>) {
+  const sandbox = createMockSandbox(sandboxOverrides)
+  const agent = createMockAgent({ extra: { sandbox } as Record<string, unknown> })
+  const context: ToolContext = { toolUse: { name: 'python_repl', toolUseId: 'test-id', input: {} }, agent }
+  return { context, sandbox, appState: agent.appState }
+}
+
+describe('pythonRepl tool', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('basic execution', () => {
+    it('executes Python code via sandbox', async () => {
+      const { context, sandbox } = createTestContext()
+      const result = await pythonRepl.invoke({ code: 'print("hello")' }, context)
+      expect(sandbox.executeCodeStreaming).toHaveBeenCalledWith('print("hello")', 'python', { timeout: 30 })
+      expect(result).toContain('hello')
+    })
+
+    it('returns (no output) for empty result', async () => {
+      const { context } = createTestContext({
+        executeCodeStreaming: vi.fn(async function* () {
+          yield { exitCode: 0, stdout: '', stderr: '', outputFiles: [] } satisfies ExecutionResult
+        }),
+      })
+      const result = await pythonRepl.invoke({ code: 'pass' }, context)
+      expect(result).toBe('(no output)')
+    })
+
+    it('includes exit code on failure', async () => {
+      const { context } = createTestContext({
+        executeCodeStreaming: vi.fn(async function* () {
+          yield {
+            exitCode: 1,
+            stdout: '',
+            stderr: 'SyntaxError: invalid syntax',
+            outputFiles: [],
+          } satisfies ExecutionResult
+        }),
+      })
+      const result = await pythonRepl.invoke({ code: 'def(' }, context)
+      expect(result).toContain('SyntaxError')
+      expect(result).toContain('Exit code: 1')
+    })
+
+    it('combines stdout and stderr', async () => {
+      const { context } = createTestContext({
+        executeCodeStreaming: vi.fn(async function* () {
+          yield { exitCode: 0, stdout: 'out', stderr: 'warn', outputFiles: [] } satisfies ExecutionResult
+        }),
+      })
+      const result = await pythonRepl.invoke({ code: 'code' }, context)
+      expect(result).toContain('out')
+      expect(result).toContain('warn')
+    })
+  })
+
+  describe('output files', () => {
+    it('reports generated files', async () => {
+      const { context } = createTestContext({
+        executeCodeStreaming: vi.fn(async function* () {
+          yield {
+            exitCode: 0,
+            stdout: 'plot done',
+            stderr: '',
+            outputFiles: [{ name: 'chart.png', content: new Uint8Array([1, 2, 3]), mimeType: 'image/png' }],
+          } satisfies ExecutionResult
+        }),
+      })
+      const result = await pythonRepl.invoke({ code: 'import matplotlib' }, context)
+      expect(result).toContain('Generated files: chart.png')
+    })
+  })
+
+  describe('timeout handling', () => {
+    it('uses default timeout of 30s', async () => {
+      const { context, sandbox } = createTestContext()
+      await pythonRepl.invoke({ code: 'pass' }, context)
+      expect(sandbox.executeCodeStreaming).toHaveBeenCalledWith(
+        'pass',
+        'python',
+        expect.objectContaining({ timeout: 30 })
+      )
+    })
+
+    it('uses per-call timeout', async () => {
+      const { context, sandbox } = createTestContext()
+      await pythonRepl.invoke({ code: 'pass', timeout: 60 }, context)
+      expect(sandbox.executeCodeStreaming).toHaveBeenCalledWith(
+        'pass',
+        'python',
+        expect.objectContaining({ timeout: 60 })
+      )
+    })
+
+    it('uses config timeout', async () => {
+      const { context, sandbox, appState } = createTestContext()
+      appState.set('strands_python_repl_tool', { timeout: 45 })
+      await pythonRepl.invoke({ code: 'pass' }, context)
+      expect(sandbox.executeCodeStreaming).toHaveBeenCalledWith(
+        'pass',
+        'python',
+        expect.objectContaining({ timeout: 45 })
+      )
+    })
+  })
+
+  describe('reset', () => {
+    it('resets REPL state', async () => {
+      const { context, appState } = createTestContext()
+      appState.set('_strands_python_repl_state', { some: 'state' })
+      const result = await pythonRepl.invoke({ code: '', reset: true }, context)
+      expect(result).toBe('Python REPL state reset.')
+      expect(appState.get('_strands_python_repl_state')).toBeUndefined()
+    })
+
+    it('resets and runs code', async () => {
+      const { context } = createTestContext()
+      const result = await pythonRepl.invoke({ code: 'print("hello")', reset: true }, context)
+      expect(result).toContain('hello')
+    })
+  })
+
+  describe('error handling', () => {
+    it('handles sandbox not returning result', async () => {
+      const { context } = createTestContext({
+        executeCodeStreaming: vi.fn(async function* () {
+          /* intentionally empty */
+        }),
+      })
+      const result = await pythonRepl.invoke({ code: 'pass' }, context)
+      expect(result).toContain('Error')
+    })
+
+    it('handles sandbox errors gracefully', async () => {
+      const { context } = createTestContext({
+        executeCodeStreaming: vi.fn(
+          // eslint-disable-next-line require-yield
+          async function* () {
+            throw new Error('Sandbox disconnected')
+          }
+        ),
+      })
+      const result = await pythonRepl.invoke({ code: 'pass' }, context)
+      expect(result).toContain('Error: Sandbox disconnected')
+    })
+
+    it('throws when no context provided', async () => {
+      await expect(pythonRepl.invoke({ code: 'pass' })).rejects.toThrow('Tool context is required')
+    })
+  })
+
+  describe('input validation', () => {
+    it('rejects negative timeout', async () => {
+      const { context } = createTestContext()
+      await expect(pythonRepl.invoke({ code: 'pass', timeout: -1 }, context)).rejects.toThrow()
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/python-repl/index.ts
+++ b/strands-ts/src/vended-tools/python-repl/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Sandbox-aware Python REPL tool for executing Python code.
+ *
+ * @example
+ * ```typescript
+ * import { pythonRepl } from '@strands-agents/sdk/vended-tools/python-repl'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [pythonRepl] })
+ * await agent.invoke('Calculate the first 10 Fibonacci numbers')
+ * ```
+ */
+
+export { pythonRepl } from './python-repl.js'
+export type { PythonReplToolConfig } from './types.js'

--- a/strands-ts/src/vended-tools/python-repl/python-repl.ts
+++ b/strands-ts/src/vended-tools/python-repl/python-repl.ts
@@ -1,0 +1,167 @@
+/**
+ * Sandbox-aware Python REPL tool implementation with streaming support.
+ *
+ * Executes Python code in the agent's sandbox using
+ * `sandbox.executeCodeStreaming(code, 'python')`. Each chunk of stdout/stderr
+ * is yielded as a `ToolStreamEvent` in real time, allowing UI consumers to
+ * display live output from code execution.
+ *
+ * The tool is an async generator: `StreamChunk` objects from the sandbox
+ * are yielded during execution, and the final return value is the formatted
+ * result string that becomes the `ToolResult`.
+ *
+ * Configuration keys (set via `agent.appState.set('strands_python_repl_tool', {...})`):
+ * - `timeout` (number): Default timeout in seconds for code execution.
+ *   Overridden by the per-call `timeout` parameter. Default: 30.
+ *
+ * @example
+ * ```typescript
+ * import { pythonRepl } from '@strands-agents/sdk/vended-tools/python-repl'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [pythonRepl] })
+ * await agent.invoke('Calculate the first 10 Fibonacci numbers')
+ * ```
+ */
+
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import type { ExecutionResult, StreamChunk } from '../../sandbox/base.js'
+import type { ToolContext } from '../../tools/tool.js'
+import type { PythonReplToolConfig } from './types.js'
+
+/**
+ * State key for Python REPL tool configuration in agent.appState.
+ */
+const STATE_KEY = 'strands_python_repl_tool'
+
+/**
+ * State key for internal Python REPL state.
+ */
+const REPL_STATE_KEY = '_strands_python_repl_state'
+
+/**
+ * Default timeout for code execution (seconds).
+ */
+const DEFAULT_TIMEOUT = 30
+
+/**
+ * Zod schema for Python REPL input validation.
+ */
+const pythonReplInputSchema = z.object({
+  code: z.string().describe('The Python code to execute'),
+  timeout: z.number().positive().optional().describe('Maximum execution time in seconds (default: 30)'),
+  reset: z.boolean().optional().describe('If true, signal the sandbox to reset execution state'),
+})
+
+/**
+ * Sandbox-aware Python REPL tool for executing Python code.
+ *
+ * Code is executed via the agent's sandbox using
+ * `sandbox.executeCodeStreaming(code, 'python')`. Each chunk of stdout/stderr
+ * is yielded as a streaming event that UI consumers can display in real time.
+ *
+ * @example
+ * ```typescript
+ * import { pythonRepl } from '@strands-agents/sdk/vended-tools/python-repl'
+ * import { Agent, HostSandbox } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({
+ *   tools: [pythonRepl],
+ *   sandbox: new HostSandbox({ workingDir: '/tmp/workspace' }),
+ * })
+ *
+ * // Configure timeout via appState
+ * agent.appState.set('strands_python_repl_tool', { timeout: 60 })
+ *
+ * await agent.invoke('Generate a histogram of random numbers')
+ * ```
+ */
+export const pythonRepl = tool({
+  name: 'python_repl',
+  description:
+    "Execute Python code in the agent's sandbox with live output streaming. " +
+    'Code runs via sandbox.executeCodeStreaming(). Use reset to clear execution state.',
+  inputSchema: pythonReplInputSchema,
+  callback: async function* (input, context?: ToolContext) {
+    if (!context) {
+      throw new Error('Tool context is required for Python REPL operations')
+    }
+
+    const config: PythonReplToolConfig = (context.agent.appState.get(STATE_KEY) as PythonReplToolConfig) ?? {}
+    const sandbox = context.agent.sandbox
+
+    // Handle reset
+    if (input.reset) {
+      try {
+        context.agent.appState.delete(REPL_STATE_KEY)
+      } catch {
+        // Ignore if key doesn't exist
+      }
+      if (!input.code || !input.code.trim()) {
+        return 'Python REPL state reset.'
+      }
+    }
+
+    // Resolve timeout: per-call > config > default
+    const effectiveTimeout = input.timeout ?? config.timeout ?? DEFAULT_TIMEOUT
+
+    // Execute via sandbox streaming
+    let result: ExecutionResult | undefined
+    try {
+      for await (const chunk of sandbox.executeCodeStreaming(input.code, 'python', {
+        timeout: effectiveTimeout,
+      })) {
+        if ('streamType' in chunk) {
+          // Yield each StreamChunk — the SDK wraps it as ToolStreamEvent
+          yield chunk as StreamChunk
+        } else if ('exitCode' in chunk) {
+          result = chunk as ExecutionResult
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        return `Error: Code execution timed out after ${effectiveTimeout} seconds.`
+      }
+      if (error instanceof Error && error.message.includes('NotImplementedError')) {
+        return 'Error: Sandbox does not support code execution (NoOpSandbox).'
+      }
+      return `Error: ${error instanceof Error ? error.message : String(error)}`
+    }
+
+    if (!result) {
+      return 'Error: Sandbox did not return an execution result.'
+    }
+
+    // Format output
+    const outputParts: string[] = []
+    if (result.stdout) {
+      outputParts.push(result.stdout)
+    }
+    if (result.stderr) {
+      outputParts.push(result.stderr)
+    }
+
+    let output = outputParts.join('\n').trimEnd()
+
+    if (result.exitCode !== 0) {
+      if (output) {
+        output += `\n\nExit code: ${result.exitCode}`
+      } else {
+        output = `Code execution failed with exit code: ${result.exitCode}`
+      }
+    }
+
+    // Handle output files (images, charts, etc.)
+    if (result.outputFiles && result.outputFiles.length > 0) {
+      const fileNames = result.outputFiles.map((f) => f.name)
+      if (output) {
+        output += `\n\nGenerated files: ${fileNames.join(', ')}`
+      } else {
+        output = `Generated files: ${fileNames.join(', ')}`
+      }
+    }
+
+    return output || '(no output)'
+  },
+})

--- a/strands-ts/src/vended-tools/python-repl/types.ts
+++ b/strands-ts/src/vended-tools/python-repl/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Type definitions for the sandbox-aware Python REPL tool.
+ */
+
+/**
+ * Configuration for the Python REPL tool, stored in agent appState.
+ *
+ * Set via `agent.appState.set('strands_python_repl_tool', { timeout: 60 })`.
+ */
+export interface PythonReplToolConfig {
+  /**
+   * Default timeout for code execution in seconds.
+   * Overridden by the per-call `timeout` parameter.
+   * @defaultValue 30
+   */
+  timeout?: number
+}

--- a/strands-ts/src/vended-tools/shell/__tests__/shell.test.ts
+++ b/strands-ts/src/vended-tools/shell/__tests__/shell.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { shell } from '../index.js'
+import type { ToolContext } from '../../../tools/tool.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import type { ExecutionResult, StreamChunk, Sandbox } from '../../../sandbox/base.js'
+
+function createMockSandbox(overrides?: Partial<Sandbox>): Sandbox {
+  return {
+    executeStreaming: vi.fn(async function* () {
+      yield { data: 'output\n', streamType: 'stdout' } satisfies StreamChunk
+      yield { exitCode: 0, stdout: 'output\n', stderr: '', outputFiles: [] } satisfies ExecutionResult
+    }),
+
+    executeCodeStreaming: vi.fn(async function* () {}),
+    execute: vi.fn(async () => ({ exitCode: 0, stdout: '/home/user\n', stderr: '', outputFiles: [] })),
+    executeCode: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '', outputFiles: [] })),
+    readFile: vi.fn(async () => new Uint8Array()),
+    writeFile: vi.fn(async () => {}),
+    removeFile: vi.fn(async () => {}),
+    listFiles: vi.fn(async () => []),
+    readText: vi.fn(async () => ''),
+    writeText: vi.fn(async () => {}),
+    ...overrides,
+  } as unknown as Sandbox
+}
+
+function createTestContext(sandboxOverrides?: Partial<Sandbox>) {
+  const sandbox = createMockSandbox(sandboxOverrides)
+  const agent = createMockAgent({ extra: { sandbox } as Record<string, unknown> })
+  const context: ToolContext = { toolUse: { name: 'shell', toolUseId: 'test-id', input: {} }, agent }
+  return { context, sandbox, appState: agent.appState }
+}
+
+describe('shell tool', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('basic execution', () => {
+    it('executes a command via sandbox', async () => {
+      const { context, sandbox } = createTestContext()
+      const result = await shell.invoke({ command: 'echo hello' }, context)
+      expect(sandbox.executeStreaming).toHaveBeenCalled()
+      expect(result).toContain('output')
+    })
+
+    it('returns (no output) for empty result', async () => {
+      const { context } = createTestContext({
+        executeStreaming: vi.fn(async function* () {
+          yield { exitCode: 0, stdout: '', stderr: '', outputFiles: [] } satisfies ExecutionResult
+        }),
+      })
+      const result = await shell.invoke({ command: 'true' }, context)
+      expect(result).toBe('(no output)')
+    })
+
+    it('includes exit code on failure', async () => {
+      const { context } = createTestContext({
+        executeStreaming: vi.fn(async function* () {
+          yield { exitCode: 1, stdout: '', stderr: 'not found', outputFiles: [] } satisfies ExecutionResult
+        }),
+      })
+      const result = await shell.invoke({ command: 'bad-cmd' }, context)
+      expect(result).toContain('not found')
+      expect(result).toContain('Exit code: 1')
+    })
+
+    it('combines stdout and stderr', async () => {
+      const { context } = createTestContext({
+        executeStreaming: vi.fn(async function* () {
+          yield { exitCode: 0, stdout: 'out', stderr: 'err', outputFiles: [] } satisfies ExecutionResult
+        }),
+      })
+      const result = await shell.invoke({ command: 'cmd' }, context)
+      expect(result).toContain('out')
+      expect(result).toContain('err')
+    })
+  })
+
+  describe('timeout handling', () => {
+    it('uses per-call timeout', async () => {
+      const { context, sandbox } = createTestContext()
+      await shell.invoke({ command: 'echo hi', timeout: 30 }, context)
+      expect(sandbox.executeStreaming).toHaveBeenCalledWith('echo hi', expect.objectContaining({ timeout: 30 }))
+    })
+
+    it('uses config timeout when no per-call timeout', async () => {
+      const { context, sandbox, appState } = createTestContext()
+      appState.set('strands_shell_tool', { timeout: 60 })
+      await shell.invoke({ command: 'echo hi' }, context)
+      expect(sandbox.executeStreaming).toHaveBeenCalledWith('echo hi', expect.objectContaining({ timeout: 60 }))
+    })
+
+    it('per-call timeout overrides config', async () => {
+      const { context, sandbox, appState } = createTestContext()
+      appState.set('strands_shell_tool', { timeout: 60 })
+      await shell.invoke({ command: 'echo hi', timeout: 10 }, context)
+      expect(sandbox.executeStreaming).toHaveBeenCalledWith('echo hi', expect.objectContaining({ timeout: 10 }))
+    })
+  })
+
+  describe('restart', () => {
+    it('clears shell state on restart', async () => {
+      const { context, appState } = createTestContext()
+      appState.set('_strands_shell_state', { cwd: '/tmp' })
+      const result = await shell.invoke({ command: '', restart: true }, context)
+      expect(result).toBe('Shell state reset.')
+      expect(appState.get('_strands_shell_state')).toBeUndefined()
+    })
+
+    it('clears state and runs command on restart with command', async () => {
+      const { context } = createTestContext()
+      const result = await shell.invoke({ command: 'ls', restart: true }, context)
+      expect(result).toContain('output')
+    })
+  })
+
+  describe('working directory tracking', () => {
+    it('tracks cwd from pwd result', async () => {
+      const { context, appState } = createTestContext()
+      await shell.invoke({ command: 'cd /tmp' }, context)
+      const shellState = appState.get('_strands_shell_state') as { cwd?: string }
+      expect(shellState?.cwd).toBe('/home/user')
+    })
+
+    it('passes tracked cwd to execute', async () => {
+      const { context, sandbox, appState } = createTestContext()
+      appState.set('_strands_shell_state', { cwd: '/tmp/workspace' })
+      await shell.invoke({ command: 'ls' }, context)
+      expect(sandbox.executeStreaming).toHaveBeenCalledWith('ls', expect.objectContaining({ cwd: '/tmp/workspace' }))
+    })
+  })
+
+  describe('error handling', () => {
+    it('handles sandbox not returning result', async () => {
+      const { context } = createTestContext({
+        executeStreaming: vi.fn(async function* () {
+          /* intentionally empty */
+        }),
+      })
+      const result = await shell.invoke({ command: 'echo test' }, context)
+      expect(result).toContain('Error')
+    })
+
+    it('handles sandbox errors gracefully', async () => {
+      const { context } = createTestContext({
+        executeStreaming: vi.fn(
+          // eslint-disable-next-line require-yield
+          async function* () {
+            throw new Error('Connection refused')
+          }
+        ),
+      })
+      const result = await shell.invoke({ command: 'echo test' }, context)
+      expect(result).toContain('Error: Connection refused')
+    })
+
+    it('throws when no context provided', async () => {
+      await expect(shell.invoke({ command: 'echo test' })).rejects.toThrow('Tool context is required')
+    })
+  })
+
+  describe('input validation', () => {
+    it('accepts valid command', async () => {
+      const { context } = createTestContext()
+      const result = await shell.invoke({ command: 'echo "hello"' }, context)
+      expect(result).toBeDefined()
+    })
+
+    it('rejects negative timeout', async () => {
+      const { context } = createTestContext()
+      await expect(shell.invoke({ command: 'echo test', timeout: -1 }, context)).rejects.toThrow()
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/shell/index.ts
+++ b/strands-ts/src/vended-tools/shell/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Sandbox-aware shell tool for executing commands in the agent's sandbox.
+ *
+ * @example
+ * ```typescript
+ * import { shell } from '@strands-agents/sdk/vended-tools/shell'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [shell] })
+ * await agent.invoke('List all files in the current directory')
+ * ```
+ */
+
+export { shell } from './shell.js'
+export type { ShellToolConfig, ShellState } from './types.js'

--- a/strands-ts/src/vended-tools/shell/shell.ts
+++ b/strands-ts/src/vended-tools/shell/shell.ts
@@ -1,0 +1,191 @@
+/**
+ * Sandbox-aware shell tool implementation with streaming support.
+ *
+ * Executes shell commands in the agent's sandbox with persistent state tracking.
+ * The tool uses `sandbox.executeStreaming()` so that stdout/stderr chunks are
+ * yielded as `ToolStreamEvent`s in real time. This allows UI consumers to display
+ * live output from sandbox execution.
+ *
+ * The tool is an async generator: each `StreamChunk` from the sandbox is yielded
+ * directly (the SDK wraps it in a `ToolStreamEvent`), and the final return value
+ * is the formatted result string (which becomes the `ToolResult`).
+ *
+ * Configuration keys (set via `agent.appState.set('strands_shell_tool', {...})`):
+ * - `timeout` (number): Default timeout in seconds. Overridden by the per-call
+ *   `timeout` parameter. Default: 120.
+ *
+ * @example
+ * ```typescript
+ * import { shell } from '@strands-agents/sdk/vended-tools/shell'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({ tools: [shell] })
+ * await agent.invoke('List all files in the current directory')
+ * ```
+ */
+
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import type { ExecuteOptions, ExecutionResult, StreamChunk } from '../../sandbox/base.js'
+import type { ToolContext } from '../../tools/tool.js'
+import type { ShellToolConfig, ShellState } from './types.js'
+
+/**
+ * State key for shell tool configuration in agent.appState.
+ */
+const STATE_KEY = 'strands_shell_tool'
+
+/**
+ * State key for internal shell state (e.g., tracked cwd).
+ */
+const SHELL_STATE_KEY = '_strands_shell_state'
+
+/**
+ * Default timeout for shell commands (seconds).
+ */
+const DEFAULT_TIMEOUT = 120
+
+/**
+ * Zod schema for shell tool input validation.
+ */
+const shellInputSchema = z.object({
+  command: z.string().describe('The shell command to execute'),
+  timeout: z.number().positive().optional().describe('Maximum execution time in seconds (default: 120)'),
+  restart: z.boolean().optional().describe('If true, reset shell state by clearing the tracked working directory'),
+})
+
+/**
+ * Build ExecuteOptions, only including cwd when it is defined.
+ * This satisfies exactOptionalPropertyTypes — we never pass `cwd: undefined`.
+ */
+function buildOptions(timeout: number, cwd: string | undefined): ExecuteOptions {
+  const opts: ExecuteOptions = { timeout }
+  if (cwd !== undefined) {
+    opts.cwd = cwd
+  }
+  return opts
+}
+
+/**
+ * Sandbox-aware shell tool for executing commands in the agent's sandbox.
+ *
+ * Unlike the legacy `bash` tool that uses `child_process.spawn` directly,
+ * this tool delegates to `context.agent.sandbox.executeStreaming()`, making
+ * it work transparently with any sandbox implementation (host, Docker, SSH,
+ * cloud environments).
+ *
+ * Commands are streamed in real time — each chunk of stdout/stderr is yielded
+ * as a `ToolStreamEvent` that UI consumers can display live.
+ *
+ * The tool tracks the working directory across calls via agent appState,
+ * enabling session continuity (e.g., `cd /tmp` in one call persists to the next).
+ *
+ * @example
+ * ```typescript
+ * import { shell } from '@strands-agents/sdk/vended-tools/shell'
+ * import { Agent, HostSandbox } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({
+ *   tools: [shell],
+ *   sandbox: new HostSandbox({ workingDir: '/tmp/workspace' }),
+ * })
+ *
+ * // Configure timeout via appState
+ * agent.appState.set('strands_shell_tool', { timeout: 60 })
+ *
+ * await agent.invoke('Run the test suite')
+ * ```
+ */
+export const shell = tool({
+  name: 'shell',
+  description:
+    "Execute a shell command in the agent's sandbox with live output streaming. " +
+    'The sandbox preserves working directory across calls. Use restart to reset shell state.',
+  inputSchema: shellInputSchema,
+  callback: async function* (input, context?: ToolContext) {
+    if (!context) {
+      throw new Error('Tool context is required for shell operations')
+    }
+
+    const config: ShellToolConfig = (context.agent.appState.get(STATE_KEY) as ShellToolConfig) ?? {}
+    const sandbox = context.agent.sandbox
+
+    // Handle restart
+    if (input.restart) {
+      try {
+        context.agent.appState.delete(SHELL_STATE_KEY)
+      } catch {
+        // Ignore if key doesn't exist
+      }
+      if (!input.command || !input.command.trim()) {
+        return 'Shell state reset.'
+      }
+    }
+
+    // Resolve timeout: per-call > config > default
+    const effectiveTimeout = input.timeout ?? config.timeout ?? DEFAULT_TIMEOUT
+
+    // Get tracked working directory from state (for session continuity)
+    const shellState: ShellState = (context.agent.appState.get(SHELL_STATE_KEY) as ShellState) ?? {}
+    const cwd = shellState.cwd
+
+    // Execute via sandbox streaming
+    let result: ExecutionResult | undefined
+    try {
+      for await (const chunk of sandbox.executeStreaming(input.command, buildOptions(effectiveTimeout, cwd))) {
+        if ('streamType' in chunk) {
+          // Yield each StreamChunk — the SDK wraps it as ToolStreamEvent
+          yield chunk as StreamChunk
+        } else if ('exitCode' in chunk) {
+          result = chunk as ExecutionResult
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        return `Error: Command timed out after ${effectiveTimeout} seconds.`
+      }
+      if (error instanceof Error && error.message.includes('NotImplementedError')) {
+        return 'Error: Sandbox does not support command execution (NoOpSandbox).'
+      }
+      return `Error: ${error instanceof Error ? error.message : String(error)}`
+    }
+
+    if (!result) {
+      return 'Error: Sandbox did not return an execution result.'
+    }
+
+    // Track working directory changes (best-effort)
+    try {
+      const cwdResult = await sandbox.execute('pwd', buildOptions(5, cwd))
+      if (cwdResult.exitCode === 0) {
+        const newCwd = cwdResult.stdout.trim()
+        if (newCwd) {
+          context.agent.appState.set(SHELL_STATE_KEY, { cwd: newCwd })
+        }
+      }
+    } catch {
+      // Best-effort cwd tracking
+    }
+
+    // Format final output (becomes the ToolResult)
+    const outputParts: string[] = []
+    if (result.stdout) {
+      outputParts.push(result.stdout)
+    }
+    if (result.stderr) {
+      outputParts.push(result.stderr)
+    }
+
+    let output = outputParts.join('\n').trimEnd()
+
+    if (result.exitCode !== 0) {
+      if (output) {
+        output += `\n\nExit code: ${result.exitCode}`
+      } else {
+        output = `Command failed with exit code: ${result.exitCode}`
+      }
+    }
+
+    return output || '(no output)'
+  },
+})

--- a/strands-ts/src/vended-tools/shell/types.ts
+++ b/strands-ts/src/vended-tools/shell/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Type definitions for the sandbox-aware shell tool.
+ */
+
+/**
+ * Configuration for the shell tool, stored in agent appState.
+ *
+ * Set via `agent.appState.set('strands_shell_tool', { timeout: 60 })`.
+ */
+export interface ShellToolConfig {
+  /**
+   * Default timeout for shell commands in seconds.
+   * Overridden by the per-call `timeout` parameter.
+   * @defaultValue 120
+   */
+  timeout?: number
+}
+
+/**
+ * Internal shell state tracked across calls for session continuity.
+ * Stored in agent appState under `_strands_shell_state`.
+ */
+export interface ShellState {
+  /**
+   * Last known working directory from the shell session.
+   */
+  cwd?: string
+}


### PR DESCRIPTION
## Summary

Port the **Sandbox** interface from the Python SDK ([PR #1968](https://github.com/strands-agents/sdk-python/pull/1968)) to TypeScript, respecting TS standards and patterns.

The Sandbox decouples tool logic from where code runs. Tools that need to execute code or access a filesystem receive a `Sandbox` instead of managing their own execution, enabling portability across host, Docker, and cloud environments.

Related: [Design Doc PR #681](https://github.com/strands-agents/docs/pull/681) · [Python SDK PR #1968](https://github.com/strands-agents/sdk-python/pull/1968) · [Tracking Issue](https://github.com/agent-of-mkmeral/strands-coder-private/issues/3)

---

## What Changed

### New Files (14 source + 7 test)

| File | Lines | Purpose |
|---|---|---|
| `src/sandbox/base.ts` | ~280 | `Sandbox` abstract class, types |
| `src/sandbox/host.ts` | ~250 | `HostSandbox` — native Node.js (default) |
| `src/sandbox/shell-based.ts` | ~160 | `ShellBasedSandbox` — for remote environments |
| `src/sandbox/noop.ts` | ~50 | `NoOpSandbox` — throws for all ops |
| `src/sandbox/index.ts` | ~20 | Module exports |
| `src/vended-tools/shell/shell.ts` | ~190 | **Sandbox-aware shell** — `executeStreaming()`, cwd tracking |
| `src/vended-tools/shell/types.ts` | ~30 | Shell config types |
| `src/vended-tools/shell/index.ts` | ~15 | Shell exports |
| `src/vended-tools/editor/editor.ts` | ~430 | **Sandbox-aware editor** — view/create/str_replace/insert/undo_edit |
| `src/vended-tools/editor/types.ts` | ~25 | Editor config types |
| `src/vended-tools/editor/index.ts` | ~15 | Editor exports |
| `src/vended-tools/python-repl/python-repl.ts` | ~170 | **Sandbox-aware Python REPL** — `executeCodeStreaming()` |
| `src/vended-tools/python-repl/types.ts` | ~17 | Python REPL config types |
| `src/vended-tools/python-repl/index.ts` | ~15 | Python REPL exports |

### Test Files (7)

| File | Tests |
|---|---|
| `src/sandbox/__tests__/base.test.ts` | 7 |
| `src/sandbox/__tests__/host.test.ts` | 22 |
| `src/sandbox/__tests__/shell-based.test.ts` | 11 |
| `src/sandbox/__tests__/noop.test.ts` | 11 |
| `src/vended-plugins/skills/__tests__/sandbox-skills.test.node.ts` | 11 |
| `src/vended-tools/shell/__tests__/shell.test.ts` | 16 |
| `src/vended-tools/editor/__tests__/editor.test.ts` | 23 |
| `src/vended-tools/python-repl/__tests__/python-repl.test.ts` | 14 |

### Modified Files (6)

| File | Change |
|---|---|
| `src/agent/agent.ts` | Added `sandbox` param, defaults to `HostSandbox()` |
| `src/types/agent.ts` | Added `sandbox: Sandbox` to `LocalAgent` |
| `src/index.ts` | Added sandbox exports |
| `src/vended-plugins/skills/skill.ts` | `fromSandbox()`, `fromSandboxDirectory()` |
| `src/vended-plugins/skills/agent-skills.ts` | `sandbox:` URI prefix |
| `AGENTS.md` | Directory structure update |

---

## Sandbox-Aware Vended Tools

Three new tools matching Python SDK's `vended_tools/shell`, `vended_tools/editor`, `vended_tools/python_repl`:

### `shell` — Command execution
```typescript
import { shell } from '@strands-agents/sdk/vended-tools/shell'
const agent = new Agent({ tools: [shell] })
// sandbox.executeStreaming() with live streaming, cwd tracking
agent.appState.set('strands_shell_tool', { timeout: 60 })
```

### `editor` — File editing (Anthropic text_editor shape)
```typescript
import { editor } from '@strands-agents/sdk/vended-tools/editor'
const agent = new Agent({ tools: [editor] })
// 5 commands: view, create, str_replace, insert, undo_edit
// sandbox.readFile/writeFile/listFiles
```

### `pythonRepl` — Python execution
```typescript
import { pythonRepl } from '@strands-agents/sdk/vended-tools/python-repl'
const agent = new Agent({ tools: [pythonRepl] })
// sandbox.executeCodeStreaming(code, 'python')
```

All tools use `agent.appState` for config, work with any `Sandbox` impl.

---

## Class Hierarchy

```
Sandbox (abstract)
  ├── HostSandbox (native Node.js, default)
  ├── ShellBasedSandbox (abstract, for Docker/SSH)
  └── NoOpSandbox (throws)
```

---

## Tests — 115 passing ✅

- Build (`tsc`) ✅
- Lint (`eslint`) ✅
- Format (`prettier`) ✅
- Type-check ✅
- 62 sandbox tests + 53 vended tool tests = 115 total

---

cc @mkmeral