### PR TITLE
fix: add version field to root package.json so downstream file: insta…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "strands",
+  "version": "0.0.0",
   "private": true,
   "workspaces": ["strands-dev", "strands-ts", "strands-wasm"],
   "devDependencies": {


### PR DESCRIPTION
## Description
Another small monorepo package.json PR. We already have `private:true` so to satisfy requirements we leave placeholder version `0.0.0` for file: installs because we don't intend to publish.

## Related Issues

n/a

## Documentation PR

n/a

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
