### PR TITLE
feat: add concurrent tool execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ bin/
 
 # LLM
 CLAUDE.md
+.claude
 
 # dev
 .vitest*

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "prettier": "^3.7.4"
   },
   "scripts": {
-    "prepare": "husky",
     "dev": "strands-dev",
+    "prepare": "husky && npm run build",
     "build": "npm run build -w strands-ts",
     "test": "npm run test -w strands-ts",
     "test:coverage": "npm run test:coverage -w strands-ts",
@@ -18,6 +18,7 @@
     "test:browser:install": "npm run test:browser:install -w strands-ts",
     "test:package": "npm run test:package -w strands-ts",
     "lint": "npm run lint -w strands-ts",
+    "format": "npm run format -w strands-ts",
     "format:check": "npm run format:check -w strands-ts",
     "type-check": "npm run type-check -w strands-ts",
     "check:browser-bundle": "npm run check:browser-bundle -w strands-ts"

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -78,7 +78,7 @@
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
     "prepack": "npm run build",
-    "check": "npm run build && npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
+    "check": "npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
     "check:browser-bundle": "esbuild src/index.ts --bundle --platform=browser --format=esm --packages=external --outfile=/dev/null",
     "clean": "rm -rf node_modules dist",
     "lock:refresh": "rm -rf node_modules && npm install --ignore-scripts --os=linux --os=darwin --os=win32 --cpu=x64 --cpu=arm64 --cpu=wasm32",

--- a/strands-ts/src/__fixtures__/mock-plugin.ts
+++ b/strands-ts/src/__fixtures__/mock-plugin.ts
@@ -12,6 +12,8 @@ import {
   AfterToolCallEvent,
   BeforeModelCallEvent,
   AfterModelCallEvent,
+  ToolResultEvent,
+  ToolStreamUpdateEvent,
 } from '../hooks/index.js'
 import type { HookableEventConstructor } from '../hooks/types.js'
 
@@ -37,6 +39,8 @@ export class MockPlugin implements Plugin {
       AfterToolCallEvent,
       BeforeModelCallEvent,
       AfterModelCallEvent,
+      ToolResultEvent,
+      ToolStreamUpdateEvent,
     ]
 
     for (const eventType of eventTypes) {

--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -9,54 +9,63 @@ import {
   ToolStreamUpdateEvent,
 } from '../../hooks/index.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
-import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { MockPlugin } from '../../__fixtures__/mock-plugin.js'
+import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
 import { Tool, ToolStreamEvent, type ToolContext, type ToolStreamGenerator } from '../../tools/tool.js'
 import type { ToolSpec } from '../../tools/types.js'
 
 /**
- * A tool that sleeps for `delayMs` then returns, recording the start and end
- * timestamps on the provided tracker. Useful for asserting concurrency and
- * cooperative cancellation behavior.
+ * A tool whose `stream()` suspends until `release()` is called. Lets tests
+ * drive concurrency deterministically without wall-clock sleeps.
+ *
+ * `started` resolves as soon as the agent enters the tool's `stream()`, so
+ * tests can await "both tools in flight" without polling. The tool also
+ * honors `ctx.agent.cancelSignal`: aborting the signal resolves the gate and
+ * marks `observations.cancelled = true`.
  */
-class TimedTool extends Tool {
+class GatedTool extends Tool {
   name: string
   description: string
   toolSpec: ToolSpec
 
-  constructor(
-    name: string,
-    private readonly delayMs: number,
-    private readonly tracker: { name: string; start: number; end: number; cancelled: boolean }[],
-    private readonly honorCancelSignal = true
-  ) {
+  readonly started: Promise<void>
+  readonly observations = { started: false, cancelled: false, completed: false }
+
+  private _signalStarted!: () => void
+  private readonly _releaser: Promise<void>
+  private _release!: () => void
+
+  constructor(name: string) {
     super()
     this.name = name
-    this.description = `Timed tool ${name}`
+    this.description = `Gated tool ${name}`
     this.toolSpec = { name, description: this.description, inputSchema: { type: 'object', properties: {} } }
+    this.started = new Promise<void>((resolve) => (this._signalStarted = resolve))
+    this._releaser = new Promise<void>((resolve) => (this._release = resolve))
+  }
+
+  release(): void {
+    this._release()
   }
 
   // eslint-disable-next-line require-yield
   async *stream(ctx: ToolContext): ToolStreamGenerator {
-    const entry = { name: this.name, start: Date.now(), end: 0, cancelled: false }
-    this.tracker.push(entry)
-    if (this.honorCancelSignal) {
-      // Cooperatively race sleep against the cancel signal.
-      await new Promise<void>((resolve) => {
-        const timer = globalThis.setTimeout(() => resolve(), this.delayMs)
-        ctx.agent.cancelSignal.addEventListener(
-          'abort',
-          () => {
-            globalThis.clearTimeout(timer)
-            entry.cancelled = true
-            resolve()
-          },
-          { once: true }
-        )
-      })
-    } else {
-      await new Promise<void>((resolve) => globalThis.setTimeout(resolve, this.delayMs))
-    }
-    entry.end = Date.now()
+    this.observations.started = true
+    this._signalStarted()
+
+    await new Promise<void>((resolve) => {
+      void this._releaser.then(resolve)
+      ctx.agent.cancelSignal.addEventListener(
+        'abort',
+        () => {
+          this.observations.cancelled = true
+          resolve()
+        },
+        { once: true }
+      )
+    })
+
+    this.observations.completed = true
     return new ToolResultBlock({
       toolUseId: ctx.toolUse.toolUseId,
       status: 'success',
@@ -66,35 +75,58 @@ class TimedTool extends Tool {
 }
 
 /**
- * A tool that yields the specified number of `ToolStreamEvent`s before returning.
- * Used to exercise cross-tool interleaving of stream updates.
+ * A streaming tool whose `emit(data)` yields a `ToolStreamEvent` and resolves
+ * only after the agent has fully dispatched it; `complete()` terminates the
+ * stream. Tests can drive exact interleaving between tools without timers.
  */
-class StreamingTool extends Tool {
+class GatedStreamingTool extends Tool {
   name: string
   description: string
   toolSpec: ToolSpec
 
-  constructor(
-    name: string,
-    private readonly steps: number,
-    private readonly stepDelayMs: number
-  ) {
+  private readonly _queue: { cmd: { type: 'emit'; data: unknown } | { type: 'complete' }; ack: () => void }[] = []
+  private _notify: (() => void) | null = null
+
+  constructor(name: string) {
     super()
     this.name = name
-    this.description = `Streaming tool ${name}`
+    this.description = `Gated streaming tool ${name}`
     this.toolSpec = { name, description: this.description, inputSchema: { type: 'object', properties: {} } }
   }
 
-  async *stream(ctx: ToolContext): ToolStreamGenerator {
-    for (let i = 0; i < this.steps; i++) {
-      await new Promise<void>((resolve) => globalThis.setTimeout(resolve, this.stepDelayMs))
-      yield new ToolStreamEvent({ data: { tool: this.name, step: i } })
-    }
-    return new ToolResultBlock({
-      toolUseId: ctx.toolUse.toolUseId,
-      status: 'success',
-      content: [new TextBlock(`${this.name} streamed ${this.steps}`)],
+  async emit(data: unknown): Promise<void> {
+    return this._send({ type: 'emit', data })
+  }
+
+  async complete(): Promise<void> {
+    return this._send({ type: 'complete' })
+  }
+
+  private _send(cmd: { type: 'emit'; data: unknown } | { type: 'complete' }): Promise<void> {
+    return new Promise<void>((ack) => {
+      this._queue.push({ cmd, ack })
+      this._notify?.()
+      this._notify = null
     })
+  }
+
+  async *stream(ctx: ToolContext): ToolStreamGenerator {
+    while (true) {
+      while (this._queue.length === 0) {
+        await new Promise<void>((resolve) => (this._notify = resolve))
+      }
+      const { cmd, ack } = this._queue.shift()!
+      if (cmd.type === 'complete') {
+        ack()
+        return new ToolResultBlock({
+          toolUseId: ctx.toolUse.toolUseId,
+          status: 'success',
+          content: [new TextBlock(`${this.name} done`)],
+        })
+      }
+      yield new ToolStreamEvent({ data: cmd.data })
+      ack()
+    }
   }
 }
 
@@ -109,78 +141,103 @@ function twoToolTurn(): MockMessageModel {
 
 describe('Agent concurrent tool execution', () => {
   it('runs multiple tools in parallel', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 80, tracker), new TimedTool('toolB', 80, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
 
-    await agent.invoke('Go')
-
-    expect(tracker).toHaveLength(2)
-    const [first, second] = tracker.sort((a, b) => a.start - b.start)
-    // B started before A finished — proves the tools ran concurrently.
-    expect(second!.start).toBeLessThan(first!.end)
+    const invocation = agent.invoke('Go')
+    // Both tools reach their stream() before either is released — proves
+    // concurrency without relying on wall-clock overlap.
+    await Promise.all([toolA.started, toolB.started])
+    expect(toolA.observations.completed).toBe(false)
+    expect(toolB.observations.completed).toBe(false)
+    toolA.release()
+    toolB.release()
+    await invocation
+    expect(toolA.observations.completed).toBe(true)
+    expect(toolB.observations.completed).toBe(true)
   })
 
   it('runs tools sequentially under default executor', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 40, tracker), new TimedTool('toolB', 40, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       // default (sequential)
       printer: false,
     })
 
-    await agent.invoke('Go')
-    const [first, second] = tracker.sort((a, b) => a.start - b.start)
-    // B did not start until A finished
-    expect(second!.start).toBeGreaterThanOrEqual(first!.end)
+    const invocation = agent.invoke('Go')
+    await toolA.started
+    // B has not started — sequential executor is still blocked on A.
+    expect(toolB.observations.started).toBe(false)
+    toolA.release()
+    await toolB.started
+    toolB.release()
+    await invocation
   })
 
   it('preserves per-tool event ordering while interleaving across tools', async () => {
-    const tools = [new StreamingTool('toolA', 3, 10), new StreamingTool('toolB', 3, 10)]
+    const toolA = new GatedStreamingTool('toolA')
+    const toolB = new GatedStreamingTool('toolB')
+    const plugin = new MockPlugin()
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
+      plugins: [plugin],
     })
 
-    const events: { kind: string; toolUseId?: string; tool?: string }[] = []
-    agent.addHook(BeforeToolCallEvent, (e) => void events.push({ kind: 'before', toolUseId: e.toolUse.toolUseId }))
-    agent.addHook(AfterToolCallEvent, (e) => void events.push({ kind: 'after', toolUseId: e.toolUse.toolUseId }))
-    agent.addHook(ToolResultEvent, (e) => void events.push({ kind: 'result', toolUseId: e.result.toolUseId }))
-    agent.addHook(ToolStreamUpdateEvent, (e) => {
-      const data = e.event.data as { tool: string } | undefined
-      events.push(data?.tool !== undefined ? { kind: 'stream', tool: data.tool } : { kind: 'stream' })
-    })
+    const invocation = agent.invoke('Go')
+    // Drive explicit A,B,A,B,A,B interleaving.
+    await toolA.emit({ tool: 'toolA', step: 0 })
+    await toolB.emit({ tool: 'toolB', step: 0 })
+    await toolA.emit({ tool: 'toolA', step: 1 })
+    await toolB.emit({ tool: 'toolB', step: 1 })
+    await toolA.emit({ tool: 'toolA', step: 2 })
+    await toolB.emit({ tool: 'toolB', step: 2 })
+    await toolA.complete()
+    await toolB.complete()
+    await invocation
 
-    await agent.invoke('Go')
+    // Reduce MockPlugin's invocations to the per-tool lifecycle events we care about.
+    type Entry = { kind: string; toolUseId?: string; tool?: string }
+    const events: Entry[] = plugin.invocations
+      .map((e): Entry | null => {
+        if (e instanceof BeforeToolCallEvent) return { kind: 'before', toolUseId: e.toolUse.toolUseId }
+        if (e instanceof AfterToolCallEvent) return { kind: 'after', toolUseId: e.toolUse.toolUseId }
+        if (e instanceof ToolResultEvent) return { kind: 'result', toolUseId: e.result.toolUseId }
+        if (e instanceof ToolStreamUpdateEvent) {
+          const data = e.event.data as { tool?: string } | undefined
+          return data?.tool !== undefined ? { kind: 'stream', tool: data.tool } : { kind: 'stream' }
+        }
+        return null
+      })
+      .filter((e): e is Entry => e !== null)
 
-    // Extract per-tool subsequence and validate its shape.
+    // Per-tool subsequence shape: [before, stream*, after, result].
     for (const toolUseId of ['a', 'b']) {
       const subseq = events.filter(
         (e) => e.toolUseId === toolUseId || (e.kind === 'stream' && e.tool === (toolUseId === 'a' ? 'toolA' : 'toolB'))
       )
       const kinds = subseq.map((e) => e.kind)
-      // First event for a tool is its BeforeToolCallEvent
       expect(kinds[0]).toBe('before')
-      // Last two are AfterToolCallEvent then ToolResultEvent
       expect(kinds.slice(-2)).toEqual(['after', 'result'])
-      // Middle events (if any) are all stream updates
       for (const k of kinds.slice(1, -2)) {
         expect(k).toBe('stream')
       }
     }
 
-    // Cross-tool interleaving: collapse consecutive same-tool events into runs.
-    // Strictly sequential execution produces 2 runs (e.g. [A,A,A,B,B,B]);
-    // anything > 2 means the stream alternated between tools at least once.
+    // Cross-tool interleaving: collapse consecutive same-tool stream events
+    // into runs. Strictly sequential execution produces 2 runs (A,A,A,B,B,B);
+    // anything > 2 means the stream alternated at least once.
     const streamTools = events.filter((e) => e.kind === 'stream').map((e) => e.tool)
     const runs = streamTools.reduce<(string | undefined)[]>((acc, t) => {
       if (acc.length === 0 || acc[acc.length - 1] !== t) acc.push(t)
@@ -191,11 +248,11 @@ describe('Agent concurrent tool execution', () => {
 
   it('retries one tool independently from the other', async () => {
     let retriesA = 0
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 5, tracker), new TimedTool('toolB', 5, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
@@ -209,18 +266,24 @@ describe('Agent concurrent tool execution', () => {
       }
     })
 
-    await agent.invoke('Go')
+    const invocation = agent.invoke('Go')
+    // Release both gates; on retry A re-enters with an already-resolved
+    // releaser and completes immediately.
+    await Promise.all([toolA.started, toolB.started])
+    toolA.release()
+    toolB.release()
+    await invocation
 
     expect(beforeCalls.filter((n) => n === 'toolA')).toHaveLength(2)
     expect(beforeCalls.filter((n) => n === 'toolB')).toHaveLength(1)
   })
 
   it('cancels all tools when BeforeToolsEvent.cancel is set (concurrent mode)', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 100, tracker), new TimedTool('toolB', 100, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
@@ -229,16 +292,16 @@ describe('Agent concurrent tool execution', () => {
       e.cancel = 'hook cancelled'
     })
 
-    let afterMessage: import('../../types/messages.js').Message | undefined
+    let afterMessage: Message | undefined
     agent.addHook(AfterToolsEvent, (e) => {
       afterMessage = e.message
     })
 
     await agent.invoke('Go')
 
-    // No tool ever ran
-    expect(tracker).toHaveLength(0)
-    // Both tool use ids produced error results in source order
+    // No tool ever ran.
+    expect(toolA.observations.started).toBe(false)
+    expect(toolB.observations.started).toBe(false)
     expect(afterMessage!.content).toHaveLength(2)
     const r0 = afterMessage!.content[0] as ToolResultBlock
     const r1 = afterMessage!.content[1] as ToolResultBlock
@@ -249,11 +312,11 @@ describe('Agent concurrent tool execution', () => {
   })
 
   it('cancels all tools when agent is cancelled before launch (concurrent mode)', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 100, tracker), new TimedTool('toolB', 100, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
@@ -263,41 +326,35 @@ describe('Agent concurrent tool execution', () => {
     })
 
     await agent.invoke('Go')
-    // No tool was invoked.
-    expect(tracker).toHaveLength(0)
+    expect(toolA.observations.started).toBe(false)
+    expect(toolB.observations.started).toBe(false)
   })
 
   it('cooperative mid-flight cancel — tools honor cancelSignal and exit', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [
-      new TimedTool('toolA', 200, tracker, /* honorCancelSignal */ true),
-      new TimedTool('toolB', 200, tracker, true),
-    ]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
 
-    // Fire cancel shortly after both tools have started.
-    agent.addHook(BeforeToolCallEvent, () => {
-      globalThis.setTimeout(() => agent.cancel(), 20)
-    })
+    // Cancel deterministically once both tools have entered their gates.
+    void Promise.all([toolA.started, toolB.started]).then(() => agent.cancel())
 
     await agent.invoke('Go')
 
-    expect(tracker).toHaveLength(2)
-    // Both tools observed the abort signal and exited cooperatively.
-    expect(tracker.every((t) => t.cancelled)).toBe(true)
+    expect(toolA.observations.cancelled).toBe(true)
+    expect(toolB.observations.cancelled).toBe(true)
   })
 
   it('handles a throwing tool without affecting siblings', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 20, tracker), new TimedTool('toolB', 20, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
@@ -316,23 +373,23 @@ describe('Agent concurrent tool execution', () => {
       }
     })
 
-    // Replace toolA's stream implementation with one that throws.
-    const broken = tools[0]!
     // eslint-disable-next-line require-yield
-    broken.stream = async function* () {
+    toolA.stream = async function* () {
       throw new Error('boom')
     }
 
-    await agent.invoke('Go')
+    const invocation = agent.invoke('Go')
+    await toolB.started
+    toolB.release()
+    await invocation
 
     const [a, b] = results.sort((x, y) => x.toolUseId.localeCompare(y.toolUseId))
     expect(a!.status).toBe('error')
     expect(b!.status).toBe('success')
   })
 
-  it('handles an unknown tool in a batch without affecting siblings', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 10, tracker)] // no 'toolB' registered
+  it('handles a hallucinated tool name in a batch without affecting siblings', async () => {
+    const toolA = new GatedTool('toolA')
     const agent = new Agent({
       model: new MockMessageModel()
         .addTurn([
@@ -340,17 +397,21 @@ describe('Agent concurrent tool execution', () => {
           { type: 'toolUseBlock', name: 'unknownTool', toolUseId: 'b', input: {} },
         ])
         .addTurn({ type: 'textBlock', text: 'Done' }),
-      tools,
+      tools: [toolA],
       toolExecutor: 'concurrent',
       printer: false,
     })
 
-    let afterMessage: import('../../types/messages.js').Message | undefined
+    let afterMessage: Message | undefined
     agent.addHook(AfterToolsEvent, (e) => {
       afterMessage = e.message
     })
 
-    await agent.invoke('Go')
+    const invocation = agent.invoke('Go')
+    await toolA.started
+    toolA.release()
+    await invocation
+
     expect(afterMessage!.content).toHaveLength(2)
     const blocks = afterMessage!.content as ToolResultBlock[]
     expect(blocks.find((r) => r.toolUseId === 'a')!.status).toBe('success')
@@ -358,37 +419,52 @@ describe('Agent concurrent tool execution', () => {
   })
 
   it('preserves source order of tool results in AfterToolsEvent.message', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    // toolA is slow, toolB is fast — concurrent completion order will be B then A.
-    const tools = [new TimedTool('toolA', 60, tracker), new TimedTool('toolB', 5, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
 
-    let afterMessage: import('../../types/messages.js').Message | undefined
+    // Deterministically complete B before A.
+    let resolveBDone: () => void = () => {}
+    const bDone = new Promise<void>((resolve) => (resolveBDone = resolve))
+    agent.addHook(ToolResultEvent, (e) => {
+      if (e.result.toolUseId === 'b') resolveBDone()
+    })
+    let afterMessage: Message | undefined
     agent.addHook(AfterToolsEvent, (e) => {
       afterMessage = e.message
     })
 
-    await agent.invoke('Go')
+    const invocation = agent.invoke('Go')
+    await Promise.all([toolA.started, toolB.started])
+    toolB.release()
+    await bDone
+    toolA.release()
+    await invocation
+
     const blocks = afterMessage!.content as ToolResultBlock[]
     expect(blocks.map((b) => b.toolUseId)).toEqual(['a', 'b'])
   })
 
   it('AfterToolsEvent.message contains completed results when consumer breaks mid-stream', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 1, tracker, true), new TimedTool('toolB', 50, tracker, true)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB') // never released
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
 
-    let afterToolsMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(BeforeToolCallEvent, (e) => {
+      if (e.toolUse.name === 'toolA') toolA.release()
+    })
+
+    let afterToolsMessage: Message | undefined
     agent.addHook(AfterToolsEvent, (e) => {
       afterToolsMessage = e.message
     })
@@ -397,7 +473,13 @@ describe('Agent concurrent tool execution', () => {
     for await (const event of agent.stream('Go')) {
       if (event.type === 'toolResultEvent') {
         toolResultsSeen++
-        if (toolResultsSeen === 1) break
+        if (toolResultsSeen === 1) {
+          // Cancel so toolB (still parked on its gate) observes cancelSignal
+          // and exits cooperatively — otherwise gen.return() stays blocked on
+          // a suspended await.
+          agent.cancel()
+          break
+        }
       }
     }
 
@@ -408,11 +490,11 @@ describe('Agent concurrent tool execution', () => {
   })
 
   it('pre-launch agent.cancel() during BeforeToolsEvent produces "Tool execution cancelled" (concurrent)', async () => {
-    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
-    const tools = [new TimedTool('toolA', 100, tracker), new TimedTool('toolB', 100, tracker)]
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
@@ -421,14 +503,15 @@ describe('Agent concurrent tool execution', () => {
       agent.cancel()
     })
 
-    let afterMessage: import('../../types/messages.js').Message | undefined
+    let afterMessage: Message | undefined
     agent.addHook(AfterToolsEvent, (e) => {
       afterMessage = e.message
     })
 
     await agent.invoke('Go')
 
-    expect(tracker).toHaveLength(0)
+    expect(toolA.observations.started).toBe(false)
+    expect(toolB.observations.started).toBe(false)
     const blocks = afterMessage!.content as ToolResultBlock[]
     expect(blocks).toHaveLength(2)
     for (const b of blocks) {
@@ -437,16 +520,20 @@ describe('Agent concurrent tool execution', () => {
   })
 
   it('closes in-flight generators and includes fallback results when consumer breaks', async () => {
-    const tools = [new TimedTool('toolA', 1, []), new StreamingTool('toolB', 20, 2)]
-
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB') // never released
     const agent = new Agent({
       model: twoToolTurn(),
-      tools,
+      tools: [toolA, toolB],
       toolExecutor: 'concurrent',
       printer: false,
     })
 
-    let afterToolsMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(BeforeToolCallEvent, (e) => {
+      if (e.toolUse.name === 'toolA') toolA.release()
+    })
+
+    let afterToolsMessage: Message | undefined
     agent.addHook(AfterToolsEvent, (e) => {
       afterToolsMessage = e.message
     })
@@ -455,7 +542,13 @@ describe('Agent concurrent tool execution', () => {
     for await (const event of agent.stream('Go')) {
       if (event.type === 'toolResultEvent') {
         toolResultsSeen++
-        if (toolResultsSeen === 1) break
+        if (toolResultsSeen === 1) {
+          // Cancel so toolB (still parked on its gate) observes cancelSignal
+          // and exits cooperatively — otherwise gen.return() stays blocked on
+          // a suspended await.
+          agent.cancel()
+          break
+        }
       }
     }
 

--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -1,0 +1,493 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../agent.js'
+import {
+  AfterToolCallEvent,
+  AfterToolsEvent,
+  BeforeToolCallEvent,
+  BeforeToolsEvent,
+  ToolResultEvent,
+  ToolStreamUpdateEvent,
+} from '../../hooks/index.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { Tool, ToolStreamEvent, type ToolContext, type ToolStreamGenerator } from '../../tools/tool.js'
+import type { ToolSpec } from '../../tools/types.js'
+
+/**
+ * A tool that sleeps for `delayMs` then returns, recording the start and end
+ * timestamps on the provided tracker. Useful for asserting concurrency and
+ * cooperative cancellation behavior.
+ */
+class TimedTool extends Tool {
+  name: string
+  description: string
+  toolSpec: ToolSpec
+
+  constructor(
+    name: string,
+    private readonly delayMs: number,
+    private readonly tracker: { name: string; start: number; end: number; cancelled: boolean }[],
+    private readonly honorCancelSignal = true
+  ) {
+    super()
+    this.name = name
+    this.description = `Timed tool ${name}`
+    this.toolSpec = { name, description: this.description, inputSchema: { type: 'object', properties: {} } }
+  }
+
+  // eslint-disable-next-line require-yield
+  async *stream(ctx: ToolContext): ToolStreamGenerator {
+    const entry = { name: this.name, start: Date.now(), end: 0, cancelled: false }
+    this.tracker.push(entry)
+    if (this.honorCancelSignal) {
+      // Cooperatively race sleep against the cancel signal.
+      await new Promise<void>((resolve) => {
+        const timer = globalThis.setTimeout(() => resolve(), this.delayMs)
+        ctx.agent.cancelSignal.addEventListener(
+          'abort',
+          () => {
+            globalThis.clearTimeout(timer)
+            entry.cancelled = true
+            resolve()
+          },
+          { once: true }
+        )
+      })
+    } else {
+      await new Promise<void>((resolve) => globalThis.setTimeout(resolve, this.delayMs))
+    }
+    entry.end = Date.now()
+    return new ToolResultBlock({
+      toolUseId: ctx.toolUse.toolUseId,
+      status: 'success',
+      content: [new TextBlock(`${this.name} done`)],
+    })
+  }
+}
+
+/**
+ * A tool that yields the specified number of `ToolStreamEvent`s before returning.
+ * Used to exercise cross-tool interleaving of stream updates.
+ */
+class StreamingTool extends Tool {
+  name: string
+  description: string
+  toolSpec: ToolSpec
+
+  constructor(
+    name: string,
+    private readonly steps: number,
+    private readonly stepDelayMs: number
+  ) {
+    super()
+    this.name = name
+    this.description = `Streaming tool ${name}`
+    this.toolSpec = { name, description: this.description, inputSchema: { type: 'object', properties: {} } }
+  }
+
+  async *stream(ctx: ToolContext): ToolStreamGenerator {
+    for (let i = 0; i < this.steps; i++) {
+      await new Promise<void>((resolve) => globalThis.setTimeout(resolve, this.stepDelayMs))
+      yield new ToolStreamEvent({ data: { tool: this.name, step: i } })
+    }
+    return new ToolResultBlock({
+      toolUseId: ctx.toolUse.toolUseId,
+      status: 'success',
+      content: [new TextBlock(`${this.name} streamed ${this.steps}`)],
+    })
+  }
+}
+
+function twoToolTurn(): MockMessageModel {
+  return new MockMessageModel()
+    .addTurn([
+      { type: 'toolUseBlock', name: 'toolA', toolUseId: 'a', input: {} },
+      { type: 'toolUseBlock', name: 'toolB', toolUseId: 'b', input: {} },
+    ])
+    .addTurn({ type: 'textBlock', text: 'Done' })
+}
+
+describe('Agent concurrent tool execution', () => {
+  it('runs multiple tools in parallel', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 80, tracker), new TimedTool('toolB', 80, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    const startAll = Date.now()
+    await agent.invoke('Go')
+    const totalDuration = Date.now() - startAll
+
+    expect(tracker).toHaveLength(2)
+    const [first, second] = tracker.sort((a, b) => a.start - b.start)
+    // B started before A finished
+    expect(second!.start).toBeLessThan(first!.end)
+    // Total wall-clock is roughly the longer tool's duration, not the sum.
+    expect(totalDuration).toBeLessThan(150)
+  })
+
+  it('runs tools sequentially under default executor', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 40, tracker), new TimedTool('toolB', 40, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      // default (sequential)
+      printer: false,
+    })
+
+    await agent.invoke('Go')
+    const [first, second] = tracker.sort((a, b) => a.start - b.start)
+    // B did not start until A finished
+    expect(second!.start).toBeGreaterThanOrEqual(first!.end)
+  })
+
+  it('preserves per-tool event ordering while interleaving across tools', async () => {
+    const tools = [new StreamingTool('toolA', 3, 10), new StreamingTool('toolB', 3, 10)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    const events: { kind: string; toolUseId?: string; tool?: string }[] = []
+    agent.addHook(BeforeToolCallEvent, (e) => void events.push({ kind: 'before', toolUseId: e.toolUse.toolUseId }))
+    agent.addHook(AfterToolCallEvent, (e) => void events.push({ kind: 'after', toolUseId: e.toolUse.toolUseId }))
+    agent.addHook(ToolResultEvent, (e) => void events.push({ kind: 'result', toolUseId: e.result.toolUseId }))
+    agent.addHook(ToolStreamUpdateEvent, (e) => {
+      const data = e.event.data as { tool: string } | undefined
+      events.push(data?.tool !== undefined ? { kind: 'stream', tool: data.tool } : { kind: 'stream' })
+    })
+
+    await agent.invoke('Go')
+
+    // Extract per-tool subsequence and validate its shape.
+    for (const toolUseId of ['a', 'b']) {
+      const subseq = events.filter(
+        (e) => e.toolUseId === toolUseId || (e.kind === 'stream' && e.tool === (toolUseId === 'a' ? 'toolA' : 'toolB'))
+      )
+      const kinds = subseq.map((e) => e.kind)
+      // First event for a tool is its BeforeToolCallEvent
+      expect(kinds[0]).toBe('before')
+      // Last two are AfterToolCallEvent then ToolResultEvent
+      expect(kinds.slice(-2)).toEqual(['after', 'result'])
+      // Middle events (if any) are all stream updates
+      for (const k of kinds.slice(1, -2)) {
+        expect(k).toBe('stream')
+      }
+    }
+
+    // Cross-tool interleaving: at least one A stream occurred between two B streams (or vice versa).
+    const streamTools = events.filter((e) => e.kind === 'stream').map((e) => e.tool)
+    const interleaved =
+      streamTools.some(
+        (t, i) =>
+          i > 0 &&
+          i < streamTools.length - 1 &&
+          t === 'toolA' &&
+          streamTools[i - 1] === 'toolB' &&
+          streamTools[i + 1] === 'toolB'
+      ) ||
+      streamTools.some(
+        (t, i) =>
+          i > 0 &&
+          i < streamTools.length - 1 &&
+          t === 'toolB' &&
+          streamTools[i - 1] === 'toolA' &&
+          streamTools[i + 1] === 'toolA'
+      ) ||
+      // weaker: simply contains both tools interspersed
+      (streamTools.includes('toolA') &&
+        streamTools.includes('toolB') &&
+        streamTools[0] !== streamTools[streamTools.length - 1])
+    expect(interleaved).toBe(true)
+  })
+
+  it('retries one tool independently from the other', async () => {
+    let retriesA = 0
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 5, tracker), new TimedTool('toolB', 5, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    const beforeCalls: string[] = []
+    agent.addHook(BeforeToolCallEvent, (e) => void beforeCalls.push(e.toolUse.name))
+    agent.addHook(AfterToolCallEvent, (e) => {
+      if (e.toolUse.name === 'toolA' && retriesA === 0) {
+        retriesA++
+        e.retry = true
+      }
+    })
+
+    await agent.invoke('Go')
+
+    expect(beforeCalls.filter((n) => n === 'toolA')).toHaveLength(2)
+    expect(beforeCalls.filter((n) => n === 'toolB')).toHaveLength(1)
+  })
+
+  it('cancels all tools when BeforeToolsEvent.cancel is set (concurrent mode)', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 100, tracker), new TimedTool('toolB', 100, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    agent.addHook(BeforeToolsEvent, (e) => {
+      e.cancel = 'hook cancelled'
+    })
+
+    let afterMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterMessage = e.message
+    })
+
+    await agent.invoke('Go')
+
+    // No tool ever ran
+    expect(tracker).toHaveLength(0)
+    // Both tool use ids produced error results in source order
+    expect(afterMessage!.content).toHaveLength(2)
+    const r0 = afterMessage!.content[0] as ToolResultBlock
+    const r1 = afterMessage!.content[1] as ToolResultBlock
+    expect(r0.status).toBe('error')
+    expect(r1.status).toBe('error')
+    expect(r0.toolUseId).toBe('a')
+    expect(r1.toolUseId).toBe('b')
+  })
+
+  it('cancels all tools when agent is cancelled before launch (concurrent mode)', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 100, tracker), new TimedTool('toolB', 100, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    agent.addHook(BeforeToolsEvent, () => {
+      agent.cancel()
+    })
+
+    await agent.invoke('Go')
+    // No tool was invoked.
+    expect(tracker).toHaveLength(0)
+  })
+
+  it('cooperative mid-flight cancel — tools honor cancelSignal and exit', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [
+      new TimedTool('toolA', 200, tracker, /* honorCancelSignal */ true),
+      new TimedTool('toolB', 200, tracker, true),
+    ]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    // Fire cancel shortly after both tools have started.
+    agent.addHook(BeforeToolCallEvent, () => {
+      globalThis.setTimeout(() => agent.cancel(), 20)
+    })
+
+    const startAll = Date.now()
+    await agent.invoke('Go')
+    const totalDuration = Date.now() - startAll
+
+    expect(tracker).toHaveLength(2)
+    expect(tracker.every((t) => t.cancelled)).toBe(true)
+    // Should be much less than 200ms since both cooperatively bailed.
+    expect(totalDuration).toBeLessThan(150)
+  })
+
+  it('normalizes unexpected generator rejection to an error result without affecting siblings', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 20, tracker), new TimedTool('toolB', 20, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    // Monkey-patch the executeTool private to force one generator to reject.
+    // We intercept via tool.stream — but tool-level errors are caught by executeTool.
+    // To exercise the Promise.race fallback, patch the Tool.stream to throw
+    // synchronously outside executeTool's catch would be tricky, so instead
+    // verify that a throwing tool (which executeTool normalizes) still lets
+    // the sibling complete. This covers the "defensive fallback is not needed
+    // for the common case" side of the contract.
+    const results: ToolResultBlock[] = []
+    agent.addHook(AfterToolsEvent, (e) => {
+      for (const b of e.message.content) {
+        if (b.type === 'toolResultBlock') results.push(b)
+      }
+    })
+
+    // Replace toolA's stream implementation with one that throws.
+    const broken = tools[0]!
+    // eslint-disable-next-line require-yield
+    broken.stream = async function* () {
+      throw new Error('boom')
+    }
+
+    await agent.invoke('Go')
+
+    const [a, b] = results.sort((x, y) => x.toolUseId.localeCompare(y.toolUseId))
+    expect(a!.status).toBe('error')
+    expect(b!.status).toBe('success')
+  })
+
+  it('handles an unknown tool in a batch without affecting siblings', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 10, tracker)] // no 'toolB' registered
+    const agent = new Agent({
+      model: new MockMessageModel()
+        .addTurn([
+          { type: 'toolUseBlock', name: 'toolA', toolUseId: 'a', input: {} },
+          { type: 'toolUseBlock', name: 'unknownTool', toolUseId: 'b', input: {} },
+        ])
+        .addTurn({ type: 'textBlock', text: 'Done' }),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    let afterMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterMessage = e.message
+    })
+
+    await agent.invoke('Go')
+    expect(afterMessage!.content).toHaveLength(2)
+    const blocks = afterMessage!.content as ToolResultBlock[]
+    expect(blocks.find((r) => r.toolUseId === 'a')!.status).toBe('success')
+    expect(blocks.find((r) => r.toolUseId === 'b')!.status).toBe('error')
+  })
+
+  it('preserves source order of tool results in AfterToolsEvent.message', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    // toolA is slow, toolB is fast — concurrent completion order will be B then A.
+    const tools = [new TimedTool('toolA', 60, tracker), new TimedTool('toolB', 5, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    let afterMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterMessage = e.message
+    })
+
+    await agent.invoke('Go')
+    const blocks = afterMessage!.content as ToolResultBlock[]
+    expect(blocks.map((b) => b.toolUseId)).toEqual(['a', 'b'])
+  })
+
+  it('AfterToolsEvent.message contains completed results when consumer breaks mid-stream', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 1, tracker, true), new TimedTool('toolB', 50, tracker, true)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    let afterToolsMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterToolsMessage = e.message
+    })
+
+    let toolResultsSeen = 0
+    for await (const event of agent.stream('Go')) {
+      if (event.type === 'toolResultEvent') {
+        toolResultsSeen++
+        if (toolResultsSeen === 1) break
+      }
+    }
+
+    expect(afterToolsMessage).toBeDefined()
+    const blocks = afterToolsMessage!.content.filter((b): b is ToolResultBlock => b.type === 'toolResultBlock')
+    expect(blocks.length).toBeGreaterThanOrEqual(1)
+    expect(blocks.some((b) => b.toolUseId === 'a')).toBe(true)
+  })
+
+  it('pre-launch agent.cancel() during BeforeToolsEvent produces "Tool execution cancelled" (concurrent)', async () => {
+    const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
+    const tools = [new TimedTool('toolA', 100, tracker), new TimedTool('toolB', 100, tracker)]
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    agent.addHook(BeforeToolsEvent, () => {
+      agent.cancel()
+    })
+
+    let afterMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterMessage = e.message
+    })
+
+    await agent.invoke('Go')
+
+    expect(tracker).toHaveLength(0)
+    const blocks = afterMessage!.content as ToolResultBlock[]
+    expect(blocks).toHaveLength(2)
+    for (const b of blocks) {
+      expect((b.content[0] as TextBlock).text).toBe('Tool execution cancelled')
+    }
+  })
+
+  it('closes in-flight generators and includes fallback results when consumer breaks', async () => {
+    const tools = [new TimedTool('toolA', 1, []), new StreamingTool('toolB', 20, 2)]
+
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools,
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    let afterToolsMessage: import('../../types/messages.js').Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterToolsMessage = e.message
+    })
+
+    let toolResultsSeen = 0
+    for await (const event of agent.stream('Go')) {
+      if (event.type === 'toolResultEvent') {
+        toolResultsSeen++
+        if (toolResultsSeen === 1) break
+      }
+    }
+
+    // AfterToolsEvent.message should have entries for both tools:
+    // toolA completed normally, toolB gets a fallback "interrupted" result.
+    expect(afterToolsMessage).toBeDefined()
+    const blocks = afterToolsMessage!.content as ToolResultBlock[]
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.toolUseId)).toEqual(['a', 'b'])
+    expect(blocks.find((b) => b.toolUseId === 'a')!.status).toBe('success')
+    expect(blocks.find((b) => b.toolUseId === 'b')!.status).toBe('error')
+  })
+})

--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -118,16 +118,12 @@ describe('Agent concurrent tool execution', () => {
       printer: false,
     })
 
-    const startAll = Date.now()
     await agent.invoke('Go')
-    const totalDuration = Date.now() - startAll
 
     expect(tracker).toHaveLength(2)
     const [first, second] = tracker.sort((a, b) => a.start - b.start)
-    // B started before A finished
+    // B started before A finished — proves the tools ran concurrently.
     expect(second!.start).toBeLessThan(first!.end)
-    // Total wall-clock is roughly the longer tool's duration, not the sum.
-    expect(totalDuration).toBeLessThan(150)
   })
 
   it('runs tools sequentially under default executor', async () => {
@@ -182,30 +178,15 @@ describe('Agent concurrent tool execution', () => {
       }
     }
 
-    // Cross-tool interleaving: at least one A stream occurred between two B streams (or vice versa).
+    // Cross-tool interleaving: collapse consecutive same-tool events into runs.
+    // Strictly sequential execution produces 2 runs (e.g. [A,A,A,B,B,B]);
+    // anything > 2 means the stream alternated between tools at least once.
     const streamTools = events.filter((e) => e.kind === 'stream').map((e) => e.tool)
-    const interleaved =
-      streamTools.some(
-        (t, i) =>
-          i > 0 &&
-          i < streamTools.length - 1 &&
-          t === 'toolA' &&
-          streamTools[i - 1] === 'toolB' &&
-          streamTools[i + 1] === 'toolB'
-      ) ||
-      streamTools.some(
-        (t, i) =>
-          i > 0 &&
-          i < streamTools.length - 1 &&
-          t === 'toolB' &&
-          streamTools[i - 1] === 'toolA' &&
-          streamTools[i + 1] === 'toolA'
-      ) ||
-      // weaker: simply contains both tools interspersed
-      (streamTools.includes('toolA') &&
-        streamTools.includes('toolB') &&
-        streamTools[0] !== streamTools[streamTools.length - 1])
-    expect(interleaved).toBe(true)
+    const runs = streamTools.reduce<(string | undefined)[]>((acc, t) => {
+      if (acc.length === 0 || acc[acc.length - 1] !== t) acc.push(t)
+      return acc
+    }, [])
+    expect(runs.length).toBeGreaterThan(2)
   })
 
   it('retries one tool independently from the other', async () => {
@@ -304,17 +285,14 @@ describe('Agent concurrent tool execution', () => {
       globalThis.setTimeout(() => agent.cancel(), 20)
     })
 
-    const startAll = Date.now()
     await agent.invoke('Go')
-    const totalDuration = Date.now() - startAll
 
     expect(tracker).toHaveLength(2)
+    // Both tools observed the abort signal and exited cooperatively.
     expect(tracker.every((t) => t.cancelled)).toBe(true)
-    // Should be much less than 200ms since both cooperatively bailed.
-    expect(totalDuration).toBeLessThan(150)
   })
 
-  it('normalizes unexpected generator rejection to an error result without affecting siblings', async () => {
+  it('handles a throwing tool without affecting siblings', async () => {
     const tracker: { name: string; start: number; end: number; cancelled: boolean }[] = []
     const tools = [new TimedTool('toolA', 20, tracker), new TimedTool('toolB', 20, tracker)]
     const agent = new Agent({
@@ -324,13 +302,13 @@ describe('Agent concurrent tool execution', () => {
       printer: false,
     })
 
-    // Monkey-patch the executeTool private to force one generator to reject.
-    // We intercept via tool.stream — but tool-level errors are caught by executeTool.
-    // To exercise the Promise.race fallback, patch the Tool.stream to throw
-    // synchronously outside executeTool's catch would be tricky, so instead
-    // verify that a throwing tool (which executeTool normalizes) still lets
-    // the sibling complete. This covers the "defensive fallback is not needed
-    // for the common case" side of the contract.
+    // A throwing tool.stream is caught by executeTool's own try/catch and
+    // normalized to an error ToolResultBlock, so the race loop never sees the
+    // rejection. This test verifies that normalization path keeps the sibling
+    // unaffected in concurrent mode. The race loop's `kind: 'throw'` fallback
+    // is a defensive backstop for generator-level rejections that escape
+    // executeTool entirely — not expected in normal operation and not exercised
+    // here.
     const results: ToolResultBlock[] = []
     agent.addHook(AfterToolsEvent, (e) => {
       for (const b of e.message.content) {

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -545,7 +545,7 @@ describe('Agent Hooks Integration', () => {
         new ToolResultBlock({
           toolUseId: 'tool-1',
           status: 'error',
-          content: [new TextBlock('tool cancelled by hook')],
+          content: [new TextBlock('Tool cancelled by hook')],
         })
       )
     })
@@ -655,7 +655,7 @@ describe('Agent Hooks Integration', () => {
         new ToolResultBlock({
           toolUseId: 'tool-1',
           status: 'error',
-          content: [new TextBlock('tool cancelled by hook')],
+          content: [new TextBlock('Tool cancelled by hook')],
         })
       )
     })

--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -449,7 +449,9 @@ describe('Agent tracer integration', () => {
         ])
         .addTurn({ type: 'textBlock', text: 'Done' })
 
-      // Tools that sleep briefly so both spans are open at the same time.
+      // Tools sleep briefly so the concurrent executor has time to launch both
+      // before either resolves. The assertions below check call order, not
+      // wall-clock timing.
       const sleep = (ms: number) => new Promise<void>((r) => globalThis.setTimeout(r, ms))
       // eslint-disable-next-line require-yield
       async function* sleepThenReturn(toolUseId: string, text: string) {
@@ -462,25 +464,25 @@ describe('Agent tracer integration', () => {
       const agent = new Agent({ model, tools: [tool1, tool2], toolExecutor: 'concurrent' })
       const tracer = getLatestTracer()
 
-      // Stamp the time each span starts/ends so we can assert overlap.
-      const startTimes: Record<string, number> = {}
-      const endTimes: Record<string, number> = {}
+      // Record span lifecycle events in order. Sequential execution would
+      // produce [start:A, end:A, start:B, end:B]; concurrent execution
+      // interleaves so both starts precede both ends.
+      const events: string[] = []
       tracer.startToolCallSpan.mockImplementation((args: { tool: { toolUseId: string } }) => {
-        startTimes[args.tool.toolUseId] = Date.now()
+        events.push(`start:${args.tool.toolUseId}`)
         return { mock: 'toolSpan', id: args.tool.toolUseId }
       })
       tracer.endToolCallSpan.mockImplementation((span: { id: string } | null) => {
-        if (span && 'id' in span) endTimes[span.id] = Date.now()
+        if (span && 'id' in span) events.push(`end:${span.id}`)
       })
 
       await agent.invoke('Use tools')
 
       expect(tracer.startToolCallSpan).toHaveBeenCalledTimes(2)
       expect(tracer.endToolCallSpan).toHaveBeenCalledTimes(2)
-      // Both spans started before either ended → they're siblings, not nested.
-      const firstEnd = Math.min(endTimes['id-1']!, endTimes['id-2']!)
-      expect(startTimes['id-1']!).toBeLessThanOrEqual(firstEnd)
-      expect(startTimes['id-2']!).toBeLessThanOrEqual(firstEnd)
+      // Both starts happened before either end — i.e. the spans overlap.
+      expect(events.slice(0, 2).sort()).toEqual(['start:id-1', 'start:id-2'])
+      expect(events.slice(2, 4).sort()).toEqual(['end:id-1', 'end:id-2'])
     })
   })
 

--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -440,6 +440,48 @@ describe('Agent tracer integration', () => {
       expect(tracer.startToolCallSpan).toHaveBeenCalledTimes(2)
       expect(tracer.endToolCallSpan).toHaveBeenCalledTimes(2)
     })
+
+    it('creates overlapping tool spans when toolExecutor is concurrent', async () => {
+      const model = new MockMessageModel()
+        .addTurn([
+          new ToolUseBlock({ name: 'tool1', toolUseId: 'id-1', input: {} }),
+          new ToolUseBlock({ name: 'tool2', toolUseId: 'id-2', input: {} }),
+        ])
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      // Tools that sleep briefly so both spans are open at the same time.
+      const sleep = (ms: number) => new Promise<void>((r) => globalThis.setTimeout(r, ms))
+      // eslint-disable-next-line require-yield
+      async function* sleepThenReturn(toolUseId: string, text: string) {
+        await sleep(20)
+        return new ToolResultBlock({ toolUseId, status: 'success', content: [new TextBlock(text)] })
+      }
+      const tool1 = createMockTool('tool1', () => sleepThenReturn('id-1', 'R1'))
+      const tool2 = createMockTool('tool2', () => sleepThenReturn('id-2', 'R2'))
+
+      const agent = new Agent({ model, tools: [tool1, tool2], toolExecutor: 'concurrent' })
+      const tracer = getLatestTracer()
+
+      // Stamp the time each span starts/ends so we can assert overlap.
+      const startTimes: Record<string, number> = {}
+      const endTimes: Record<string, number> = {}
+      tracer.startToolCallSpan.mockImplementation((args: { tool: { toolUseId: string } }) => {
+        startTimes[args.tool.toolUseId] = Date.now()
+        return { mock: 'toolSpan', id: args.tool.toolUseId }
+      })
+      tracer.endToolCallSpan.mockImplementation((span: { id: string } | null) => {
+        if (span && 'id' in span) endTimes[span.id] = Date.now()
+      })
+
+      await agent.invoke('Use tools')
+
+      expect(tracer.startToolCallSpan).toHaveBeenCalledTimes(2)
+      expect(tracer.endToolCallSpan).toHaveBeenCalledTimes(2)
+      // Both spans started before either ended → they're siblings, not nested.
+      const firstEnd = Math.min(endTimes['id-1']!, endTimes['id-2']!)
+      expect(startTimes['id-1']!).toBeLessThanOrEqual(firstEnd)
+      expect(startTimes['id-2']!).toBeLessThanOrEqual(firstEnd)
+    })
   })
 
   describe('token usage accumulation', () => {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -83,8 +83,7 @@ export type ToolList = (Tool | McpClient | Agent | ToolList)[]
 /**
  * Strategy for executing tool calls that the model emits in a single assistant turn.
  *
- * - `'sequential'` (default) — runs tool calls one at a time, matching the historical
- *   behavior of the agent loop.
+ * - `'sequential'` (default) — runs tool calls one at a time
  * - `'concurrent'` — runs all tool calls from a single turn in parallel. Per-tool event
  *   order (`BeforeToolCallEvent` → `ToolStreamUpdateEvent*` → `AfterToolCallEvent` →
  *   `ToolResultEvent`) is preserved, while cross-tool events may interleave.
@@ -94,7 +93,7 @@ export type ToolList = (Tool | McpClient | Agent | ToolList)[]
  * In concurrent mode, prompt batch-wide cancellation requires every in-flight tool
  * to honor the signal.
  */
-export type ToolExecutor = 'sequential' | 'concurrent'
+export type ToolExecutorStrategy = 'sequential' | 'concurrent'
 
 /**
  * Configuration object for creating a new Agent.
@@ -180,9 +179,9 @@ export type AgentConfig = {
   id?: string
   /**
    * Strategy for executing tool calls from a single assistant turn.
-   * Defaults to `'sequential'`. See {@link ToolExecutor} for details.
+   * Defaults to `'sequential'`. See {@link ToolExecutorStrategy} for details.
    */
-  toolExecutor?: ToolExecutor
+  toolExecutor?: ToolExecutorStrategy
 }
 
 /** Default name assigned to agents when none is provided. */
@@ -255,7 +254,8 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _tracer: Tracer
   /** Meter instance for accumulating loop metrics during invocation. */
   private _meter: Meter
-  private readonly _toolExecutor: ToolExecutor
+  /** Strategy for executing tool calls from a single assistant turn. */
+  private readonly _toolExecutor: ToolExecutorStrategy
 
   /**
    * Creates an instance of the Agent.
@@ -1040,7 +1040,10 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Dispatches to the configured tool executor. See {@link ToolExecutor}.
+   * Emits `BeforeToolsEvent`, handles the pre-launch cancel paths, then
+   * delegates per-tool execution to the configured {@link ToolExecutorStrategy}.
+   * Always pairs `BeforeToolsEvent` with a terminal `AfterToolsEvent`, even on
+   * the invariant-violation throw path.
    *
    * @param assistantMessage - The assistant message containing tool use blocks
    * @param toolRegistry - Registry containing available tools
@@ -1050,11 +1053,33 @@ export class Agent implements LocalAgent, InvokableAgent {
     assistantMessage: Message,
     toolRegistry: ToolRegistry
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
+    yield beforeToolsEvent
+
+    const toolUseBlocks = assistantMessage.content.filter(
+      (block): block is ToolUseBlock => block.type === 'toolUseBlock'
+    )
+    if (toolUseBlocks.length === 0) {
+      // Preserve BeforeToolsEvent/AfterToolsEvent bracket symmetry even on
+      // this invariant-violation branch.
+      yield new AfterToolsEvent({ agent: this, message: new Message({ role: 'user', content: [] }) })
+      throw new Error('Model indicated toolUse but no tool use blocks found in message')
+    }
+
+    // Pre-launch cancel paths are strategy-independent.
+    if (beforeToolsEvent.cancel) {
+      const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
+      return yield* this._yieldCancelledToolResults(toolUseBlocks, message)
+    }
+    if (this.isCancelled) {
+      return yield* this._yieldCancelledToolResults(toolUseBlocks, 'Tool execution cancelled')
+    }
+
     switch (this._toolExecutor) {
       case 'sequential':
-        return yield* this._executeToolsSequential(assistantMessage, toolRegistry)
+        return yield* this._executeToolsSequential(toolUseBlocks, toolRegistry)
       case 'concurrent':
-        return yield* this._executeToolsConcurrent(assistantMessage, toolRegistry)
+        return yield* this._executeToolsConcurrent(toolUseBlocks, toolRegistry)
       default: {
         const _exhaustive: never = this._toolExecutor
         throw new Error(`Unknown toolExecutor: ${_exhaustive as string}`)
@@ -1063,67 +1088,53 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Executes tools sequentially and streams all tool events.
+   * Emits a `ToolResultEvent` for every block plus an `AfterToolsEvent`, and
+   * returns the resulting tool-result message. Used by the pre-launch cancel
+   * paths shared across executors.
+   */
+  private async *_yieldCancelledToolResults(
+    toolUseBlocks: ToolUseBlock[],
+    message: string
+  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+    const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
+    for (const result of cancelBlocks) {
+      yield new ToolResultEvent({ agent: this, result })
+    }
+    const toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
+    yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+    return toolResultMessage
+  }
+
+  /**
+   * Executes tools one at a time, honoring `agent.cancelSignal` between
+   * iterations to short-circuit not-yet-started tools.
    */
   private async *_executeToolsSequential(
-    assistantMessage: Message,
+    toolUseBlocks: ToolUseBlock[],
     toolRegistry: ToolRegistry
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
-    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
-    yield beforeToolsEvent
-
     const toolResultBlocks: ToolResultBlock[] = []
     let toolResultMessage: Message
 
     try {
-      // Extract tool use blocks from assistant message
-      const toolUseBlocks = assistantMessage.content.filter(
-        (block): block is ToolUseBlock => block.type === 'toolUseBlock'
-      )
-
-      if (toolUseBlocks.length === 0) {
-        // No tool use blocks found even though stopReason is toolUse
-        throw new Error('Model indicated toolUse but no tool use blocks found in message')
-      }
-
-      // Pre-launch cancel: hook requested cancel, or agent is already cancelled.
-      if (beforeToolsEvent.cancel) {
-        const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
-        const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
-        for (const result of cancelBlocks) {
-          yield new ToolResultEvent({ agent: this, result })
+      for (const toolUseBlock of toolUseBlocks) {
+        if (this.isCancelled) {
+          const cancelBlock = new ToolResultBlock({
+            toolUseId: toolUseBlock.toolUseId,
+            status: 'error',
+            content: [new TextBlock('Tool execution cancelled')],
+          })
+          toolResultBlocks.push(cancelBlock)
+          yield new ToolResultEvent({ agent: this, result: cancelBlock })
+          continue
         }
-        toolResultBlocks.push(...cancelBlocks)
-      } else if (this.isCancelled) {
-        const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, 'Tool execution cancelled')
-        for (const result of cancelBlocks) {
-          yield new ToolResultEvent({ agent: this, result })
-        }
-        toolResultBlocks.push(...cancelBlocks)
-      } else {
-        for (const toolUseBlock of toolUseBlocks) {
-          if (this.isCancelled) {
-            const cancelBlock = new ToolResultBlock({
-              toolUseId: toolUseBlock.toolUseId,
-              status: 'error',
-              content: [new TextBlock('Tool execution cancelled')],
-            })
-            toolResultBlocks.push(cancelBlock)
-            yield new ToolResultEvent({ agent: this, result: cancelBlock })
-            continue
-          }
 
-          const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
-          toolResultBlocks.push(toolResultBlock)
-          yield new ToolResultEvent({ agent: this, result: toolResultBlock })
-        }
+        const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
+        toolResultBlocks.push(toolResultBlock)
+        yield new ToolResultEvent({ agent: this, result: toolResultBlock })
       }
     } finally {
-      toolResultMessage = new Message({
-        role: 'user',
-        content: toolResultBlocks,
-      })
-
+      toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
       yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
     }
 
@@ -1156,73 +1167,41 @@ export class Agent implements LocalAgent, InvokableAgent {
    * disturb its siblings.
    */
   private async *_executeToolsConcurrent(
-    assistantMessage: Message,
+    toolUseBlocks: ToolUseBlock[],
     toolRegistry: ToolRegistry
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
-    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
-    yield beforeToolsEvent
-
-    const toolUseBlocks = assistantMessage.content.filter(
-      (block): block is ToolUseBlock => block.type === 'toolUseBlock'
-    )
-
-    if (toolUseBlocks.length === 0) {
-      throw new Error('Model indicated toolUse but no tool use blocks found in message')
-    }
-
     let toolResultMessage: Message
-
-    // Pre-launch cancel: hook requested cancel, or agent is already cancelled.
-    if (beforeToolsEvent.cancel) {
-      const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
-      const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
-      for (const result of cancelBlocks) {
-        yield new ToolResultEvent({ agent: this, result })
-      }
-      toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
-      return toolResultMessage
-    }
-    if (this.isCancelled) {
-      const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, 'Tool execution cancelled')
-      for (const result of cancelBlocks) {
-        yield new ToolResultEvent({ agent: this, result })
-      }
-      toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
-      return toolResultMessage
-    }
 
     // Wrap each in-flight `.next()` so the raced promise always resolves to a
     // tagged Step. That prevents one generator rejection from rejecting the
     // whole race and lets us convert per-tool failures into ToolResultBlocks
     // without orphaning other generators.
     type Step =
-      | { i: number; kind: 'next'; r: IteratorResult<AgentStreamEvent, ToolResultBlock> }
-      | { i: number; kind: 'throw'; error: unknown }
+      | { idx: number; kind: 'next'; res: IteratorResult<AgentStreamEvent, ToolResultBlock> }
+      | { idx: number; kind: 'throw'; error: unknown }
 
     const gens = toolUseBlocks.map((block) => ({
       block,
       gen: this.executeTool(block, toolRegistry),
     }))
 
-    const step = (i: number): Promise<Step> =>
-      gens[i]!.gen.next().then(
-        (r): Step => ({ i, kind: 'next', r }),
-        (error: unknown): Step => ({ i, kind: 'throw', error })
+    const step = (idx: number): Promise<Step> =>
+      gens[idx]!.gen.next().then(
+        (res): Step => ({ idx, kind: 'next', res }),
+        (error: unknown): Step => ({ idx, kind: 'throw', error })
       )
 
-    const pendingNext = new Map<number, Promise<Step>>(gens.map((_, i) => [i, step(i)]))
+    const pendingNext = new Map<number, Promise<Step>>(gens.map((_, idx) => [idx, step(idx)]))
     const resultsByToolUseId = new Map<string, ToolResultBlock>()
 
     try {
       while (pendingNext.size > 0) {
         const winner = await Promise.race(pendingNext.values())
-        const { i } = winner
-        const block = gens[i]!.block
+        const { idx } = winner
+        const block = gens[idx]!.block
 
         if (winner.kind === 'throw') {
-          pendingNext.delete(i)
+          pendingNext.delete(idx)
           const err = normalizeError(winner.error)
           const result = new ToolResultBlock({
             toolUseId: block.toolUseId,
@@ -1235,19 +1214,19 @@ export class Agent implements LocalAgent, InvokableAgent {
           continue
         }
 
-        if (winner.r.done) {
-          pendingNext.delete(i)
-          resultsByToolUseId.set(block.toolUseId, winner.r.value)
-          yield new ToolResultEvent({ agent: this, result: winner.r.value })
+        if (winner.res.done) {
+          pendingNext.delete(idx)
+          resultsByToolUseId.set(block.toolUseId, winner.res.value)
+          yield new ToolResultEvent({ agent: this, result: winner.res.value })
         } else {
-          yield winner.r.value
-          pendingNext.set(i, step(i))
+          yield winner.res.value
+          pendingNext.set(idx, step(idx))
         }
       }
     } finally {
       // Close any generators still in-flight (e.g. consumer broke out of stream).
       await Promise.allSettled(
-        Array.from(pendingNext.keys(), (i) => gens[i]!.gen.return(undefined as unknown as ToolResultBlock))
+        Array.from(pendingNext.keys(), (idx) => gens[idx]!.gen.return(undefined as unknown as ToolResultBlock))
       )
 
       // Build the result message from whatever completed, in source order.

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1087,8 +1087,15 @@ export class Agent implements LocalAgent, InvokableAgent {
       }
 
       // Pre-launch cancel: hook requested cancel, or agent is already cancelled.
-      if (beforeToolsEvent.cancel || this.isCancelled) {
-        const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, beforeToolsEvent.cancel)
+      if (beforeToolsEvent.cancel) {
+        const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
+        const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
+        for (const result of cancelBlocks) {
+          yield new ToolResultEvent({ agent: this, result })
+        }
+        toolResultBlocks.push(...cancelBlocks)
+      } else if (this.isCancelled) {
+        const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, 'Tool execution cancelled')
         for (const result of cancelBlocks) {
           yield new ToolResultEvent({ agent: this, result })
         }
@@ -1124,21 +1131,10 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Produces error ToolResultBlocks for every tool use block, reflecting a
-   * pre-launch cancellation. Shared by sequential and concurrent executors.
-   *
-   * Message precedence:
-   * - Hook string (`BeforeToolsEvent.cancel = 'reason'`) → that string
-   * - Hook flag (`BeforeToolsEvent.cancel = true`) → `'Tool cancelled by hook'`
-   * - Otherwise (agent.cancel()) → `'Tool execution cancelled'`
+   * Produces one error ToolResultBlock per tool use block, each carrying
+   * `message` as its error text. Shared by pre-launch cancel paths.
    */
-  private _cancelAllAsResults(toolUseBlocks: ToolUseBlock[], beforeToolsCancel: boolean | string): ToolResultBlock[] {
-    const message =
-      typeof beforeToolsCancel === 'string'
-        ? beforeToolsCancel
-        : beforeToolsCancel === true
-          ? 'Tool cancelled by hook'
-          : 'Tool execution cancelled'
+  private _cancelAllAsResults(toolUseBlocks: ToolUseBlock[], message: string): ToolResultBlock[] {
     return toolUseBlocks.map(
       (block) =>
         new ToolResultBlock({
@@ -1177,12 +1173,21 @@ export class Agent implements LocalAgent, InvokableAgent {
     let toolResultMessage: Message
 
     // Pre-launch cancel: hook requested cancel, or agent is already cancelled.
-    if (beforeToolsEvent.cancel || this.isCancelled) {
-      const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, beforeToolsEvent.cancel)
+    if (beforeToolsEvent.cancel) {
+      const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
+      const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
       for (const result of cancelBlocks) {
         yield new ToolResultEvent({ agent: this, result })
       }
-
+      toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
+      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+      return toolResultMessage
+    }
+    if (this.isCancelled) {
+      const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, 'Tool execution cancelled')
+      for (const result of cancelBlocks) {
+        yield new ToolResultEvent({ agent: this, result })
+      }
       toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
       yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
       return toolResultMessage

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -81,6 +81,22 @@ import { CancelledError } from '../errors.js'
 export type ToolList = (Tool | McpClient | Agent | ToolList)[]
 
 /**
+ * Strategy for executing tool calls that the model emits in a single assistant turn.
+ *
+ * - `'sequential'` (default) — runs tool calls one at a time, matching the historical
+ *   behavior of the agent loop.
+ * - `'concurrent'` — runs all tool calls from a single turn in parallel. Per-tool event
+ *   order (`BeforeToolCallEvent` → `ToolStreamUpdateEvent*` → `AfterToolCallEvent` →
+ *   `ToolResultEvent`) is preserved, while cross-tool events may interleave.
+ *
+ * Cancellation works identically in both modes: {@link Agent.cancel} flips
+ * {@link Agent.cancelSignal} and tools must observe it cooperatively to stop early.
+ * In concurrent mode, prompt batch-wide cancellation requires every in-flight tool
+ * to honor the signal.
+ */
+export type ToolExecutor = 'sequential' | 'concurrent'
+
+/**
  * Configuration object for creating a new Agent.
  */
 export type AgentConfig = {
@@ -162,6 +178,11 @@ export type AgentConfig = {
    * Optional unique identifier for the agent. Defaults to "agent".
    */
   id?: string
+  /**
+   * Strategy for executing tool calls from a single assistant turn.
+   * Defaults to `'sequential'`. See {@link ToolExecutor} for details.
+   */
+  toolExecutor?: ToolExecutor
 }
 
 /** Default name assigned to agents when none is provided. */
@@ -234,6 +255,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _tracer: Tracer
   /** Meter instance for accumulating loop metrics during invocation. */
   private _meter: Meter
+  private readonly _toolExecutor: ToolExecutor
 
   /**
    * Creates an instance of the Agent.
@@ -287,6 +309,9 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Initialize meter for local metrics accumulation
     this._meter = new Meter()
+
+    // Default to sequential tool execution
+    this._toolExecutor = config?.toolExecutor ?? 'sequential'
 
     this._initialized = false
   }
@@ -1015,13 +1040,32 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Executes tools sequentially and streams all tool events.
+   * Dispatches to the configured tool executor. See {@link ToolExecutor}.
    *
    * @param assistantMessage - The assistant message containing tool use blocks
    * @param toolRegistry - Registry containing available tools
    * @returns User message containing tool results
    */
   private async *executeTools(
+    assistantMessage: Message,
+    toolRegistry: ToolRegistry
+  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+    switch (this._toolExecutor) {
+      case 'sequential':
+        return yield* this._executeToolsSequential(assistantMessage, toolRegistry)
+      case 'concurrent':
+        return yield* this._executeToolsConcurrent(assistantMessage, toolRegistry)
+      default: {
+        const _exhaustive: never = this._toolExecutor
+        throw new Error(`Unknown toolExecutor: ${_exhaustive as string}`)
+      }
+    }
+  }
+
+  /**
+   * Executes tools sequentially and streams all tool events.
+   */
+  private async *_executeToolsSequential(
     assistantMessage: Message,
     toolRegistry: ToolRegistry
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
@@ -1042,17 +1086,9 @@ export class Agent implements LocalAgent, InvokableAgent {
         throw new Error('Model indicated toolUse but no tool use blocks found in message')
       }
 
-      // Cancel all tools if hook requested it
-      if (beforeToolsEvent.cancel) {
-        const cancelMessage = cancelToolMessage(beforeToolsEvent.cancel)
-        const cancelBlocks = toolUseBlocks.map(
-          (block) =>
-            new ToolResultBlock({
-              toolUseId: block.toolUseId,
-              status: 'error',
-              content: [new TextBlock(cancelMessage)],
-            })
-        )
+      // Pre-launch cancel: hook requested cancel, or agent is already cancelled.
+      if (beforeToolsEvent.cancel || this.isCancelled) {
+        const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, beforeToolsEvent.cancel)
         for (const result of cancelBlocks) {
           yield new ToolResultEvent({ agent: this, result })
         }
@@ -1081,6 +1117,154 @@ export class Agent implements LocalAgent, InvokableAgent {
         content: toolResultBlocks,
       })
 
+      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+    }
+
+    return toolResultMessage
+  }
+
+  /**
+   * Produces error ToolResultBlocks for every tool use block, reflecting a
+   * pre-launch cancellation. Shared by sequential and concurrent executors.
+   *
+   * Message precedence:
+   * - Hook string (`BeforeToolsEvent.cancel = 'reason'`) → that string
+   * - Hook flag (`BeforeToolsEvent.cancel = true`) → `'Tool cancelled by hook'`
+   * - Otherwise (agent.cancel()) → `'Tool execution cancelled'`
+   */
+  private _cancelAllAsResults(toolUseBlocks: ToolUseBlock[], beforeToolsCancel: boolean | string): ToolResultBlock[] {
+    const message =
+      typeof beforeToolsCancel === 'string'
+        ? beforeToolsCancel
+        : beforeToolsCancel === true
+          ? 'Tool cancelled by hook'
+          : 'Tool execution cancelled'
+    return toolUseBlocks.map(
+      (block) =>
+        new ToolResultBlock({
+          toolUseId: block.toolUseId,
+          status: 'error',
+          content: [new TextBlock(message)],
+        })
+    )
+  }
+
+  /**
+   * Executes tools concurrently by merging N per-tool {@link executeTool}
+   * async generators via `Promise.race`. Per-tool event order is preserved
+   * (because each generator is iterated serially); cross-tool events may
+   * interleave at race resolution boundaries.
+   *
+   * Per-tool retry (`AfterToolCallEvent.retry`) is isolated — it lives inside
+   * `executeTool`'s own `while(true)` loop, so one tool retrying does not
+   * disturb its siblings.
+   */
+  private async *_executeToolsConcurrent(
+    assistantMessage: Message,
+    toolRegistry: ToolRegistry
+  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
+    yield beforeToolsEvent
+
+    const toolUseBlocks = assistantMessage.content.filter(
+      (block): block is ToolUseBlock => block.type === 'toolUseBlock'
+    )
+
+    if (toolUseBlocks.length === 0) {
+      throw new Error('Model indicated toolUse but no tool use blocks found in message')
+    }
+
+    let toolResultMessage: Message
+
+    // Pre-launch cancel: hook requested cancel, or agent is already cancelled.
+    if (beforeToolsEvent.cancel || this.isCancelled) {
+      const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, beforeToolsEvent.cancel)
+      for (const result of cancelBlocks) {
+        yield new ToolResultEvent({ agent: this, result })
+      }
+
+      toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
+      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+      return toolResultMessage
+    }
+
+    // Wrap each in-flight `.next()` so the raced promise always resolves to a
+    // tagged Step. That prevents one generator rejection from rejecting the
+    // whole race and lets us convert per-tool failures into ToolResultBlocks
+    // without orphaning other generators.
+    type Step =
+      | { i: number; kind: 'next'; r: IteratorResult<AgentStreamEvent, ToolResultBlock> }
+      | { i: number; kind: 'throw'; error: unknown }
+
+    const gens = toolUseBlocks.map((block) => ({
+      block,
+      gen: this.executeTool(block, toolRegistry),
+    }))
+
+    const step = (i: number): Promise<Step> =>
+      gens[i]!.gen.next().then(
+        (r): Step => ({ i, kind: 'next', r }),
+        (error: unknown): Step => ({ i, kind: 'throw', error })
+      )
+
+    const pendingNext = new Map<number, Promise<Step>>(gens.map((_, i) => [i, step(i)]))
+    const resultsByToolUseId = new Map<string, ToolResultBlock>()
+
+    try {
+      while (pendingNext.size > 0) {
+        const winner = await Promise.race(pendingNext.values())
+        const { i } = winner
+        const block = gens[i]!.block
+
+        if (winner.kind === 'throw') {
+          pendingNext.delete(i)
+          const err = normalizeError(winner.error)
+          const result = new ToolResultBlock({
+            toolUseId: block.toolUseId,
+            status: 'error',
+            content: [new TextBlock(err.message)],
+            error: err,
+          })
+          resultsByToolUseId.set(block.toolUseId, result)
+          yield new ToolResultEvent({ agent: this, result })
+          continue
+        }
+
+        if (winner.r.done) {
+          pendingNext.delete(i)
+          resultsByToolUseId.set(block.toolUseId, winner.r.value)
+          yield new ToolResultEvent({ agent: this, result: winner.r.value })
+        } else {
+          yield winner.r.value
+          pendingNext.set(i, step(i))
+        }
+      }
+    } finally {
+      // Close any generators still in-flight (e.g. consumer broke out of stream).
+      await Promise.allSettled(
+        Array.from(pendingNext.keys(), (i) => gens[i]!.gen.return(undefined as unknown as ToolResultBlock))
+      )
+
+      // Build the result message from whatever completed, in source order.
+      // Missing entries get a fallback error block so the message always
+      // accounts for every toolUseBlock the model emitted.
+      const toolResultBlocks: ToolResultBlock[] = []
+      for (const block of toolUseBlocks) {
+        const result = resultsByToolUseId.get(block.toolUseId)
+        if (result) {
+          toolResultBlocks.push(result)
+        } else {
+          toolResultBlocks.push(
+            new ToolResultBlock({
+              toolUseId: block.toolUseId,
+              status: 'error',
+              content: [new TextBlock('Tool execution interrupted')],
+            })
+          )
+        }
+      }
+
+      toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
       yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
     }
 
@@ -1117,7 +1301,8 @@ export class Agent implements LocalAgent, InvokableAgent {
 
       // Cancel individual tool if hook requested it
       if (beforeToolCallEvent.cancel) {
-        const cancelMessage = cancelToolMessage(beforeToolCallEvent.cancel)
+        const cancelMessage =
+          typeof beforeToolCallEvent.cancel === 'string' ? beforeToolCallEvent.cancel : 'Tool cancelled by hook'
         const toolResult = new ToolResultBlock({
           toolUseId: toolUseBlock.toolUseId,
           status: 'error',
@@ -1291,15 +1476,6 @@ export class Agent implements LocalAgent, InvokableAgent {
     this.messages.push(message)
     return new MessageAddedEvent({ agent: this, message })
   }
-}
-
-/**
- * Returns the cancel message for a cancelled tool.
- * @param cancelTool - The cancel value (true or custom message)
- * @returns The cancel message string
- */
-function cancelToolMessage(cancelTool: true | string): string {
-  return typeof cancelTool === 'string' ? cancelTool : 'tool cancelled by hook'
 }
 
 /**

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -13,7 +13,7 @@ export { StateStore } from './state-store.js'
 
 // Agent types
 export { AgentResult } from './types/agent.js'
-export type { AgentConfig, ToolList, ToolExecutor } from './agent/agent.js'
+export type { AgentConfig, ToolList, ToolExecutorStrategy } from './agent/agent.js'
 export type { AgentAsToolOptions } from './agent/agent-as-tool.js'
 export type { LocalAgent, InvokeOptions } from './types/agent.js'
 

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -13,7 +13,7 @@ export { StateStore } from './state-store.js'
 
 // Agent types
 export { AgentResult } from './types/agent.js'
-export type { AgentConfig, ToolList } from './agent/agent.js'
+export type { AgentConfig, ToolList, ToolExecutor } from './agent/agent.js'
 export type { AgentAsToolOptions } from './agent/agent-as-tool.js'
 export type { LocalAgent, InvokeOptions } from './types/agent.js'
 


### PR DESCRIPTION
## Description

Adds an opt-in concurrent tool executor so that when a model emits multiple
`toolUse` blocks in a single assistant turn, the agent can run them in parallel
instead of serially. Today, two independent 5-second tool calls take 10 seconds;
with `toolExecutor: 'concurrent'` they take ~5.

### Motivation

Tool calls from a single assistant turn are independent by construction — the
model asked for N things before seeing any of their results. Running them
sequentially turns latency-bound tool batches (HTTP fetches, LLM-as-tool calls)
into an artificial bottleneck. The Python SDK already supports this via
`ConcurrentToolExecutor`; this brings TypeScript to parity.

### Public API Changes

New `AgentConfig.toolExecutor` field and exported `ToolExecutor` type:

```typescript
import { Agent, type ToolExecutor } from '@strands-agents/sdk'

// Default: historical behavior, one tool at a time.
const sequential = new Agent({
  tools: [fetchUser, fetchOrders],
  // toolExecutor: 'sequential',  // implicit
})

// Opt in to parallelism for independent tool calls.
const concurrent = new Agent({
  tools: [fetchUser, fetchOrders],
  toolExecutor: 'concurrent',
})
```

`ToolExecutor` is a string union (`'sequential' | 'concurrent'`). Class-based
executors can come later if needed; keeping the surface small avoids
over-committing.

Event contract is preserved in both modes:
- Per-tool event order (`BeforeToolCallEvent` → `ToolStreamUpdateEvent*` →
  `AfterToolCallEvent` → `ToolResultEvent`) is always preserved.
- In concurrent mode, events from different tools may interleave.
- `BeforeToolsEvent` / `AfterToolsEvent` continue to bracket the batch, and
  `AfterToolsEvent.message` always contains results in the original
  tool-use-block source order regardless of completion order.

Cancellation semantics differ slightly between modes — worth calling out:
- Pre-launch cancel (hook sets `BeforeToolsEvent.cancel`, or `agent.cancel()`
  fires before tools start) produces error results for every tool in the batch
  in both modes.
- Mid-flight `agent.cancel()` in sequential mode short-circuits not-yet-started
  tools. In concurrent mode all N tools have already launched, so prompt
  batch-wide cancellation requires each in-flight tool to cooperatively observe
  `agent.cancelSignal`. Tools that ignore the signal run to completion — same
  contract as sequential mode today, just more visible.

No behavior change for existing users: the default remains `'sequential'`.

### Implementation note: `Promise.race` merge vs. Python's queue

The Python SDK's `ConcurrentToolExecutor` fans each tool out onto its own
`asyncio.Task`, which pushes events onto a shared `asyncio.Queue` that the
agent loop drains. That pattern fits Python well because tasks and queues are
cheap and `asyncio` has first-class cancellation.

TypeScript doesn't have a direct analogue, and porting the queue shape would
mean either (a) introducing a bounded async queue utility and buffer-management
code, or (b) dropping back to a single-consumer pattern anyway once events
cross back into the agent generator. Neither earns its complexity here.

Instead, the concurrent executor merges the N per-tool async generators
directly: it keeps a `Map<index, Promise<Step>>` of in-flight `.next()` calls,
`Promise.race`s them, yields the winner's event, and replaces that entry with
its next `.next()`. A few properties fall out naturally:

- **Per-tool ordering is free.** Each generator is still iterated strictly
  serially — the next `.next()` for generator `i` is only scheduled after the
  previous one resolved and its value was yielded. No ordering primitive
  required.
- **Retry stays per-tool.** `executeTool`'s own `while(true)` retry loop is
  unchanged. A retry on generator A re-enters its own loop without touching
  generator B.
- **No buffering.** Events flow straight through the race; there's no queue to
  size, drain, or close.
- **Failure isolation.** Each `.next()` is wrapped into a non-rejecting
  discriminated union (`{ kind: 'next' | 'throw' }`) so a misbehaving generator
  can't reject the whole `Promise.race` and orphan its siblings.
- **Cleanup on consumer break.** A `finally` block calls `.return()` on every
  still-pending generator via `Promise.allSettled`, ensuring tracer spans and
  hook callbacks don't leak when the caller exits the `for await` early.

### Use Cases

- Agents with tool-heavy turns (e.g., fanout retrievals across multiple
  sources) where end-to-end latency scales with the slowest tool rather than
  the sum.
- LLM-as-tool patterns where sub-agents each make their own model call.
- Tools that are naturally I/O-bound and benefit from overlapping network
  waits.

#### Call out

Minor: normalized 'tool cancelled by hook' → 'Tool cancelled by hook' to match the sibling 'Tool execution cancelled' message. 

This is technically a breaking change but it is a minor edge case and normalizes our messages.

## Related Issues

Resolves #817

## Documentation PR

Will follow up

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

- unit testing

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
