### PR TITLE
docs: update wasm content with guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,30 @@ When proposing solutions or reviewing code, we reference these principles to gui
 
 The repo is an npm workspace. The SDK source lives in `strands-ts/`, and the root `package.json` proxies common commands (`test`, `lint`, `format:check`, `type-check`, `build`) into that workspace. For commands that aren't proxied at root (like `test:integ` or `test:watch`), run them from `strands-ts/` directly.
 
+### WASM and Python Development
+
+If you're working on the WASM bridge (`strands-wasm/`) or the Python SDK (`strands-py/`), additional setup is needed:
+
+1. Build the full pipeline (TS → WASM → Python types):
+   ```bash
+   npm run dev -- bootstrap
+   ```
+
+2. Set up the Python virtual environment:
+   ```bash
+   python3 -m venv strands-py/.venv
+   source strands-py/.venv/bin/activate
+   pip install -e "strands-py[dev]"
+   pip install componentize-py boto3 pytest pytest-asyncio
+   ```
+
+3. Run Python integration tests (from `strands-py/`, venv activated):
+   ```bash
+   python3 -m pytest tests_integ/models/test_model_bedrock.py -xvs
+   ```
+
+See [strands-wasm/README.md](strands-wasm/README.md) for the full architecture guide and `validate` commands.
+
 ## Testing Instructions and Best Practices
 
 ### Running Tests

--- a/strands-py/strands/_conversions.py
+++ b/strands-py/strands/_conversions.py
@@ -3,6 +3,11 @@
 Stream events are Union-typed dataclasses (one per variant case) with a
 ``.value`` payload.  Functions here convert these to the dict format the
 upstream Python SDK expects.
+
+Message format note:
+  The TS SDK uses class-based discriminators: {"type": "textBlock", "text": "..."}
+  The Python SDK uses wrapper keys:          {"text": "..."}
+  convert_message() and _convert_block() handle this translation.
 """
 
 from __future__ import annotations

--- a/strands-py/strands/_wasm_host.py
+++ b/strands-py/strands/_wasm_host.py
@@ -2,6 +2,16 @@
 
 Loads the WASM component, links WASI + custom imports, and provides
 a ``WasmAgent`` class with the same API as the former native ``Agent``.
+
+Data flow across the WASM boundary:
+
+  Exports (TS implements, Python calls in):
+    api — agent construction, generate, get/set messages, session ops.
+    All model HTTP calls (Bedrock, Anthropic, etc.) happen inside the guest.
+
+  Imports (Python implements, TS calls back):
+    tool-provider — the guest calls call-tool when the model requests tool use.
+    host-log — the guest emits structured log entries for Python's logging.
 """
 
 from __future__ import annotations

--- a/strands-wasm/README.md
+++ b/strands-wasm/README.md
@@ -2,6 +2,17 @@
 
 WASM build tooling and monorepo developer guide. Describes the WebAssembly component architecture, build pipeline, WIT contracts, and cross-package development workflow.
 
+## How it works
+
+The TypeScript SDK is compiled into a WebAssembly component (`strands-agent.wasm`). Python loads this component via wasmtime-py and drives it.
+
+The WIT contract (`wit/agent.wit`) defines what crosses the WASM boundary:
+
+- **Exports** (TS implements, Python calls): The `api` interface — agent construction, streaming, conversation management. All model provider HTTP calls (Bedrock, Anthropic, OpenAI, Gemini) happen inside the WASM guest.
+- **Imports** (Python implements, TS calls back into): `tool-provider` for executing Python-defined tools, and `host-log` for routing log entries to Python's logging framework.
+
+In WIT terminology, the WASM component is the "guest" and Python is the "host". When the TS agent loop decides a tool needs to run, it calls the `tool-provider` import which crosses the WASM boundary back to Python where the actual tool function lives.
+
 ## Getting started
 
 ### Prerequisites

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -48,6 +48,7 @@ function errContext(err: unknown, extra?: Record<string, unknown>): Record<strin
   return { error: e.message, stack: e.stack, ...extra };
 }
 
+/** Convert TS SDK Usage to WIT Usage. */
 function mapUsage(src: any): import('strands:agent/types').Usage | undefined {
   if (src == null) return undefined;
   return {
@@ -59,11 +60,13 @@ function mapUsage(src: any): import('strands:agent/types').Usage | undefined {
   };
 }
 
+/** Convert TS SDK Metrics to WIT Metrics. */
 function mapMetrics(src: any): import('strands:agent/types').Metrics | undefined {
   if (src == null) return undefined;
   return { latencyMs: typeof src.latencyMs === 'number' ? src.latencyMs : 0 };
 }
 
+/** Convert a TS SDK StopReason to a WIT StopData with usage/metrics. */
 function mapStopReason(reason: StopReason, agentResult?: any): StopData {
   const mapped: StopData['reason'] = (() => {
     switch (reason) {
@@ -81,6 +84,7 @@ function mapStopReason(reason: StopReason, agentResult?: any): StopData {
   return { reason: mapped, usage: mapUsage(agentResult?.usage), metrics: mapMetrics(agentResult?.metrics) };
 }
 
+/** Convert a TS SDK AgentStreamEvent to a WIT StreamEvent for the host. */
 function mapEvent(event: AgentStreamEvent): StreamEvent | null {
   if ('interrupt' in event || ('type' in event && (event as any).type === 'interrupt')) {
     return { tag: 'interrupt', val: JSON.stringify(event) };
@@ -155,6 +159,7 @@ function mapEvent(event: AgentStreamEvent): StreamEvent | null {
   return null;
 }
 
+/** Extract WIT ModelParams into a plain config object for TS model constructors. */
 function modelParamsConfig(params?: ModelParams): Record<string, unknown> {
   if (!params) return {};
   return {
@@ -164,6 +169,7 @@ function modelParamsConfig(params?: ModelParams): Record<string, unknown> {
   };
 }
 
+/** Instantiate a TS SDK Model from the WIT ModelConfig variant. */
 function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseModelConfig> {
   const base = modelParamsConfig(params);
 
@@ -227,6 +233,7 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
   }
 }
 
+/** Convert WIT ToolSpecs into TS FunctionTools that call back to the host via tool-provider. */
 function createTools(specs: ToolSpec[] | undefined): FunctionTool[] | undefined {
   if (!specs || specs.length === 0) return undefined;
 
@@ -273,6 +280,7 @@ function createTools(specs: ToolSpec[] | undefined): FunctionTool[] | undefined 
   );
 }
 
+/** Build a system prompt from the agent config (string or JSON content blocks). */
 function buildSystemPrompt(config: AgentConfig): any {
   if (config.systemPromptBlocks) {
     return JSON.parse(config.systemPromptBlocks);
@@ -280,6 +288,7 @@ function buildSystemPrompt(config: AgentConfig): any {
   return config.systemPrompt ?? undefined;
 }
 
+/** Wrap a model in a Proxy that injects toolChoice into every stream() call. */
 function createToolChoiceProxy(baseModel: any, toolChoice: any): any {
   return new Proxy(baseModel, {
     get(target: any, prop: string | symbol, receiver: any) {
@@ -305,6 +314,7 @@ import {
   MessageAddedEvent,
 } from '@strands-agents/sdk';
 
+/** Bridges TS SDK lifecycle hooks to WIT StreamEvent lifecycle variants for the host. */
 class LifecycleBridge implements HookProvider {
   queue: StreamEvent[] = [];
 
@@ -341,6 +351,7 @@ class LifecycleBridge implements HookProvider {
   }
 }
 
+/** Parse user input — JSON arrays pass through, plain strings stay as-is. */
 function parseInput(input: string): any {
   try {
     const parsed = JSON.parse(input);
@@ -349,6 +360,7 @@ function parseInput(input: string): any {
   return input;
 }
 
+/** Build a SessionManager from the WIT session config. */
 function createSessionManager(config: AgentConfig): SessionManager | undefined {
   if (!config.session) return undefined;
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

New developers joining the WASM project face a steep onboarding curve. The WIT contract, WASM entry point, Python host, and conversion layer all lack inline documentation explaining what they do and how they connect. The CONTRIBUTING guide doesn't mention WASM or Python setup at all, and the README jumps straight into CLI commands without explaining the guest/host mental model.

These changes add targeted documentation across the WASM stack to reduce time-to-productivity for new contributors.

### Use Cases

- Read the README's "How it works" section to understand the guest/host split and why tools are imports but the agent API is an export
- Scan entry.ts function signatures to understand what each bridge function does without reading the implementation
- Open _wasm_host.py and immediately see the data flow diagram showing what crosses the WASM boundary in each direction
- Follow CONTRIBUTING.md to set up the Python venv and run integration tests without trial and error

### Changes
- strands-wasm/README.md — Added "How it works" section explaining exports vs imports, guest vs host
- strands-wasm/entry.ts — Added JSDoc one-liners to all bridge functions (mapEvent, createModel, createTools, etc.)
- strands-py/strands/_wasm_host.py — Expanded module docstring with data flow diagram
- strands-py/strands/_conversions.py — Documented the TS vs Python message format difference
- CONTRIBUTING.md — Added WASM/Python development section with venv setup and test commands

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update


## Testing

How have you tested the change?

- [ ] I ran `npm run check`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
