### PR TITLE
feat: add mcp tool result multimodal support

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -38,7 +38,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
 }))
 
 vi.mock('../tools/tool.js', () => ({
-  Tool: class { },
+  Tool: class {},
   createErrorResult: (err: unknown, toolUseId: string) => ({
     type: 'toolResultBlock',
     status: 'error',
@@ -74,7 +74,7 @@ function mockActiveSpan(traceId: string = '1234567890abcdef1234567890abcdef', tr
   vi.spyOn(trace, 'getSpan').mockReturnValue(mockSpan as unknown as ReturnType<typeof trace.getSpan>)
   vi.spyOn(propagation, 'inject').mockImplementation((_context, carrier) => {
     if (carrier && typeof carrier === 'object') {
-      ; (carrier as Record<string, string>).traceparent = `00-${traceId}-1234567890abcdef-01`
+      ;(carrier as Record<string, string>).traceparent = `00-${traceId}-1234567890abcdef-01`
     }
   })
 }

--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -4,6 +4,7 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { McpClient } from '../mcp.js'
 import { McpTool } from '../tools/mcp-tool.js'
 import { JsonBlock, type TextBlock, type ToolResultBlock } from '../types/messages.js'
+import { ImageBlock } from '../types/media.js'
 import type { LocalAgent } from '../types/agent.js'
 import type { ToolContext } from '../tools/tool.js'
 import { context, propagation, trace, TraceFlags } from '@opentelemetry/api'
@@ -370,5 +371,108 @@ describe('MCP Integration', () => {
       expect(result.status).toBe('error')
       expect((result.content[0] as TextBlock).text).toContain('missing content array')
     })
+
+    it('maps MCP image content to ImageBlock', async () => {
+      // "iVBOR..." is a minimal base64 PNG prefix
+      const base64Data = 'iVBORw0KGgoAAAANSUhEUg=='
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'image', data: base64Data, mimeType: 'image/png' }],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('success')
+      expect(result.content).toHaveLength(1)
+      const imageBlock = result.content[0] as ImageBlock
+      expect(imageBlock).toBeInstanceOf(ImageBlock)
+      expect(imageBlock.format).toBe('png')
+      expect(imageBlock.source.type).toBe('imageSourceBytes')
+    })
+
+    it('falls back to JsonBlock for unsupported image mime type', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'image', data: 'abc123', mimeType: 'image/bmp' }],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.content[0]).toBeInstanceOf(JsonBlock)
+    })
+
+    it('falls back to JsonBlock for image content missing data', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'image', mimeType: 'image/png' }],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.content[0]).toBeInstanceOf(JsonBlock)
+    })
+
+    it('maps MCP text resource to TextBlock', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [
+          { type: 'resource', resource: { uri: 'file:///doc.txt', text: 'hello world', mimeType: 'text/plain' } },
+        ],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('success')
+      expect((result.content[0] as TextBlock).text).toBe('hello world')
+    })
+
+    it('maps MCP blob resource with image mime type to ImageBlock', async () => {
+      const base64Data = 'iVBORw0KGgoAAAANSUhEUg=='
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'resource', resource: { uri: 'file:///img.png', blob: base64Data, mimeType: 'image/jpeg' } }],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.content[0]).toBeInstanceOf(ImageBlock)
+      expect((result.content[0] as ImageBlock).format).toBe('jpeg')
+    })
+
+    it('falls back to JsonBlock for blob resource with non-image mime type', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [
+          { type: 'resource', resource: { uri: 'file:///doc.pdf', blob: 'abc123', mimeType: 'application/pdf' } },
+        ],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.content[0]).toBeInstanceOf(JsonBlock)
+    })
+
+    it('falls back to JsonBlock for resource with neither text nor blob', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'resource', resource: { uri: 'file:///unknown' } }],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.content[0]).toBeInstanceOf(JsonBlock)
+    })
+
+    it('handles mixed content types in a single result', async () => {
+      const base64Data = 'iVBORw0KGgoAAAANSUhEUg=='
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [
+          { type: 'text', text: 'Here is the image:' },
+          { type: 'image', data: base64Data, mimeType: 'image/png' },
+          { type: 'resource', resource: { uri: 'file:///notes.txt', text: 'Some notes' } },
+        ],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.content).toHaveLength(3)
+      expect((result.content[0] as TextBlock).text).toBe('Here is the image:')
+      expect(result.content[1]).toBeInstanceOf(ImageBlock)
+      expect((result.content[2] as TextBlock).text).toBe('Some notes')
+    })
   })
 })
+

--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -38,7 +38,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
 }))
 
 vi.mock('../tools/tool.js', () => ({
-  Tool: class {},
+  Tool: class { },
   createErrorResult: (err: unknown, toolUseId: string) => ({
     type: 'toolResultBlock',
     status: 'error',
@@ -74,7 +74,7 @@ function mockActiveSpan(traceId: string = '1234567890abcdef1234567890abcdef', tr
   vi.spyOn(trace, 'getSpan').mockReturnValue(mockSpan as unknown as ReturnType<typeof trace.getSpan>)
   vi.spyOn(propagation, 'inject').mockImplementation((_context, carrier) => {
     if (carrier && typeof carrier === 'object') {
-      ;(carrier as Record<string, string>).traceparent = `00-${traceId}-1234567890abcdef-01`
+      ; (carrier as Record<string, string>).traceparent = `00-${traceId}-1234567890abcdef-01`
     }
   })
 }
@@ -473,6 +473,8 @@ describe('MCP Integration', () => {
       expect((result.content[0] as TextBlock).text).toBe('Here is the image:')
       expect(result.content[1]).toBeInstanceOf(ImageBlock)
       expect((result.content[2] as TextBlock).text).toBe('Some notes')
+    })
+
     it('surfaces elicitation data for McpError with code -32042', async () => {
       const elicitations = [
         {

--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -475,4 +475,3 @@ describe('MCP Integration', () => {
     })
   })
 })
-

--- a/strands-ts/src/mime.ts
+++ b/strands-ts/src/mime.ts
@@ -4,7 +4,9 @@
  * Provides bidirectional mapping between media formats and MIME types.
  */
 
-export type ImageFormat = 'png' | 'jpg' | 'jpeg' | 'gif' | 'webp'
+export const IMAGE_FORMATS = ['png', 'jpg', 'jpeg', 'gif', 'webp'] as const
+
+export type ImageFormat = (typeof IMAGE_FORMATS)[number]
 
 export type VideoFormat = 'mkv' | 'mov' | 'mp4' | 'webm' | 'flv' | 'mpeg' | 'mpg' | 'wmv' | '3gp'
 

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -187,4 +187,3 @@ export class McpTool extends Tool {
     return (IMAGE_FORMATS as readonly string[]).includes(format)
   }
 }
-

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -1,8 +1,11 @@
 import { createErrorResult, Tool, type ToolContext, type ToolStreamGenerator } from './tool.js'
 import type { ToolSpec } from './types.js'
 import type { JSONSchema, JSONValue } from '../types/json.js'
-import { JsonBlock, TextBlock, ToolResultBlock } from '../types/messages.js'
+import { JsonBlock, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
+import { ImageBlock, decodeBase64 } from '../types/media.js'
+import { toMediaFormat, IMAGE_FORMATS, type ImageFormat } from '../mime.js'
 import type { McpClient } from '../mcp.js'
+import { logger } from '../logging/logger.js'
 
 export interface McpToolConfig {
   name: string
@@ -48,13 +51,11 @@ export class McpTool extends Tool {
         throw new Error('Invalid tool result from MCP Client: missing content array')
       }
 
-      const content = rawResult.content.map((item: unknown) => {
-        if (this._isMcpTextContent(item)) {
-          return new TextBlock(item.text)
-        }
+      const content: ToolResultContent[] = []
 
-        return new JsonBlock({ json: item as JSONValue })
-      })
+      for (const item of rawResult.content) {
+        content.push(this._mapMcpContent(item))
+      }
 
       if (content.length === 0) {
         content.push(new TextBlock('Tool execution completed successfully with no output.'))
@@ -68,6 +69,100 @@ export class McpTool extends Tool {
     } catch (error) {
       return createErrorResult(error, toolUseId)
     }
+  }
+
+  /**
+   * Maps a single MCP content item to an SDK ToolResultContent block.
+   *
+   * @param item - MCP content item from tool result
+   * @returns Mapped content block
+   */
+  private _mapMcpContent(item: unknown): ToolResultContent {
+    if (!item || typeof item !== 'object') {
+      return new JsonBlock({ json: item as JSONValue })
+    }
+
+    const record = item as Record<string, unknown>
+
+    switch (record.type) {
+      case 'text':
+        if (typeof record.text === 'string') {
+          return new TextBlock(record.text)
+        }
+        return new JsonBlock({ json: item as JSONValue })
+
+      case 'image':
+        return this._mapMcpImageContent(record)
+
+      case 'resource':
+        return this._mapMcpEmbeddedResource(record)
+
+      default:
+        return new JsonBlock({ json: item as JSONValue })
+    }
+  }
+
+  /**
+   * Maps an MCP image content item to an ImageBlock.
+   *
+   * @param record - MCP image content with data (base64) and mimeType
+   * @returns ImageBlock or TextBlock fallback if format is unsupported
+   */
+  private _mapMcpImageContent(record: Record<string, unknown>): ToolResultContent {
+    const data = record.data
+    const mimeType = record.mimeType
+
+    if (typeof data !== 'string' || typeof mimeType !== 'string') {
+      logger.warn('content_type=<image> | mcp image content missing data or mimeType, falling back to json')
+      return new JsonBlock({ json: record as JSONValue })
+    }
+
+    const format = toMediaFormat(mimeType)
+    if (!format || !this._isImageFormat(format)) {
+      logger.warn(`mime_type=<${mimeType}> | unsupported mcp image mime type, falling back to json`)
+      return new JsonBlock({ json: record as JSONValue })
+    }
+
+    return new ImageBlock({
+      format,
+      source: { bytes: decodeBase64(data) },
+    })
+  }
+
+  /**
+   * Maps an MCP embedded resource to an SDK content block.
+   * Text resources become TextBlock, blob resources with image MIME types become ImageBlock.
+   *
+   * @param record - MCP embedded resource content
+   * @returns Mapped content block or undefined if unsupported
+   */
+  private _mapMcpEmbeddedResource(record: Record<string, unknown>): ToolResultContent {
+    const resource = record.resource
+    if (!resource || typeof resource !== 'object') {
+      return new JsonBlock({ json: record as JSONValue })
+    }
+
+    const res = resource as Record<string, unknown>
+
+    // Text resource
+    if (typeof res.text === 'string') {
+      return new TextBlock(res.text)
+    }
+
+    // Blob resource
+    if (typeof res.blob === 'string' && typeof res.mimeType === 'string') {
+      const format = toMediaFormat(res.mimeType)
+      if (format && this._isImageFormat(format)) {
+        return new ImageBlock({
+          format,
+          source: { bytes: decodeBase64(res.blob) },
+        })
+      }
+      // Non-image blob: fall back to json
+      logger.warn(`mime_type=<${res.mimeType}> | unsupported mcp resource blob mime type, falling back to json`)
+    }
+
+    return new JsonBlock({ json: record as JSONValue })
   }
 
   /**
@@ -86,16 +181,10 @@ export class McpTool extends Tool {
   }
 
   /**
-   * Type Guard: Checks if an item is a Text content block.
-   * \{ type: 'text'; text: string \}
+   * Type Guard: Checks if a media format is a supported image format.
    */
-  private _isMcpTextContent(value: unknown): value is { type: 'text'; text: string } {
-    if (typeof value !== 'object' || value === null) {
-      return false
-    }
-
-    const record = value as Record<string, unknown>
-
-    return record.type === 'text' && typeof record.text === 'string'
+  private _isImageFormat(format: string): format is ImageFormat {
+    return (IMAGE_FORMATS as readonly string[]).includes(format)
   }
 }
+


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

MCP tools can return multi-modal content — images, embedded resources, and mixed content — but McpTool only handled text content blocks,falling back to JsonBlock for everything else. This meant image data from MCP servers was passed to the model as raw JSON (base64 strings) instead of proper ImageBlock instances, preventing models from actually interpreting the visual content.

## Related Issues

<!-- Link to related issues using #issue-number format -->
#675 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->


New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
