### PR TITLE
chore: upgrade to otel js sdk v2

### DIFF
--- a/strands-ts/src/telemetry/config.ts
+++ b/strands-ts/src/telemetry/config.ts
@@ -15,7 +15,13 @@
  */
 
 import { context as otelContext, metrics as otelMetrics, propagation, trace } from '@opentelemetry/api'
-import type { ContextManager, Meter as OtelMeter, TextMapPropagator, TracerProvider, Tracer as OtelTracer } from '@opentelemetry/api'
+import type {
+  ContextManager,
+  Meter as OtelMeter,
+  TextMapPropagator,
+  TracerProvider,
+  Tracer as OtelTracer,
+} from '@opentelemetry/api'
 import { resourceFromAttributes, envDetector, type Resource } from '@opentelemetry/resources'
 import {
   BasicTracerProvider,

--- a/strands-ts/src/telemetry/config.ts
+++ b/strands-ts/src/telemetry/config.ts
@@ -15,8 +15,7 @@
  */
 
 import { context as otelContext, metrics as otelMetrics, propagation, trace } from '@opentelemetry/api'
-import type { ContextManager, TextMapPropagator } from '@opentelemetry/api'
-import type { Meter as OtelMeter, Tracer as OtelTracer } from '@opentelemetry/api'
+import type { ContextManager, Meter as OtelMeter, TextMapPropagator, TracerProvider, Tracer as OtelTracer } from '@opentelemetry/api'
 import { resourceFromAttributes, envDetector, type Resource } from '@opentelemetry/resources'
 import {
   BasicTracerProvider,
@@ -120,7 +119,7 @@ export interface TracerConfig {
    * Custom TracerProvider instance. If not provided, NodeTracerProvider is
    * used when available, otherwise BasicTracerProvider.
    */
-  provider?: BasicTracerProvider
+  provider?: TracerProvider
 
   /**
    * Exporter configuration.
@@ -139,9 +138,15 @@ export interface TracerConfig {
 }
 
 let _provider: BasicTracerProvider | null = null
+let _customProvider: TracerProvider | null = null
 
 /**
  * Set up the tracer provider with the given configuration.
+ *
+ * When called without a custom provider, returns a BasicTracerProvider and
+ * registers the async context manager + W3C propagators for trace propagation.
+ * When a custom provider is passed, the caller is responsible for their own
+ * context manager / propagator setup (e.g. via provider.register()).
  *
  * @param config - Tracer configuration options
  * @returns The configured tracer provider
@@ -153,34 +158,34 @@ let _provider: BasicTracerProvider | null = null
  * telemetry.setupTracer({ exporters: { otlp: true } })
  * ```
  */
-export function setupTracer(config: TracerConfig = {}): BasicTracerProvider {
-  if (_provider) {
+export function setupTracer(config?: Omit<TracerConfig, 'provider'>): BasicTracerProvider
+export function setupTracer(config: TracerConfig): TracerProvider
+export function setupTracer(config: TracerConfig = {}): TracerProvider {
+  if (_provider || _customProvider) {
     logger.warn('tracer provider already initialized, returning existing provider')
-    return _provider
+    return _customProvider ?? _provider!
   }
 
   if (config.provider) {
-    _provider = config.provider
-  } else {
-    const spanProcessors: SpanProcessor[] = []
-    if (config.exporters?.otlp) spanProcessors.push(new BatchSpanProcessor(new OTLPTraceExporter()))
-    if (config.exporters?.console) spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()))
-    _provider = new DefaultTracerProvider({ resource: getOtelResource(), spanProcessors })
+    _customProvider = config.provider
+    trace.setGlobalTracerProvider(_customProvider)
+    return _customProvider
   }
 
+  const spanProcessors: SpanProcessor[] = []
+  if (config.exporters?.otlp) spanProcessors.push(new BatchSpanProcessor(new OTLPTraceExporter()))
+  if (config.exporters?.console) spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()))
+  _provider = new DefaultTracerProvider({ resource: getOtelResource(), spanProcessors })
+
   trace.setGlobalTracerProvider(_provider)
-  if (!config.provider) {
-    if (DefaultContextManager) otelContext.setGlobalContextManager(new DefaultContextManager())
-    if (DefaultPropagator) propagation.setGlobalPropagator(DefaultPropagator)
-  }
+  if (DefaultContextManager) otelContext.setGlobalContextManager(new DefaultContextManager())
+  if (DefaultPropagator) propagation.setGlobalPropagator(DefaultPropagator)
 
   if (typeof globalThis.process?.once === 'function') {
     globalThis.process.once('beforeExit', () => {
-      if (_provider) {
-        _provider.forceFlush().catch((err: unknown) => {
-          logger.warn(`error=<${err}> | failed to flush tracer provider on exit`)
-        })
-      }
+      _provider?.forceFlush()?.catch((err: unknown) => {
+        logger.warn(`error=<${err}> | failed to flush tracer provider on exit`)
+      })
     })
   }
 

--- a/strands-ts/src/telemetry/config.ts
+++ b/strands-ts/src/telemetry/config.ts
@@ -169,8 +169,10 @@ export function setupTracer(config: TracerConfig = {}): BasicTracerProvider {
   }
 
   trace.setGlobalTracerProvider(_provider)
-  if (DefaultContextManager) otelContext.setGlobalContextManager(new DefaultContextManager())
-  if (DefaultPropagator) propagation.setGlobalPropagator(DefaultPropagator)
+  if (!config.provider) {
+    if (DefaultContextManager) otelContext.setGlobalContextManager(new DefaultContextManager())
+    if (DefaultPropagator) propagation.setGlobalPropagator(DefaultPropagator)
+  }
 
   if (typeof globalThis.process?.once === 'function') {
     globalThis.process.once('beforeExit', () => {

--- a/strands-ts/src/telemetry/config.ts
+++ b/strands-ts/src/telemetry/config.ts
@@ -14,7 +14,8 @@
  * environments without async_hooks support.
  */
 
-import { metrics as otelMetrics, trace } from '@opentelemetry/api'
+import { context as otelContext, metrics as otelMetrics, propagation, trace } from '@opentelemetry/api'
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api'
 import type { Meter as OtelMeter, Tracer as OtelTracer } from '@opentelemetry/api'
 import { resourceFromAttributes, envDetector, type Resource } from '@opentelemetry/resources'
 import {
@@ -36,12 +37,19 @@ import { logger } from '../logging/index.js'
 import { getServiceName } from './utils.js'
 
 let DefaultTracerProvider: typeof BasicTracerProvider = BasicTracerProvider
+let DefaultContextManager: (new () => ContextManager) | undefined
+let DefaultPropagator: TextMapPropagator | undefined
 if (typeof globalThis.process?.getBuiltinModule === 'function') {
   try {
     const nodeModule = globalThis.process.getBuiltinModule('node:module') as typeof import('module') | undefined
     if (nodeModule) {
       const req = nodeModule.createRequire(import.meta.url)
       DefaultTracerProvider = req('@opentelemetry/sdk-trace-node').NodeTracerProvider
+      DefaultContextManager = req('@opentelemetry/context-async-hooks').AsyncLocalStorageContextManager
+      const { W3CTraceContextPropagator, W3CBaggagePropagator, CompositePropagator } = req('@opentelemetry/core')
+      DefaultPropagator = new CompositePropagator({
+        propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+      })
     }
   } catch {
     logger.info('sdk-trace-node not available | using BasicTracerProvider without async context propagation')
@@ -161,6 +169,8 @@ export function setupTracer(config: TracerConfig = {}): BasicTracerProvider {
   }
 
   trace.setGlobalTracerProvider(_provider)
+  if (DefaultContextManager) otelContext.setGlobalContextManager(new DefaultContextManager())
+  if (DefaultPropagator) propagation.setGlobalPropagator(DefaultPropagator)
 
   if (typeof globalThis.process?.once === 'function') {
     globalThis.process.once('beforeExit', () => {

--- a/strands-ts/test/integ/telemetry.test.node.ts
+++ b/strands-ts/test/integ/telemetry.test.node.ts
@@ -65,7 +65,7 @@ describe.sequential('Telemetry Integration', () => {
   beforeAll(() => {
     exporter = new InMemorySpanExporter()
     provider = new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
-    trace.setGlobalTracerProvider(provider)
+    provider.register()
   })
 
   beforeEach(() => {


### PR DESCRIPTION
## Description

PR #831 upgraded the OTel JS SDK from v1 to v2 and replaced `provider.register()` with `trace.setGlobalTracerProvider()`. This broke context propagation because `register()` also sets the `AsyncLocalStorageContextManager` and W3C propagators — without them, `context.active()` always returns a noop root context.


This is because `.register` was removed from `BasicTraceProvider` in OTEL JS SDK v2: https://github.com/open-telemetry/opentelemetry-js/pull/5503

This caused:
- `trace.getSpan(context.active())` returning `undefined` inside tool callbacks
- MCP trace context injection (`injectTraceContext`) writing no `traceparent` into `_meta`
- `tracer.startActiveSpan()` not propagating parent context to child spans

**Fix:** Alongside `trace.setGlobalTracerProvider()`, also register the `AsyncLocalStorageContextManager` and `CompositePropagator` (W3C TraceContext + Baggage) using the same dynamic require pattern already used for `NodeTracerProvider`. In browser environments (where these aren't available), only the tracer provider is registered — matching the existing behavior.

Also fixes the integration test which had the same `setGlobalTracerProvider` bug, causing a flaky context propagation test.

## Related Issues

Fixes context propagation regression introduced by #831

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?
- [X] I ran `npm run check`
- Tested locally in various smoke tests w langfuse

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.