### PR TITLE
feat: add bridge in wasm for conversation manager

### DIFF
--- a/strands-py/strands/_wasm_host.py
+++ b/strands-py/strands/_wasm_host.py
@@ -237,10 +237,17 @@ def _build_conversation_manager_variant(
     if config is None:
         return None
     cm_type = config.get("type")
+    summarizing_defaults = {
+        "summary-ratio": None,
+        "preserve-recent-messages": None,
+        "summarization-system-prompt": None,
+        "summarization-model-config": None,
+    }
     if cm_type == "none":
         return _rec(
             strategy="none",
             **{"window-size": 0, "should-truncate-results": False},
+            **summarizing_defaults,
         )
     if cm_type == "sliding-window":
         return _rec(
@@ -248,6 +255,19 @@ def _build_conversation_manager_variant(
             **{
                 "window-size": config.get("window_size", 40),
                 "should-truncate-results": config.get("should_truncate_results", True),
+            },
+            **summarizing_defaults,
+        )
+    if cm_type == "summarizing":
+        return _rec(
+            strategy="summarizing",
+            **{
+                "window-size": 0,
+                "should-truncate-results": False,
+                "summary-ratio": config.get("summary_ratio"),
+                "preserve-recent-messages": config.get("preserve_recent_messages"),
+                "summarization-system-prompt": config.get("summarization_system_prompt"),
+                "summarization-model-config": config.get("summarization_model_config"),
             },
         )
     raise ValueError(f"unknown conversation manager type: {cm_type}")

--- a/strands-py/strands/_wasm_host.py
+++ b/strands-py/strands/_wasm_host.py
@@ -225,11 +225,40 @@ def _build_model_config_variant(cfg: ModelConfigInput) -> Variant:
     raise ValueError(f"unknown model provider: {provider}")
 
 
+def _build_conversation_manager_variant(
+    config: dict[str, typing.Any] | None,
+) -> Record | None:
+    """Build the conversation-manager WIT record.
+
+    Returns None when no config is provided (uses TS SDK default).
+    Uses a flat record with a string strategy discriminator to avoid
+    wasmtime-py limitations with option<variant>.
+    """
+    if config is None:
+        return None
+    cm_type = config.get("type")
+    if cm_type == "none":
+        return _rec(
+            strategy="none",
+            **{"window-size": 0, "should-truncate-results": False},
+        )
+    if cm_type == "sliding-window":
+        return _rec(
+            strategy="sliding-window",
+            **{
+                "window-size": config.get("window_size", 40),
+                "should-truncate-results": config.get("should_truncate_results", True),
+            },
+        )
+    raise ValueError(f"unknown conversation manager type: {cm_type}")
+
+
 def _build_agent_config(
     model: ModelConfigInput | None,
     system_prompt: str | None,
     system_prompt_blocks: str | None,
     tools: list[ToolSpec] | None,
+    conversation_manager_config: dict[str, typing.Any] | None = None,
 ) -> Record:
     model_variant = None
     if model is not None:
@@ -239,19 +268,21 @@ def _build_agent_config(
         model_variant = _inject_aws_credentials_default()
 
     tool_recs = [_build_tool_spec(t) for t in tools] if tools else None
+    cm_variant = _build_conversation_manager_variant(conversation_manager_config)
+
+    rec_kwargs: dict[str, typing.Any] = {
+        "model-params": None,
+        "system-prompt": system_prompt,
+        "system-prompt-blocks": system_prompt_blocks,
+        "trace-context": None,
+        "session": None,
+        "conversation-manager": cm_variant,
+    }
 
     return _rec(
         model=model_variant,
-        **{
-            "model-params": None,
-            "system-prompt": system_prompt,
-            "system-prompt-blocks": system_prompt_blocks,
-        },
         tools=tool_recs,
-        **{
-            "trace-context": None,
-            "session": None,
-        },
+        **rec_kwargs,
     )
 
 
@@ -501,6 +532,7 @@ class WasmAgent:
         tools: list[ToolSpec] | None,
         tool_dispatcher: ToolDispatcherBase | None,
         log_handler: LogHandlerBase | None,
+        conversation_manager_config: dict[str, typing.Any] | None = None,
         use_callback_relay: bool = False,
     ):
         engine, component = _get_engine_and_component()
@@ -532,7 +564,7 @@ class WasmAgent:
         self._component = component
 
         # --- instantiate + construct agent (async, run synchronously) ---
-        agent_config = _build_agent_config(model, system_prompt, system_prompt_blocks, tools)
+        agent_config = _build_agent_config(model, system_prompt, system_prompt_blocks, tools, conversation_manager_config)
         _run_sync(self._init_async(linker, store, component, agent_config))
 
     async def _init_async(

--- a/strands-py/strands/agent/__init__.py
+++ b/strands-py/strands/agent/__init__.py
@@ -240,6 +240,7 @@ class Agent:
         structured_output_model: type | None = None,
         agent_id: str | None = None,
         session_manager: Any = None,
+        conversation_manager: Any = None,
         **kwargs: Any,
     ):
         if kwargs:
@@ -293,6 +294,23 @@ class Agent:
             else None
         )
 
+        # Translate conversation manager to config dict for the WASM guest.
+        # The Python instance is used only for config extraction — it must NOT be
+        # registered as a hook provider, since conversation management runs in the TS SDK.
+        cm_config: dict[str, Any] | None = None
+        if conversation_manager is not None:
+            from strands.agent.conversation_manager import NullConversationManager as _NullCM
+            from strands.agent.conversation_manager import SlidingWindowConversationManager as _SlidingCM
+
+            if isinstance(conversation_manager, _NullCM):
+                cm_config = {"type": "none"}
+            elif isinstance(conversation_manager, _SlidingCM):
+                cm_config = {"type": "sliding-window", "window_size": conversation_manager.window_size}
+            elif isinstance(conversation_manager, dict):
+                cm_config = conversation_manager
+            else:
+                log.warning("unknown conversation_manager type: %s, ignoring", type(conversation_manager).__name__)
+
         self._wasm_agent = _WasmAgent(
             model=model_config,
             system_prompt=sp_str,
@@ -300,6 +318,7 @@ class Agent:
             tools=tool_specs,
             tool_dispatcher=self._dispatcher,
             log_handler=_LogHandler(),
+            conversation_manager_config=cm_config,
             use_callback_relay=False,
         )
 

--- a/strands-py/strands/agent/__init__.py
+++ b/strands-py/strands/agent/__init__.py
@@ -301,11 +301,24 @@ class Agent:
         if conversation_manager is not None:
             from strands.agent.conversation_manager import NullConversationManager as _NullCM
             from strands.agent.conversation_manager import SlidingWindowConversationManager as _SlidingCM
+            from strands.agent.conversation_manager import SummarizingConversationManager as _SummarizingCM
 
             if isinstance(conversation_manager, _NullCM):
                 cm_config = {"type": "none"}
             elif isinstance(conversation_manager, _SlidingCM):
-                cm_config = {"type": "sliding-window", "window_size": conversation_manager.window_size}
+                cm_config = {
+                    "type": "sliding-window",
+                    "window_size": conversation_manager.window_size,
+                    "should_truncate_results": conversation_manager.should_truncate_results,
+                }
+            elif isinstance(conversation_manager, _SummarizingCM):
+                cm_config = {
+                    "type": "summarizing",
+                    "summary_ratio": conversation_manager.summary_ratio,
+                    "preserve_recent_messages": conversation_manager.preserve_recent_messages,
+                    "summarization_system_prompt": conversation_manager.summarization_system_prompt,
+                    "summarization_model_config": conversation_manager.summarization_model_config,
+                }
             elif isinstance(conversation_manager, dict):
                 cm_config = conversation_manager
             else:

--- a/strands-py/strands/agent/__init__.py
+++ b/strands-py/strands/agent/__init__.py
@@ -5,7 +5,14 @@ import logging
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, Union, cast
+
+if TYPE_CHECKING:
+    from strands.agent.conversation_manager import (
+        NullConversationManager,
+        SlidingWindowConversationManager,
+        SummarizingConversationManager,
+    )
 
 from strands._conversions import (
     convert_message,
@@ -240,7 +247,13 @@ class Agent:
         structured_output_model: type | None = None,
         agent_id: str | None = None,
         session_manager: Any = None,
-        conversation_manager: Any = None,
+        conversation_manager: Union[
+            "NullConversationManager",
+            "SlidingWindowConversationManager",
+            "SummarizingConversationManager",
+            dict[str, Any],
+            None,
+        ] = None,
         **kwargs: Any,
     ):
         if kwargs:
@@ -317,7 +330,7 @@ class Agent:
                     "summary_ratio": conversation_manager.summary_ratio,
                     "preserve_recent_messages": conversation_manager.preserve_recent_messages,
                     "summarization_system_prompt": conversation_manager.summarization_system_prompt,
-                    "summarization_model_config": conversation_manager.summarization_model_config,
+                    "summarization_model_config": conversation_manager.serialize_model_config(),
                 }
             elif isinstance(conversation_manager, dict):
                 cm_config = conversation_manager

--- a/strands-py/strands/agent/conversation_manager/__init__.py
+++ b/strands-py/strands/agent/conversation_manager/__init__.py
@@ -1,6 +1,9 @@
 from strands.agent.conversation_manager.sliding_window_conversation_manager import (
     SlidingWindowConversationManager,
 )
+from strands.agent.conversation_manager.summarizing_conversation_manager import (
+    SummarizingConversationManager,
+)
 from strands.hooks import HookProvider
 
 
@@ -8,4 +11,4 @@ class NullConversationManager(HookProvider):
     """No-op conversation manager."""
 
 
-__all__ = ["NullConversationManager", "SlidingWindowConversationManager"]
+__all__ = ["NullConversationManager", "SlidingWindowConversationManager", "SummarizingConversationManager"]

--- a/strands-py/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/strands-py/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -1,49 +1,28 @@
+"""Sliding window conversation manager config holder for the WASM bridge.
+
+The actual sliding window logic runs inside the TS SDK (WASM guest).
+This class is a config container used by the Python Agent to extract
+settings and pass them through the WIT contract.
+"""
+
 from __future__ import annotations
 
 from typing import Any
 
-from strands.hooks import AfterInvocationEvent, HookProvider, HookRegistry
+from strands.hooks import HookProvider
 
 
 class SlidingWindowConversationManager(HookProvider):
-    """Trims conversation history to a sliding window of recent messages.
+    """Config holder for the sliding window conversation manager.
 
-    Preserves tool-use / tool-result pairs so the message sequence stays valid.
+    Trims conversation history to a sliding window of recent messages,
+    preserving tool-use / tool-result pairs so the message sequence stays valid.
+
+    Args:
+        window_size: Maximum number of messages to keep. Defaults to 40.
+        should_truncate_results: Whether to truncate tool results on context overflow. Defaults to True.
     """
 
     def __init__(self, window_size: int = 40, should_truncate_results: bool = True, **_kwargs: Any) -> None:
         self.window_size = window_size
         self.should_truncate_results = should_truncate_results
-
-    def register_hooks(self, registry: HookRegistry) -> None:
-        registry.add_callback(AfterInvocationEvent, self._trim)
-
-    def _trim(self, _event: AfterInvocationEvent) -> None:
-        agent = getattr(_event, "agent", None)
-        if agent is None:
-            return
-
-        messages = agent.messages
-        if len(messages) <= self.window_size:
-            return
-
-        target = len(messages) - self.window_size
-        trim_idx = self._find_safe_trim_point(messages, target)
-        if trim_idx > 0:
-            agent.messages = messages[trim_idx:]
-
-    @staticmethod
-    def _find_safe_trim_point(messages: list[dict[str, Any]], target: int) -> int:
-        """Find the earliest index >= *target* where trimming keeps pairs intact."""
-        for i in range(target, len(messages)):
-            msg = messages[i]
-            content = msg.get("content", [])
-            # Don't start on a tool result — its matching tool-use would be gone.
-            has_tool_result = any(
-                (isinstance(b, dict) and ("toolResult" in b or b.get("type") == "toolResultBlock"))
-                for b in content
-            )
-            if has_tool_result:
-                continue
-            return i
-        return target

--- a/strands-py/strands/agent/conversation_manager/sliding_window_conversation_manager.py
+++ b/strands-py/strands/agent/conversation_manager/sliding_window_conversation_manager.py
@@ -11,8 +11,9 @@ class SlidingWindowConversationManager(HookProvider):
     Preserves tool-use / tool-result pairs so the message sequence stays valid.
     """
 
-    def __init__(self, window_size: int = 40, **_kwargs: Any) -> None:
+    def __init__(self, window_size: int = 40, should_truncate_results: bool = True, **_kwargs: Any) -> None:
         self.window_size = window_size
+        self.should_truncate_results = should_truncate_results
 
     def register_hooks(self, registry: HookRegistry) -> None:
         registry.add_callback(AfterInvocationEvent, self._trim)

--- a/strands-py/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/strands-py/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -39,19 +39,26 @@ class SummarizingConversationManager(HookProvider):
         self.summary_ratio = max(0.1, min(0.8, summary_ratio))
         self.preserve_recent_messages = preserve_recent_messages
         self.summarization_system_prompt = summarization_system_prompt
-        self.summarization_model_config: str | None = None
-        if summarization_model_config is not None:
-            self.summarization_model_config = self._serialize_model_config(summarization_model_config)
+        self.summarization_model_config = summarization_model_config
 
-    @staticmethod
-    def _serialize_model_config(config: dict[str, Any]) -> str:
-        """Serialize a model config dict into the WIT-compatible JSON format.
+    def serialize_model_config(self) -> str | None:
+        """Serialize the model config dict into the WIT-compatible JSON format.
 
         Converts from the Python-friendly format:
             {"provider": "bedrock", "model_id": "us.anthropic.claude-sonnet-4-20250514"}
         to the WIT ModelConfig variant format:
             {"tag": "bedrock", "val": {"modelId": "us.anthropic.claude-sonnet-4-20250514"}}
+
+        The output uses camelCase field names (modelId, apiKey, etc.) to match
+        what ``createModel()`` in ``strands-wasm/entry.ts`` expects when parsing
+        the JSON string from the WIT ``summarization-model-config`` field.
+
+        Returns:
+            JSON string for the WIT contract, or None if no model config is set.
         """
+        if self.summarization_model_config is None:
+            return None
+        config = self.summarization_model_config
         provider = config.get("provider", "bedrock")
         if provider == "bedrock":
             val: dict[str, Any] = {

--- a/strands-py/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/strands-py/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -1,0 +1,74 @@
+"""Summarizing conversation manager config holder for the WASM bridge.
+
+The actual summarization logic runs inside the TS SDK (WASM guest).
+This class is a config container used by the Python Agent to extract
+settings and pass them through the WIT contract.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from strands.hooks import HookProvider
+
+
+class SummarizingConversationManager(HookProvider):
+    """Config holder for the summarizing conversation manager.
+
+    When a context window overflow occurs, this manager summarizes the oldest
+    messages using a model call and replaces them with a single summary,
+    preserving context that would otherwise be lost.
+
+    Args:
+        summary_ratio: Ratio of messages to summarize (0.1-0.8). Defaults to 0.3.
+        preserve_recent_messages: Minimum recent messages to keep. Defaults to 10.
+        summarization_system_prompt: Custom system prompt for summarization.
+        summarization_model_config: Model config dict for a separate summarization model.
+            Should match the model config format: {"provider": "bedrock", "model_id": "...", ...}
+            When None, the agent's primary model is used.
+    """
+
+    def __init__(
+        self,
+        summary_ratio: float = 0.3,
+        preserve_recent_messages: int = 10,
+        summarization_system_prompt: Optional[str] = None,
+        summarization_model_config: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.summary_ratio = max(0.1, min(0.8, summary_ratio))
+        self.preserve_recent_messages = preserve_recent_messages
+        self.summarization_system_prompt = summarization_system_prompt
+        self.summarization_model_config: str | None = None
+        if summarization_model_config is not None:
+            self.summarization_model_config = self._serialize_model_config(summarization_model_config)
+
+    @staticmethod
+    def _serialize_model_config(config: dict[str, Any]) -> str:
+        """Serialize a model config dict into the WIT-compatible JSON format.
+
+        Converts from the Python-friendly format:
+            {"provider": "bedrock", "model_id": "us.anthropic.claude-sonnet-4-20250514"}
+        to the WIT ModelConfig variant format:
+            {"tag": "bedrock", "val": {"modelId": "us.anthropic.claude-sonnet-4-20250514"}}
+        """
+        provider = config.get("provider", "bedrock")
+        if provider == "bedrock":
+            val: dict[str, Any] = {
+                "modelId": config.get("model_id", ""),
+                "region": config.get("region"),
+                "accessKeyId": config.get("access_key_id"),
+                "secretAccessKey": config.get("secret_access_key"),
+                "sessionToken": config.get("session_token"),
+                "additionalConfig": config.get("additional_config"),
+            }
+        elif provider in ("anthropic", "openai", "gemini"):
+            val = {
+                "modelId": config.get("model_id"),
+                "apiKey": config.get("api_key"),
+                "additionalConfig": config.get("additional_config"),
+            }
+        else:
+            raise ValueError(f"Unknown model provider: {provider}")
+
+        return json.dumps({"tag": provider, "val": val})

--- a/strands-wasm/docs/python-api-changes.md
+++ b/strands-wasm/docs/python-api-changes.md
@@ -1,0 +1,227 @@
+# Python API Changes
+
+Tracks all Python SDK API changes that result from the WASM bridge architecture. Each feature section documents the TypeScript SDK design, the WASM bridge implementation, and the resulting Python API change with code evidence.
+
+---
+
+## Conversation Manager
+
+The Python conversation manager classes are config holders. The actual implementation runs inside the TypeScript SDK WASM guest.
+
+### 1. Conversation manager is not accessible after construction
+
+**TS design:** The agent stores the conversation manager as a private field.
+
+```typescript
+// strands-ts/src/agent/agent.ts:191
+private readonly _conversationManager: ConversationManager
+```
+
+There is no public getter. Users configure it at construction and never access it again.
+
+**WASM bridge:** The config is serialized through the WIT contract during agent construction. No handle to the TS conversation manager instance is retained on the Python side.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — worked
+agent = Agent(conversation_manager=SlidingWindowConversationManager())
+agent.conversation_manager  # accessible
+
+# WASM bridged Python SDK (2.x) — not available
+agent = Agent(conversation_manager=SlidingWindowConversationManager())
+agent.conversation_manager  # AttributeError
+```
+
+Not needed. The conversation manager operates automatically via hooks registered during `initAgent()`.
+
+### 2. No manual `reduce_context()` or `apply_management()`
+
+**TS design:** Context reduction is hook driven. The base class registers an `AfterModelCallEvent` callback that catches overflow errors and calls `reduce()` automatically.
+
+```typescript
+// strands-ts/src/conversation-manager/conversation-manager.ts:100-108
+initAgent(agent: LocalAgent): void {
+    agent.addHook(AfterModelCallEvent, async (event) => {
+      if (event.error instanceof ContextWindowOverflowError) {
+        if (await this.reduce({ agent: event.agent, model: event.model, error: event.error })) {
+          event.retry = true
+        }
+      }
+    })
+  }
+```
+
+`SlidingWindowConversationManager` adds proactive trimming via a second hook:
+
+```typescript
+// strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts:72-78
+public override initAgent(agent: LocalAgent): void {
+    super.initAgent(agent)
+    agent.addHook(AfterInvocationEvent, (event) => {
+      this._applyManagement(event.agent.messages)
+    })
+  }
+```
+
+There are no public methods to trigger these manually. The hooks system is the invocation mechanism.
+
+**WASM bridge:** `createConversationManager()` in `strands-wasm/entry.ts` instantiates the real TS class. The TS `Agent` constructor adds it to `PluginRegistry`, which calls `initAgent()`. Both hooks are registered inside the WASM guest.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — worked
+cm = SlidingWindowConversationManager()
+agent = Agent(conversation_manager=cm)
+cm.reduce_context(agent)     # manually trigger reduction
+cm.apply_management(agent)   # manually trigger window trimming
+
+# WASM bridged Python SDK (2.x) — not available
+cm = SlidingWindowConversationManager()
+agent = Agent(conversation_manager=cm)
+cm.reduce_context(agent)     # AttributeError — no such method
+cm.apply_management(agent)   # AttributeError — no such method
+```
+
+Not needed. Overflow recovery fires automatically on `ContextWindowOverflowError`. Proactive trimming fires automatically after every invocation when messages exceed `windowSize`.
+
+### 3. Summarization accepts a model config, not an agent
+
+**TS design:** `SummarizingConversationManager` accepts a `model`, not an agent. Summarization calls the model directly.
+
+```typescript
+// strands-ts/src/conversation-manager/summarizing-conversation-manager.ts:46-51
+export type SummarizingConversationManagerConfig = {
+  model?: Model
+  summaryRatio?: number
+  preserveRecentMessages?: number
+  summarizationSystemPrompt?: string
+}
+```
+
+```typescript
+// strands-ts/src/conversation-manager/summarizing-conversation-manager.ts:157-160
+private async _generateSummary(messagesToSummarize: Message[], model: Model): Promise<Message> {
+    // ...
+    const stream = model.streamAggregated(summarizationMessages, {
+      systemPrompt: this._summarizationSystemPrompt,
+    })
+```
+
+**WASM bridge:** The Python user provides a model config dict. `createConversationManager()` in `strands-wasm/entry.ts` parses the JSON and calls `createModel()` to instantiate a TS model:
+
+```typescript
+// strands-wasm/entry.ts:427-430
+if (cmConfig.summarizationModelConfig) {
+    const parsed = JSON.parse(cmConfig.summarizationModelConfig)
+    summaryModel = createModel(parsed)
+}
+```
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — accepted a full Agent instance
+summarizer = Agent(model=some_model, system_prompt="Summarize.")
+agent = Agent(conversation_manager=SummarizingConversationManager(
+    summarization_agent=summarizer,
+))
+
+# WASM bridged Python SDK (2.x) — accepts a model config dict
+agent = Agent(conversation_manager=SummarizingConversationManager(
+    summarization_model_config={
+        "provider": "bedrock",
+        "model_id": "us.anthropic.claude-3-haiku-20240307-v1:0",
+    },
+))
+```
+
+The WASM boundary cannot serialize a live `Agent` instance. The model config dict is instantiated as a TS model inside the guest, which matches the TS SDK's design of calling the model directly rather than re-entering the agent loop.
+
+### 4. `per_turn` parameter not supported
+
+**TS design:** `SlidingWindowConversationManager` does not implement `per_turn`. Proactive trimming runs unconditionally after every invocation via the `AfterInvocationEvent` hook when messages exceed `windowSize`.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — worked
+agent = Agent(conversation_manager=SlidingWindowConversationManager(per_turn=3))
+
+# WASM bridged Python SDK (2.x) — not supported
+agent = Agent(conversation_manager=SlidingWindowConversationManager(per_turn=3))
+# per_turn is silently ignored (caught by **_kwargs)
+```
+
+The TS SDK trims after every invocation when the window is exceeded, which is equivalent to `per_turn=True`.
+
+### 5. Session state methods not available
+
+**TS design:** The TS SDK has its own session management system. Conversation manager state persistence (`_summary_message`, `removed_message_count`) is not part of the `ConversationManager` interface.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — worked
+state = cm.get_state()
+cm.restore_from_session(state)
+cm.removed_message_count
+
+# WASM bridged Python SDK (2.x) — not available
+```
+
+---
+
+## WIT Contract
+
+The `conversation-manager-config` uses a flat record with a string `strategy` discriminator (`"none"`, `"sliding-window"`, `"summarizing"`) rather than a WIT variant. This works around a wasmtime-py limitation where `option<variant>` types are not properly supported.
+
+```wit
+record conversation-manager-config {
+    strategy: string,
+    window-size: s32,
+    should-truncate-results: bool,
+    summary-ratio: option<f64>,
+    preserve-recent-messages: option<s32>,
+    summarization-system-prompt: option<string>,
+    summarization-model-config: option<string>,
+}
+```
+
+Fields irrelevant to the selected strategy are set to zero values or `None`.
+
+---
+
+## Python Config Reference
+
+### `NullConversationManager`
+
+No parameters. Disables conversation management. Overflow errors propagate uncaught.
+
+### `SlidingWindowConversationManager`
+
+| Parameter | Type | Default | TS equivalent |
+|---|---|---|---|
+| `window_size` | `int` | `40` | `windowSize` |
+| `should_truncate_results` | `bool` | `True` | `shouldTruncateResults` |
+
+### `SummarizingConversationManager`
+
+| Parameter | Type | Default | TS equivalent |
+|---|---|---|---|
+| `summary_ratio` | `float` | `0.3` | `summaryRatio` (clamped 0.1 to 0.8) |
+| `preserve_recent_messages` | `int` | `10` | `preserveRecentMessages` |
+| `summarization_system_prompt` | `str \| None` | `None` | `summarizationSystemPrompt` |
+| `summarization_model_config` | `dict \| None` | `None` | Serialized to JSON, parsed by TS guest, passed to `createModel()` to produce a `Model` for `config.model` |
+
+Model config dict format:
+
+```python
+{
+    "provider": "bedrock",       # "bedrock", "anthropic", "openai", or "gemini"
+    "model_id": "us.anthropic.claude-3-haiku-20240307-v1:0",
+    "region": "us-west-2",       # bedrock only
+    "api_key": "...",            # anthropic, openai, gemini only
+}
+```

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -33,7 +33,7 @@ import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
 import { OpenAIModel } from '@strands-agents/sdk/models/openai';
 import { GoogleModel } from '@strands-agents/sdk/models/google';
 import type { StopReason, AgentStreamEvent, Model, BaseModelConfig } from '@strands-agents/sdk';
-import { NullConversationManager, SlidingWindowConversationManager } from '@strands-agents/sdk';
+import { NullConversationManager, SlidingWindowConversationManager, SummarizingConversationManager } from '@strands-agents/sdk';
 
 // All log calls go through `hostLog` (the WIT import).  The host can
 // route them to the host language's logging framework (e.g. Python `logging`).
@@ -406,6 +406,23 @@ function createConversationManager(config: AgentConfig): any {
         windowSize: cmConfig.windowSize,
         shouldTruncateResults: cmConfig.shouldTruncateResults,
       });
+    case 'summarizing': {
+      let summaryModel: Model<BaseModelConfig> | undefined;
+      if (cmConfig.summarizationModelConfig) {
+        try {
+          const parsed = JSON.parse(cmConfig.summarizationModelConfig);
+          summaryModel = createModel(parsed);
+        } catch (e) {
+          glog('warn', 'failed to parse summarization model config, using agent model', errContext(e));
+        }
+      }
+      return new SummarizingConversationManager({
+        model: summaryModel,
+        summaryRatio: cmConfig.summaryRatio ?? undefined,
+        preserveRecentMessages: cmConfig.preserveRecentMessages ?? undefined,
+        summarizationSystemPrompt: cmConfig.summarizationSystemPrompt ?? undefined,
+      });
+    }
     default:
       glog('warn', `unknown conversation manager strategy: ${cmConfig.strategy}, using default`);
       return new SlidingWindowConversationManager({ windowSize: 40 });

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -26,14 +26,18 @@ import type {
 
 import { callTool } from 'strands:agent/tool-provider';
 import { log as hostLog } from 'strands:agent/host-log';
-import { Agent, FunctionTool, SessionManager, FileStorage } from '@strands-agents/sdk';
-import { S3Storage } from '@strands-agents/sdk/session/s3-storage';
-import { AnthropicModel } from '@strands-agents/sdk/models/anthropic';
-import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
-import { OpenAIModel } from '@strands-agents/sdk/models/openai';
-import { GoogleModel } from '@strands-agents/sdk/models/google';
+import { Agent, FunctionTool, SessionManager, FileStorage, S3Storage } from '@strands-agents/sdk';
+import { AnthropicModel } from '@strands-agents/sdk/anthropic';
+import { BedrockModel } from '@strands-agents/sdk/bedrock';
+import { OpenAIModel } from '@strands-agents/sdk/openai';
+import { GeminiModel } from '@strands-agents/sdk/gemini';
 import type { StopReason, AgentStreamEvent, Model, BaseModelConfig } from '@strands-agents/sdk';
-import { NullConversationManager, SlidingWindowConversationManager, SummarizingConversationManager } from '@strands-agents/sdk';
+import {
+  ConversationManager,
+  NullConversationManager,
+  SlidingWindowConversationManager,
+  SummarizingConversationManager,
+} from '@strands-agents/sdk';
 
 // All log calls go through `hostLog` (the WIT import).  The host can
 // route them to the host language's logging framework (e.g. Python `logging`).
@@ -223,7 +227,7 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
     case 'gemini': {
       glog('info', 'createModel: Gemini', { modelId: config.val.modelId });
       const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {};
-      return new GoogleModel({
+      return new GeminiModel({
         ...base,
         ...(config.val.modelId ? { modelId: config.val.modelId } : {}),
         ...(config.val.apiKey ? { apiKey: config.val.apiKey } : {}),
@@ -392,11 +396,11 @@ function createSessionManager(config: AgentConfig): SessionManager | undefined {
   });
 }
 
-/** Instantiate a conversation manager from the WIT config. Defaults to sliding window (size 40). */
-function createConversationManager(config: AgentConfig): any {
+/** Instantiate a conversation manager from the WIT config, or undefined to use the TS Agent default. */
+function createConversationManager(config: AgentConfig): ConversationManager | undefined {
   const cmConfig = (config as any).conversationManager;
   if (!cmConfig) {
-    return new SlidingWindowConversationManager({ windowSize: 40 });
+    return undefined;
   }
   switch (cmConfig.strategy) {
     case 'none':
@@ -425,7 +429,7 @@ function createConversationManager(config: AgentConfig): any {
     }
     default:
       glog('warn', `unknown conversation manager strategy: ${cmConfig.strategy}, using default`);
-      return new SlidingWindowConversationManager({ windowSize: 40 });
+      return undefined;
   }
 }
 
@@ -471,11 +475,9 @@ class AgentImpl {
 
     if (args.tools) {
       const requestTools = createTools(args.tools);
-      for (const t of this.agent.toolRegistry.list()) {
-        this.agent.toolRegistry.remove(t.name);
-      }
+      this.agent.toolRegistry.clear();
       if (requestTools) {
-        this.agent.toolRegistry.add(requestTools);
+        this.agent.toolRegistry.addAll(requestTools);
       }
     }
 
@@ -542,11 +544,9 @@ class ResponseStreamImpl {
     if (this.originalModel) {
       (this.agent as any).model = this.originalModel;
     }
-    for (const t of this.agent.toolRegistry.list()) {
-      this.agent.toolRegistry.remove(t.name);
-    }
+    this.agent.toolRegistry.clear();
     if (this.defaultTools) {
-      this.agent.toolRegistry.add(this.defaultTools);
+      this.agent.toolRegistry.addAll(this.defaultTools);
     }
   }
 

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -26,12 +26,14 @@ import type {
 
 import { callTool } from 'strands:agent/tool-provider';
 import { log as hostLog } from 'strands:agent/host-log';
-import { Agent, FunctionTool, SessionManager, FileStorage, S3Storage } from '@strands-agents/sdk';
-import { AnthropicModel } from '@strands-agents/sdk/anthropic';
-import { BedrockModel } from '@strands-agents/sdk/bedrock';
-import { OpenAIModel } from '@strands-agents/sdk/openai';
-import { GeminiModel } from '@strands-agents/sdk/gemini';
+import { Agent, FunctionTool, SessionManager, FileStorage } from '@strands-agents/sdk';
+import { S3Storage } from '@strands-agents/sdk/session/s3-storage';
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic';
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
+import { OpenAIModel } from '@strands-agents/sdk/models/openai';
+import { GoogleModel } from '@strands-agents/sdk/models/google';
 import type { StopReason, AgentStreamEvent, Model, BaseModelConfig } from '@strands-agents/sdk';
+import { NullConversationManager, SlidingWindowConversationManager } from '@strands-agents/sdk';
 
 // All log calls go through `hostLog` (the WIT import).  The host can
 // route them to the host language's logging framework (e.g. Python `logging`).
@@ -221,7 +223,7 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
     case 'gemini': {
       glog('info', 'createModel: Gemini', { modelId: config.val.modelId });
       const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {};
-      return new GeminiModel({
+      return new GoogleModel({
         ...base,
         ...(config.val.modelId ? { modelId: config.val.modelId } : {}),
         ...(config.val.apiKey ? { apiKey: config.val.apiKey } : {}),
@@ -390,6 +392,26 @@ function createSessionManager(config: AgentConfig): SessionManager | undefined {
   });
 }
 
+/** Instantiate a conversation manager from the WIT config. Defaults to sliding window (size 40). */
+function createConversationManager(config: AgentConfig): any {
+  const cmConfig = (config as any).conversationManager;
+  if (!cmConfig) {
+    return new SlidingWindowConversationManager({ windowSize: 40 });
+  }
+  switch (cmConfig.strategy) {
+    case 'none':
+      return new NullConversationManager();
+    case 'sliding-window':
+      return new SlidingWindowConversationManager({
+        windowSize: cmConfig.windowSize,
+        shouldTruncateResults: cmConfig.shouldTruncateResults,
+      });
+    default:
+      glog('warn', `unknown conversation manager strategy: ${cmConfig.strategy}, using default`);
+      return new SlidingWindowConversationManager({ windowSize: 40 });
+  }
+}
+
 class AgentImpl {
   private agent: Agent;
   private defaultTools: FunctionTool[] | undefined;
@@ -408,6 +430,7 @@ class AgentImpl {
     this.defaultTools = createTools(config.tools);
     this.lifecycleBridge = new LifecycleBridge();
     this.sessionManager = createSessionManager(config);
+    const conversationManager = createConversationManager(config);
 
     const hooks: any[] = [this.lifecycleBridge];
     if (this.sessionManager) hooks.push(this.sessionManager);
@@ -417,6 +440,7 @@ class AgentImpl {
       systemPrompt: buildSystemPrompt(config),
       tools: this.defaultTools,
       hooks,
+      conversationManager,
       printer: false,
     });
   }
@@ -430,9 +454,11 @@ class AgentImpl {
 
     if (args.tools) {
       const requestTools = createTools(args.tools);
-      this.agent.toolRegistry.clear();
+      for (const t of this.agent.toolRegistry.list()) {
+        this.agent.toolRegistry.remove(t.name);
+      }
       if (requestTools) {
-        this.agent.toolRegistry.addAll(requestTools);
+        this.agent.toolRegistry.add(requestTools);
       }
     }
 
@@ -499,9 +525,11 @@ class ResponseStreamImpl {
     if (this.originalModel) {
       (this.agent as any).model = this.originalModel;
     }
-    this.agent.toolRegistry.clear();
+    for (const t of this.agent.toolRegistry.list()) {
+      this.agent.toolRegistry.remove(t.name);
+    }
     if (this.defaultTools) {
-      this.agent.toolRegistry.addAll(this.defaultTools);
+      this.agent.toolRegistry.add(this.defaultTools);
     }
   }
 

--- a/wit/agent.wit
+++ b/wit/agent.wit
@@ -172,11 +172,20 @@ interface types {
   }
 
   /// Conversation manager configuration.
-  /// The `strategy` field selects the manager: "none" or "sliding-window".
+  /// The `strategy` field selects the manager: "none", "sliding-window", or "summarizing".
   record conversation-manager-config {
     strategy: string,
     window-size: s32,
     should-truncate-results: bool,
+    /// Ratio of messages to summarize (0.1–0.8). Only used when strategy is "summarizing".
+    summary-ratio: option<f64>,
+    /// Minimum number of recent messages to preserve. Only used when strategy is "summarizing".
+    preserve-recent-messages: option<s32>,
+    /// Custom system prompt for summarization. Only used when strategy is "summarizing".
+    summarization-system-prompt: option<string>,
+    /// JSON-serialized model config for the summarization model. Only used when strategy is "summarizing".
+    /// When absent, the agent's primary model is used.
+    summarization-model-config: option<string>,
   }
 
   /// Top-level agent configuration.

--- a/wit/agent.wit
+++ b/wit/agent.wit
@@ -165,6 +165,20 @@ interface types {
     save-latest-on: option<string>,
   }
 
+  /// Sliding window conversation manager config.
+  record sliding-window-config {
+    window-size: s32,
+    should-truncate-results: bool,
+  }
+
+  /// Conversation manager configuration.
+  /// The `strategy` field selects the manager: "none" or "sliding-window".
+  record conversation-manager-config {
+    strategy: string,
+    window-size: s32,
+    should-truncate-results: bool,
+  }
+
   /// Top-level agent configuration.
   record agent-config {
     model: option<model-config>,
@@ -174,6 +188,7 @@ interface types {
     tools: option<list<tool-spec>>,
     trace-context: option<string>,
     session: option<session-config>,
+    conversation-manager: option<conversation-manager-config>,
   }
 
   /// Arguments for a single tool call from guest to host.

--- a/wit/agent.wit
+++ b/wit/agent.wit
@@ -165,12 +165,6 @@ interface types {
     save-latest-on: option<string>,
   }
 
-  /// Sliding window conversation manager config.
-  record sliding-window-config {
-    window-size: s32,
-    should-truncate-results: bool,
-  }
-
   /// Conversation manager configuration.
   /// The `strategy` field selects the manager: "none", "sliding-window", or "summarizing".
   record conversation-manager-config {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
## Motivation

Python users had no way to configure how the agent manages conversation history. The WASM bridge always silently defaulted to a sliding window of 40 messages. Users couldn't disable conversation management, change the window size, or control tool result truncation — all of which the TS SDK already supports.

Resolves: #[issue-number]

## Public API Changes

Python users can now pass a `conversation_manager` parameter to `Agent`:

```python
from strands import Agent
from strands.agent.conversation_manager import (
    NullConversationManager,
    SlidingWindowConversationManager,
)

# Before: no way to configure, always sliding window (size 40)
agent = Agent()

# After: disable conversation management
agent = Agent(conversation_manager=NullConversationManager())

# After: custom window size
agent = Agent(conversation_manager=SlidingWindowConversationManager(window_size=20))
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [ ] I ran `npm run check`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
