### PR TITLE
feat: add countTokens() heuristic to Model base class

### DIFF
--- a/strands-ts/src/__fixtures__/model-test-helpers.ts
+++ b/strands-ts/src/__fixtures__/model-test-helpers.ts
@@ -54,11 +54,6 @@ export class TestModelProvider extends Model<BaseModelConfig> {
     }
     yield* this.eventGenerator()
   }
-
-  /** Exposes protected estimateTokens for testing. */
-  async testEstimateTokens(messages: Message[], options?: StreamOptions): Promise<number> {
-    return this.estimateTokens(messages, options)
-  }
 }
 
 /**

--- a/strands-ts/src/__fixtures__/model-test-helpers.ts
+++ b/strands-ts/src/__fixtures__/model-test-helpers.ts
@@ -54,6 +54,11 @@ export class TestModelProvider extends Model<BaseModelConfig> {
     }
     yield* this.eventGenerator()
   }
+
+  /** Exposes protected estimateTokens for testing. */
+  async testEstimateTokens(messages: Message[], options?: StreamOptions): Promise<number> {
+    return this.estimateTokens(messages, options)
+  }
 }
 
 /**

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -162,7 +162,7 @@ export {
 } from './models/streaming.js'
 
 // Model provider types
-export type { BaseModelConfig, StreamOptions, CacheConfig } from './models/model.js'
+export type { BaseModelConfig, CountTokensOptions, StreamOptions, CacheConfig } from './models/model.js'
 
 export { Model } from './models/model.js'
 

--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -828,12 +828,12 @@ describe('Model.modelId', () => {
   })
 })
 
-describe('estimateTokens', () => {
+describe('countTokens', () => {
   it('estimates text block tokens using chars/4 heuristic', async () => {
     const provider = new TestModelProvider()
     const messages = [new Message({ role: 'user', content: [new TextBlock('Hello world')] })]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(3)
   })
@@ -847,7 +847,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(3 + 9)
   })
@@ -867,7 +867,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(Math.ceil('72°F and sunny'.length / 4))
   })
@@ -881,7 +881,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(Math.ceil('Let me think about this step by step'.length / 4))
   })
@@ -899,7 +899,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(Math.ceil('Is this safe?'.length / 4))
   })
@@ -918,7 +918,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(Math.ceil('cited text here'.length / 4))
   })
@@ -927,7 +927,7 @@ describe('estimateTokens', () => {
     const provider = new TestModelProvider()
     const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
-    const result = await provider.testEstimateTokens(messages, {
+    const result = await provider.countTokens(messages, {
       systemPrompt: 'You are a helpful assistant',
     })
 
@@ -938,7 +938,7 @@ describe('estimateTokens', () => {
     const provider = new TestModelProvider()
     const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
-    const result = await provider.testEstimateTokens(messages, {
+    const result = await provider.countTokens(messages, {
       systemPrompt: [new TextBlock('System instructions')],
     })
 
@@ -950,7 +950,7 @@ describe('estimateTokens', () => {
     const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
     const toolSpecs = [{ name: 'get_weather', description: 'Get weather for a city' }]
 
-    const result = await provider.testEstimateTokens(messages, { toolSpecs })
+    const result = await provider.countTokens(messages, { toolSpecs })
 
     const specJson = JSON.stringify(toolSpecs[0])
     expect(result).toBe(Math.ceil('Hi'.length / 4) + Math.ceil(specJson.length / 2))
@@ -959,7 +959,7 @@ describe('estimateTokens', () => {
   it('returns 0 for empty messages', async () => {
     const provider = new TestModelProvider()
 
-    const result = await provider.testEstimateTokens([])
+    const result = await provider.countTokens([])
 
     expect(result).toBe(0)
   })
@@ -973,7 +973,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages)
+    const result = await provider.countTokens(messages)
 
     expect(result).toBe(0)
   })
@@ -982,7 +982,7 @@ describe('estimateTokens', () => {
     const provider = new TestModelProvider()
     const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
-    const result = await provider.testEstimateTokens(messages, {
+    const result = await provider.countTokens(messages, {
       systemPrompt: [new GuardContentBlock({ text: { qualifiers: ['query'], text: 'Guard text here' } })],
     })
 
@@ -1003,7 +1003,7 @@ describe('estimateTokens', () => {
       }),
     ]
 
-    const result = await provider.testEstimateTokens(messages, { systemPrompt: 'You are helpful' })
+    const result = await provider.countTokens(messages, { systemPrompt: 'You are helpful' })
 
     const expected =
       Math.ceil('You are helpful'.length / 4) +

--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { Message, TextBlock } from '../../types/messages.js'
+import {
+  Message,
+  TextBlock,
+  ToolUseBlock,
+  ToolResultBlock,
+  ReasoningBlock,
+  GuardContentBlock,
+} from '../../types/messages.js'
+import { CitationsBlock } from '../../types/citations.js'
 import { TestModelProvider, collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { MaxTokensError, ModelError } from '../../errors.js'
 import { Model } from '../model.js'
@@ -817,5 +825,192 @@ describe('Model.modelId', () => {
     provider.updateConfig({ modelId: 'my-model' })
 
     expect(provider.modelId).toBe('my-model')
+  })
+})
+
+describe('estimateTokens', () => {
+  it('estimates text block tokens using chars/4 heuristic', async () => {
+    const provider = new TestModelProvider()
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Hello world')] })]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(3)
+  })
+
+  it('estimates toolUse block tokens (name + JSON input)', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({
+        role: 'assistant',
+        content: [new ToolUseBlock({ name: 'get_weather', toolUseId: 'id1', input: { city: 'Seattle' } })],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(3 + 9)
+  })
+
+  it('estimates toolResult block tokens (text items only)', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({
+        role: 'user',
+        content: [
+          new ToolResultBlock({
+            toolUseId: 'id1',
+            status: 'success',
+            content: [new TextBlock('72°F and sunny')],
+          }),
+        ],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(Math.ceil('72°F and sunny'.length / 4))
+  })
+
+  it('estimates reasoning block tokens', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({
+        role: 'assistant',
+        content: [new ReasoningBlock({ text: 'Let me think about this step by step' })],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(Math.ceil('Let me think about this step by step'.length / 4))
+  })
+
+  it('estimates guardContent block tokens', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({
+        role: 'user',
+        content: [
+          new GuardContentBlock({
+            text: { qualifiers: ['query'], text: 'Is this safe?' },
+          }),
+        ],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(Math.ceil('Is this safe?'.length / 4))
+  })
+
+  it('estimates citations block tokens', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({
+        role: 'assistant',
+        content: [
+          new CitationsBlock({
+            citations: [],
+            content: [{ text: 'cited text here' }],
+          }),
+        ],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(Math.ceil('cited text here'.length / 4))
+  })
+
+  it('estimates string system prompt tokens', async () => {
+    const provider = new TestModelProvider()
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+    const result = await provider.testEstimateTokens(messages, {
+      systemPrompt: 'You are a helpful assistant',
+    })
+
+    expect(result).toBe(Math.ceil('You are a helpful assistant'.length / 4) + Math.ceil('Hi'.length / 4))
+  })
+
+  it('estimates array system prompt tokens', async () => {
+    const provider = new TestModelProvider()
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+    const result = await provider.testEstimateTokens(messages, {
+      systemPrompt: [new TextBlock('System instructions')],
+    })
+
+    expect(result).toBe(Math.ceil('System instructions'.length / 4) + Math.ceil('Hi'.length / 4))
+  })
+
+  it('estimates tool spec tokens', async () => {
+    const provider = new TestModelProvider()
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+    const toolSpecs = [{ name: 'get_weather', description: 'Get weather for a city' }]
+
+    const result = await provider.testEstimateTokens(messages, { toolSpecs })
+
+    const specJson = JSON.stringify(toolSpecs[0])
+    expect(result).toBe(Math.ceil('Hi'.length / 4) + Math.ceil(specJson.length / 2))
+  })
+
+  it('returns 0 for empty messages', async () => {
+    const provider = new TestModelProvider()
+
+    const result = await provider.testEstimateTokens([])
+
+    expect(result).toBe(0)
+  })
+
+  it('skips reasoning blocks without text', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({
+        role: 'assistant',
+        content: [new ReasoningBlock({ signature: 'sig123' })],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages)
+
+    expect(result).toBe(0)
+  })
+
+  it('estimates guardContent in array system prompt', async () => {
+    const provider = new TestModelProvider()
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+    const result = await provider.testEstimateTokens(messages, {
+      systemPrompt: [new GuardContentBlock({ text: { qualifiers: ['query'], text: 'Guard text here' } })],
+    })
+
+    expect(result).toBe(Math.ceil('Guard text here'.length / 4) + Math.ceil('Hi'.length / 4))
+  })
+
+  it('accumulates tokens across multiple messages with mixed content', async () => {
+    const provider = new TestModelProvider()
+    const messages = [
+      new Message({ role: 'user', content: [new TextBlock('What is the weather?')] }),
+      new Message({
+        role: 'assistant',
+        content: [new ToolUseBlock({ name: 'get_weather', toolUseId: 'id1', input: { city: 'Seattle' } })],
+      }),
+      new Message({
+        role: 'user',
+        content: [new ToolResultBlock({ toolUseId: 'id1', status: 'success', content: [new TextBlock('72F')] })],
+      }),
+    ]
+
+    const result = await provider.testEstimateTokens(messages, { systemPrompt: 'You are helpful' })
+
+    const expected =
+      Math.ceil('You are helpful'.length / 4) +
+      Math.ceil('What is the weather?'.length / 4) +
+      Math.ceil('get_weather'.length / 4) +
+      Math.ceil(JSON.stringify({ city: 'Seattle' }).length / 2) +
+      Math.ceil('72F'.length / 4)
+    expect(result).toBe(expected)
   })
 })

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -123,6 +123,22 @@ export interface StreamOptions {
 }
 
 /**
+ * Options for counting tokens in a set of messages.
+ */
+export interface CountTokensOptions {
+  /**
+   * System prompt to guide the model's behavior.
+   * Can be a simple string or an array of content blocks for advanced caching.
+   */
+  systemPrompt?: SystemPrompt
+
+  /**
+   * Array of tool specifications to include in the count.
+   */
+  toolSpecs?: ToolSpec[]
+}
+
+/**
  * Result interface for the streamAggregated method.
  * Contains the complete message, stop reason, and optional metadata.
  */
@@ -192,19 +208,20 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
   abstract stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent>
 
   /**
-   * Estimate token count for the given input before sending to the model.
+   * Count tokens for the given input before sending to the model.
    *
-   * Used internally for proactive context management.
+   * Used for proactive context management (e.g., triggering compression at a threshold).
    * The base implementation uses a character-based heuristic (chars/4 for text, chars/2 for JSON).
    *
-   * Subclasses should override this method to use native token counting APIs for improved accuracy,
-   * falling back to `super.estimateTokens()` on API failure.
+   * Subclasses should override this method to use native token counting APIs
+   * (e.g., Bedrock CountTokens, Anthropic countTokens, Gemini countTokens)
+   * for improved accuracy, falling back to `super.countTokens()` on API failure.
    *
-   * @param messages - Array of conversation messages to estimate tokens for
-   * @param options - Optional streaming options containing system prompt and tool specs
-   * @returns Estimated total input tokens
+   * @param messages - Array of conversation messages to count tokens for
+   * @param options - Optional options containing system prompt and tool specs
+   * @returns Total input token count
    */
-  protected async estimateTokens(messages: Message[], options?: StreamOptions): Promise<number> {
+  async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
     return estimateTokensHeuristic(messages, options)
   }
 
@@ -502,7 +519,7 @@ function estimateContentBlockTokens(block: ContentBlock): number {
  * Estimate token count using character-based heuristics (text: chars/4, JSON: chars/2).
  * Dependency-free fallback used by the base Model class.
  */
-function estimateTokensHeuristic(messages: Message[], options?: StreamOptions): number {
+function estimateTokensHeuristic(messages: Message[], options?: CountTokensOptions): number {
   let total = 0
 
   if (options?.systemPrompt) {

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -192,6 +192,23 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
   abstract stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent>
 
   /**
+   * Estimate token count for the given input before sending to the model.
+   *
+   * Used internally for proactive context management.
+   * The base implementation uses a character-based heuristic (chars/4 for text, chars/2 for JSON).
+   *
+   * Subclasses should override this method to use native token counting APIs for improved accuracy,
+   * falling back to `super.estimateTokens()` on API failure.
+   *
+   * @param messages - Array of conversation messages to estimate tokens for
+   * @param options - Optional streaming options containing system prompt and tool specs
+   * @returns Estimated total input tokens
+   */
+  protected async estimateTokens(messages: Message[], options?: StreamOptions): Promise<number> {
+    return estimateTokensHeuristic(messages, options)
+  }
+
+  /**
    * Converts event data to event class representation
    *
    * @param event_data - Interface representation of event
@@ -434,5 +451,95 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       const normalizedError = normalizeError(error)
       throw new ModelError(normalizedError.message, { cause: error })
     }
+  }
+}
+
+/**
+ * Estimate tokens for a content block using character-based heuristics.
+ *
+ * @param block - Content block to estimate tokens for
+ * @returns Estimated token count
+ */
+function estimateContentBlockTokens(block: ContentBlock): number {
+  let total = 0
+
+  switch (block.type) {
+    case 'textBlock':
+      total += heuristicText(block.text)
+      break
+    case 'toolUseBlock':
+      total += heuristicText(block.name)
+      total += heuristicJson(block.input)
+      break
+    case 'toolResultBlock':
+      for (const item of block.content) {
+        if (item.type === 'textBlock') {
+          total += heuristicText(item.text)
+        } else if (item.type === 'jsonBlock') {
+          total += heuristicJson(item.json)
+        }
+      }
+      break
+    case 'reasoningBlock':
+      if (block.text) total += heuristicText(block.text)
+      break
+    case 'guardContentBlock':
+      if (block.text) total += heuristicText(block.text.text)
+      break
+    case 'citationsBlock':
+      for (const item of block.content) {
+        if ('text' in item) total += heuristicText(item.text)
+      }
+      break
+    default:
+      break
+  }
+
+  return total
+}
+
+/**
+ * Estimate token count using character-based heuristics (text: chars/4, JSON: chars/2).
+ * Dependency-free fallback used by the base Model class.
+ */
+function estimateTokensHeuristic(messages: Message[], options?: StreamOptions): number {
+  let total = 0
+
+  if (options?.systemPrompt) {
+    if (typeof options.systemPrompt === 'string') {
+      total += heuristicText(options.systemPrompt)
+    } else {
+      for (const block of options.systemPrompt) {
+        if (block.type === 'textBlock') total += heuristicText(block.text)
+        else if (block.type === 'guardContentBlock' && block.text) total += heuristicText(block.text.text)
+      }
+    }
+  }
+
+  for (const message of messages) {
+    for (const block of message.content) {
+      total += estimateContentBlockTokens(block)
+    }
+  }
+
+  if (options?.toolSpecs) {
+    for (const spec of options.toolSpecs) {
+      total += heuristicJson(spec)
+    }
+  }
+
+  return total
+}
+
+function heuristicText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+function heuristicJson(obj: unknown): number {
+  try {
+    return Math.ceil(JSON.stringify(obj).length / 2)
+  } catch {
+    logger.debug('unable to serialize object for token estimation, skipping')
+    return 0
   }
 }


### PR DESCRIPTION
## Description

Adds `countTokens()` to the `Model` base class for estimating input token count before sending to the model, enabling proactive context management (e.g., triggering compression at a threshold).

Uses a character-based heuristic (`chars/4` for text, `chars/2` for JSON) as a universal fallback for all providers. Individual providers can override with native counting APIs in a follow-up PR.

Handles all content block types: text, toolUse, toolResult, reasoningContent, guardContent, citationsContent, system prompts (string and array), and tool specs. Non-serializable content (e.g., image bytes) is gracefully skipped.

### TypeScript port of
- Python PR: strands-agents/sdk-python#2031

### Follow-up
- Native provider overrides (Bedrock `CountTokens`, Anthropic `countTokens`, Google `countTokens`) tracked separately — branch `feat/token-estimation-all` on fork has the implementation ready.
- OpenAI Chat Completions has no native counting endpoint (only the Responses API does); documented in JSDoc.

## Type of Change

New feature

## Testing

- 12 new unit tests covering all content block types, system prompts, tool specs, edge cases
- All 2027 existing tests continue to pass
- `npm run build`, `lint`, `format:check`, `type-check` all pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings
- [x] Existing tests continue to pass