### PR TITLE
feat: export MultiagentSaveLatestStrategy in top level index

### DIFF
--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -229,7 +229,11 @@ export { type McpClientConfig, type TasksConfig, McpClient } from './mcp.js'
 
 // Session management
 export { SessionManager } from './session/session-manager.js'
-export type { SessionManagerConfig, SaveLatestStrategy } from './session/session-manager.js'
+export type {
+  SessionManagerConfig,
+  SaveLatestStrategy,
+  MultiAgentSaveLatestStrategy,
+} from './session/session-manager.js'
 export type { SnapshotManifest, SnapshotTriggerCallback, SnapshotTriggerParams } from './session/types.js'
 export type { SessionStorage, SnapshotStorage, SnapshotLocation } from './session/storage.js'
 export { FileStorage } from './session/file-storage.js'


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Since I've finished Multiagent session manager integration, we can now export `MultiagentSaveLatestStrategy` in top level index to match with single agent.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
