### PR TITLE
feat: override countTokens with native token counting for supported providers

### DIFF
--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -173,6 +173,19 @@ export class SessionError extends Error {
 }
 
 /**
+ * Thrown when a model provider's native token counting API fails.
+ *
+ * This error is used as internal control flow within provider `countTokens()` overrides.
+ * When caught, the provider falls back to the base class heuristic estimation.
+ */
+export class ProviderTokenCountError extends ModelError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'ProviderTokenCountError'
+  }
+}
+
+/**
  * Thrown when a tool fails validation during registration.
  */
 export class ToolValidationError extends Error {

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -27,6 +27,7 @@ export {
   JsonValidationError,
   ConcurrentInvocationError,
   ModelThrottledError,
+  ProviderTokenCountError,
   ToolValidationError,
   StructuredOutputError,
 } from './errors.js'

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -22,6 +22,7 @@ function createMockClient(streamGenerator: () => AsyncGenerator<unknown>): Anthr
   return {
     messages: {
       stream: vi.fn(() => streamGenerator()),
+      countTokens: vi.fn(),
     },
   } as unknown as Anthropic
 }
@@ -32,6 +33,7 @@ vi.mock('@anthropic-ai/sdk', () => {
     return {
       messages: {
         stream: vi.fn(),
+        countTokens: vi.fn(),
       },
     }
   })
@@ -664,6 +666,102 @@ describe('AnthropicModel', () => {
         expect(warnSpy).toHaveBeenCalled()
         warnSpy.mockRestore()
       })
+    })
+  })
+
+  describe('countTokens', () => {
+    const messages: Message[] = [new Message({ role: 'user', content: [new TextBlock('hello')] })]
+    const toolSpecs = [
+      { name: 'test_tool', description: 'A test tool', inputSchema: { type: 'object' as const, properties: {} } },
+    ]
+
+    function createCountTokensClient(mockCountTokens: ReturnType<typeof vi.fn>): Anthropic {
+      return {
+        messages: {
+          stream: vi.fn(),
+          countTokens: mockCountTokens,
+        },
+      } as unknown as Anthropic
+    }
+
+    it('should return native token count on success', async () => {
+      const mockCountTokens = vi.fn(async () => ({ input_tokens: 42 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      const result = await model.countTokens(messages)
+
+      expect(result).toBe(42)
+      expect(mockCountTokens).toHaveBeenCalledOnce()
+    })
+
+    it('should include system prompt in request', async () => {
+      const mockCountTokens = vi.fn(async () => ({ input_tokens: 55 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      const result = await model.countTokens(messages, { systemPrompt: 'Be helpful.' })
+
+      expect(result).toBe(55)
+      expect(mockCountTokens).toHaveBeenCalledWith({
+        model: 'claude-sonnet-4-6',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+        system: 'Be helpful.',
+      })
+    })
+
+    it('should include tool specs in request', async () => {
+      const mockCountTokens = vi.fn(async () => ({ input_tokens: 100 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      const result = await model.countTokens(messages, { toolSpecs })
+
+      expect(result).toBe(100)
+      expect(mockCountTokens).toHaveBeenCalledWith({
+        model: 'claude-sonnet-4-6',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+        tools: [{ name: 'test_tool', description: 'A test tool', input_schema: { type: 'object', properties: {} } }],
+      })
+    })
+
+    it('should strip max_tokens from request', async () => {
+      const mockCountTokens = vi.fn(async () => ({ input_tokens: 10 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      await model.countTokens(messages)
+
+      expect(mockCountTokens).toHaveBeenCalledWith({
+        model: 'claude-sonnet-4-6',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+      })
+    })
+
+    it('should fall back to estimation on API error', async () => {
+      const mockCountTokens = vi.fn(async () => {
+        throw new Error('Unsupported')
+      })
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should fall back to estimation on generic exception', async () => {
+      const mockCountTokens = vi.fn(async () => {
+        throw new Error('Connection failed')
+      })
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
     })
   })
 })

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { BedrockRuntimeClient, ConverseStreamCommand, ValidationException } from '@aws-sdk/client-bedrock-runtime'
+import {
+  BedrockRuntimeClient,
+  ConverseStreamCommand,
+  CountTokensCommand,
+  ValidationException,
+} from '@aws-sdk/client-bedrock-runtime'
 import { isNode } from '../../__fixtures__/environment.js'
 import { BedrockModel } from '../bedrock.js'
 import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
@@ -115,6 +120,9 @@ vi.mock('@aws-sdk/client-bedrock-runtime', async (importOriginal) => {
     throw new Error('Unhandled command type in mock')
   })
 
+  // Create a mock CountTokensCommand class
+  const CountTokensCommand = vi.fn()
+
   // Create a mock ValidationException class
   class MockValidationException extends Error {
     constructor(opts: { message: string; $metadata: Record<string, unknown> }) {
@@ -137,6 +145,7 @@ vi.mock('@aws-sdk/client-bedrock-runtime', async (importOriginal) => {
     }),
     ConverseStreamCommand,
     ConverseCommand,
+    CountTokensCommand,
     ValidationException: MockValidationException,
   }
 })
@@ -4048,6 +4057,122 @@ describe('BedrockModel', () => {
           additionalModelRequestFields: expect.anything(),
         })
       )
+    })
+  })
+
+  describe('countTokens', () => {
+    const messages: Message[] = [new Message({ role: 'user', content: [new TextBlock('hello')] })]
+    const toolSpecs = [
+      { name: 'test_tool', description: 'A test tool', inputSchema: { type: 'object' as const, properties: {} } },
+    ]
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should return native token count on success', async () => {
+      const mockSend = vi.fn(async () => ({ inputTokens: 42 }))
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      const result = await model.countTokens(messages)
+
+      expect(result).toBe(42)
+      expect(mockSend).toHaveBeenCalledOnce()
+    })
+
+    it('should include system prompt in request', async () => {
+      const mockSend = vi.fn(async () => ({ inputTokens: 55 }))
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      const result = await model.countTokens(messages, { systemPrompt: 'Be helpful.' })
+
+      expect(result).toBe(55)
+      const commandInput = vi.mocked(CountTokensCommand).mock.calls[0]![0]!
+      expect(commandInput).toStrictEqual({
+        modelId: expect.any(String),
+        input: {
+          converse: {
+            messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+            system: [{ text: 'Be helpful.' }],
+          },
+        },
+      })
+    })
+
+    it('should include tool specs in request', async () => {
+      const mockSend = vi.fn(async () => ({ inputTokens: 100 }))
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      const result = await model.countTokens(messages, { toolSpecs })
+
+      expect(result).toBe(100)
+      const commandInput = vi.mocked(CountTokensCommand).mock.calls[0]![0]!
+      expect(commandInput).toStrictEqual({
+        modelId: expect.any(String),
+        input: {
+          converse: {
+            messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+            toolConfig: {
+              tools: [
+                {
+                  toolSpec: {
+                    name: 'test_tool',
+                    description: 'A test tool',
+                    inputSchema: { json: { type: 'object', properties: {} } },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+
+    it('should strip inferenceConfig from request', async () => {
+      const mockSend = vi.fn(async () => ({ inputTokens: 10 }))
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel({ maxTokens: 100 })
+
+      await model.countTokens(messages)
+
+      const commandInput = vi.mocked(CountTokensCommand).mock.calls[0]![0]!
+      expect(commandInput).toStrictEqual({
+        modelId: expect.any(String),
+        input: {
+          converse: {
+            messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+          },
+        },
+      })
+    })
+
+    it('should fall back to estimation on API error', async () => {
+      const mockSend = vi.fn(async () => {
+        throw new Error('API error')
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should fall back to estimation on generic exception', async () => {
+      const mockSend = vi.fn(async () => {
+        throw new Error('Connection failed')
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
     })
   })
 })

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -1182,4 +1182,88 @@ describe('GoogleModel', () => {
       expect(events[4]).toEqual({ type: 'modelMessageStopEvent', stopReason: 'toolUse' })
     })
   })
+
+  describe('countTokens', () => {
+    const messages: Message[] = [new Message({ role: 'user', content: [new TextBlock('hello')] })]
+    const toolSpecs = [
+      { name: 'test_tool', description: 'A test tool', inputSchema: { type: 'object' as const, properties: {} } },
+    ]
+
+    function createCountTokensClient(mockCountTokens: ReturnType<typeof vi.fn>): GoogleGenAI {
+      return {
+        models: {
+          generateContentStream: vi.fn(),
+          countTokens: mockCountTokens,
+        },
+      } as unknown as GoogleGenAI
+    }
+
+    it('should return native token count on success', async () => {
+      const mockCountTokens = vi.fn(async () => ({ totalTokens: 42 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages)
+
+      expect(result).toBe(42)
+      expect(mockCountTokens).toHaveBeenCalledOnce()
+    })
+
+    it('should add heuristic estimate for system prompt', async () => {
+      const mockCountTokens = vi.fn(async () => ({ totalTokens: 55 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages, { systemPrompt: 'Be helpful.' })
+
+      expect(result).toBeGreaterThan(55) // native (55) + heuristic for system prompt
+    })
+
+    it('should add heuristic estimate for tool specs', async () => {
+      const mockCountTokens = vi.fn(async () => ({ totalTokens: 100 }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages, { toolSpecs })
+
+      expect(result).toBeGreaterThan(100) // native (100) + heuristic for tools
+    })
+
+    it('should fall back on null totalTokens', async () => {
+      const mockCountTokens = vi.fn(async () => ({ totalTokens: null }))
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should fall back to estimation on API error', async () => {
+      const mockCountTokens = vi.fn(async () => {
+        throw new Error('Unsupported')
+      })
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should fall back to estimation on generic exception', async () => {
+      const mockCountTokens = vi.fn(async () => {
+        throw new Error('Connection failed')
+      })
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages)
+
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThanOrEqual(0)
+    })
+  })
 })

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -1,5 +1,5 @@
 import Anthropic, { type ClientOptions } from '@anthropic-ai/sdk'
-import { Model, type BaseModelConfig, type StreamOptions } from '../models/model.js'
+import { Model, type BaseModelConfig, type CountTokensOptions, type StreamOptions } from '../models/model.js'
 import type { Message, ContentBlock } from '../types/messages.js'
 import type { ModelStreamEvent } from '../models/streaming.js'
 import { createEmptyUsage } from '../models/streaming.js'
@@ -82,6 +82,37 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
 
   getConfig(): AnthropicModelConfig {
     return this._config
+  }
+
+  /**
+   * Count tokens using Anthropic's native countTokens API.
+   *
+   * Uses the same message format as the Messages API to get accurate token counts
+   * directly from the Anthropic service. Falls back to the base class heuristic on failure.
+   *
+   * @param messages - Array of conversation messages to count tokens for
+   * @param options - Optional options containing system prompt and tool specs
+   * @returns Total input token count
+   */
+  override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    try {
+      const request = this._formatRequest(messages, options)
+      const params: Anthropic.MessageCountTokensParams = {
+        model: request.model,
+        messages: request.messages,
+        ...(request.system && { system: request.system }),
+        ...(request.tools && { tools: request.tools }),
+        ...(request.tool_choice && { tool_choice: request.tool_choice }),
+      }
+
+      const response = await this._client.messages.countTokens(params)
+
+      logger.debug(`total_tokens=<${response.input_tokens}> | native token count`)
+      return response.input_tokens
+    } catch (error) {
+      logger.warn(`error=<${error}> | native token counting failed, falling back to estimation`)
+      return super.countTokens(messages, options)
+    }
   }
 
   async *stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent> {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -16,6 +16,7 @@ import {
   ConverseCommand,
   type ConverseCommandOutput,
   ConverseStreamCommand,
+  CountTokensCommand,
   type ConverseStreamCommandInput,
   type ConverseStreamMetadataEvent as BedrockConverseStreamMetadataEvent,
   type ConverseStreamOutput,
@@ -41,13 +42,19 @@ import {
   type CitationsContentBlock as BedrockCitationsContentBlock,
   type GuardrailTraceAssessment,
 } from '@aws-sdk/client-bedrock-runtime'
-import { type BaseModelConfig, type CacheConfig, Model, type StreamOptions } from '../models/model.js'
+import {
+  type BaseModelConfig,
+  type CacheConfig,
+  type CountTokensOptions,
+  Model,
+  type StreamOptions,
+} from '../models/model.js'
 import type { ContentBlock, Message, StopReason, ToolUseBlock } from '../types/messages.js'
 import type { ImageSource, VideoSource, DocumentSource } from '../types/media.js'
 import type { CitationsDelta, ModelStreamEvent, ReasoningContentDelta, Usage } from '../models/streaming.js'
 import type { Citation, CitationLocation, CitationsBlockData } from '../types/citations.js'
 import type { JSONValue } from '../types/json.js'
-import { ContextWindowOverflowError, ModelThrottledError, normalizeError } from '../errors.js'
+import { ContextWindowOverflowError, ModelThrottledError, ProviderTokenCountError, normalizeError } from '../errors.js'
 import { ensureDefined } from '../types/validation.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
@@ -457,6 +464,43 @@ export class BedrockModel extends Model<BedrockModelConfig> {
    */
   getConfig(): BedrockModelConfig {
     return this._config
+  }
+
+  /**
+   * Count tokens using Bedrock's native CountTokens API.
+   *
+   * Uses the same message format as the Converse API to get accurate token counts
+   * directly from the Bedrock service. Falls back to the base class heuristic on failure.
+   *
+   * @param messages - Array of conversation messages to count tokens for
+   * @param options - Optional options containing system prompt and tool specs
+   * @returns Total input token count
+   */
+  override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    try {
+      const request = this._formatRequest(messages, options)
+      const converseInput: Record<string, unknown> = {}
+      if (request.messages) converseInput.messages = request.messages
+      if (request.system) converseInput.system = request.system
+      if (request.toolConfig) converseInput.toolConfig = request.toolConfig
+
+      const response = await this._client.send(
+        new CountTokensCommand({
+          modelId: this._config.modelId,
+          input: { converse: converseInput },
+        })
+      )
+
+      if (response.inputTokens == null) {
+        throw new ProviderTokenCountError('Bedrock CountTokens returned undefined for inputTokens')
+      }
+
+      logger.debug(`total_tokens=<${response.inputTokens}> | native token count`)
+      return response.inputTokens
+    } catch (error) {
+      logger.warn(`error=<${error}> | native token counting failed, falling back to estimation`)
+      return super.countTokens(messages, options)
+    }
   }
 
   /**

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -14,10 +14,10 @@ import {
   type GenerateContentParameters,
 } from '@google/genai'
 import { Model } from '../model.js'
-import type { StreamOptions } from '../model.js'
+import type { CountTokensOptions, StreamOptions } from '../model.js'
 import type { Message } from '../../types/messages.js'
 import type { ModelStreamEvent } from '../streaming.js'
-import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
+import { ContextWindowOverflowError, ModelThrottledError, ProviderTokenCountError } from '../../errors.js'
 import type { GoogleModelConfig, GoogleModelOptions, GoogleStreamState } from './types.js'
 export type { GoogleModelConfig, GoogleModelOptions }
 import { classifyGoogleError } from './errors.js'
@@ -145,6 +145,53 @@ export class GoogleModel extends Model<GoogleModelConfig> {
    */
   getConfig(): GoogleModelConfig {
     return this._config
+  }
+
+  /**
+   * Count tokens using Gemini's native countTokens API.
+   *
+   * Uses the Gemini countTokens API for message contents. System instructions and tools
+   * are estimated via the base class heuristic because the Gemini API (non-Vertex backend)
+   * does not support these in CountTokensConfig.
+   * Falls back to the base class heuristic on failure.
+   *
+   * @param messages - Array of conversation messages to count tokens for
+   * @param options - Optional options containing system prompt and tool specs
+   * @returns Total input token count
+   */
+  override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    try {
+      const params = this._formatRequest(messages, options)
+      const modelId = params.model
+
+      // The Gemini API (non-Vertex backend) raises an error for systemInstruction and tools
+      // in CountTokensConfig. Use native counting for message contents only, then add the
+      // heuristic estimate for system prompt and tools.
+      const response = await this._client.models.countTokens({
+        model: modelId,
+        contents: params.contents,
+      })
+
+      if (response.totalTokens == null) {
+        throw new ProviderTokenCountError('Gemini countTokens returned null for totalTokens')
+      }
+
+      let totalTokens = response.totalTokens
+
+      // Add heuristic estimate for system prompt and tools (not supported by the API)
+      if (options?.systemPrompt || options?.toolSpecs) {
+        totalTokens += await super.countTokens([], {
+          ...(options.systemPrompt && { systemPrompt: options.systemPrompt }),
+          ...(options.toolSpecs && { toolSpecs: options.toolSpecs }),
+        })
+      }
+
+      logger.debug(`total_tokens=<${totalTokens}> | native token count`)
+      return totalTokens
+    } catch (error) {
+      logger.warn(`error=<${error}> | native token counting failed, falling back to estimation`)
+      return super.countTokens(messages, options)
+    }
   }
 
   /**

--- a/strands-ts/test/integ/models/anthropic.test.ts
+++ b/strands-ts/test/integ/models/anthropic.test.ts
@@ -159,4 +159,31 @@ describe.skipIf(anthropic.skip)('AnthropicModel Integration Tests', () => {
       }
     })
   })
+
+  describe('countTokens', () => {
+    const messages = [
+      new Message({ role: 'user', content: [new TextBlock('What is the capital of France? Explain in detail.')] }),
+    ]
+    const toolSpecs = [
+      {
+        name: 'get_weather',
+        description: 'Get the current weather for a location',
+        inputSchema: { type: 'object' as const, properties: { location: { type: 'string' as const } } },
+      },
+    ]
+
+    it.concurrent('should count tokens for messages only', async () => {
+      const model = anthropic.createModel()
+      const result = await model.countTokens(messages)
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThan(0)
+    })
+
+    it.concurrent('should return more tokens with tools and system prompt', async () => {
+      const model = anthropic.createModel()
+      const without = await model.countTokens(messages)
+      const withTools = await model.countTokens(messages, { toolSpecs, systemPrompt: 'Be helpful.' })
+      expect(withTools).toBeGreaterThan(without)
+    })
+  })
 })

--- a/strands-ts/test/integ/models/bedrock.test.ts
+++ b/strands-ts/test/integ/models/bedrock.test.ts
@@ -742,4 +742,31 @@ describe.skipIf(bedrock.skip)('BedrockModel Integration Tests', () => {
       }, 30000)
     })
   })
+
+  describe('countTokens', () => {
+    const messages = [
+      new Message({ role: 'user', content: [new TextBlock('What is the capital of France? Explain in detail.')] }),
+    ]
+    const toolSpecs = [
+      {
+        name: 'get_weather',
+        description: 'Get the current weather for a location',
+        inputSchema: { type: 'object' as const, properties: { location: { type: 'string' as const } } },
+      },
+    ]
+
+    it.concurrent('should count tokens for messages only', async () => {
+      const model = bedrock.createModel()
+      const result = await model.countTokens(messages)
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThan(0)
+    })
+
+    it.concurrent('should return more tokens with tools and system prompt', async () => {
+      const model = bedrock.createModel()
+      const without = await model.countTokens(messages)
+      const withTools = await model.countTokens(messages, { toolSpecs, systemPrompt: 'Be helpful.' })
+      expect(withTools).toBeGreaterThan(without)
+    })
+  })
 })

--- a/strands-ts/test/integ/models/google.test.ts
+++ b/strands-ts/test/integ/models/google.test.ts
@@ -130,4 +130,31 @@ describe.skipIf(gemini.skip)('GoogleModel Integration Tests', () => {
       })
     })
   })
+
+  describe('countTokens', () => {
+    const messages = [
+      new Message({ role: 'user', content: [new TextBlock('What is the capital of France? Explain in detail.')] }),
+    ]
+    const toolSpecs = [
+      {
+        name: 'get_weather',
+        description: 'Get the current weather for a location',
+        inputSchema: { type: 'object' as const, properties: { location: { type: 'string' as const } } },
+      },
+    ]
+
+    it.concurrent('should count tokens for messages only', async () => {
+      const model = gemini.createModel()
+      const result = await model.countTokens(messages)
+      expect(typeof result).toBe('number')
+      expect(result).toBeGreaterThan(0)
+    })
+
+    it.concurrent('should return more tokens with tools and system prompt', async () => {
+      const model = gemini.createModel()
+      const without = await model.countTokens(messages)
+      const withTools = await model.countTokens(messages, { toolSpecs, systemPrompt: 'Be helpful.' })
+      expect(withTools).toBeGreaterThan(without)
+    })
+  })
 })


### PR DESCRIPTION
## Description                                                                                                                                                                                          
                                                                                                                                                                                                        
Override `countTokens()` in provider subclasses that expose native token counting APIs, improving accuracy over the character-based heuristic added in #853. The method signature is unchanged — native 
counting is transparent to callers.                                                                                                                                                                     

Each provider reuses its existing request formatting logic, calls the native counting API, and falls back to `super.countTokens()` with a warning log on any failure:                                   

- **Bedrock** — `CountTokensCommand` via AWS SDK (same format as Converse API)                                                                                                                          
- **Anthropic** — `client.messages.countTokens()` (same format as Messages API)                                                                                                                         
- **Google Gemini** — `client.models.countTokens()` for message contents; system instructions and tools are estimated via the base class heuristic because the Gemini API (non-Vertex backend) does not support `systemInstruction`/`tools` in `CountTokensConfig`                                                                                                                                              

Fields irrelevant to token counting are stripped from the request before calling the counting API.                                     
                                                                                                                                                                                                        
### TypeScript port of                                                                                                                                                                                  
                                                                                                                                                                                                        
- Python PR: https://github.com/strands-agents/sdk-python/pull/2189                                                                                                                                     
                                                                                                                                                                                                        
## Related Issues                                                                                                                                                                                       
                                                                                                                                                                                                        
https://github.com/strands-agents/sdk-python/issues/2179
                                                                                                                                                                                                        
## Documentation PR                                                                                                                                                                                     
                                                                                                                                                                                                        
Documentation will be updated alongside proactive compression work
                                                                                                                                                                                                        
## Type of Change                                                                                                                                                                                       
                                                                                                                                                                                                        
New feature
                                                                                                                                                                                                        
## Testing                                                                                                                                                                                              
                                                                                                                                                                                                        
How have you tested the change?                                                                                                                                                                         
                                                                                                                                                                                                        
- [x] I ran `npm run check`                                                                                                                                                                             
- 18 new unit tests (6 per provider) covering: success, system prompt, tool specs, inference config stripping, API error fallback, generic exception fallback                                           
- 6 new integration tests (2 per provider) covering: messages-only counting, tools+system prompt returns more tokens than without                                                                       
- All 402 existing model unit tests continue to pass                                                                                                                                                    

## Checklist                                                                                                                                                                                            
- [x] I have read the CONTRIBUTING document                                                                                                                                                             
- [x] I have added any necessary tests that prove my fix is effective or my feature works                                                                                                               
- [ ] I have updated the documentation accordingly                                                                                                                                                      
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed                                                                                        
- [x] My changes generate no new warnings                                                                                                                                                               
- [x] Any dependent changes have been merged and published 