### PR TITLE
feat(mcp): add elicitation callback support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ sdk-typescript/
 │   │   │   ├── __tests__/
 │   │   │   ├── agent.ts
 │   │   │   ├── citations.ts
+│   │   │   ├── elicitation.ts
 │   │   │   ├── json.ts
 │   │   │   ├── media.ts
 │   │   │   ├── messages.ts

--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'
+import {
+  McpError,
+  ErrorCode,
+  ElicitRequestSchema,
+  UrlElicitationRequiredError,
+} from '@modelcontextprotocol/sdk/types.js'
 import { McpClient } from '../mcp.js'
 import { McpTool } from '../tools/mcp-tool.js'
 import { JsonBlock, type TextBlock, type ToolResultBlock } from '../types/messages.js'
 import { ImageBlock } from '../types/media.js'
 import type { LocalAgent } from '../types/agent.js'
 import type { ToolContext } from '../tools/tool.js'
+import type { ElicitationCallback } from '../types/elicitation.js'
 import { context, propagation, trace, TraceFlags } from '@opentelemetry/api'
 import type { SpanContext } from '@opentelemetry/api'
 
@@ -28,6 +34,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
       close: vi.fn(),
       listTools: vi.fn(),
       callTool: vi.fn(),
+      setRequestHandler: vi.fn(),
       experimental: {
         tasks: {
           callToolStream: vi.fn(),
@@ -94,6 +101,24 @@ describe('MCP Integration', () => {
     vi.restoreAllMocks()
   })
 
+  function createElicitationClient(callback: ElicitationCallback) {
+    const resultsLengthBefore = vi.mocked(Client).mock.results.length
+    const elicitClient = new McpClient({
+      applicationName: 'TestApp',
+      transport: mockTransport,
+      elicitationCallback: callback,
+    })
+    const elicitSdkClientMock = vi.mocked(Client).mock.results[resultsLengthBefore]!.value
+    return { elicitClient, elicitSdkClientMock }
+  }
+
+  async function connectAndGetElicitationHandler(callback: ElicitationCallback) {
+    const { elicitClient, elicitSdkClientMock } = createElicitationClient(callback)
+    await elicitClient.connect()
+    const handler = elicitSdkClientMock.setRequestHandler.mock.calls[0]![1]
+    return { handler, elicitSdkClientMock }
+  }
+
   describe('McpClient', () => {
     let client: McpClient
     let sdkClientMock: {
@@ -101,6 +126,7 @@ describe('MCP Integration', () => {
       close: ReturnType<typeof vi.fn>
       listTools: ReturnType<typeof vi.fn>
       callTool: ReturnType<typeof vi.fn>
+      setRequestHandler: ReturnType<typeof vi.fn>
       experimental: { tasks: { callToolStream: ReturnType<typeof vi.fn> } }
     }
 
@@ -113,7 +139,7 @@ describe('MCP Integration', () => {
     })
 
     it('initializes SDK client with correct configuration', () => {
-      expect(Client).toHaveBeenCalledWith({ name: 'TestApp', version: '0.0.1' })
+      expect(Client).toHaveBeenCalledWith({ name: 'TestApp', version: '0.0.1' }, undefined)
     })
 
     it('injects trace context into tool arguments when active span exists', async () => {
@@ -293,6 +319,109 @@ describe('MCP Integration', () => {
       await client.disconnect()
       expect(sdkClientMock.close).toHaveBeenCalled()
       expect(mockTransport.close).toHaveBeenCalled()
+    })
+
+    it('registers elicitation handler before connecting when callback is provided', async () => {
+      const resultsLengthBefore = vi.mocked(Client).mock.results.length
+      const callback: ElicitationCallback = vi.fn()
+      const elicitClient = new McpClient({
+        applicationName: 'TestApp',
+        transport: mockTransport,
+        elicitationCallback: callback,
+      })
+      const elicitSdkClientMock = vi.mocked(Client).mock.results[resultsLengthBefore]!.value
+
+      await elicitClient.connect()
+
+      expect(elicitSdkClientMock.setRequestHandler).toHaveBeenCalledWith(ElicitRequestSchema, expect.any(Function))
+      const setHandlerOrder = elicitSdkClientMock.setRequestHandler.mock.invocationCallOrder[0]!
+      const connectOrder = elicitSdkClientMock.connect.mock.invocationCallOrder[0]!
+      expect(setHandlerOrder).toBeLessThan(connectOrder)
+    })
+
+    it('does not register elicitation handler when no callback is provided', async () => {
+      await client.connect()
+
+      expect(sdkClientMock.setRequestHandler).not.toHaveBeenCalled()
+    })
+
+    it('passes elicitation capabilities to Client when callback is provided', () => {
+      const callback: ElicitationCallback = vi.fn()
+      new McpClient({
+        applicationName: 'TestApp',
+        transport: mockTransport,
+        elicitationCallback: callback,
+      })
+
+      const lastCall = vi.mocked(Client).mock.calls.at(-1)!
+      expect(lastCall[1]).toEqual({ capabilities: { elicitation: { form: {}, url: {} } } })
+    })
+
+    it('elicitation handler returns accepted result with content', async () => {
+      const callbackResult = { action: 'accept' as const, content: { username: 'alice' } }
+      const callback: ElicitationCallback = vi.fn().mockResolvedValue(callbackResult)
+      const { handler } = await connectAndGetElicitationHandler(callback)
+      const request = {
+        method: 'elicitation/create',
+        params: { message: 'Enter username', requestedSchema: { type: 'object' } },
+      }
+      const extra = { signal: new AbortController().signal }
+
+      const result = await handler(request, extra)
+
+      expect(callback).toHaveBeenCalledWith(extra, request.params)
+      expect(result).toEqual({ action: 'accept', content: { username: 'alice' } })
+    })
+
+    it.each([{ action: 'decline' as const }, { action: 'cancel' as const }])(
+      'elicitation handler returns $action result',
+      async (callbackResult) => {
+        const callback: ElicitationCallback = vi.fn().mockResolvedValue(callbackResult)
+        const { handler } = await connectAndGetElicitationHandler(callback)
+        const request = {
+          method: 'elicitation/create',
+          params: { message: 'Enter username', requestedSchema: { type: 'object' } },
+        }
+        const extra = { signal: new AbortController().signal }
+
+        const result = await handler(request, extra)
+
+        expect(callback).toHaveBeenCalledWith(extra, request.params)
+        expect(result).toEqual({ action: callbackResult.action })
+      }
+    )
+
+    it('elicitation handler works for URL mode params', async () => {
+      const callbackResult = { action: 'accept' as const }
+      const callback: ElicitationCallback = vi.fn().mockResolvedValue(callbackResult)
+      const { handler } = await connectAndGetElicitationHandler(callback)
+      const request = {
+        method: 'elicitation/create',
+        params: {
+          mode: 'url',
+          message: 'Please authenticate',
+          url: 'https://example.com/auth',
+          elicitationId: 'elicit-123',
+        },
+      }
+      const extra = { signal: new AbortController().signal }
+
+      const result = await handler(request, extra)
+
+      expect(callback).toHaveBeenCalledWith(extra, request.params)
+      expect(result).toEqual({ action: 'accept' })
+    })
+
+    it('elicitation callback errors propagate', async () => {
+      const callback: ElicitationCallback = vi.fn().mockRejectedValue(new Error('User cancelled'))
+      const { handler } = await connectAndGetElicitationHandler(callback)
+      const request = {
+        method: 'elicitation/create',
+        params: { message: 'Confirm?' },
+      }
+      const extra = { signal: new AbortController().signal }
+
+      await expect(handler(request, extra)).rejects.toThrow('User cancelled')
     })
   })
 
@@ -531,6 +660,59 @@ describe('MCP Integration', () => {
 
       expect(result.status).toBe('error')
       expect((result.content[0] as TextBlock).text).toBe('MCP error -32042: Authorization required')
+    })
+
+    it('surfaces elicitation data for UrlElicitationRequiredError', async () => {
+      const elicitations = [
+        {
+          mode: 'url' as const,
+          message: 'Please authorize',
+          elicitationId: 'e-1',
+          url: 'https://example.com/auth',
+        },
+      ]
+      const error = new UrlElicitationRequiredError(elicitations, 'Auth required')
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(error)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toContain('MCP Elicitation required')
+      expect((result.content[0] as TextBlock).text).toContain('https://example.com/auth')
+    })
+
+    it('falls through to generic error for McpError -32042 with undefined data', async () => {
+      const mcpError = new McpError(ErrorCode.UrlElicitationRequired, 'Auth required')
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe('MCP error -32042: Auth required')
+    })
+
+    it('falls through to generic error for McpError -32042 with non-array elicitations', async () => {
+      const mcpError = new McpError(ErrorCode.UrlElicitationRequired, 'Auth required', {
+        elicitations: 'not-an-array',
+      })
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe('MCP error -32042: Auth required')
+    })
+
+    it('falls through to generic error for McpError -32042 with empty elicitations', async () => {
+      const mcpError = new McpError(ErrorCode.UrlElicitationRequired, 'Auth required', {
+        elicitations: [],
+      })
+      vi.mocked(mockClientWrapper.callTool).mockRejectedValue(mcpError)
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('error')
+      expect((result.content[0] as TextBlock).text).toBe('MCP error -32042: Auth required')
     })
 
     it('falls through to generic error for McpError with a different code', async () => {

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -226,6 +226,7 @@ export type { Logger } from './logging/types.js'
 
 // MCP Client types and implementations
 export { type McpClientConfig, type TasksConfig, McpClient } from './mcp.js'
+export type { ElicitationCallback, ElicitationContext } from './types/elicitation.js'
 
 // Session management
 export { SessionManager } from './session/session-manager.js'

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -1,8 +1,10 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { takeResult } from '@modelcontextprotocol/sdk/shared/responseMessage.js'
+import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { context, propagation, trace } from '@opentelemetry/api'
 import type { JSONSchema, JSONValue } from './types/json.js'
+import type { ElicitationCallback } from './types/elicitation.js'
 import { McpTool } from './tools/mcp-tool.js'
 import { logger } from './logging/index.js'
 
@@ -49,6 +51,13 @@ export type McpClientConfig = RuntimeConfig & {
    * When undefined, tools are called directly without task management.
    */
   tasksConfig?: TasksConfig
+
+  /**
+   * Callback to handle server-initiated elicitation requests.
+   * When provided, the client advertises elicitation support (form + url modes)
+   * and routes incoming elicitation requests to this callback.
+   */
+  elicitationCallback?: ElicitationCallback
 }
 
 /** MCP Client for interacting with Model Context Protocol servers. */
@@ -66,6 +75,7 @@ export class McpClient {
   private _client: Client
   private _disableMcpInstrumentation: boolean
   private _tasksConfig: TasksConfig | undefined
+  private _elicitationCallback: ElicitationCallback | undefined
 
   constructor(args: McpClientConfig) {
     this._clientName = args.applicationName || 'strands-agents-ts-sdk'
@@ -73,10 +83,14 @@ export class McpClient {
     this._transport = args.transport
     this._connected = false
     this._tasksConfig = args.tasksConfig
-    this._client = new Client({
-      name: this._clientName,
-      version: this._clientVersion,
-    })
+    this._elicitationCallback = args.elicitationCallback
+    this._client = new Client(
+      {
+        name: this._clientName,
+        version: this._clientVersion,
+      },
+      this._elicitationCallback ? { capabilities: { elicitation: { form: {}, url: {} } } } : undefined
+    )
 
     this._disableMcpInstrumentation = args.disableMcpInstrumentation ?? false
   }
@@ -102,8 +116,14 @@ export class McpClient {
       this._connected = false
     }
 
-    await this._client.connect(this._transport)
+    if (this._elicitationCallback) {
+      const callback = this._elicitationCallback
+      this._client.setRequestHandler(ElicitRequestSchema, async (request, extra) => {
+        return await callback(extra, request.params)
+      })
+    }
 
+    await this._client.connect(this._transport)
     this._connected = true
   }
 

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -1,4 +1,4 @@
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'
+import { McpError, ErrorCode, UrlElicitationRequiredError } from '@modelcontextprotocol/sdk/types.js'
 
 import { createErrorResult, Tool, type ToolContext, type ToolStreamGenerator } from './tool.js'
 import type { ToolSpec } from './types.js'
@@ -69,21 +69,22 @@ export class McpTool extends Tool {
         content,
       })
     } catch (error) {
-      if (error instanceof McpError && error.code === ErrorCode.UrlElicitationRequired) {
-        try {
-          const data = error.data as Record<string, unknown> | undefined
-          const elicitations = data?.elicitations
-          if (Array.isArray(elicitations)) {
-            return new ToolResultBlock({
-              toolUseId,
-              status: 'error',
-              content: [
-                new TextBlock(`MCP Elicitation required: [${String(error)}] with data ${JSON.stringify(elicitations)}`),
-              ],
-            })
-          }
-        } catch {
-          // Intentionally empty — fall through to createErrorResult below
+      if (
+        error instanceof UrlElicitationRequiredError ||
+        (error instanceof McpError && error.code === ErrorCode.UrlElicitationRequired)
+      ) {
+        const elicitations =
+          error instanceof UrlElicitationRequiredError
+            ? error.elicitations
+            : (error.data as Record<string, unknown> | undefined)?.elicitations
+        if (Array.isArray(elicitations) && elicitations.length > 0) {
+          return new ToolResultBlock({
+            toolUseId,
+            status: 'error',
+            content: [
+              new TextBlock(`MCP Elicitation required: [${String(error)}] with data ${JSON.stringify(elicitations)}`),
+            ],
+          })
         }
       }
       return createErrorResult(error, toolUseId)

--- a/strands-ts/src/types/elicitation.ts
+++ b/strands-ts/src/types/elicitation.ts
@@ -1,0 +1,21 @@
+import type {
+  ElicitResult,
+  ElicitRequestParams,
+  ClientRequest,
+  ClientNotification,
+} from '@modelcontextprotocol/sdk/types.js'
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js'
+
+/**
+ * Context provided to an elicitation callback, including the abort signal for the in-flight request.
+ */
+export type ElicitationContext = RequestHandlerExtra<ClientRequest, ClientNotification>
+
+/**
+ * Callback invoked when an MCP server sends an elicitation request to gather user input during tool execution.
+ *
+ * @param context - Request context including abort signal.
+ * @param params - The elicitation parameters from the server (message, requested schema or URL).
+ * @returns The user's response: accept (with content), decline, or cancel.
+ */
+export type ElicitationCallback = (context: ElicitationContext, params: ElicitRequestParams) => Promise<ElicitResult>

--- a/strands-ts/test/integ/__fixtures__/test-mcp-server.ts
+++ b/strands-ts/test/integ/__fixtures__/test-mcp-server.ts
@@ -106,6 +106,39 @@ function createTestServer(): McpServer {
     }
   )
 
+  // Register confirm_action tool (tests elicitation)
+  server.registerTool(
+    'confirm_action',
+    {
+      title: 'Confirm Action Tool',
+      description: 'Asks the user to confirm before proceeding. Use this tool when you need user confirmation.',
+      inputSchema: {
+        action: z.string(),
+      },
+    },
+    async ({ action }) => {
+      const result = await server.server.elicitInput({
+        message: `Do you want to proceed with: ${action}?`,
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            confirmed: { type: 'boolean', description: 'Whether the user confirms' },
+          },
+        },
+      })
+
+      if (result.action === 'accept') {
+        return {
+          content: [{ type: 'text', text: `Action "${action}" confirmed by user` }],
+        }
+      }
+
+      return {
+        content: [{ type: 'text', text: `Action "${action}" was ${result.action}d by user` }],
+      }
+    }
+  )
+
   // Register error tool
   server.registerTool(
     'error_tool',

--- a/strands-ts/test/integ/mcp/mcp.test.node.ts
+++ b/strands-ts/test/integ/mcp/mcp.test.node.ts
@@ -5,8 +5,9 @@
  * Verifies that agents can successfully use MCP tools via the Bedrock model.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { McpClient, Agent } from '@strands-agents/sdk'
+import type { ElicitationCallback } from '@strands-agents/sdk'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { resolve } from 'node:path'
@@ -115,5 +116,51 @@ describe('MCP Integration Tests', () => {
       )
       expect(hasErrorResult).toBe(true)
     }, 30000)
+  })
+
+  // Elicitation handler registration is transport-agnostic (happens in McpClient.connect),
+  // so a single transport suffices here.
+  describe('elicitation', () => {
+    it('agent can use MCP tool that requests elicitation', async () => {
+      const elicitationCallback: ElicitationCallback = vi.fn().mockResolvedValue({
+        action: 'accept',
+        content: { confirmed: true },
+      })
+
+      const client = new McpClient({
+        applicationName: 'test-mcp-elicitation',
+        transport: new StdioClientTransport({
+          command: 'npx',
+          args: ['tsx', serverPath],
+        }),
+        elicitationCallback,
+      })
+
+      const model = bedrock.createModel({ maxTokens: 300 })
+
+      const agent = new Agent({
+        systemPrompt: 'You are a helpful assistant. Use the confirm_action tool when asked to confirm something.',
+        tools: [client],
+        model,
+      })
+
+      const result = await agent.invoke('Use the confirm_action tool to confirm "deploy to production"')
+
+      expect(result).toBeDefined()
+      expect(result.stopReason).toBeDefined()
+      expect(elicitationCallback).toHaveBeenCalled()
+
+      const hasConfirmUse = agent.messages.some((msg) =>
+        msg.content.some((block) => block.type === 'toolUseBlock' && block.name === 'confirm_action')
+      )
+      expect(hasConfirmUse).toBe(true)
+
+      const hasSuccessResult = agent.messages.some((msg) =>
+        msg.content.some((block) => block.type === 'toolResultBlock' && block.status === 'success')
+      )
+      expect(hasSuccessResult).toBe(true)
+
+      await client.disconnect()
+    }, 60000)
   })
 })


### PR DESCRIPTION
## Description

This PR adds an optional `elicitationCallback` to `McpClientConfig`. When provided, the client advertises elicitation support (form + URL modes) and routes incoming `elicitation/create` requests from the server to the callback, enabling human-in-the-loop patterns like confirming destructive actions, collecting user credentials, or completing OAuth flows mid-tool-execution.

### API Surface

```typescript
// New optional field on McpClientConfig
elicitationCallback?: ElicitationCallback

// Exported types
type ElicitationContext = RequestHandlerExtra<ClientRequest, ClientNotification>
type ElicitationCallback = (context: ElicitationContext, params: ElicitRequestParams) => Promise<ElicitResult>

// ElicitResult (from @modelcontextprotocol/sdk)
interface ElicitResult {
  action: 'accept' | 'decline' | 'cancel'
  content?: { [key: string]: string | number | boolean | string[] }  // present when action is 'accept' and mode was 'form'
}
```

When `elicitationCallback` is omitted (default), the client does not advertise elicitation support and the server cannot request user input.

### Usage Example

```typescript
import { McpClient, Agent, BedrockModel } from '@strands-agents/sdk'
import type { ElicitationCallback } from '@strands-agents/sdk'
import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'

const elicitationCallback: ElicitationCallback = async (_context, params) => {
  if (params.mode === 'url') {
    // URL mode: open a browser for the user to complete an OAuth flow, etc.
    console.log(`Please visit: ${params.url}`)
    return { action: 'accept' }
  }

  // Form mode: prompt the user with the server's message and collect input
  const userConfirmed = await promptUser(params.message) // your UI logic here
  if (userConfirmed) {
    return { action: 'accept', content: { confirmed: true } }
  }
  return { action: 'decline' }
}

const client = new McpClient({
  applicationName: 'my-app',
  transport: new StdioClientTransport({
    command: 'node',
    args: ['./my-mcp-server.js'],
  }),
  elicitationCallback,
})

const agent = new Agent({
  model: new BedrockModel({ modelId: 'us.anthropic.claude-sonnet-4-20250514' }),
  tools: [client],
})

const result = await agent.invoke('Deploy to production')
// If the server's tool calls elicitInput(), elicitationCallback fires
// and the user can confirm or decline before the tool proceeds.
```

## Related Issues

Closes #232
Closes #480

## Documentation PR

Will raise after this is merged (otherwise CI will fail)

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I WILL update the documentation accordingly
- [x] I WILL add an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.