### PR TITLE
feat: add interventions primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,13 @@ sdk-typescript/
 │   │   │   ├── plugins.ts        # Multi-agent plugins
 │   │   │   └── index.ts
 │   │   │
+│   │   ├── interventions/         # Intervention system for authorization, guardrails, steering
+│   │   │   ├── __tests__/
+│   │   │   ├── actions.ts
+│   │   │   ├── handler.ts
+│   │   │   ├── registry.ts
+│   │   │   └── index.ts
+│   │   │
 │   │   ├── plugins/              # Plugin system
 │   │   │   ├── __tests__/
 │   │   │   ├── plugin.ts

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -447,8 +447,6 @@ export class Agent implements LocalAgent, InvokableAgent {
       })
     )
 
-    await this._interventionRegistry?.initialize(this)
-
     await this._pluginRegistry.initialize(this)
 
     await this._hooksRegistry.invokeCallbacks(new InitializedEvent({ agent: this }))

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -36,6 +36,8 @@ import { ToolRegistry } from '../registry/tool-registry.js'
 import { StateStore } from '../state-store.js'
 import { AgentPrinter, getDefaultAppender, type Printer } from './printer.js'
 import type { Plugin } from '../plugins/plugin.js'
+import type { InterventionHandler } from '../interventions/handler.js'
+import { InterventionRegistry } from '../interventions/registry.js'
 import { PluginRegistry } from '../plugins/registry.js'
 import { SlidingWindowConversationManager } from '../conversation-manager/sliding-window-conversation-manager.js'
 import { NullConversationManager } from '../conversation-manager/null-conversation-manager.js'
@@ -181,6 +183,10 @@ export type AgentConfig = {
    */
   retryStrategy?: RetryStrategy | RetryStrategy[] | null
   /**
+   * Intervention handlers evaluated in registration order at each lifecycle point.
+   */
+  interventions?: InterventionHandler[]
+  /**
    * Zod schema for structured output validation.
    */
   structuredOutputSchema?: z.ZodSchema
@@ -280,6 +286,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
   private readonly _hooksRegistry: HookRegistryImplementation
   private readonly _pluginRegistry: PluginRegistry
+  private readonly _interventionRegistry?: InterventionRegistry
   private _toolRegistry: ToolRegistry
   private _mcpClients: McpClient[]
   private _initialized: boolean
@@ -336,6 +343,10 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Initialize hooks registry
     this._hooksRegistry = new HookRegistryImplementation()
+
+    if (config?.interventions && config.interventions.length > 0) {
+      this._interventionRegistry = new InterventionRegistry(config.interventions, this._hooksRegistry)
+    }
 
     // `undefined` (omitted) → install the default; `null`/`[]` → explicit opt-out.
     const retryStrategies: RetryStrategy[] =
@@ -435,6 +446,8 @@ export class Agent implements LocalAgent, InvokableAgent {
         }
       })
     )
+
+    await this._interventionRegistry?.initialize(this)
 
     await this._pluginRegistry.initialize(this)
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -286,7 +286,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
   private readonly _hooksRegistry: HookRegistryImplementation
   private readonly _pluginRegistry: PluginRegistry
-  private readonly _interventionRegistry?: InterventionRegistry
+  private readonly _interventionRegistry: InterventionRegistry
   private _toolRegistry: ToolRegistry
   private _mcpClients: McpClient[]
   private _initialized: boolean
@@ -344,9 +344,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     // Initialize hooks registry
     this._hooksRegistry = new HookRegistryImplementation()
 
-    if (config?.interventions && config.interventions.length > 0) {
-      this._interventionRegistry = new InterventionRegistry(config.interventions, this._hooksRegistry)
-    }
+    this._interventionRegistry = new InterventionRegistry(config?.interventions ?? [], this._hooksRegistry)
 
     // `undefined` (omitted) → install the default; `null`/`[]` → explicit opt-out.
     const retryStrategies: RetryStrategy[] =

--- a/strands-ts/src/hooks/types.ts
+++ b/strands-ts/src/hooks/types.ts
@@ -47,8 +47,8 @@ export type HookCleanup = () => void
  */
 export const HookOrder = {
   SDK_FIRST: -100,
-  INTERVENTIONS_AFTER: -90,
+  INTERVENTION_OUTPUT: -90,
   DEFAULT: 0,
-  INTERVENTIONS_BEFORE: 90,
+  INTERVENTION_INPUT: 90,
   SDK_LAST: 100,
 } as const

--- a/strands-ts/src/hooks/types.ts
+++ b/strands-ts/src/hooks/types.ts
@@ -47,6 +47,8 @@ export type HookCleanup = () => void
  */
 export const HookOrder = {
   SDK_FIRST: -100,
+  INTERVENTIONS_AFTER: -90,
   DEFAULT: 0,
+  INTERVENTIONS_BEFORE: 90,
   SDK_LAST: 100,
 } as const

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -225,7 +225,7 @@ export type { Plugin } from './plugins/index.js'
 
 // Intervention system
 export { InterventionHandler } from './interventions/index.js'
-export { proceed, deny, guide, interrupt, transform } from './interventions/index.js'
+export { interventions } from './interventions/index.js'
 export type { OnError } from './interventions/index.js'
 
 // Retry

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -223,6 +223,11 @@ export type {
 // Plugin system
 export type { Plugin } from './plugins/index.js'
 
+// Intervention system
+export { InterventionHandler } from './interventions/index.js'
+export { proceed, deny, guide, interrupt, transform } from './interventions/index.js'
+export type { OnError } from './interventions/index.js'
+
 // Retry
 export {
   type BackoffContext,

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -225,7 +225,7 @@ export type { Plugin } from './plugins/index.js'
 
 // Intervention system
 export { InterventionHandler } from './interventions/index.js'
-export { interventions } from './interventions/index.js'
+export { InterventionActions } from './interventions/index.js'
 export type { OnError } from './interventions/index.js'
 
 // Retry

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -224,8 +224,7 @@ export type {
 export type { Plugin } from './plugins/index.js'
 
 // Intervention system
-export { InterventionHandler } from './interventions/index.js'
-export { InterventionActions } from './interventions/index.js'
+export { InterventionHandler, InterventionActions } from './interventions/index.js'
 export type { OnError } from './interventions/index.js'
 
 // Retry

--- a/strands-ts/src/interventions/__tests__/handler.test.ts
+++ b/strands-ts/src/interventions/__tests__/handler.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { InterventionHandler } from '../handler.js'
+import { Agent } from '../../agent/agent.js'
+import { BeforeToolCallEvent, AfterModelCallEvent } from '../../hooks/events.js'
+import type { InterventionAction } from '../actions.js'
+
+class NoOpHandler extends InterventionHandler {
+  readonly name = 'no-op'
+}
+
+class ToolOnlyHandler extends InterventionHandler {
+  readonly name = 'tool-only'
+
+  override beforeToolCall(): InterventionAction {
+    return { type: 'deny', reason: 'blocked' }
+  }
+}
+
+describe('InterventionHandler', () => {
+  const agent = new Agent()
+  const toolUse = { name: 'test', toolUseId: 'id', input: {} }
+
+  it('default methods return proceed', () => {
+    const handler = new NoOpHandler()
+
+    expect(
+      handler.beforeToolCall(new BeforeToolCallEvent({ agent, toolUse, tool: undefined, invocationState: {} }))
+    ).toEqual({
+      type: 'proceed',
+    })
+    expect(
+      handler.afterModelCall(
+        new AfterModelCallEvent({ agent, model: {} as never, invocationState: {}, attemptCount: 0 })
+      )
+    ).toEqual({
+      type: 'proceed',
+    })
+  })
+
+  it('override detection works via prototype comparison', () => {
+    const noOp = new NoOpHandler()
+    const toolOnly = new ToolOnlyHandler()
+
+    expect(noOp.beforeToolCall).toBe(InterventionHandler.prototype.beforeToolCall)
+    expect(noOp.afterModelCall).toBe(InterventionHandler.prototype.afterModelCall)
+
+    expect(toolOnly.beforeToolCall).not.toBe(InterventionHandler.prototype.beforeToolCall)
+    expect(toolOnly.afterModelCall).toBe(InterventionHandler.prototype.afterModelCall)
+  })
+})

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -644,7 +644,7 @@ describe('InterventionRegistry', () => {
       new InterventionRegistry([new InterruptOnInvocation()], hookRegistry)
 
       await hookRegistry.invokeCallbacks(makeBeforeInvocationEvent())
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('has no effect on this event type'))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('has no effect'))
 
       warnSpy.mockRestore()
     })

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -485,41 +485,6 @@ describe('InterventionRegistry', () => {
     })
   })
 
-  describe('initAgent', () => {
-    it('is called during initialize()', async () => {
-      const initFn = vi.fn()
-
-      class InitHandler extends InterventionHandler {
-        readonly name = 'init-handler'
-        override initAgent(): void {
-          initFn()
-        }
-      }
-
-      const registry = new InterventionRegistry([new InitHandler()], hookRegistry)
-      expect(initFn).not.toHaveBeenCalled()
-
-      await registry.initialize({} as never)
-      expect(initFn).toHaveBeenCalledOnce()
-    })
-
-    it('only runs once even if called multiple times', async () => {
-      const initFn = vi.fn()
-
-      class InitHandler extends InterventionHandler {
-        readonly name = 'init-handler'
-        override initAgent(): void {
-          initFn()
-        }
-      }
-
-      const registry = new InterventionRegistry([new InitHandler()], hookRegistry)
-      await registry.initialize({} as never)
-      await registry.initialize({} as never)
-      expect(initFn).toHaveBeenCalledOnce()
-    })
-  })
-
   describe('agent integration', () => {
     it('deny on beforeToolCall prevents tool execution', async () => {
       const { MockMessageModel } = await import('../../__fixtures__/mock-message-model.js')
@@ -662,19 +627,26 @@ describe('InterventionRegistry', () => {
       await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow('apply boom')
     })
 
-    it('initAgent throwing leaves registry uninitialized for retry', async () => {
-      class FailingInit extends InterventionHandler {
-        readonly name = 'failing-init'
-        override initAgent(): void {
-          throw new Error('init failed')
+    it('warns when action has no effect on event type', async () => {
+      const { logger } = await import('../../logging/logger.js')
+      const warnSpy = vi.spyOn(logger, 'warn')
+
+      // Force an interrupt return on beforeInvocation (which doesn't support it)
+      // via cast to test the runtime warning path
+      class InterruptOnInvocation extends InterventionHandler {
+        readonly name = 'interrupt-invocation'
+        override beforeInvocation() {
+          // Force an interrupt return via any cast to test the runtime warning
+          return { type: 'interrupt', prompt: 'test' } as never
         }
       }
 
-      const registry = new InterventionRegistry([new FailingInit()], hookRegistry)
+      new InterventionRegistry([new InterruptOnInvocation()], hookRegistry)
 
-      await expect(registry.initialize({} as never)).rejects.toThrow('init failed')
-      // Can retry — not marked as initialized
-      await expect(registry.initialize({} as never)).rejects.toThrow('init failed')
+      await hookRegistry.invokeCallbacks(makeBeforeInvocationEvent())
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('has no effect on this event type'))
+
+      warnSpy.mockRestore()
     })
   })
 })

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -1,0 +1,594 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { InterventionRegistry } from '../registry.js'
+import { InterventionHandler } from '../handler.js'
+import { HookRegistryImplementation } from '../../hooks/registry.js'
+import { Agent } from '../../agent/agent.js'
+import {
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  BeforeModelCallEvent,
+  AfterModelCallEvent,
+} from '../../hooks/events.js'
+import { Message, TextBlock } from '../../types/messages.js'
+import { deny } from '../actions.js'
+import type { InterventionAction, Guide, Transform, Proceed } from '../actions.js'
+
+class DenyHandler extends InterventionHandler {
+  readonly name = 'deny-handler'
+
+  override beforeToolCall(): InterventionAction {
+    return { type: 'deny', reason: 'not authorized' }
+  }
+}
+
+class GuideHandler extends InterventionHandler {
+  readonly name = 'guide-handler'
+
+  override beforeToolCall(): InterventionAction {
+    return { type: 'guide', feedback: 'add more context' }
+  }
+}
+
+class InterruptHandler extends InterventionHandler {
+  readonly name = 'interrupt-handler'
+
+  override beforeToolCall(): InterventionAction {
+    return { type: 'interrupt', prompt: 'approve this action?' }
+  }
+}
+
+class ProceedHandler extends InterventionHandler {
+  readonly name = 'proceed-handler'
+
+  override beforeToolCall(): InterventionAction {
+    return { type: 'proceed', reason: 'all good' }
+  }
+}
+
+class ThrowingHandler extends InterventionHandler {
+  readonly name = 'throwing-handler'
+  override readonly onError = 'throw' as const
+
+  override beforeToolCall(): InterventionAction {
+    throw new Error('handler crashed')
+  }
+}
+
+class ThrowingProceedHandler extends InterventionHandler {
+  readonly name = 'throwing-proceed'
+  override readonly onError = 'proceed' as const
+
+  override beforeToolCall(): InterventionAction {
+    throw new Error('handler crashed')
+  }
+}
+
+class ThrowingDenyHandler extends InterventionHandler {
+  readonly name = 'throwing-deny'
+  override readonly onError = 'deny' as const
+
+  override beforeToolCall(): InterventionAction {
+    throw new Error('handler crashed')
+  }
+}
+
+class AsyncDenyHandler extends InterventionHandler {
+  readonly name = 'async-deny'
+
+  override async beforeToolCall(): Promise<InterventionAction> {
+    return { type: 'deny', reason: 'async denial' }
+  }
+}
+
+class ModelGuideHandler extends InterventionHandler {
+  readonly name = 'model-guide'
+
+  override afterModelCall(): Proceed | Guide | Transform {
+    return { type: 'guide', feedback: 'be more specific' }
+  }
+}
+
+describe('InterventionRegistry', () => {
+  let hookRegistry: HookRegistryImplementation
+  let agent: Agent
+  const toolUse = { name: 'testTool', toolUseId: 'id-1', input: {} }
+
+  beforeEach(() => {
+    hookRegistry = new HookRegistryImplementation()
+    agent = new Agent()
+  })
+
+  function makeBeforeInvocationEvent() {
+    return new BeforeInvocationEvent({ agent, invocationState: {} })
+  }
+
+  function makeBeforeToolCallEvent() {
+    return new BeforeToolCallEvent({ agent, toolUse, tool: undefined, invocationState: {} })
+  }
+
+  function makeBeforeModelCallEvent() {
+    return new BeforeModelCallEvent({ agent, model: {} as never, invocationState: {} })
+  }
+
+  function makeAfterModelCallEvent() {
+    return new AfterModelCallEvent({
+      agent,
+      model: {} as never,
+      invocationState: {},
+      attemptCount: 0,
+      stopData: {
+        message: new Message({ role: 'assistant', content: [new TextBlock('response')] }),
+        stopReason: 'endTurn',
+      },
+    })
+  }
+
+  describe('constructor', () => {
+    it('rejects duplicate handler names', () => {
+      expect(() => new InterventionRegistry([new DenyHandler(), new DenyHandler()], hookRegistry)).toThrow(
+        "Duplicate intervention handler name: 'deny-handler'"
+      )
+    })
+
+    it('accepts handlers with unique names', () => {
+      // No throw means success
+      new InterventionRegistry([new DenyHandler(), new GuideHandler()], hookRegistry)
+    })
+  })
+
+  describe('hook registration', () => {
+    it('only registers hooks for overridden methods', async () => {
+      new InterventionRegistry([new DenyHandler()], hookRegistry)
+
+      const beforeToolEvent = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(beforeToolEvent)
+      expect(beforeToolEvent.cancel).toBe('DENIED: not authorized')
+
+      // afterModelCall should not be registered — no handler overrides it
+      const afterModelEvent = makeAfterModelCallEvent()
+      await hookRegistry.invokeCallbacks(afterModelEvent)
+      expect(afterModelEvent.retry).toBeUndefined()
+    })
+  })
+
+  describe('dispatch ordering', () => {
+    it('calls handlers in registration order', async () => {
+      const callOrder: string[] = []
+
+      class First extends InterventionHandler {
+        readonly name = 'first'
+        override beforeToolCall(): InterventionAction {
+          callOrder.push('first')
+          return { type: 'proceed' }
+        }
+      }
+      class Second extends InterventionHandler {
+        readonly name = 'second'
+        override beforeToolCall(): InterventionAction {
+          callOrder.push('second')
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new First(), new Second()], hookRegistry)
+
+      await hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())
+      expect(callOrder).toEqual(['first', 'second'])
+    })
+
+    it('skips handlers that do not override the method', async () => {
+      const callOrder: string[] = []
+
+      class ToolHandler extends InterventionHandler {
+        readonly name = 'tool'
+        override beforeToolCall(): InterventionAction {
+          callOrder.push('tool')
+          return { type: 'proceed' }
+        }
+      }
+      class ModelHandler extends InterventionHandler {
+        readonly name = 'model'
+        override afterModelCall(): Proceed | Guide | Transform {
+          callOrder.push('model')
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new ToolHandler(), new ModelHandler()], hookRegistry)
+
+      await hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())
+      expect(callOrder).toEqual(['tool'])
+    })
+  })
+
+  describe('deny', () => {
+    it('sets cancel on BeforeToolCallEvent', async () => {
+      new InterventionRegistry([new DenyHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+
+      expect(event.cancel).toBe('DENIED: not authorized')
+    })
+
+    it('short-circuits — later handlers do not run', async () => {
+      const laterCalled = vi.fn()
+
+      class LaterHandler extends InterventionHandler {
+        readonly name = 'later'
+        override beforeToolCall(): InterventionAction {
+          laterCalled()
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new DenyHandler(), new LaterHandler()], hookRegistry)
+
+      await hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())
+      expect(laterCalled).not.toHaveBeenCalled()
+    })
+
+    it('sets cancel on BeforeInvocationEvent', async () => {
+      class InvocationDeny extends InterventionHandler {
+        readonly name = 'invocation-deny'
+        override beforeInvocation() {
+          return deny('unauthorized user')
+        }
+      }
+
+      new InterventionRegistry([new InvocationDeny()], hookRegistry)
+
+      const event = makeBeforeInvocationEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('DENIED: unauthorized user')
+    })
+
+    it('sets cancel on BeforeModelCallEvent', async () => {
+      class ModelDeny extends InterventionHandler {
+        readonly name = 'model-deny'
+        override beforeModelCall() {
+          return deny('prompt injection detected')
+        }
+      }
+
+      new InterventionRegistry([new ModelDeny()], hookRegistry)
+
+      const event = makeBeforeModelCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('DENIED: prompt injection detected')
+    })
+  })
+
+  describe('guide', () => {
+    it('sets cancel with guidance on BeforeToolCallEvent', async () => {
+      new InterventionRegistry([new GuideHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('GUIDANCE: [guide-handler] add more context')
+    })
+
+    it('accumulates feedback from multiple handlers', async () => {
+      class SecondGuide extends InterventionHandler {
+        readonly name = 'second-guide'
+        override beforeToolCall(): InterventionAction {
+          return { type: 'guide', feedback: 'also check permissions' }
+        }
+      }
+
+      new InterventionRegistry([new GuideHandler(), new SecondGuide()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('GUIDANCE: [guide-handler] add more context\n[second-guide] also check permissions')
+    })
+
+    it('sets retry=true and injects guidance message on AfterModelCallEvent', async () => {
+      new InterventionRegistry([new ModelGuideHandler()], hookRegistry)
+
+      const event = makeAfterModelCallEvent()
+      const messageCountBefore = event.agent.messages.length
+      await hookRegistry.invokeCallbacks(event)
+
+      expect(event.retry).toBe(true)
+      expect(event.agent.messages).toHaveLength(messageCountBefore + 1)
+      const guidanceMessage = event.agent.messages[event.agent.messages.length - 1]!
+      expect(guidanceMessage.role).toBe('user')
+      expect(guidanceMessage.content[0]).toMatchObject({ type: 'textBlock', text: '[model-guide] be more specific' })
+    })
+  })
+
+  describe('interrupt', () => {
+    it('calls event.interrupt() on BeforeToolCallEvent', async () => {
+      new InterventionRegistry([new InterruptHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
+    })
+
+    it('short-circuits — later handlers do not run', async () => {
+      const laterCalled = vi.fn()
+
+      class LaterHandler extends InterventionHandler {
+        readonly name = 'later'
+        override beforeToolCall(): InterventionAction {
+          laterCalled()
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new InterruptHandler(), new LaterHandler()], hookRegistry)
+
+      await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow()
+      expect(laterCalled).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('transform', () => {
+    it('calls the apply function with the event', async () => {
+      const applyFn = vi.fn()
+
+      class TransformHandler extends InterventionHandler {
+        readonly name = 'transform-handler'
+        override beforeToolCall(): InterventionAction {
+          return { type: 'transform', apply: applyFn, reason: 'sanitized input' }
+        }
+      }
+
+      new InterventionRegistry([new TransformHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(applyFn).toHaveBeenCalledWith(event)
+    })
+
+    it('later handlers see the transformed state', async () => {
+      const observed: string[] = []
+
+      class Transformer extends InterventionHandler {
+        readonly name = 'transformer'
+        override beforeToolCall(): InterventionAction {
+          return {
+            type: 'transform',
+            apply: (e) => {
+              ;(e as BeforeToolCallEvent).cancel = 'transformed'
+            },
+          }
+        }
+      }
+
+      class Observer extends InterventionHandler {
+        readonly name = 'observer'
+        override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
+          observed.push(String(event.cancel))
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new Transformer(), new Observer()], hookRegistry)
+
+      await hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())
+      expect(observed).toEqual(['transformed'])
+    })
+
+    it('works on AfterModelCallEvent', async () => {
+      const applyFn = vi.fn()
+
+      class ModelTransform extends InterventionHandler {
+        readonly name = 'model-transform'
+        override afterModelCall(): Proceed | Guide | Transform {
+          return { type: 'transform', apply: applyFn, reason: 'redacted output' }
+        }
+      }
+
+      new InterventionRegistry([new ModelTransform()], hookRegistry)
+
+      const event = makeAfterModelCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(applyFn).toHaveBeenCalledWith(event)
+    })
+
+    it('is logged in the audit trail', async () => {
+      class TransformHandler extends InterventionHandler {
+        readonly name = 'transform-handler'
+        override beforeToolCall(): InterventionAction {
+          return { type: 'transform', apply: () => {}, reason: 'sanitized' }
+        }
+      }
+
+      new InterventionRegistry([new TransformHandler()], hookRegistry)
+
+      await hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())
+      // Transform was applied (verified by the apply fn mock tests above)
+    })
+  })
+
+  describe('proceed', () => {
+    it('does not mutate the event', async () => {
+      new InterventionRegistry([new ProceedHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe(false)
+    })
+  })
+
+  describe('error handling', () => {
+    it('onError=throw (default) rethrows the error', async () => {
+      new InterventionRegistry([new ThrowingHandler(), new ProceedHandler()], hookRegistry)
+
+      await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow('handler crashed')
+    })
+
+    it('onError=proceed skips the handler and continues to next', async () => {
+      new InterventionRegistry([new ThrowingProceedHandler(), new ProceedHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe(false)
+    })
+
+    it('onError=deny logs the error and applies deny', async () => {
+      const laterCalled = vi.fn()
+
+      class LaterHandler extends InterventionHandler {
+        readonly name = 'later'
+        override beforeToolCall(): InterventionAction {
+          laterCalled()
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new ThrowingDenyHandler(), new LaterHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+
+      expect(event.cancel).toBe('DENIED: Handler threw: handler crashed')
+      expect(laterCalled).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('async handlers', () => {
+    it('awaits async handler results', async () => {
+      new InterventionRegistry([new AsyncDenyHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('DENIED: async denial')
+    })
+  })
+
+  describe('conflict resolution', () => {
+    it('deny wins over guide', async () => {
+      new InterventionRegistry([new GuideHandler(), new DenyHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+
+      expect(event.cancel).toBe('DENIED: not authorized')
+    })
+
+    it('deny short-circuits before guide can accumulate', async () => {
+      new InterventionRegistry([new DenyHandler(), new GuideHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+
+      expect(event.cancel).toBe('DENIED: not authorized')
+    })
+
+    it('interrupt short-circuits before guide can accumulate', async () => {
+      new InterventionRegistry([new InterruptHandler(), new GuideHandler()], hookRegistry)
+
+      await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow('Interrupt raised')
+    })
+  })
+
+  describe('initAgent', () => {
+    it('is called during initialize()', async () => {
+      const initFn = vi.fn()
+
+      class InitHandler extends InterventionHandler {
+        readonly name = 'init-handler'
+        override initAgent(): void {
+          initFn()
+        }
+      }
+
+      const registry = new InterventionRegistry([new InitHandler()], hookRegistry)
+      expect(initFn).not.toHaveBeenCalled()
+
+      await registry.initialize({} as never)
+      expect(initFn).toHaveBeenCalledOnce()
+    })
+
+    it('only runs once even if called multiple times', async () => {
+      const initFn = vi.fn()
+
+      class InitHandler extends InterventionHandler {
+        readonly name = 'init-handler'
+        override initAgent(): void {
+          initFn()
+        }
+      }
+
+      const registry = new InterventionRegistry([new InitHandler()], hookRegistry)
+      await registry.initialize({} as never)
+      await registry.initialize({} as never)
+      expect(initFn).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('agent integration', () => {
+    it('deny on beforeToolCall prevents tool execution', async () => {
+      const { MockMessageModel } = await import('../../__fixtures__/mock-message-model.js')
+      const { createMockTool } = await import('../../__fixtures__/tool-helpers.js')
+
+      let toolExecuted = false
+      const tool = createMockTool('blockedTool', () => {
+        toolExecuted = true
+        return 'should not reach here'
+      })
+
+      class BlockAllTools extends InterventionHandler {
+        readonly name = 'block-all'
+        override beforeToolCall(): InterventionAction {
+          return { type: 'deny', reason: 'blocked by intervention' }
+        }
+      }
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'blockedTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new BlockAllTools()],
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(false)
+    })
+
+    it('interventions run closest to execution (after plugins on Before*, before plugins on After*)', async () => {
+      const { MockMessageModel } = await import('../../__fixtures__/mock-message-model.js')
+      const { createMockTool } = await import('../../__fixtures__/tool-helpers.js')
+
+      const callOrder: string[] = []
+
+      const tool = createMockTool('testTool', () => 'result')
+
+      class OrderTracker extends InterventionHandler {
+        readonly name = 'order-tracker'
+        override beforeToolCall(): InterventionAction {
+          callOrder.push('intervention-before')
+          return { type: 'proceed' }
+        }
+      }
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new OrderTracker()],
+      })
+
+      agent.addHook(BeforeToolCallEvent, () => {
+        callOrder.push('plugin-before')
+      })
+
+      await agent.invoke('Test')
+
+      // On Before*: plugins run first, intervention runs last (closest to tool execution)
+      expect(callOrder[0]).toBe('plugin-before')
+      expect(callOrder[1]).toBe('intervention-before')
+    })
+  })
+})

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -519,7 +519,7 @@ describe('InterventionRegistry', () => {
       expect(toolExecuted).toBe(false)
     })
 
-    it('interventions run closest to execution (after plugins on Before*, before plugins on After*)', async () => {
+    it('interventions run before plugins (HookOrder.INTERVENTIONS < DEFAULT)', async () => {
       const { MockMessageModel } = await import('../../__fixtures__/mock-message-model.js')
       const { createMockTool } = await import('../../__fixtures__/tool-helpers.js')
 
@@ -530,7 +530,7 @@ describe('InterventionRegistry', () => {
       class OrderTracker extends InterventionHandler {
         readonly name = 'order-tracker'
         override beforeToolCall(): InterventionAction {
-          callOrder.push('intervention-before')
+          callOrder.push('intervention')
           return { type: 'proceed' }
         }
       }
@@ -546,14 +546,14 @@ describe('InterventionRegistry', () => {
       })
 
       agent.addHook(BeforeToolCallEvent, () => {
-        callOrder.push('plugin-before')
+        callOrder.push('plugin')
       })
 
       await agent.invoke('Test')
 
-      // On Before*: plugins run first, intervention runs last (closest to tool execution)
-      expect(callOrder[0]).toBe('plugin-before')
-      expect(callOrder[1]).toBe('intervention-before')
+      // On Before*: plugins run first (DEFAULT:0), interventions last (INTERVENTIONS:90)
+      expect(callOrder[0]).toBe('plugin')
+      expect(callOrder[1]).toBe('intervention')
     })
   })
 

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -591,4 +591,90 @@ describe('InterventionRegistry', () => {
       expect(callOrder[1]).toBe('intervention-before')
     })
   })
+
+  describe('edge cases', () => {
+    it('guide on beforeModelCall injects a user message', async () => {
+      class ModelGuide extends InterventionHandler {
+        readonly name = 'model-guide'
+        override beforeModelCall(): Proceed | Guide | Transform {
+          return { type: 'guide', feedback: 'check your sources' }
+        }
+      }
+
+      new InterventionRegistry([new ModelGuide()], hookRegistry)
+
+      const event = makeBeforeModelCallEvent()
+      const messageCountBefore = event.agent.messages.length
+      await hookRegistry.invokeCallbacks(event)
+
+      expect(event.cancel).toBe(false)
+      expect(event.agent.messages).toHaveLength(messageCountBefore + 1)
+      const injected = event.agent.messages[event.agent.messages.length - 1]!
+      expect(injected.role).toBe('user')
+      expect(injected.content[0]).toMatchObject({ type: 'textBlock', text: '[model-guide] check your sources' })
+    })
+
+    it('transform apply() error is handled via onError policy', async () => {
+      class BadTransform extends InterventionHandler {
+        readonly name = 'bad-transform'
+        override readonly onError = 'proceed' as const
+        override beforeToolCall(): InterventionAction {
+          return {
+            type: 'transform',
+            apply: () => {
+              throw new Error('apply boom')
+            },
+          }
+        }
+      }
+
+      class AfterTransform extends InterventionHandler {
+        readonly name = 'after-transform'
+        override beforeToolCall(): InterventionAction {
+          return { type: 'proceed', reason: 'still running' }
+        }
+      }
+
+      new InterventionRegistry([new BadTransform(), new AfterTransform()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      // onError=proceed means the error is swallowed and next handler runs
+      expect(event.cancel).toBe(false)
+    })
+
+    it('transform apply() error with onError=throw propagates', async () => {
+      class BadTransform extends InterventionHandler {
+        readonly name = 'bad-transform'
+        override readonly onError = 'throw' as const
+        override beforeToolCall(): InterventionAction {
+          return {
+            type: 'transform',
+            apply: () => {
+              throw new Error('apply boom')
+            },
+          }
+        }
+      }
+
+      new InterventionRegistry([new BadTransform()], hookRegistry)
+
+      await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow('apply boom')
+    })
+
+    it('initAgent throwing leaves registry uninitialized for retry', async () => {
+      class FailingInit extends InterventionHandler {
+        readonly name = 'failing-init'
+        override initAgent(): void {
+          throw new Error('init failed')
+        }
+      }
+
+      const registry = new InterventionRegistry([new FailingInit()], hookRegistry)
+
+      await expect(registry.initialize({} as never)).rejects.toThrow('init failed')
+      // Can retry — not marked as initialized
+      await expect(registry.initialize({} as never)).rejects.toThrow('init failed')
+    })
+  })
 })

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -1,0 +1,142 @@
+import type {
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  AfterToolCallEvent,
+  BeforeModelCallEvent,
+  AfterModelCallEvent,
+} from '../hooks/events.js'
+
+export type LifecycleEvent =
+  | BeforeInvocationEvent
+  | BeforeToolCallEvent
+  | AfterToolCallEvent
+  | BeforeModelCallEvent
+  | AfterModelCallEvent
+
+/**
+ * Allow the operation to continue unchanged.
+ *
+ * @example
+ * ```typescript
+ * return { type: 'proceed' }
+ * ```
+ */
+export type Proceed = { type: 'proceed'; reason?: string }
+
+/**
+ * Block the operation. On Before* events, sets event.cancel. On afterToolCall,
+ * sets event.retry = false.
+ *
+ * @example
+ * ```typescript
+ * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
+ *   if (!this.isAuthorized(event.agent.appState.get('user_id'), event.toolUse.name)) {
+ *     return { type: 'deny', reason: 'User not authorized for this tool' }
+ *   }
+ *   return { type: 'proceed' }
+ * }
+ * ```
+ */
+export type Deny = { type: 'deny'; reason: string }
+
+/**
+ * Provide feedback to steer behavior. On beforeToolCall/beforeInvocation, sets
+ * event.cancel so the model sees the feedback and adjusts. On beforeModelCall,
+ * injects feedback as a user message so the model sees it on this call.
+ * On afterModelCall, the response is discarded and the model retries with the
+ * feedback injected as a user message.
+ *
+ * @example
+ * ```typescript
+ * override afterModelCall(event: AfterModelCallEvent): InterventionAction {
+ *   if (this.isTooVague(event.stopData?.message)) {
+ *     return { type: 'guide', feedback: 'Be more specific in your response.' }
+ *   }
+ *   return { type: 'proceed' }
+ * }
+ * ```
+ */
+export type Guide = { type: 'guide'; feedback: string; reason?: string }
+
+/**
+ * Pause for human approval. Calls event.interrupt() to halt agent execution
+ * until the user responds. Only supported on beforeToolCall.
+ *
+ * @example
+ * ```typescript
+ * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
+ *   if (this.requiresApproval(event.toolUse.name)) {
+ *     return { type: 'interrupt', prompt: `Approve ${event.toolUse.name}?` }
+ *   }
+ *   return { type: 'proceed' }
+ * }
+ * ```
+ */
+export type Interrupt = { type: 'interrupt'; prompt: string; reason?: string }
+
+/**
+ * Modify event content in-place. The `apply` function mutates the event before
+ * execution proceeds. Later handlers in the pipeline see the transformed content.
+ *
+ * The handler already has the typed event from its lifecycle method, so `apply`
+ * can close over it directly — no cast needed:
+ *
+ * @example
+ * ```typescript
+ * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
+ *   const redacted = redactPII(event.toolUse.input)
+ *   return {
+ *     type: 'transform',
+ *     apply: () => { event.toolUse.input = redacted },
+ *     reason: 'PII redacted from tool input',
+ *   }
+ * }
+ * ```
+ */
+export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => void; reason?: string }
+
+/**
+ * Union of all intervention actions a handler can return.
+ *
+ * | Action    | beforeInvocation | beforeToolCall | beforeModelCall | afterToolCall | afterModelCall |
+ * |-----------|------------------|----------------|-----------------|---------------|----------------|
+ * | Proceed   | —                | —              | —               | —             | —              |
+ * | Deny      | cancel           | cancel         | cancel          | —             | —              |
+ * | Guide     | cancel+          | cancel+        | inject          | —             | inject + retry |
+ * | Interrupt | —                | interrupt      | —               | —             | —              |
+ * | Transform | apply            | apply          | apply           | apply         | apply          |
+ *
+ * — = no-op (logged in audit trail, warns at runtime)
+ * cancel = sets event.cancel, short-circuits (remaining handlers skipped)
+ * cancel+ = sets event.cancel with accumulated feedback from all guiding handlers
+ * interrupt = calls event.interrupt() for native pause/resume (human-in-the-loop)
+ * inject = appends accumulated feedback as a user message so the model sees it on this call
+ * inject + retry = appends accumulated feedback and retries so the model sees guidance
+ * apply = calls action.apply(event) for in-place mutation, later handlers see the change
+ */
+export type InterventionAction = Proceed | Deny | Guide | Interrupt | Transform
+
+/** Allow the operation to continue. */
+export function proceed(reason?: string): Proceed {
+  return { type: 'proceed', ...(reason !== undefined && { reason }) }
+}
+
+/** Block the operation. */
+export function deny(reason: string): Deny {
+  return { type: 'deny', reason }
+}
+
+/** Provide feedback to steer behavior. */
+export function guide(feedback: string, reason?: string): Guide {
+  return { type: 'guide', feedback, ...(reason !== undefined && { reason }) }
+}
+
+/** Pause for human approval. */
+export function interrupt(prompt: string, reason?: string): Interrupt {
+  return { type: 'interrupt', prompt, ...(reason !== undefined && { reason }) }
+}
+
+/** Modify event content in-place. */
+export function transform(apply: (event: LifecycleEvent) => void, reason?: string): Transform {
+  return { type: 'transform', apply, ...(reason !== undefined && { reason }) }
+}

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -46,6 +46,9 @@ export type Deny = { type: 'deny'; reason: string }
  * On afterModelCall, the response is discarded and the model retries with the
  * feedback injected as a user message.
  *
+ * @param feedback - The guidance text shown to the model.
+ * @param reason - Optional metadata for debugging/logging. Not shown to the model.
+ *
  * @example
  * ```typescript
  * override afterModelCall(event: AfterModelCallEvent): InterventionAction {

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -16,6 +16,8 @@ export type LifecycleEvent =
 /**
  * Allow the operation to continue unchanged.
  *
+ * @param reason - Optional metadata for debugging/logging. Not shown to the model.
+ *
  * @example
  * ```typescript
  * return { type: 'proceed' }
@@ -24,8 +26,10 @@ export type LifecycleEvent =
 export type Proceed = { type: 'proceed'; reason?: string }
 
 /**
- * Block the operation. On Before* events, sets event.cancel. On afterToolCall,
- * sets event.retry = false.
+ * Block the operation. On Before* events, sets event.cancel with the reason text.
+ * The reason is shown to the model as the cancellation message.
+ *
+ * @param reason - Why the operation was blocked. Shown to the model.
  *
  * @example
  * ```typescript
@@ -65,6 +69,9 @@ export type Guide = { type: 'guide'; feedback: string; reason?: string }
  * Pause for human approval. Calls event.interrupt() to halt agent execution
  * until the user responds. Only supported on beforeToolCall.
  *
+ * @param prompt - The message shown to the human for approval. Not shown to the model.
+ * @param reason - Optional metadata for debugging/logging. Not shown to the model.
+ *
  * @example
  * ```typescript
  * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
@@ -83,6 +90,9 @@ export type Interrupt = { type: 'interrupt'; prompt: string; reason?: string }
  *
  * The handler already has the typed event from its lifecycle method, so `apply`
  * can close over it directly — no cast needed:
+ *
+ * @param apply - Function that mutates the event. Not shown to the model.
+ * @param reason - Optional metadata for debugging/logging. Not shown to the model.
  *
  * @example
  * ```typescript

--- a/strands-ts/src/interventions/handler.ts
+++ b/strands-ts/src/interventions/handler.ts
@@ -7,6 +7,8 @@ import type {
 } from '../hooks/events.js'
 import type { Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
 
+type Awaitable<T> = T | Promise<T>
+
 /**
  * What to do when a handler throws during evaluation.
  *
@@ -43,29 +45,23 @@ export abstract class InterventionHandler {
   /** What to do when this handler throws. Defaults to 'throw'. */
   readonly onError: OnError = 'throw'
 
-  beforeInvocation(
-    _event: BeforeInvocationEvent
-  ): (Proceed | Deny | Guide | Transform) | Promise<Proceed | Deny | Guide | Transform> {
+  beforeInvocation(_event: BeforeInvocationEvent): Awaitable<Proceed | Deny | Guide | Transform> {
     return { type: 'proceed' }
   }
 
-  beforeToolCall(
-    _event: BeforeToolCallEvent
-  ): (Proceed | Deny | Guide | Interrupt | Transform) | Promise<Proceed | Deny | Guide | Interrupt | Transform> {
+  beforeToolCall(_event: BeforeToolCallEvent): Awaitable<Proceed | Deny | Guide | Interrupt | Transform> {
     return { type: 'proceed' }
   }
 
-  afterToolCall(_event: AfterToolCallEvent): (Proceed | Transform) | Promise<Proceed | Transform> {
+  afterToolCall(_event: AfterToolCallEvent): Awaitable<Proceed | Transform> {
     return { type: 'proceed' }
   }
 
-  beforeModelCall(
-    _event: BeforeModelCallEvent
-  ): (Proceed | Deny | Guide | Transform) | Promise<Proceed | Deny | Guide | Transform> {
+  beforeModelCall(_event: BeforeModelCallEvent): Awaitable<Proceed | Deny | Guide | Transform> {
     return { type: 'proceed' }
   }
 
-  afterModelCall(_event: AfterModelCallEvent): (Proceed | Guide | Transform) | Promise<Proceed | Guide | Transform> {
+  afterModelCall(_event: AfterModelCallEvent): Awaitable<Proceed | Guide | Transform> {
     return { type: 'proceed' }
   }
 }

--- a/strands-ts/src/interventions/handler.ts
+++ b/strands-ts/src/interventions/handler.ts
@@ -1,0 +1,75 @@
+import type {
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  AfterToolCallEvent,
+  BeforeModelCallEvent,
+  AfterModelCallEvent,
+} from '../hooks/events.js'
+import type { LocalAgent } from '../types/agent.js'
+import type { Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
+
+/**
+ * What to do when a handler throws during evaluation.
+ *
+ * - `'throw'` — rethrow the error (default, safest: a broken policy check blocks execution)
+ * - `'proceed'` — log the error and continue as if the handler returned Proceed
+ * - `'deny'` — log the error and treat it as a Deny (fail-closed)
+ */
+export type OnError = 'throw' | 'proceed' | 'deny'
+
+/**
+ * Base class for intervention handlers.
+ *
+ * Handlers override the lifecycle methods they care about. Default implementations
+ * return Proceed. The framework detects which methods are overridden and only
+ * registers hook callbacks for those.
+ *
+ * @example
+ * ```typescript
+ * class CedarAuth extends InterventionHandler {
+ *   readonly name = 'cedar-auth'
+ *
+ *   override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
+ *     if (!this.isAuthorized(event)) {
+ *       return deny('User not authorized for this tool')
+ *     }
+ *     return proceed()
+ *   }
+ * }
+ * ```
+ */
+export abstract class InterventionHandler {
+  abstract readonly name: string
+
+  /** What to do when this handler throws. Defaults to 'throw'. */
+  readonly onError: OnError = 'throw'
+
+  /** Called once during agent initialization. Use to register context-gathering hooks. */
+  initAgent(_agent: LocalAgent): void | Promise<void> {}
+
+  beforeInvocation(
+    _event: BeforeInvocationEvent
+  ): (Proceed | Deny | Guide | Transform) | Promise<Proceed | Deny | Guide | Transform> {
+    return { type: 'proceed' }
+  }
+
+  beforeToolCall(
+    _event: BeforeToolCallEvent
+  ): (Proceed | Deny | Guide | Interrupt | Transform) | Promise<Proceed | Deny | Guide | Interrupt | Transform> {
+    return { type: 'proceed' }
+  }
+
+  afterToolCall(_event: AfterToolCallEvent): (Proceed | Transform) | Promise<Proceed | Transform> {
+    return { type: 'proceed' }
+  }
+
+  beforeModelCall(
+    _event: BeforeModelCallEvent
+  ): (Proceed | Deny | Guide | Transform) | Promise<Proceed | Deny | Guide | Transform> {
+    return { type: 'proceed' }
+  }
+
+  afterModelCall(_event: AfterModelCallEvent): (Proceed | Guide | Transform) | Promise<Proceed | Guide | Transform> {
+    return { type: 'proceed' }
+  }
+}

--- a/strands-ts/src/interventions/handler.ts
+++ b/strands-ts/src/interventions/handler.ts
@@ -5,7 +5,6 @@ import type {
   BeforeModelCallEvent,
   AfterModelCallEvent,
 } from '../hooks/events.js'
-import type { LocalAgent } from '../types/agent.js'
 import type { Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
 
 /**
@@ -43,9 +42,6 @@ export abstract class InterventionHandler {
 
   /** What to do when this handler throws. Defaults to 'throw'. */
   readonly onError: OnError = 'throw'
-
-  /** Called once during agent initialization. Use to register context-gathering hooks. */
-  initAgent(_agent: LocalAgent): void | Promise<void> {}
 
   beforeInvocation(
     _event: BeforeInvocationEvent

--- a/strands-ts/src/interventions/index.ts
+++ b/strands-ts/src/interventions/index.ts
@@ -1,0 +1,5 @@
+export type { InterventionAction, LifecycleEvent, Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
+export { proceed, deny, guide, interrupt, transform } from './actions.js'
+export { InterventionHandler } from './handler.js'
+export type { OnError } from './handler.js'
+export { InterventionRegistry } from './registry.js'

--- a/strands-ts/src/interventions/index.ts
+++ b/strands-ts/src/interventions/index.ts
@@ -2,4 +2,3 @@ export type { InterventionAction, LifecycleEvent, Proceed, Deny, Guide, Interrup
 export { proceed, deny, guide, interrupt, transform } from './actions.js'
 export { InterventionHandler } from './handler.js'
 export type { OnError } from './handler.js'
-export { InterventionRegistry } from './registry.js'

--- a/strands-ts/src/interventions/index.ts
+++ b/strands-ts/src/interventions/index.ts
@@ -1,4 +1,5 @@
 export type { InterventionAction, LifecycleEvent, Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
-export { proceed, deny, guide, interrupt, transform } from './actions.js'
+import { proceed, deny, guide, interrupt, transform } from './actions.js'
+export const interventions = { proceed, deny, guide, interrupt, transform }
 export { InterventionHandler } from './handler.js'
 export type { OnError } from './handler.js'

--- a/strands-ts/src/interventions/index.ts
+++ b/strands-ts/src/interventions/index.ts
@@ -1,5 +1,5 @@
 export type { InterventionAction, LifecycleEvent, Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
 import { proceed, deny, guide, interrupt, transform } from './actions.js'
-export const interventions = { proceed, deny, guide, interrupt, transform }
+export const InterventionActions = { proceed, deny, guide, interrupt, transform }
 export { InterventionHandler } from './handler.js'
 export type { OnError } from './handler.js'

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -10,7 +10,6 @@ import type { HookRegistry } from '../hooks/registry.js'
 import { HookOrder } from '../hooks/types.js'
 import type { HookableEventConstructor } from '../hooks/types.js'
 import { Message, TextBlock } from '../types/messages.js'
-import type { LocalAgent } from '../types/agent.js'
 import type { Guide, InterventionAction } from './actions.js'
 import { InterventionHandler } from './handler.js'
 import { logger } from '../logging/logger.js'
@@ -67,17 +66,6 @@ export class InterventionRegistry {
         hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), { order: HookOrder.SDK_FIRST })
       }
     }
-  }
-
-  private _initialized = false
-
-  /** Initialize all handlers. Safe to call multiple times — only runs once. */
-  async initialize(agent: LocalAgent): Promise<void> {
-    if (this._initialized) return
-    for (const handler of this._handlers) {
-      await handler.initAgent(agent)
-    }
-    this._initialized = true
   }
 
   /**

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -54,16 +54,18 @@ export class InterventionRegistry {
   }
 
   private _registerHooks(hookRegistry: HookRegistry): void {
-    // Before*: interventions run last (closest to execution)
     for (const [method, eventType] of BEFORE_EVENTS) {
       if (this._handlers.some((h) => h[method] !== InterventionHandler.prototype[method])) {
-        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), { order: HookOrder.SDK_LAST })
+        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), {
+          order: HookOrder.INTERVENTIONS_BEFORE,
+        })
       }
     }
-    // After*: interventions run first (closest to execution)
     for (const [method, eventType] of AFTER_EVENTS) {
       if (this._handlers.some((h) => h[method] !== InterventionHandler.prototype[method])) {
-        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), { order: HookOrder.SDK_FIRST })
+        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), {
+          order: HookOrder.INTERVENTIONS_AFTER,
+        })
       }
     }
   }

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -1,0 +1,286 @@
+import {
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  AfterToolCallEvent,
+  BeforeModelCallEvent,
+  AfterModelCallEvent,
+  type HookableEvent,
+} from '../hooks/events.js'
+import type { HookRegistry } from '../hooks/registry.js'
+import { HookOrder } from '../hooks/types.js'
+import type { HookableEventConstructor } from '../hooks/types.js'
+import { Message, TextBlock } from '../types/messages.js'
+import type { LocalAgent } from '../types/agent.js'
+import type { Guide, InterventionAction } from './actions.js'
+import { InterventionHandler } from './handler.js'
+import { logger } from '../logging/logger.js'
+
+type LifecycleMethod = 'beforeInvocation' | 'beforeToolCall' | 'afterToolCall' | 'beforeModelCall' | 'afterModelCall'
+
+// Before* events: interventions run last (closest to execution, highest order).
+const BEFORE_EVENTS: ReadonlyArray<[LifecycleMethod, HookableEventConstructor]> = [
+  ['beforeInvocation', BeforeInvocationEvent],
+  ['beforeToolCall', BeforeToolCallEvent],
+  ['beforeModelCall', BeforeModelCallEvent],
+]
+
+// After* events: interventions run first (closest to execution, lowest order).
+const AFTER_EVENTS: ReadonlyArray<[LifecycleMethod, HookableEventConstructor]> = [
+  ['afterToolCall', AfterToolCallEvent],
+  ['afterModelCall', AfterModelCallEvent],
+]
+
+/**
+ * Bridges {@link InterventionHandler} instances and the Strands hook system.
+ *
+ * Registers one hook callback per lifecycle event type, then dispatches to
+ * all handlers that override that method — in registration order, with
+ * short-circuiting on Deny/Interrupt and accumulation for Guide.
+ *
+ * See {@link InterventionAction} for the action-to-event compatibility matrix.
+ */
+export class InterventionRegistry {
+  private readonly _handlers: InterventionHandler[]
+
+  constructor(handlers: InterventionHandler[], hookRegistry: HookRegistry) {
+    const seen = new Set<string>()
+    for (const h of handlers) {
+      if (seen.has(h.name)) {
+        throw new Error(`Duplicate intervention handler name: '${h.name}'`)
+      }
+      seen.add(h.name)
+    }
+    this._handlers = handlers
+    this._registerHooks(hookRegistry)
+  }
+
+  private _registerHooks(hookRegistry: HookRegistry): void {
+    // Before*: interventions run last (closest to execution)
+    for (const [method, eventType] of BEFORE_EVENTS) {
+      if (this._handlers.some((h) => h[method] !== InterventionHandler.prototype[method])) {
+        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), { order: HookOrder.SDK_LAST })
+      }
+    }
+    // After*: interventions run first (closest to execution)
+    for (const [method, eventType] of AFTER_EVENTS) {
+      if (this._handlers.some((h) => h[method] !== InterventionHandler.prototype[method])) {
+        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), { order: HookOrder.SDK_FIRST })
+      }
+    }
+  }
+
+  private _initialized = false
+
+  /** Initialize all handlers. Safe to call multiple times — only runs once. */
+  async initialize(agent: LocalAgent): Promise<void> {
+    if (this._initialized) return
+    for (const handler of this._handlers) {
+      await handler.initAgent(agent)
+    }
+    this._initialized = true
+  }
+
+  /**
+   * Iterate handlers in registration order and resolve the winning action.
+   *
+   * - Deny / Interrupt short-circuit immediately (remaining handlers are skipped).
+   * - Guide feedback strings accumulate across handlers and are applied at the end.
+   * - Transform is applied in-place so later handlers see the mutation.
+   * - If a handler throws, behavior depends on {@link InterventionHandler.onError}:
+   *   `'throw'` (default) rethrows, `'deny'` fails closed, `'proceed'` skips.
+   */
+  private async _dispatch(event: HookableEvent, method: LifecycleMethod): Promise<void> {
+    logger.debug(`event=<${method}> | dispatching to ${this._handlers.length} handler(s)`)
+    const guides: Array<{ handlerName: string; action: Guide }> = []
+    const apply = this._getApplier(event, method)
+
+    for (const handler of this._handlers) {
+      if (handler[method] === InterventionHandler.prototype[method]) continue
+
+      logger.debug(`handler=<${handler.name}>, event=<${method}> | evaluating`)
+
+      let action: InterventionAction | undefined
+      try {
+        // Safe: _registerHooks() only wires each method to its matching event type,
+        // so the event is always the correct type for the method being called.
+        action = await handler[method](event as never)
+      } catch (error) {
+        action = this._handleError(handler, method, error)
+        if (!action) continue
+      }
+
+      logger.debug(`handler=<${handler.name}>, event=<${method}> | returned ${action.type}`)
+
+      if (action.type === 'guide') {
+        guides.push({ handlerName: handler.name, action })
+      } else {
+        try {
+          if (apply(action, handler.name)) {
+            logger.debug(`handler=<${handler.name}>, event=<${method}> | short-circuited`)
+            return
+          }
+        } catch (error) {
+          const errorAction = this._handleError(handler, method, error)
+          if (errorAction) {
+            if (apply(errorAction, handler.name)) {
+              return
+            }
+          }
+        }
+      }
+    }
+
+    // Guide feedback accumulates across handlers. Only logged and applied if
+    // no earlier handler short-circuited (deny/interrupt).
+    if (guides.length > 0) {
+      logger.debug(`event=<${method}> | applying accumulated guide from ${guides.length} handler(s)`)
+      const feedback = guides.map((g) => `[${g.handlerName}] ${g.action.feedback}`).join('\n')
+      apply({ type: 'guide', feedback }, '')
+    }
+  }
+
+  /**
+   * Returns a function that applies a single action to the event.
+   * Returns true if the action short-circuits (deny/interrupt), false otherwise.
+   */
+  private _getApplier(
+    event: HookableEvent,
+    method: LifecycleMethod
+  ): (action: InterventionAction, handlerName: string) => boolean {
+    // beforeToolCall: supports all actions including native interrupt
+    if (event instanceof BeforeToolCallEvent) {
+      return (action, handlerName) => {
+        const actionType = action.type
+        switch (actionType) {
+          case 'deny':
+            event.cancel = `DENIED: ${action.reason}`
+            return true
+          case 'interrupt':
+            event.interrupt({ name: handlerName, reason: action.prompt })
+            return true
+          case 'guide':
+            event.cancel = `GUIDANCE: ${action.feedback}`
+            return false
+          case 'transform':
+            action.apply(event)
+            return false
+          case 'proceed':
+            return false
+          default:
+            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${actionType} has no effect on this event type`)
+            return false
+        }
+      }
+    }
+
+    // beforeInvocation: cancel-based (does not implement Interruptible)
+    if (event instanceof BeforeInvocationEvent) {
+      return (action, handlerName) => {
+        const actionType = action.type
+        switch (actionType) {
+          case 'deny':
+            event.cancel = `DENIED: ${action.reason}`
+            return true
+          case 'guide':
+            event.cancel = `GUIDANCE: ${action.feedback}`
+            return false
+          case 'transform':
+            action.apply(event)
+            return false
+          case 'proceed':
+            return false
+          default:
+            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${actionType} has no effect on this event type`)
+            return false
+        }
+      }
+    }
+
+    // beforeModelCall: Guide injects feedback as a user message so the model sees
+    // it on this call, rather than cancelling (which would end the invocation).
+    if (event instanceof BeforeModelCallEvent) {
+      return (action, handlerName) => {
+        switch (action.type) {
+          case 'deny':
+            event.cancel = `DENIED: ${action.reason}`
+            return true
+          case 'guide':
+            // Direct push bypasses MessageAddedEvent and conversation manager.
+            // This matches what plugins can do today via event.agent.messages.
+            event.agent.messages.push(new Message({ role: 'user', content: [new TextBlock(action.feedback)] }))
+            return false
+          case 'transform':
+            action.apply(event)
+            return false
+          case 'proceed':
+            return false
+          default:
+            logger.warn(
+              `handler=<${handlerName}>, event=<${method}> | ${(action as InterventionAction).type} has no effect on this event type`
+            )
+            return false
+        }
+      }
+    }
+
+    // afterToolCall: tool already ran, only Transform (e.g. redact result) is meaningful
+    if (event instanceof AfterToolCallEvent) {
+      return (action, handlerName) => {
+        switch (action.type) {
+          case 'transform':
+            action.apply(event)
+            return false
+          case 'proceed':
+            return false
+          default:
+            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${action.type} has no effect on this event type`)
+            return false
+        }
+      }
+    }
+
+    // afterModelCall: has retry
+    if (event instanceof AfterModelCallEvent) {
+      return (action, handlerName) => {
+        switch (action.type) {
+          case 'guide':
+            event.retry = true
+            // Direct push bypasses MessageAddedEvent and conversation manager, so this
+            // message won't trigger context management and could push the context over
+            // the limit. LocalAgent doesn't expose a message-append method that goes
+            // through the hook pipeline. This matches what plugins can do today.
+            event.agent.messages.push(new Message({ role: 'user', content: [new TextBlock(action.feedback)] }))
+            return false
+          case 'transform':
+            action.apply(event)
+            return false
+          case 'proceed':
+            return false
+          default:
+            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${action.type} has no effect on this event type`)
+            return false
+        }
+      }
+    }
+
+    // Fallback for future event types not yet handled above
+    return (action, handlerName) => {
+      if (action.type !== 'proceed') {
+        logger.warn(`handler=<${handlerName}>, event=<${method}> | ${action.type} has no effect on this event type`)
+      }
+      return false
+    }
+  }
+
+  private _handleError(handler: InterventionHandler, method: string, error: unknown): InterventionAction | undefined {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+
+    if (handler.onError === 'throw') {
+      throw error
+    } else if (handler.onError === 'deny') {
+      return { type: 'deny', reason: `Handler threw: ${errorMsg}` }
+    } else {
+      return undefined
+    }
+  }
+}

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -8,26 +8,12 @@ import {
 } from '../hooks/events.js'
 import type { HookRegistry } from '../hooks/registry.js'
 import { HookOrder } from '../hooks/types.js'
-import type { HookableEventConstructor } from '../hooks/types.js'
 import { Message, TextBlock } from '../types/messages.js'
 import type { Guide, InterventionAction } from './actions.js'
 import { InterventionHandler } from './handler.js'
 import { logger } from '../logging/logger.js'
 
 type LifecycleMethod = 'beforeInvocation' | 'beforeToolCall' | 'afterToolCall' | 'beforeModelCall' | 'afterModelCall'
-
-// Before* events: interventions run last (closest to execution, highest order).
-const BEFORE_EVENTS: ReadonlyArray<[LifecycleMethod, HookableEventConstructor]> = [
-  ['beforeInvocation', BeforeInvocationEvent],
-  ['beforeToolCall', BeforeToolCallEvent],
-  ['beforeModelCall', BeforeModelCallEvent],
-]
-
-// After* events: interventions run first (closest to execution, lowest order).
-const AFTER_EVENTS: ReadonlyArray<[LifecycleMethod, HookableEventConstructor]> = [
-  ['afterToolCall', AfterToolCallEvent],
-  ['afterModelCall', AfterModelCallEvent],
-]
 
 /**
  * Bridges {@link InterventionHandler} instances and the Strands hook system.
@@ -54,20 +40,140 @@ export class InterventionRegistry {
   }
 
   private _registerHooks(hookRegistry: HookRegistry): void {
-    for (const [method, eventType] of BEFORE_EVENTS) {
-      if (this._handlers.some((h) => h[method] !== InterventionHandler.prototype[method])) {
-        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), {
-          order: HookOrder.INTERVENTIONS_BEFORE,
-        })
-      }
+    if (this._handlers.some((h) => h.beforeInvocation !== InterventionHandler.prototype.beforeInvocation)) {
+      hookRegistry.addCallback(BeforeInvocationEvent, (e) => this._onBeforeInvocation(e), {
+        order: HookOrder.INTERVENTION_INPUT,
+      })
     }
-    for (const [method, eventType] of AFTER_EVENTS) {
-      if (this._handlers.some((h) => h[method] !== InterventionHandler.prototype[method])) {
-        hookRegistry.addCallback(eventType, (event) => this._dispatch(event, method), {
-          order: HookOrder.INTERVENTIONS_AFTER,
-        })
-      }
+    if (this._handlers.some((h) => h.beforeToolCall !== InterventionHandler.prototype.beforeToolCall)) {
+      hookRegistry.addCallback(BeforeToolCallEvent, (e) => this._onBeforeToolCall(e), {
+        order: HookOrder.INTERVENTION_INPUT,
+      })
     }
+    if (this._handlers.some((h) => h.afterToolCall !== InterventionHandler.prototype.afterToolCall)) {
+      hookRegistry.addCallback(AfterToolCallEvent, (e) => this._onAfterToolCall(e), {
+        order: HookOrder.INTERVENTION_OUTPUT,
+      })
+    }
+    if (this._handlers.some((h) => h.beforeModelCall !== InterventionHandler.prototype.beforeModelCall)) {
+      hookRegistry.addCallback(BeforeModelCallEvent, (e) => this._onBeforeModelCall(e), {
+        order: HookOrder.INTERVENTION_INPUT,
+      })
+    }
+    if (this._handlers.some((h) => h.afterModelCall !== InterventionHandler.prototype.afterModelCall)) {
+      hookRegistry.addCallback(AfterModelCallEvent, (e) => this._onAfterModelCall(e), {
+        order: HookOrder.INTERVENTION_OUTPUT,
+      })
+    }
+  }
+
+  private async _onBeforeInvocation(event: BeforeInvocationEvent): Promise<void> {
+    return this._dispatch(event, 'beforeInvocation', (action, handlerName) => {
+      switch (action.type) {
+        case 'deny':
+          event.cancel = `DENIED: ${action.reason}`
+          return true
+        case 'guide':
+          event.cancel = `GUIDANCE: ${action.feedback}`
+          return false
+        case 'transform':
+          action.apply(event)
+          return false
+        case 'proceed':
+          return false
+        default:
+          logger.warn(`handler=<${handlerName}>, event=<beforeInvocation> | ${action.type} has no effect`)
+          return false
+      }
+    })
+  }
+
+  private async _onBeforeToolCall(event: BeforeToolCallEvent): Promise<void> {
+    return this._dispatch(event, 'beforeToolCall', (action, handlerName) => {
+      const actionType = action.type
+      switch (actionType) {
+        case 'deny':
+          event.cancel = `DENIED: ${action.reason}`
+          return true
+        case 'interrupt':
+          event.interrupt({ name: handlerName, reason: action.prompt })
+          return true
+        case 'guide':
+          event.cancel = `GUIDANCE: ${action.feedback}`
+          return false
+        case 'transform':
+          action.apply(event)
+          return false
+        case 'proceed':
+          return false
+        default:
+          logger.warn(`handler=<${handlerName}>, event=<beforeToolCall> | ${actionType} has no effect`)
+          return false
+      }
+    })
+  }
+
+  private async _onAfterToolCall(event: AfterToolCallEvent): Promise<void> {
+    return this._dispatch(event, 'afterToolCall', (action, handlerName) => {
+      switch (action.type) {
+        case 'transform':
+          action.apply(event)
+          return false
+        case 'proceed':
+          return false
+        default:
+          logger.warn(`handler=<${handlerName}>, event=<afterToolCall> | ${action.type} has no effect`)
+          return false
+      }
+    })
+  }
+
+  // Guide on beforeModelCall injects feedback as a user message so the model sees
+  // it on this call, rather than cancelling (which would end the invocation).
+  private async _onBeforeModelCall(event: BeforeModelCallEvent): Promise<void> {
+    return this._dispatch(event, 'beforeModelCall', (action, handlerName) => {
+      switch (action.type) {
+        case 'deny':
+          event.cancel = `DENIED: ${action.reason}`
+          return true
+        case 'guide':
+          // Direct push bypasses MessageAddedEvent and conversation manager.
+          // This matches what plugins can do today via event.agent.messages.
+          event.agent.messages.push(new Message({ role: 'user', content: [new TextBlock(action.feedback)] }))
+          return false
+        case 'transform':
+          action.apply(event)
+          return false
+        case 'proceed':
+          return false
+        default:
+          logger.warn(`handler=<${handlerName}>, event=<beforeModelCall> | ${action.type} has no effect`)
+          return false
+      }
+    })
+  }
+
+  private async _onAfterModelCall(event: AfterModelCallEvent): Promise<void> {
+    return this._dispatch(event, 'afterModelCall', (action, handlerName) => {
+      switch (action.type) {
+        case 'guide':
+          event.retry = true
+          // Direct push bypasses MessageAddedEvent and conversation manager, so this
+          // message won't trigger context management and could push the context over
+          // the limit. LocalAgent doesn't expose a message-append method that goes
+          // through the hook pipeline. This matches what plugins can do today.
+          event.agent.messages.push(new Message({ role: 'user', content: [new TextBlock(action.feedback)] }))
+          return false
+        case 'transform':
+          action.apply(event)
+          return false
+        case 'proceed':
+          return false
+        default:
+          logger.warn(`handler=<${handlerName}>, event=<afterModelCall> | ${action.type} has no effect`)
+          return false
+      }
+    })
   }
 
   /**
@@ -79,10 +185,13 @@ export class InterventionRegistry {
    * - If a handler throws, behavior depends on {@link InterventionHandler.onError}:
    *   `'throw'` (default) rethrows, `'deny'` fails closed, `'proceed'` skips.
    */
-  private async _dispatch(event: HookableEvent, method: LifecycleMethod): Promise<void> {
+  private async _dispatch(
+    event: HookableEvent,
+    method: LifecycleMethod,
+    apply: (action: InterventionAction, handlerName: string) => boolean
+  ): Promise<void> {
     logger.debug(`event=<${method}> | dispatching to ${this._handlers.length} handler(s)`)
     const guides: Array<{ handlerName: string; action: Guide }> = []
-    const apply = this._getApplier(event, method)
 
     for (const handler of this._handlers) {
       if (handler[method] === InterventionHandler.prototype[method]) continue
@@ -91,8 +200,6 @@ export class InterventionRegistry {
 
       let action: InterventionAction | undefined
       try {
-        // Safe: _registerHooks() only wires each method to its matching event type,
-        // so the event is always the correct type for the method being called.
         action = await handler[method](event as never)
       } catch (error) {
         action = this._handleError(handler, method, error)
@@ -120,145 +227,12 @@ export class InterventionRegistry {
       }
     }
 
-    // Guide feedback accumulates across handlers. Only logged and applied if
+    // Guide feedback accumulates across handlers. Only applied if
     // no earlier handler short-circuited (deny/interrupt).
     if (guides.length > 0) {
       logger.debug(`event=<${method}> | applying accumulated guide from ${guides.length} handler(s)`)
       const feedback = guides.map((g) => `[${g.handlerName}] ${g.action.feedback}`).join('\n')
       apply({ type: 'guide', feedback }, '')
-    }
-  }
-
-  /**
-   * Returns a function that applies a single action to the event.
-   * Returns true if the action short-circuits (deny/interrupt), false otherwise.
-   */
-  private _getApplier(
-    event: HookableEvent,
-    method: LifecycleMethod
-  ): (action: InterventionAction, handlerName: string) => boolean {
-    // beforeToolCall: supports all actions including native interrupt
-    if (event instanceof BeforeToolCallEvent) {
-      return (action, handlerName) => {
-        const actionType = action.type
-        switch (actionType) {
-          case 'deny':
-            event.cancel = `DENIED: ${action.reason}`
-            return true
-          case 'interrupt':
-            event.interrupt({ name: handlerName, reason: action.prompt })
-            return true
-          case 'guide':
-            event.cancel = `GUIDANCE: ${action.feedback}`
-            return false
-          case 'transform':
-            action.apply(event)
-            return false
-          case 'proceed':
-            return false
-          default:
-            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${actionType} has no effect on this event type`)
-            return false
-        }
-      }
-    }
-
-    // beforeInvocation: cancel-based (does not implement Interruptible)
-    if (event instanceof BeforeInvocationEvent) {
-      return (action, handlerName) => {
-        const actionType = action.type
-        switch (actionType) {
-          case 'deny':
-            event.cancel = `DENIED: ${action.reason}`
-            return true
-          case 'guide':
-            event.cancel = `GUIDANCE: ${action.feedback}`
-            return false
-          case 'transform':
-            action.apply(event)
-            return false
-          case 'proceed':
-            return false
-          default:
-            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${actionType} has no effect on this event type`)
-            return false
-        }
-      }
-    }
-
-    // beforeModelCall: Guide injects feedback as a user message so the model sees
-    // it on this call, rather than cancelling (which would end the invocation).
-    if (event instanceof BeforeModelCallEvent) {
-      return (action, handlerName) => {
-        switch (action.type) {
-          case 'deny':
-            event.cancel = `DENIED: ${action.reason}`
-            return true
-          case 'guide':
-            // Direct push bypasses MessageAddedEvent and conversation manager.
-            // This matches what plugins can do today via event.agent.messages.
-            event.agent.messages.push(new Message({ role: 'user', content: [new TextBlock(action.feedback)] }))
-            return false
-          case 'transform':
-            action.apply(event)
-            return false
-          case 'proceed':
-            return false
-          default:
-            logger.warn(
-              `handler=<${handlerName}>, event=<${method}> | ${(action as InterventionAction).type} has no effect on this event type`
-            )
-            return false
-        }
-      }
-    }
-
-    // afterToolCall: tool already ran, only Transform (e.g. redact result) is meaningful
-    if (event instanceof AfterToolCallEvent) {
-      return (action, handlerName) => {
-        switch (action.type) {
-          case 'transform':
-            action.apply(event)
-            return false
-          case 'proceed':
-            return false
-          default:
-            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${action.type} has no effect on this event type`)
-            return false
-        }
-      }
-    }
-
-    // afterModelCall: has retry
-    if (event instanceof AfterModelCallEvent) {
-      return (action, handlerName) => {
-        switch (action.type) {
-          case 'guide':
-            event.retry = true
-            // Direct push bypasses MessageAddedEvent and conversation manager, so this
-            // message won't trigger context management and could push the context over
-            // the limit. LocalAgent doesn't expose a message-append method that goes
-            // through the hook pipeline. This matches what plugins can do today.
-            event.agent.messages.push(new Message({ role: 'user', content: [new TextBlock(action.feedback)] }))
-            return false
-          case 'transform':
-            action.apply(event)
-            return false
-          case 'proceed':
-            return false
-          default:
-            logger.warn(`handler=<${handlerName}>, event=<${method}> | ${action.type} has no effect on this event type`)
-            return false
-        }
-      }
-    }
-
-    // Fallback for future event types not yet handled above
-    return (action, handlerName) => {
-      if (action.type !== 'proceed') {
-        logger.warn(`handler=<${handlerName}>, event=<${method}> | ${action.type} has no effect on this event type`)
-      }
-      return false
     }
   }
 


### PR DESCRIPTION
## Description

Adds the intervention primitive — a composable control layer for agents that enables authorization (Cedar, OPA), guardrails (Datadog AI Guard, content filtering), steering (LLM-based guidance), and operational controls (Galileo Agent Control) to share a common interface with ordered evaluation, short-circuiting, and typed actions.

### Example usage

```typescript
import { Agent, InterventionHandler, BeforeToolCallEvent, deny, proceed } from '@strands-agents/sdk'

class CedarAuth extends InterventionHandler {
  readonly name = 'cedar-auth'

  override beforeToolCall(event: BeforeToolCallEvent) {
    const userId = event.agent.appState.get('user_id')
    if (!this.isAuthorized(userId, event.toolUse.name)) {
      return deny(`User ${userId} not authorized for ${event.toolUse.name}`)
    }
    return proceed()
  }
}

class ToneSteeringHandler extends InterventionHandler {
  readonly name = 'tone-steering'

  override afterModelCall(event: AfterModelCallEvent) {
    const text = event.stopData?.message.content
      .filter((b) => b.type === 'textBlock')
      .map((b) => b.text)
      .join('')
    if (text && this.isTooAgressive(text)) {
      return guide('Use a more professional tone.')
    }
    return proceed()
  }
}

const agent = new Agent({
  tools: [queryDatabase, sendEmail],
  interventions: [new CedarAuth(), new ToneSteeringHandler()],
})

const result = await agent.invoke('Send an email to the client')
```

Cedar denies in sub-ms, steering never runs for denied tool calls (short-circuiting).

---

## API Contract

### Public Exports (from `@strands-agents/sdk`)

```typescript
// Class — consumers extend this
export { InterventionHandler }

// Factory helpers — construct action return values
export { proceed, deny, guide, interrupt, transform }

// Type — error policy
export type { OnError }
```

### `AgentConfig.interventions`

```typescript
interventions?: InterventionHandler[]
```

### `InterventionHandler`

```typescript
abstract class InterventionHandler {
  abstract readonly name: string
  readonly onError: OnError = 'throw'

  initAgent(agent: LocalAgent): void | Promise<void>

  beforeInvocation(event): Proceed | Deny | Guide | Transform
  beforeToolCall(event): Proceed | Deny | Guide | Interrupt | Transform
  afterToolCall(event): Proceed | Transform
  beforeModelCall(event): Proceed | Deny | Guide | Transform
  afterModelCall(event): Proceed | Guide | Transform
}
```

All lifecycle methods default to `proceed()`. Override only the ones you need — the framework detects overrides and only registers hooks for those.

### Action Types

| Action | Factory | Description |
|--------|---------|-------------|
| Proceed | `proceed(reason?)` | Allow the operation to continue |
| Deny | `deny(reason)` | Block the operation (sets event.cancel) |
| Guide | `guide(feedback, reason?)` | Steer with feedback |
| Interrupt | `interrupt(prompt, reason?)` | Pause for human approval (beforeToolCall only) |
| Transform | `transform(apply, reason?)` | Modify event content in-place |

### Action-to-Event Compatibility Matrix

| Action    | beforeInvocation | beforeToolCall | beforeModelCall | afterToolCall | afterModelCall |
|-----------|------------------|----------------|-----------------|---------------|----------------|
| Proceed   | —                | —              | —               | —             | —              |
| Deny      | cancel           | cancel         | cancel          | —             | —              |
| Guide     | cancel+          | cancel+        | inject          | —             | inject + retry |
| Interrupt | —                | interrupt      | —               | —             | —              |
| Transform | apply            | apply          | apply           | apply         | apply          |

- **—** = no-op (warns at runtime)
- **cancel** = sets event.cancel, short-circuits remaining handlers
- **cancel+** = sets event.cancel with accumulated feedback from all guiding handlers
- **interrupt** = calls event.interrupt() for native pause/resume
- **inject** = appends feedback as a user message so the model sees it on this call
- **inject + retry** = appends feedback and retries so the model sees guidance
- **apply** = calls action.apply(event) for in-place mutation

### Hook Ordering

- Before* events: interventions run **last** (`SDK_LAST`) — closest to execution
- After* events: interventions run **first** (`SDK_FIRST`) — closest to execution

Flow: `plugins → intervention → [operation] → intervention → plugins`

### `onError` Policy

| Value | Behavior |
|-------|----------|
| `'throw'` | Rethrow (default). Invocation fails. |
| `'proceed'` | Skip handler, continue to next. |
| `'deny'` | Apply Deny (fail-closed). |

### `initAgent(agent)`

Called once during agent initialization. Use to register context-gathering hooks (e.g. steering context providers):

```typescript
override initAgent(agent: LocalAgent): void {
  agent.addHook(MessageAddedEvent, (event) => this.updateContext(event))
}
```

---

## What's NOT included (internal / planned)

- **InterventionRegistry** — not publicly exported. Internal dispatch mechanism.
- **Audit log** — removed for now. Will be added when consumption patterns are clear.
- **`agent.interventions` getter** — removed. Registry is fully internal.

## Related Issues

- strands-agents/sdk-typescript#846
- strands-agents/sdk-typescript#889
- strands-agents/sdk-typescript#906

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?
- [x] I ran `npm run check`
- 32 unit tests covering all action types, short-circuiting, guide accumulation, dispatch ordering, override detection, all three onError modes, async handlers, duplicate name rejection, conflict resolution, initAgent, native interrupt, and full Agent integration (deny prevents tool execution, hook ordering verified)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
