### PR TITLE
feat(mcp): handle -32042 elicitation error in tool results

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { McpClient } from '../mcp.js'
 import { McpTool } from '../tools/mcp-tool.js'
 import { JsonBlock, type TextBlock, type ToolResultBlock } from '../types/messages.js'
@@ -369,6 +370,74 @@ describe('MCP Integration', () => {
 
       expect(result.status).toBe('error')
       expect((result.content[0] as TextBlock).text).toContain('missing content array')
+    })
+
+    it('surfaces elicitation data for McpError with code -32042', async () => {
+      const elicitations = [
+        {
+          mode: 'url',
+          message: 'Please authorize with GitHub',
+          elicitationId: 'e-123',
+          url: 'https://github.com/login/oauth/authorize?client_id=abc',
+        },
+      ]
+      const mcpError = new McpError(ErrorCode.UrlElicitationRequired, 'Authorization required', { elicitations })
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe(
+        `MCP Elicitation required: [${String(mcpError)}] with data ${JSON.stringify(elicitations)}`
+      )
+    })
+
+    it('surfaces multiple elicitations for McpError with code -32042', async () => {
+      const elicitations = [
+        {
+          mode: 'url',
+          message: 'Authorize with GitHub',
+          elicitationId: 'e-1',
+          url: 'https://github.com/login/oauth/authorize',
+        },
+        {
+          mode: 'url',
+          message: 'Authorize with Google',
+          elicitationId: 'e-2',
+          url: 'https://accounts.google.com/o/oauth2/auth',
+        },
+      ]
+      const mcpError = new McpError(ErrorCode.UrlElicitationRequired, 'Authorization required', { elicitations })
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe(
+        `MCP Elicitation required: [${String(mcpError)}] with data ${JSON.stringify(elicitations)}`
+      )
+    })
+
+    it('falls through to generic error for McpError -32042 with malformed data', async () => {
+      const mcpError = new McpError(ErrorCode.UrlElicitationRequired, 'Authorization required', {
+        unexpected: 'shape',
+      })
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe('MCP error -32042: Authorization required')
+    })
+
+    it('falls through to generic error for McpError with a different code', async () => {
+      const mcpError = new McpError(ErrorCode.InvalidRequest, 'Bad request')
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe('MCP error -32600: Bad request')
     })
   })
 })

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -1,3 +1,5 @@
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'
+
 import { createErrorResult, Tool, type ToolContext, type ToolStreamGenerator } from './tool.js'
 import type { ToolSpec } from './types.js'
 import type { JSONSchema, JSONValue } from '../types/json.js'
@@ -66,6 +68,23 @@ export class McpTool extends Tool {
         content,
       })
     } catch (error) {
+      if (error instanceof McpError && error.code === ErrorCode.UrlElicitationRequired) {
+        try {
+          const data = error.data as Record<string, unknown> | undefined
+          const elicitations = data?.elicitations
+          if (Array.isArray(elicitations)) {
+            return new ToolResultBlock({
+              toolUseId,
+              status: 'error',
+              content: [
+                new TextBlock(`MCP Elicitation required: [${String(error)}] with data ${JSON.stringify(elicitations)}`),
+              ],
+            })
+          }
+        } catch {
+          // Intentionally empty — fall through to createErrorResult below
+        }
+      }
       return createErrorResult(error, toolUseId)
     }
   }


### PR DESCRIPTION
## Description

Now, authorization URL(s) embedded in MCP tool result error data will be surfaced to the user instead of being swallowed into a generic error string. This unlocks human-in-the-loop patterns such as completing OAuth + other auth flows.

## Related Issues

Closes #760 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix / enhancement

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
