### PR TITLE
feat: add invocation state; apply to all events

### DIFF
--- a/strands-ts/src/__fixtures__/agent-helpers.ts
+++ b/strands-ts/src/__fixtures__/agent-helpers.ts
@@ -130,6 +130,13 @@ export interface AgentResultMatcher extends Omit<LoopMetricsMatcher, 'cycleCount
    * When omitted, asserts traces array exists with at least one element.
    */
   traceCount?: number
+
+  /**
+   * Expected `invocationState` on the result. When provided, the full object
+   * must match exactly — extra keys fail. When omitted, only asserts
+   * `invocationState` is present (any object).
+   */
+  invocationState?: Record<string, unknown>
 }
 
 /**
@@ -149,7 +156,7 @@ export interface AgentResultMatcher extends Omit<LoopMetricsMatcher, 'cycleCount
  * ```
  */
 export function expectAgentResult(options: AgentResultMatcher): AgentResult {
-  const { stopReason, messageText, cycleCount, traceCount, toolNames, usage } = options
+  const { stopReason, messageText, cycleCount, traceCount, toolNames, usage, invocationState } = options
 
   const expectedLastMessage = messageText
     ? expect.objectContaining({
@@ -178,5 +185,6 @@ export function expectAgentResult(options: AgentResultMatcher): AgentResult {
     lastMessage: expectedLastMessage,
     metrics: expectLoopMetrics(metricsOptions),
     traces: expectedTraces,
+    invocationState: invocationState ?? expect.any(Object),
   }) as AgentResult
 }

--- a/strands-ts/src/__fixtures__/tool-helpers.ts
+++ b/strands-ts/src/__fixtures__/tool-helpers.ts
@@ -9,18 +9,20 @@ import type { JSONValue } from '../types/json.js'
 import { StateStore } from '../state-store.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
 import type { PlainToolResultBlock } from './slim-types.js'
-import type { LocalAgent } from '../types/agent.js'
+import type { InvocationState, LocalAgent } from '../types/agent.js'
 
 /**
  * Helper to create a mock ToolContext for testing.
  *
  * @param toolUse - The tool use request
  * @param appState - Optional initial app state
+ * @param invocationState - Optional initial invocation state
  * @returns Mock ToolContext object
  */
 export function createMockContext(
   toolUse: { name: string; toolUseId: string; input: JSONValue },
-  appState?: Record<string, JSONValue>
+  appState?: Record<string, JSONValue>,
+  invocationState?: InvocationState
 ): ToolContext {
   return {
     toolUse,
@@ -31,6 +33,7 @@ export function createMockContext(
       toolRegistry: new ToolRegistry(),
       addHook: () => () => {},
     } as unknown as LocalAgent,
+    invocationState: invocationState ?? {},
   }
 }
 

--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -437,6 +437,7 @@ describe('MCP Integration', () => {
     const toolContext: ToolContext = {
       toolUse: { toolUseId: 'id-123', name: 'weather', input: { city: 'NYC' } },
       agent: {} as LocalAgent,
+      invocationState: {},
     }
 
     it('returns text results on success', async () => {

--- a/strands-ts/src/a2a/__tests__/events.test.ts
+++ b/strands-ts/src/a2a/__tests__/events.test.ts
@@ -41,6 +41,7 @@ describe('A2AResultEvent', () => {
       stopReason: 'endTurn',
       lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Done')] }),
       metrics: new AgentMetrics(),
+      invocationState: {},
     })
     const event = new A2AResultEvent({ result })
 
@@ -54,6 +55,7 @@ describe('A2AResultEvent', () => {
         stopReason: 'endTurn',
         lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Done')] }),
         metrics: new AgentMetrics(),
+        invocationState: {},
       }),
     })
 

--- a/strands-ts/src/a2a/__tests__/executor.test.ts
+++ b/strands-ts/src/a2a/__tests__/executor.test.ts
@@ -133,11 +133,25 @@ describe('A2AExecutor', () => {
 
       await executor.execute(context, eventBus)
 
-      expect(agent.stream).toHaveBeenCalledWith([
-        new TextBlock('Line 1'),
-        new TextBlock('[File: file (file://test.txt)]'),
-        new TextBlock('Line 2'),
-      ])
+      expect(agent.stream).toHaveBeenCalledWith(
+        [new TextBlock('Line 1'), new TextBlock('[File: file (file://test.txt)]'), new TextBlock('Line 2')],
+        { invocationState: { a2aRequestContext: context } }
+      )
+    })
+
+    it('forwards the A2A request context to the agent via invocationState', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Response' })
+      const agent = new Agent({ model, printer: false })
+      const streamSpy = vi.spyOn(agent, 'stream')
+      const executor = new A2AExecutor(agent)
+      const eventBus = createMockEventBus()
+      const context = createRequestContext('hello', 'task-42')
+
+      await executor.execute(context, eventBus)
+
+      expect(streamSpy).toHaveBeenCalledTimes(1)
+      const [, options] = streamSpy.mock.calls[0]!
+      expect(options?.invocationState).toEqual({ a2aRequestContext: context })
     })
 
     it('re-throws when agent throws, publishing only the initial task event', async () => {

--- a/strands-ts/src/a2a/__tests__/executor.test.ts
+++ b/strands-ts/src/a2a/__tests__/executor.test.ts
@@ -166,15 +166,18 @@ describe('A2AExecutor', () => {
           yield new ModelStreamUpdateEvent({
             agent,
             event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Here is the image:' } },
+            invocationState: {},
           })
           // Image content block
           yield new ContentBlockEvent({
             agent,
             contentBlock: new ImageBlock({ format: 'png', source: { bytes: imageBytes } }),
+            invocationState: {},
           })
           return new AgentResult({
             stopReason: 'endTurn',
             lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Here is the image:')] }),
+            invocationState: {},
           })
         },
       }

--- a/strands-ts/src/a2a/a2a-agent.ts
+++ b/strands-ts/src/a2a/a2a-agent.ts
@@ -10,7 +10,7 @@
 import type { AgentCard, Part } from '@a2a-js/sdk'
 import type { Client as A2AClientSdk, ClientFactory as ClientFactoryType } from '@a2a-js/sdk/client'
 import { ClientFactory } from '@a2a-js/sdk/client'
-import type { InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
+import type { InvocationState, InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
 import { AgentResult } from '../types/agent.js'
 import { Message, TextBlock, type ContentBlock, type ContentBlockData, type MessageData } from '../types/messages.js'
 import { A2AStreamUpdateEvent, A2AResultEvent, type A2AEventData, type A2AStreamEvent } from './events.js'
@@ -91,7 +91,7 @@ export class A2AAgent implements InvokableAgent {
    * Built on top of `stream()` — consumes the full event stream and returns the final result.
    *
    * @param args - Arguments for invoking the agent
-   * @param options - Optional invocation options (unused for remote agents)
+   * @param options - Optional invocation options. See {@link stream} for behavior.
    * @returns Promise that resolves to the AgentResult
    */
   async invoke(args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
@@ -111,12 +111,16 @@ export class A2AAgent implements InvokableAgent {
    * containing the final result built from the last complete event.
    *
    * @param args - Arguments for invoking the agent
-   * @param _options - Optional invocation options (unused for remote agents)
+   * @param options - Optional invocation options. If `invocationState` is
+   *   provided, it is returned on the resulting `AgentResult`. The remote
+   *   agent runs in another process and cannot read or mutate it. Other
+   *   fields on `options` are ignored.
    * @returns Async generator that yields AgentStreamEvent objects and returns AgentResult
    */
-  async *stream(args: InvokeArgs, _options?: InvokeOptions): AsyncGenerator<A2AStreamEvent, AgentResult, undefined> {
+  async *stream(args: InvokeArgs, options?: InvokeOptions): AsyncGenerator<A2AStreamEvent, AgentResult, undefined> {
     const client = await this._getClient()
     const text = this._extractTextFromArgs(args)
+    const invocationState = options?.invocationState ?? {}
 
     let lastEvent: A2AEventData | undefined
     let lastCompleteEvent: A2AEventData | undefined
@@ -153,7 +157,7 @@ export class A2AAgent implements InvokableAgent {
 
     const finalEvent = lastCompleteEvent ?? lastEvent
     const accumulatedText = [...artifactTexts.values()].map((chunks) => chunks.join('')).join('\n')
-    const result = this._buildResult(finalEvent, accumulatedText)
+    const result = this._buildResult(finalEvent, invocationState, accumulatedText)
 
     yield new A2AResultEvent({ result })
     return result
@@ -239,15 +243,21 @@ export class A2AAgent implements InvokableAgent {
    * Builds an AgentResult from the final A2A streaming event.
    *
    * @param event - The final A2A event, or undefined if no events were received
+   * @param invocationState - Caller-provided invocation state, threaded through to the result
+   * @param accumulatedText - Optional accumulated text from streaming artifacts
    * @returns The constructed AgentResult
    */
-  private _buildResult(event: A2AEventData | undefined, accumulatedText?: string): AgentResult {
+  private _buildResult(
+    event: A2AEventData | undefined,
+    invocationState: InvocationState,
+    accumulatedText?: string
+  ): AgentResult {
     const text = this._extractTextFromEvent(event) || accumulatedText || ''
     const lastMessage = new Message({
       role: 'assistant',
       content: [new TextBlock(text)],
     })
-    return new AgentResult({ stopReason: 'endTurn', lastMessage })
+    return new AgentResult({ stopReason: 'endTurn', lastMessage, invocationState })
   }
 
   /**

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -22,6 +22,19 @@ import { logger } from '../logging/logger.js'
  * event bus. Text chunks are appended to a single artifact as they arrive,
  * implementing A2A-compliant streaming behavior.
  *
+ * ## Invocation state
+ *
+ * The executor populates the agent's `invocationState` with the incoming A2A
+ * {@link RequestContext} under the reserved key `a2aRequestContext`. Hooks and
+ * tools running inside the agent can read `event.invocationState.a2aRequestContext`
+ * to correlate with the A2A request (taskId, contextId, user message metadata)
+ * for logging, metrics, or audit.
+ *
+ * Because the A2A framework (not user code) drives `execute()`, there is no
+ * per-request path for the user to supply their own `invocationState`. If a
+ * user hook writes to the `a2aRequestContext` key, it will be overwritten on
+ * the next request.
+ *
  * @example
  * ```typescript
  * import { Agent } from '@strands-agents/sdk'
@@ -71,7 +84,12 @@ export class A2AExecutor implements AgentExecutor {
     let isFirstChunk = true
 
     try {
-      const stream = this._agent.stream(contentBlocks)
+      // Forward the A2A RequestContext to the agent under a reserved key so
+      // hooks and tools can correlate with the A2A request (taskId, contextId,
+      // user message metadata).
+      const stream = this._agent.stream(contentBlocks, {
+        invocationState: { a2aRequestContext: context },
+      })
       let next = await stream.next()
 
       while (!next.done) {

--- a/strands-ts/src/agent/__tests__/agent-as-tool.invocation-state.test.ts
+++ b/strands-ts/src/agent/__tests__/agent-as-tool.invocation-state.test.ts
@@ -22,8 +22,7 @@ describe('AgentAsTool invocationState forwarding', () => {
 
     const result = await outer.invoke('run inner', { invocationState: { userId: 'u-1' } })
 
-    expect(innerSawState?.userId).toBe('u-1')
-    expect(result.invocationState.innerTouched).toBe(true)
-    expect(result.invocationState.userId).toBe('u-1')
+    expect(innerSawState).toEqual({ userId: 'u-1', innerTouched: true })
+    expect(result.invocationState).toEqual({ userId: 'u-1', innerTouched: true })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent-as-tool.invocation-state.test.ts
+++ b/strands-ts/src/agent/__tests__/agent-as-tool.invocation-state.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../agent.js'
+import { BeforeModelCallEvent } from '../../hooks/events.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import type { InvocationState } from '../../types/agent.js'
+
+describe('AgentAsTool invocationState forwarding', () => {
+  it('forwards outer invocationState into the wrapped agent and reflects inner mutations on outer result', async () => {
+    const innerModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'inner-done' })
+    const inner = new Agent({ model: innerModel, name: 'inner', description: 'inner agent' })
+
+    let innerSawState: InvocationState | undefined
+    inner.addHook(BeforeModelCallEvent, (event) => {
+      innerSawState = event.invocationState
+      event.invocationState.innerTouched = true
+    })
+
+    const outerModel = new MockMessageModel()
+      .addTurn([{ type: 'toolUseBlock', name: 'inner', toolUseId: 'tu-1', input: { input: 'hi' } }])
+      .addTurn({ type: 'textBlock', text: 'outer-done' })
+    const outer = new Agent({ model: outerModel, tools: [inner.asTool()] })
+
+    const result = await outer.invoke('run inner', { invocationState: { userId: 'u-1' } })
+
+    expect(innerSawState?.userId).toBe('u-1')
+    expect(result.invocationState.innerTouched).toBe(true)
+    expect(result.invocationState.userId).toBe('u-1')
+  })
+})

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -39,17 +39,27 @@ describe('Agent Hooks Integration', () => {
       expect(lifecyclePlugin.invocations).toHaveLength(7)
 
       expect(lifecyclePlugin.invocations[0]).toEqual(new InitializedEvent({ agent }))
-      expect(lifecyclePlugin.invocations[1]).toEqual(new BeforeInvocationEvent({ agent }))
+      expect(lifecyclePlugin.invocations[1]).toEqual(new BeforeInvocationEvent({ agent, invocationState: {} }))
       expect(lifecyclePlugin.invocations[2]).toEqual(
-        new MessageAddedEvent({ agent, message: new Message({ role: 'user', content: [new TextBlock('Hi')] }) })
+        new MessageAddedEvent({
+          agent,
+          message: new Message({ role: 'user', content: [new TextBlock('Hi')] }),
+          invocationState: {},
+        })
       )
       expect(lifecyclePlugin.invocations[3]).toEqual(
-        new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: expect.any(Number) as number })
+        new BeforeModelCallEvent({
+          agent,
+          model: agent.model,
+          invocationState: {},
+          projectedInputTokens: expect.any(Number) as number,
+        })
       )
       expect(lifecyclePlugin.invocations[4]).toEqual(
         new AfterModelCallEvent({
           agent,
           model: agent.model,
+          invocationState: {},
           stopData: {
             stopReason: 'endTurn',
             message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
@@ -60,9 +70,10 @@ describe('Agent Hooks Integration', () => {
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
+          invocationState: {},
         })
       )
-      expect(lifecyclePlugin.invocations[6]).toEqual(new AfterInvocationEvent({ agent }))
+      expect(lifecyclePlugin.invocations[6]).toEqual(new AfterInvocationEvent({ agent, invocationState: {} }))
     })
 
     it('fires hooks during stream', async () => {
@@ -75,20 +86,27 @@ describe('Agent Hooks Integration', () => {
       expect(lifecyclePlugin.invocations).toHaveLength(7)
 
       expect(lifecyclePlugin.invocations[0]).toEqual(new InitializedEvent({ agent }))
-      expect(lifecyclePlugin.invocations[1]).toEqual(new BeforeInvocationEvent({ agent }))
+      expect(lifecyclePlugin.invocations[1]).toEqual(new BeforeInvocationEvent({ agent, invocationState: {} }))
       expect(lifecyclePlugin.invocations[2]).toEqual(
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'user', content: [new TextBlock('Hi')] }),
+          invocationState: {},
         })
       )
       expect(lifecyclePlugin.invocations[3]).toEqual(
-        new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: expect.any(Number) as number })
+        new BeforeModelCallEvent({
+          agent,
+          model: agent.model,
+          invocationState: {},
+          projectedInputTokens: expect.any(Number) as number,
+        })
       )
       expect(lifecyclePlugin.invocations[4]).toEqual(
         new AfterModelCallEvent({
           agent,
           model: agent.model,
+          invocationState: {},
           stopData: {
             stopReason: 'endTurn',
             message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
@@ -99,9 +117,10 @@ describe('Agent Hooks Integration', () => {
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
+          invocationState: {},
         })
       )
-      expect(lifecyclePlugin.invocations[6]).toEqual(new AfterInvocationEvent({ agent }))
+      expect(lifecyclePlugin.invocations[6]).toEqual(new AfterInvocationEvent({ agent, invocationState: {} }))
     })
   })
 
@@ -122,8 +141,8 @@ describe('Agent Hooks Integration', () => {
       await agent.invoke('Hi')
 
       expect(invocations).toHaveLength(2)
-      expect(invocations[0]).toEqual(new BeforeInvocationEvent({ agent }))
-      expect(invocations[1]).toEqual(new AfterInvocationEvent({ agent }))
+      expect(invocations[0]).toEqual(new BeforeInvocationEvent({ agent, invocationState: {} }))
+      expect(invocations[1]).toEqual(new AfterInvocationEvent({ agent, invocationState: {} }))
     })
   })
 
@@ -191,6 +210,7 @@ describe('Agent Hooks Integration', () => {
           agent,
           toolUse: { name: 'testTool', toolUseId: 'tool-1', input: {} },
           tool,
+          invocationState: {},
         })
       )
 
@@ -206,6 +226,7 @@ describe('Agent Hooks Integration', () => {
             status: 'success',
             content: [new TextBlock('Tool result')],
           }),
+          invocationState: {},
         })
       )
     })
@@ -246,6 +267,7 @@ describe('Agent Hooks Integration', () => {
             content: [new TextBlock('Tool execution failed')],
           }),
           error: new Error('Tool execution failed'),
+          invocationState: {},
         })
       )
     })
@@ -302,12 +324,14 @@ describe('Agent Hooks Integration', () => {
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'user', content: [new TextBlock('New message')] }),
+          invocationState: {},
         })
       )
       expect(messageAddedEvents[1]).toEqual(
         new MessageAddedEvent({
           agent,
           message: new Message({ role: 'assistant', content: [new TextBlock('Response')] }),
+          invocationState: {},
         })
       )
     })

--- a/strands-ts/src/agent/__tests__/agent.invocation-state.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.invocation-state.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../agent.js'
+import {
+  AfterInvocationEvent,
+  AfterModelCallEvent,
+  AfterToolCallEvent,
+  BeforeInvocationEvent,
+  BeforeModelCallEvent,
+  MessageAddedEvent,
+} from '../../hooks/events.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { ToolResultBlock, TextBlock } from '../../types/messages.js'
+import type { InvocationState } from '../../types/agent.js'
+
+describe('invocationState', () => {
+  describe('round-trip', () => {
+    it('returns an empty object on AgentResult when no invocationState is passed', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+
+      const result = await agent.invoke('Hi')
+
+      expect(result.invocationState).toEqual({})
+    })
+
+    it('returns the passed invocationState on AgentResult', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+
+      const result = await agent.invoke('Hi', { invocationState: { userId: 'u-1', traceId: 't-1' } })
+
+      expect(result.invocationState).toEqual({ userId: 'u-1', traceId: 't-1' })
+    })
+
+    it('preserves reference identity: caller keeps the same object they passed in', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+
+      const state: InvocationState = { userId: 'u-1' }
+      const result = await agent.invoke('Hi', { invocationState: state })
+
+      expect(result.invocationState).toBe(state)
+    })
+  })
+
+  describe('hook mutation', () => {
+    it('propagates mutations from BeforeModelCallEvent to AfterModelCallEvent and AgentResult', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+
+      let seenInAfter: InvocationState | undefined
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        event.invocationState.counter = (event.invocationState.counter as number | undefined) ?? 0
+        event.invocationState.counter = (event.invocationState.counter as number) + 1
+      })
+      agent.addHook(AfterModelCallEvent, (event) => {
+        seenInAfter = event.invocationState
+      })
+
+      const result = await agent.invoke('Hi')
+
+      expect(seenInAfter?.counter).toBe(1)
+      expect(result.invocationState.counter).toBe(1)
+    })
+
+    it('shares the same invocationState object across all lifecycle events in one invocation', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+
+      const seen: InvocationState[] = []
+      const collect = (event: { invocationState: InvocationState }): void => {
+        seen.push(event.invocationState)
+      }
+
+      agent.addHook(BeforeInvocationEvent, collect)
+      agent.addHook(BeforeModelCallEvent, collect)
+      agent.addHook(AfterModelCallEvent, collect)
+      agent.addHook(MessageAddedEvent, collect)
+      agent.addHook(AfterInvocationEvent, collect)
+
+      const result = await agent.invoke('Hi')
+
+      // Every hook, plus the result, sees the same reference.
+      expect(seen.length).toBeGreaterThan(0)
+      for (const observed of seen) {
+        expect(observed).toBe(result.invocationState)
+      }
+    })
+  })
+
+  describe('multi-cycle persistence', () => {
+    it('persists mutations across recursive agent loop cycles (tool-use scenario)', async () => {
+      const tool = createMockTool(
+        'ping',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('pong')],
+          })
+      )
+
+      const model = new MockMessageModel()
+        .addTurn([{ type: 'toolUseBlock', name: 'ping', toolUseId: 'tool-1', input: {} }])
+        .addTurn({ type: 'textBlock', text: 'Done' })
+      const agent = new Agent({ model, tools: [tool] })
+
+      // Write in AfterToolCallEvent during cycle 1; read in BeforeModelCallEvent during cycle 2.
+      let cycle2State: InvocationState | undefined
+      let modelCalls = 0
+      agent.addHook(AfterToolCallEvent, (event) => {
+        event.invocationState.toolCompleted = true
+      })
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        modelCalls++
+        if (modelCalls === 2) {
+          cycle2State = event.invocationState
+        }
+      })
+
+      const result = await agent.invoke('Run ping')
+
+      expect(modelCalls).toBe(2)
+      expect(cycle2State?.toolCompleted).toBe(true)
+      expect(result.invocationState.toolCompleted).toBe(true)
+    })
+  })
+
+  describe('tool access', () => {
+    it('passes invocationState to tools via ToolContext and surfaces mutations on the result', async () => {
+      const tool = createMockTool('writer', () => {
+        throw new Error('unused')
+      })
+      // Override stream to read/write invocationState.
+      // eslint-disable-next-line require-yield
+      tool.stream = async function* (context) {
+        const prev = (context.invocationState.callCount as number | undefined) ?? 0
+        context.invocationState.callCount = prev + 1
+        context.invocationState.lastToolSeenUserId = context.invocationState.userId
+        return new ToolResultBlock({
+          toolUseId: context.toolUse.toolUseId,
+          status: 'success',
+          content: [new TextBlock('ok')],
+        })
+      }
+
+      const model = new MockMessageModel()
+        .addTurn([{ type: 'toolUseBlock', name: 'writer', toolUseId: 'tu-1', input: {} }])
+        .addTurn({ type: 'textBlock', text: 'Done' })
+      const agent = new Agent({ model, tools: [tool] })
+
+      const result = await agent.invoke('Run writer', { invocationState: { userId: 'u-42' } })
+
+      expect(result.invocationState.callCount).toBe(1)
+      expect(result.invocationState.lastToolSeenUserId).toBe('u-42')
+      expect(result.invocationState.userId).toBe('u-42')
+    })
+  })
+
+  describe('isolation from appState', () => {
+    it('does not touch agent.appState when invocationState is mutated', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, appState: { persistent: 'yes' } })
+
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        event.invocationState.ephemeral = 'only-this-run'
+      })
+
+      const result = await agent.invoke('Hi', { invocationState: { requestId: 'r-1' } })
+
+      expect(result.invocationState).toEqual({ requestId: 'r-1', ephemeral: 'only-this-run' })
+      expect(agent.appState.get('persistent')).toBe('yes')
+      expect(agent.appState.get('ephemeral')).toBeUndefined()
+      expect(agent.appState.get('requestId')).toBeUndefined()
+    })
+  })
+
+  describe('across invocations', () => {
+    it('does not leak state between invocations on the same agent (default bag)', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'A' })
+        .addTurn({ type: 'textBlock', text: 'B' })
+      const agent = new Agent({ model })
+
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        event.invocationState.seen = true
+      })
+
+      const first = await agent.invoke('1')
+      const second = await agent.invoke('2')
+
+      expect(first.invocationState.seen).toBe(true)
+      expect(second.invocationState.seen).toBe(true)
+      expect(first.invocationState).not.toBe(second.invocationState)
+    })
+  })
+
+  describe('retry paths', () => {
+    it('preserves same invocationState reference across AfterModelCallEvent retry', async () => {
+      const model = new MockMessageModel()
+        .addTurn(new Error('transient failure'))
+        .addTurn({ type: 'textBlock', text: 'Success after retry' })
+      const agent = new Agent({ model, printer: false })
+
+      let retried = false
+      const seen: InvocationState[] = []
+
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        seen.push(event.invocationState)
+        event.invocationState.modelCalls = (event.invocationState.modelCalls as number | undefined) ?? 0
+        event.invocationState.modelCalls = (event.invocationState.modelCalls as number) + 1
+      })
+      agent.addHook(AfterModelCallEvent, (event) => {
+        seen.push(event.invocationState)
+        if (!retried && event.error) {
+          retried = true
+          event.retry = true
+        }
+      })
+
+      const result = await agent.invoke('Test', { invocationState: { userId: 'u-1' } })
+
+      // Retry path was exercised: two Before + two After observations.
+      expect(seen.length).toBe(4)
+      // Every observation is the same object the caller passed in.
+      for (const observed of seen) {
+        expect(observed).toBe(result.invocationState)
+      }
+      // Mutations from the first attempt survive into the retry.
+      expect(result.invocationState.userId).toBe('u-1')
+      expect(result.invocationState.modelCalls).toBe(2)
+    })
+
+    it('preserves same invocationState reference across AfterToolCallEvent retry', async () => {
+      let toolCalls = 0
+      const tool = createMockTool('flaky', () => {
+        toolCalls++
+        return new ToolResultBlock({
+          toolUseId: 'tu-1',
+          status: toolCalls === 1 ? 'error' : 'success',
+          content: [new TextBlock(toolCalls === 1 ? 'fail' : 'ok')],
+        })
+      })
+
+      const model = new MockMessageModel()
+        .addTurn([{ type: 'toolUseBlock', name: 'flaky', toolUseId: 'tu-1', input: {} }])
+        .addTurn({ type: 'textBlock', text: 'Done' })
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      let retried = false
+      const seen: InvocationState[] = []
+
+      agent.addHook(AfterToolCallEvent, (event) => {
+        seen.push(event.invocationState)
+        event.invocationState.toolAttempts = (event.invocationState.toolAttempts as number | undefined) ?? 0
+        event.invocationState.toolAttempts = (event.invocationState.toolAttempts as number) + 1
+        if (!retried && event.result.status === 'error') {
+          retried = true
+          event.retry = true
+        }
+      })
+
+      const result = await agent.invoke('Run flaky', { invocationState: { requestId: 'r-1' } })
+
+      // Retry fired twice: failed attempt + successful attempt.
+      expect(toolCalls).toBe(2)
+      expect(seen.length).toBe(2)
+      for (const observed of seen) {
+        expect(observed).toBe(result.invocationState)
+      }
+      expect(result.invocationState.requestId).toBe('r-1')
+      expect(result.invocationState.toolAttempts).toBe(2)
+    })
+  })
+})

--- a/strands-ts/src/agent/__tests__/agent.invocation-state.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.invocation-state.test.ts
@@ -60,8 +60,8 @@ describe('invocationState', () => {
 
       const result = await agent.invoke('Hi')
 
-      expect(seenInAfter?.counter).toBe(1)
-      expect(result.invocationState.counter).toBe(1)
+      expect(seenInAfter).toEqual({ counter: 1 })
+      expect(result.invocationState).toEqual({ counter: 1 })
     })
 
     it('shares the same invocationState object across all lifecycle events in one invocation', async () => {
@@ -122,8 +122,8 @@ describe('invocationState', () => {
       const result = await agent.invoke('Run ping')
 
       expect(modelCalls).toBe(2)
-      expect(cycle2State?.toolCompleted).toBe(true)
-      expect(result.invocationState.toolCompleted).toBe(true)
+      expect(cycle2State).toEqual({ toolCompleted: true })
+      expect(result.invocationState).toEqual({ toolCompleted: true })
     })
   })
 
@@ -152,9 +152,11 @@ describe('invocationState', () => {
 
       const result = await agent.invoke('Run writer', { invocationState: { userId: 'u-42' } })
 
-      expect(result.invocationState.callCount).toBe(1)
-      expect(result.invocationState.lastToolSeenUserId).toBe('u-42')
-      expect(result.invocationState.userId).toBe('u-42')
+      expect(result.invocationState).toEqual({
+        userId: 'u-42',
+        callCount: 1,
+        lastToolSeenUserId: 'u-42',
+      })
     })
   })
 
@@ -190,8 +192,8 @@ describe('invocationState', () => {
       const first = await agent.invoke('1')
       const second = await agent.invoke('2')
 
-      expect(first.invocationState.seen).toBe(true)
-      expect(second.invocationState.seen).toBe(true)
+      expect(first.invocationState).toEqual({ seen: true })
+      expect(second.invocationState).toEqual({ seen: true })
       expect(first.invocationState).not.toBe(second.invocationState)
     })
   })
@@ -228,8 +230,7 @@ describe('invocationState', () => {
         expect(observed).toBe(result.invocationState)
       }
       // Mutations from the first attempt survive into the retry.
-      expect(result.invocationState.userId).toBe('u-1')
-      expect(result.invocationState.modelCalls).toBe(2)
+      expect(result.invocationState).toEqual({ userId: 'u-1', modelCalls: 2 })
     })
 
     it('preserves same invocationState reference across AfterToolCallEvent retry', async () => {
@@ -269,8 +270,7 @@ describe('invocationState', () => {
       for (const observed of seen) {
         expect(observed).toBe(result.invocationState)
       }
-      expect(result.invocationState.requestId).toBe('r-1')
-      expect(result.invocationState.toolAttempts).toBe(2)
+      expect(result.invocationState).toEqual({ requestId: 'r-1', toolAttempts: 2 })
     })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -63,7 +63,7 @@ describe('Agent', () => {
 
         expect(items.length).toBeGreaterThan(0)
         const firstItem = items[0]
-        expect(firstItem).toEqual(new BeforeInvocationEvent({ agent: agent }))
+        expect(firstItem).toEqual(new BeforeInvocationEvent({ agent: agent, invocationState: {} }))
       })
 
       it('returns AgentResult as generator return value', async () => {
@@ -146,6 +146,7 @@ describe('Agent', () => {
               role: 'assistant',
               content: [new ToolUseBlock({ name: 'testTool', toolUseId: 'tool-1', input: {} })],
             }),
+            invocationState: {},
           })
         )
 

--- a/strands-ts/src/agent/agent-as-tool.ts
+++ b/strands-ts/src/agent/agent-as-tool.ts
@@ -162,8 +162,10 @@ export class AgentAsTool extends Tool {
         loadSnapshot(this._agent, this._initialSnapshot)
       }
 
-      // Stream the sub-agent
-      const gen = this._agent.stream(input)
+      // Stream the sub-agent, forwarding the outer invocation's state so
+      // mutations in the inner agent's hooks/tools are visible to the outer
+      // agent's downstream callbacks and final AgentResult.
+      const gen = this._agent.stream(input, { invocationState: toolContext.invocationState })
       let next = await gen.next()
       while (!next.done) {
         const event = next.value

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1,6 +1,7 @@
 import {
   AgentResult,
   type AgentStreamEvent,
+  type InvocationState,
   type InvokableAgent,
   type InvokeArgs,
   type InvokeOptions,
@@ -536,7 +537,9 @@ export class Agent implements LocalAgent, InvokableAgent {
         result = await streamGenerator.next()
       }
 
-      yield await this._invokeCallbacks(new AgentResultEvent({ agent: this, result: result.value }))
+      yield await this._invokeCallbacks(
+        new AgentResultEvent({ agent: this, result: result.value, invocationState: result.value.invocationState })
+      )
 
       return result.value
     } catch (error) {
@@ -629,20 +632,27 @@ export class Agent implements LocalAgent, InvokableAgent {
     const structuredOutputTool = structuredOutputSchema ? new StructuredOutputTool(structuredOutputSchema) : undefined
     let structuredOutputChoice: ToolChoice | undefined
 
-    const beforeInvocationEvent = new BeforeInvocationEvent({ agent: this })
+    // Resolve per-invocation state once. The same object is threaded through
+    // every lifecycle hook event, every tool context, and is surfaced on the
+    // AgentResult. Mutations by hooks/tools are visible across all recursive
+    // agent loop cycles within this invocation.
+    const invocationState: InvocationState = options?.invocationState ?? {}
+
+    const beforeInvocationEvent = new BeforeInvocationEvent({ agent: this, invocationState })
     yield beforeInvocationEvent
 
     if (beforeInvocationEvent.cancel) {
       const cancelText =
         typeof beforeInvocationEvent.cancel === 'string' ? beforeInvocationEvent.cancel : 'invocation denied by hook'
       const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
-      yield this._appendMessage(message)
-      yield new AfterInvocationEvent({ agent: this })
+      yield this._appendMessage(message, invocationState)
+      yield new AfterInvocationEvent({ agent: this, invocationState })
       return new AgentResult({
         stopReason: 'endTurn',
         lastMessage: message,
         traces: this._tracer.localTraces,
         metrics: this._meter.metrics,
+        invocationState,
       })
     }
 
@@ -687,12 +697,12 @@ export class Agent implements LocalAgent, InvokableAgent {
           if (currentArgs !== undefined) {
             const messagesToAppend = this._normalizeInput(currentArgs)
             for (const message of messagesToAppend) {
-              yield this._appendMessage(message)
+              yield this._appendMessage(message, invocationState)
             }
             currentArgs = undefined
           }
 
-          const modelResult = yield* this._invokeModel(structuredOutputChoice)
+          const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice)
 
           if (modelResult.stopReason !== 'toolUse') {
             // If structured output is required, force it
@@ -709,7 +719,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             this._meter.endCycle(cycleStartTime)
             this._tracer.endAgentLoopSpan(cycleSpan)
 
-            yield this._appendMessage(modelResult.message)
+            yield this._appendMessage(modelResult.message, invocationState)
 
             if (structuredOutputChoice) {
               continue
@@ -720,6 +730,7 @@ export class Agent implements LocalAgent, InvokableAgent {
               lastMessage: modelResult.message,
               traces: this._tracer.localTraces,
               metrics: this._meter.metrics,
+              invocationState,
             })
             return result
           }
@@ -739,8 +750,8 @@ export class Agent implements LocalAgent, InvokableAgent {
             )
             const toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
 
-            yield this._appendMessage(modelResult.message)
-            yield this._appendMessage(toolResultMessage)
+            yield this._appendMessage(modelResult.message, invocationState)
+            yield this._appendMessage(toolResultMessage, invocationState)
 
             this._meter.endCycle(cycleStartTime)
             this._tracer.endAgentLoopSpan(cycleSpan)
@@ -750,12 +761,13 @@ export class Agent implements LocalAgent, InvokableAgent {
               lastMessage: modelResult.message,
               traces: this._tracer.localTraces,
               metrics: this._meter.metrics,
+              invocationState,
             })
             return result
           }
 
           // Execute tools
-          const toolResultMessage = yield* this.executeTools(modelResult.message, this._toolRegistry)
+          const toolResultMessage = yield* this.executeTools(modelResult.message, this._toolRegistry, invocationState)
 
           /**
            * Deferred append: both messages are added AFTER tool execution completes.
@@ -763,8 +775,8 @@ export class Agent implements LocalAgent, InvokableAgent {
            * If interrupted during tool execution, messages has no dangling toolUse
            * without a matching toolResult, so the agent can be reinvoked cleanly.
            */
-          yield this._appendMessage(modelResult.message)
-          yield this._appendMessage(toolResultMessage)
+          yield this._appendMessage(modelResult.message, invocationState)
+          yield this._appendMessage(toolResultMessage, invocationState)
 
           this._meter.endCycle(cycleStartTime)
           this._tracer.endAgentLoopSpan(cycleSpan)
@@ -780,6 +792,7 @@ export class Agent implements LocalAgent, InvokableAgent {
               traces: this._tracer.localTraces,
               structuredOutput,
               metrics: this._meter.metrics,
+              invocationState,
             })
             return result
           }
@@ -797,13 +810,14 @@ export class Agent implements LocalAgent, InvokableAgent {
           role: 'assistant',
           content: [new TextBlock('Cancelled by user')],
         })
-        yield this._appendMessage(cancelMessage)
+        yield this._appendMessage(cancelMessage, invocationState)
 
         result = new AgentResult({
           stopReason: 'cancelled',
           lastMessage: cancelMessage,
           traces: this._tracer.localTraces,
           metrics: this._meter.metrics,
+          invocationState,
         })
         return result
       }
@@ -818,7 +832,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           role: 'assistant',
           content: [new TextBlock('Cancelled by user')],
         })
-        yield this._appendMessage(cancelMessage)
+        yield this._appendMessage(cancelMessage, invocationState)
       }
 
       this._tracer.endAgentSpan(agentSpan, {
@@ -834,7 +848,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       }
 
       // Always emit final event
-      yield new AfterInvocationEvent({ agent: this })
+      yield new AfterInvocationEvent({ agent: this, invocationState })
     }
   }
 
@@ -923,6 +937,7 @@ export class Agent implements LocalAgent, InvokableAgent {
    * @returns Object containing the assistant message, stop reason, and optional redaction message
    */
   private async *_invokeModel(
+    invocationState: InvocationState,
     toolChoice?: ToolChoice
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
@@ -947,6 +962,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     const beforeModelCallEvent = new BeforeModelCallEvent({
       agent: this,
       model: this.model,
+      invocationState,
       ...(projectedInputTokens !== undefined && { projectedInputTokens }),
     })
     yield beforeModelCallEvent
@@ -956,11 +972,16 @@ export class Agent implements LocalAgent, InvokableAgent {
         typeof beforeModelCallEvent.cancel === 'string' ? beforeModelCallEvent.cancel : 'model call denied by hook'
       const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
       const stopData: ModelStopData = { message, stopReason: 'endTurn' }
-      const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, stopData })
+      const afterModelCallEvent = new AfterModelCallEvent({
+        agent: this,
+        model: this.model,
+        stopData,
+        invocationState,
+      })
       yield afterModelCallEvent
 
       if (afterModelCallEvent.retry) {
-        return yield* this._invokeModel(toolChoice)
+        return yield* this._invokeModel(invocationState, toolChoice)
       }
 
       return { message, stopReason: 'endTurn' }
@@ -975,7 +996,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     })
 
     try {
-      const result = yield* this._streamFromModel(this.messages, streamOptions)
+      const result = yield* this._streamFromModel(this.messages, streamOptions, invocationState)
 
       // Accumulate token usage and model latency metrics
       this._meter.updateCycle(result.metadata)
@@ -990,7 +1011,12 @@ export class Agent implements LocalAgent, InvokableAgent {
         ...(metrics && { metrics }),
       })
 
-      yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
+      yield new ModelMessageEvent({
+        agent: this,
+        message: result.message,
+        stopReason: result.stopReason,
+        invocationState,
+      })
 
       // Handle user content redaction if guardrails blocked input
       if (result.redaction?.userMessage) {
@@ -1003,11 +1029,16 @@ export class Agent implements LocalAgent, InvokableAgent {
         ...(result.redaction && { redaction: result.redaction }),
       }
 
-      const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, stopData })
+      const afterModelCallEvent = new AfterModelCallEvent({
+        agent: this,
+        model: this.model,
+        stopData,
+        invocationState,
+      })
       yield afterModelCallEvent
 
       if (afterModelCallEvent.retry) {
-        return yield* this._invokeModel(toolChoice)
+        return yield* this._invokeModel(invocationState, toolChoice)
       }
 
       return result
@@ -1018,7 +1049,12 @@ export class Agent implements LocalAgent, InvokableAgent {
       this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
 
       // Create error event
-      const errorEvent = new AfterModelCallEvent({ agent: this, model: this.model, error: modelError })
+      const errorEvent = new AfterModelCallEvent({
+        agent: this,
+        model: this.model,
+        error: modelError,
+        invocationState,
+      })
 
       // Yield error event - stream will invoke hooks
       yield errorEvent
@@ -1031,7 +1067,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
       // After yielding, hooks have been invoked and may have set retry
       if (errorEvent.retry) {
-        return yield* this._invokeModel(toolChoice)
+        return yield* this._invokeModel(invocationState, toolChoice)
       }
 
       // Re-throw error
@@ -1057,7 +1093,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_streamFromModel(
     messages: Message[],
-    streamOptions: StreamOptions
+    streamOptions: StreamOptions,
+    invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     const streamGenerator = this.model.streamAggregated(messages, streamOptions)
     let result = await streamGenerator.next()
@@ -1069,10 +1106,10 @@ export class Agent implements LocalAgent, InvokableAgent {
 
       if (isModelStreamEvent(event)) {
         // ModelStreamEvent: wrap in ModelStreamUpdateEvent
-        yield new ModelStreamUpdateEvent({ agent: this, event })
+        yield new ModelStreamUpdateEvent({ agent: this, event, invocationState })
       } else {
         // ContentBlock: wrap in ContentBlockEvent
-        yield new ContentBlockEvent({ agent: this, contentBlock: event })
+        yield new ContentBlockEvent({ agent: this, contentBlock: event, invocationState })
       }
       result = await streamGenerator.next()
     }
@@ -1093,9 +1130,10 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *executeTools(
     assistantMessage: Message,
-    toolRegistry: ToolRegistry
+    toolRegistry: ToolRegistry,
+    invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
-    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
+    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage, invocationState })
     yield beforeToolsEvent
 
     const toolUseBlocks = assistantMessage.content.filter(
@@ -1104,24 +1142,28 @@ export class Agent implements LocalAgent, InvokableAgent {
     if (toolUseBlocks.length === 0) {
       // Preserve BeforeToolsEvent/AfterToolsEvent bracket symmetry even on
       // this invariant-violation branch.
-      yield new AfterToolsEvent({ agent: this, message: new Message({ role: 'user', content: [] }) })
+      yield new AfterToolsEvent({
+        agent: this,
+        message: new Message({ role: 'user', content: [] }),
+        invocationState,
+      })
       throw new Error('Model indicated toolUse but no tool use blocks found in message')
     }
 
     // Pre-launch cancel paths are strategy-independent.
     if (beforeToolsEvent.cancel) {
       const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
-      return yield* this._yieldCancelledToolResults(toolUseBlocks, message)
+      return yield* this._yieldCancelledToolResults(toolUseBlocks, message, invocationState)
     }
     if (this.isCancelled) {
-      return yield* this._yieldCancelledToolResults(toolUseBlocks, 'Tool execution cancelled')
+      return yield* this._yieldCancelledToolResults(toolUseBlocks, 'Tool execution cancelled', invocationState)
     }
 
     switch (this._toolExecutor) {
       case 'sequential':
-        return yield* this._executeToolsSequential(toolUseBlocks, toolRegistry)
+        return yield* this._executeToolsSequential(toolUseBlocks, toolRegistry, invocationState)
       case 'concurrent':
-        return yield* this._executeToolsConcurrent(toolUseBlocks, toolRegistry)
+        return yield* this._executeToolsConcurrent(toolUseBlocks, toolRegistry, invocationState)
       default: {
         const _exhaustive: never = this._toolExecutor
         throw new Error(`Unknown toolExecutor: ${_exhaustive as string}`)
@@ -1136,14 +1178,15 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_yieldCancelledToolResults(
     toolUseBlocks: ToolUseBlock[],
-    message: string
+    message: string,
+    invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
     const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
     for (const result of cancelBlocks) {
-      yield new ToolResultEvent({ agent: this, result })
+      yield new ToolResultEvent({ agent: this, result, invocationState })
     }
     const toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
-    yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+    yield new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
     return toolResultMessage
   }
 
@@ -1153,7 +1196,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_executeToolsSequential(
     toolUseBlocks: ToolUseBlock[],
-    toolRegistry: ToolRegistry
+    toolRegistry: ToolRegistry,
+    invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
     const toolResultBlocks: ToolResultBlock[] = []
     let toolResultMessage: Message
@@ -1167,17 +1211,17 @@ export class Agent implements LocalAgent, InvokableAgent {
             content: [new TextBlock('Tool execution cancelled')],
           })
           toolResultBlocks.push(cancelBlock)
-          yield new ToolResultEvent({ agent: this, result: cancelBlock })
+          yield new ToolResultEvent({ agent: this, result: cancelBlock, invocationState })
           continue
         }
 
-        const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
+        const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry, invocationState)
         toolResultBlocks.push(toolResultBlock)
-        yield new ToolResultEvent({ agent: this, result: toolResultBlock })
+        yield new ToolResultEvent({ agent: this, result: toolResultBlock, invocationState })
       }
     } finally {
       toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+      yield new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
     }
 
     return toolResultMessage
@@ -1210,7 +1254,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_executeToolsConcurrent(
     toolUseBlocks: ToolUseBlock[],
-    toolRegistry: ToolRegistry
+    toolRegistry: ToolRegistry,
+    invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
     let toolResultMessage: Message
 
@@ -1224,7 +1269,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     const gens = toolUseBlocks.map((block) => ({
       block,
-      gen: this.executeTool(block, toolRegistry),
+      gen: this.executeTool(block, toolRegistry, invocationState),
     }))
 
     const step = (idx: number): Promise<Step> =>
@@ -1252,14 +1297,14 @@ export class Agent implements LocalAgent, InvokableAgent {
             error: err,
           })
           resultsByToolUseId.set(block.toolUseId, result)
-          yield new ToolResultEvent({ agent: this, result })
+          yield new ToolResultEvent({ agent: this, result, invocationState })
           continue
         }
 
         if (winner.res.done) {
           pendingNext.delete(idx)
           resultsByToolUseId.set(block.toolUseId, winner.res.value)
-          yield new ToolResultEvent({ agent: this, result: winner.res.value })
+          yield new ToolResultEvent({ agent: this, result: winner.res.value, invocationState })
         } else {
           yield winner.res.value
           pendingNext.set(idx, step(idx))
@@ -1291,7 +1336,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       }
 
       toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+      yield new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
     }
 
     return toolResultMessage
@@ -1309,7 +1354,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *executeTool(
     toolUseBlock: ToolUseBlock,
-    toolRegistry: ToolRegistry
+    toolRegistry: ToolRegistry,
+    invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
     const tool = toolRegistry.get(toolUseBlock.name)
 
@@ -1322,7 +1368,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     // Retry loop for tool execution
     while (true) {
-      const beforeToolCallEvent = new BeforeToolCallEvent({ agent: this, toolUse, tool })
+      const beforeToolCallEvent = new BeforeToolCallEvent({ agent: this, toolUse, tool, invocationState })
       yield beforeToolCallEvent
 
       // Cancel individual tool if hook requested it
@@ -1339,6 +1385,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           toolUse,
           tool,
           result: toolResult,
+          invocationState,
         })
         yield afterToolCallEvent
         if (afterToolCallEvent.retry) {
@@ -1374,6 +1421,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             input: toolUseBlock.input,
           },
           agent: this,
+          invocationState,
         }
 
         try {
@@ -1385,7 +1433,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           const toolGenerator = this._tracer.withSpanContext(toolSpan, () => tool.stream(toolContext))
           let toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
           while (!toolNext.done) {
-            yield new ToolStreamUpdateEvent({ agent: this, event: toolNext.value })
+            yield new ToolStreamUpdateEvent({ agent: this, event: toolNext.value, invocationState })
             toolNext = await this._tracer.withSpanContext(toolSpan, () => toolGenerator.next())
           }
           const result = toolNext.value
@@ -1429,6 +1477,7 @@ export class Agent implements LocalAgent, InvokableAgent {
         toolUse,
         tool,
         result: toolResult,
+        invocationState,
         ...(error !== undefined && { error }),
       })
       yield afterToolCallEvent
@@ -1540,9 +1589,9 @@ export class Agent implements LocalAgent, InvokableAgent {
    * @param message - The message to append
    * @returns MessageAddedEvent to be yielded
    */
-  private _appendMessage(message: Message): MessageAddedEvent {
+  private _appendMessage(message: Message, invocationState: InvocationState): MessageAddedEvent {
     this.messages.push(message)
-    return new MessageAddedEvent({ agent: this, message })
+    return new MessageAddedEvent({ agent: this, message, invocationState })
   }
 }
 

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -42,7 +42,7 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error })
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(1)
@@ -57,7 +57,7 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error })
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(1)
@@ -70,7 +70,7 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new Error('some other error')
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error })
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(0)
@@ -92,7 +92,7 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error })
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
       await invokeTrackedHook(mockAgent, event)
 
       expect(receivedArgs).toHaveLength(1)

--- a/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
@@ -17,7 +17,7 @@ describe('NullConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('Context overflow')
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error })
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
       await invokeTrackedHook(mockAgent, event)
 
       // Messages should be unchanged — NullConversationManager never reduces
@@ -32,7 +32,7 @@ describe('NullConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('Context overflow')
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error })
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
       await invokeTrackedHook(mockAgent, event)
 
       // reduce() returns false, so retry should not be set

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -15,7 +15,7 @@ import type { Agent } from '../../agent/agent.js'
 async function triggerSlidingWindow(manager: SlidingWindowConversationManager, agent: Agent): Promise<void> {
   const pluginAgent = createMockAgent()
   manager.initAgent(pluginAgent)
-  await invokeTrackedHook(pluginAgent, new AfterInvocationEvent({ agent }))
+  await invokeTrackedHook(pluginAgent, new AfterInvocationEvent({ agent, invocationState: {} }))
 }
 
 // Helper to trigger context overflow handling through hooks
@@ -26,7 +26,7 @@ async function triggerContextOverflow(
 ): Promise<{ retry?: boolean }> {
   const pluginAgent = createMockAgent()
   manager.initAgent(pluginAgent)
-  const event = new AfterModelCallEvent({ agent, model: {} as any, error })
+  const event = new AfterModelCallEvent({ agent, model: {} as any, error, invocationState: {} })
   await invokeTrackedHook(pluginAgent, event)
   return event
 }
@@ -633,7 +633,12 @@ describe('SlidingWindowConversationManager', () => {
 
       // The base class hook does not set event.retry when reduce returns false,
       // so the original error propagates out of the hook chain
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error: originalError })
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        error: originalError,
+        invocationState: {},
+      })
       const pluginAgent = createMockAgent()
       manager.initAgent(pluginAgent)
       await invokeTrackedHook(pluginAgent, event)

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -309,6 +309,7 @@ describe('SummarizingConversationManager', () => {
         agent,
         model: model as unknown as Model,
         error: new ContextWindowOverflowError('overflow'),
+        invocationState: {},
       })
       await invokeTrackedHook(pluginAgent, event)
 

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -47,12 +47,13 @@ describe('InitializedEvent', () => {
 describe('BeforeInvocationEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
-    const event = new BeforeInvocationEvent({ agent })
+    const event = new BeforeInvocationEvent({ agent, invocationState: {} })
 
     expect(event).toEqual({
       type: 'beforeInvocationEvent',
       agent: agent,
       cancel: false,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -60,13 +61,13 @@ describe('BeforeInvocationEvent', () => {
 
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
-    const event = new BeforeInvocationEvent({ agent })
+    const event = new BeforeInvocationEvent({ agent, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 
   it('allows cancel to be set to true', () => {
     const agent = new Agent()
-    const event = new BeforeInvocationEvent({ agent })
+    const event = new BeforeInvocationEvent({ agent, invocationState: {} })
 
     expect(event.cancel).toBe(false)
     event.cancel = true
@@ -75,7 +76,7 @@ describe('BeforeInvocationEvent', () => {
 
   it('allows cancel to be set to a string message', () => {
     const agent = new Agent()
-    const event = new BeforeInvocationEvent({ agent })
+    const event = new BeforeInvocationEvent({ agent, invocationState: {} })
 
     event.cancel = 'unauthorized'
     expect(event.cancel).toBe('unauthorized')
@@ -85,11 +86,12 @@ describe('BeforeInvocationEvent', () => {
 describe('AfterInvocationEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
-    const event = new AfterInvocationEvent({ agent })
+    const event = new AfterInvocationEvent({ agent, invocationState: {} })
 
     expect(event).toEqual({
       type: 'afterInvocationEvent',
       agent: agent,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -97,7 +99,7 @@ describe('AfterInvocationEvent', () => {
 
   it('returns true for _shouldReverseCallbacks', () => {
     const agent = new Agent()
-    const event = new AfterInvocationEvent({ agent })
+    const event = new AfterInvocationEvent({ agent, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 })
@@ -106,12 +108,13 @@ describe('MessageAddedEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [new TextBlock('Hello')] })
-    const event = new MessageAddedEvent({ agent, message })
+    const event = new MessageAddedEvent({ agent, message, invocationState: {} })
 
     expect(event).toEqual({
       type: 'messageAddedEvent',
       agent: agent,
       message: message,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -122,7 +125,7 @@ describe('MessageAddedEvent', () => {
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
-    const event = new MessageAddedEvent({ agent, message })
+    const event = new MessageAddedEvent({ agent, message, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 })
@@ -141,7 +144,7 @@ describe('BeforeToolCallEvent', () => {
       toolUseId: 'test-id',
       input: { arg: 'value' },
     }
-    const event = new BeforeToolCallEvent({ agent, toolUse, tool })
+    const event = new BeforeToolCallEvent({ agent, toolUse, tool, invocationState: {} })
 
     expect(event).toEqual({
       type: 'beforeToolCallEvent',
@@ -149,6 +152,7 @@ describe('BeforeToolCallEvent', () => {
       toolUse: toolUse,
       tool: tool,
       cancel: false,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -165,7 +169,7 @@ describe('BeforeToolCallEvent', () => {
       toolUseId: 'test-id',
       input: {},
     }
-    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined })
+    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined, invocationState: {} })
 
     expect(event).toEqual({
       type: 'beforeToolCallEvent',
@@ -173,20 +177,21 @@ describe('BeforeToolCallEvent', () => {
       toolUse: toolUse,
       tool: undefined,
       cancel: false,
+      invocationState: {},
     })
   })
 
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
     const toolUse = { name: 'test', toolUseId: 'id', input: {} }
-    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined })
+    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 
   it('allows cancel to be set to true', () => {
     const agent = new Agent()
     const toolUse = { name: 'test', toolUseId: 'id', input: {} }
-    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined })
+    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined, invocationState: {} })
 
     expect(event.cancel).toBe(false)
     event.cancel = true
@@ -196,7 +201,7 @@ describe('BeforeToolCallEvent', () => {
   it('allows cancel to be set to a string message', () => {
     const agent = new Agent()
     const toolUse = { name: 'test', toolUseId: 'id', input: {} }
-    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined })
+    const event = new BeforeToolCallEvent({ agent, toolUse, tool: undefined, invocationState: {} })
 
     event.cancel = 'tool not allowed'
     expect(event.cancel).toBe('tool not allowed')
@@ -222,7 +227,7 @@ describe('AfterToolCallEvent', () => {
       status: 'success',
       content: [new TextBlock('Success')],
     })
-    const event = new AfterToolCallEvent({ agent, toolUse, tool, result })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool, result, invocationState: {} })
 
     expect(event).toEqual({
       type: 'afterToolCallEvent',
@@ -231,6 +236,7 @@ describe('AfterToolCallEvent', () => {
       tool: tool,
       result: result,
       error: undefined,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -244,7 +250,7 @@ describe('AfterToolCallEvent', () => {
     const agent = new Agent()
     const toolUse = { name: 'test', toolUseId: 'id', input: {} }
     const result = new ToolResultBlock({ toolUseId: 'id', status: 'success', content: [new TextBlock('original')] })
-    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, invocationState: {} })
 
     const replacedResult = new ToolResultBlock({
       toolUseId: 'id',
@@ -264,7 +270,7 @@ describe('AfterToolCallEvent', () => {
       content: [new TextBlock('Error')],
     })
     const error = new Error('Tool failed')
-    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, error })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, error, invocationState: {} })
 
     expect(event).toEqual({
       type: 'afterToolCallEvent',
@@ -273,6 +279,7 @@ describe('AfterToolCallEvent', () => {
       tool: undefined,
       result: result,
       error: error,
+      invocationState: {},
     })
   })
 
@@ -284,7 +291,7 @@ describe('AfterToolCallEvent', () => {
       status: 'success',
       content: [],
     })
-    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
@@ -297,7 +304,7 @@ describe('AfterToolCallEvent', () => {
       content: [new TextBlock('Error')],
     })
     const error = new Error('Tool failed')
-    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, error })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, error, invocationState: {} })
 
     expect(event.retry).toBeUndefined()
 
@@ -316,7 +323,7 @@ describe('AfterToolCallEvent', () => {
       status: 'success',
       content: [new TextBlock('Success')],
     })
-    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, invocationState: {} })
 
     expect(event.retry).toBeUndefined()
 
@@ -328,13 +335,14 @@ describe('AfterToolCallEvent', () => {
 describe('BeforeModelCallEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
-    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+    const event = new BeforeModelCallEvent({ agent, model: agent.model, invocationState: {} })
 
     expect(event).toEqual({
       type: 'beforeModelCallEvent',
       agent: agent,
       model: agent.model,
       cancel: false,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -342,13 +350,19 @@ describe('BeforeModelCallEvent', () => {
 
   it('includes projectedInputTokens when provided', () => {
     const agent = new Agent()
-    const event = new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: 500 })
+    const event = new BeforeModelCallEvent({
+      agent,
+      model: agent.model,
+      invocationState: {},
+      projectedInputTokens: 500,
+    })
 
     expect(event).toEqual({
       type: 'beforeModelCallEvent',
       agent,
       model: agent.model,
       cancel: false,
+      invocationState: {},
       projectedInputTokens: 500,
     })
     expect(event.toJSON()).toStrictEqual({
@@ -359,7 +373,7 @@ describe('BeforeModelCallEvent', () => {
 
   it('excludes projectedInputTokens from toJSON when not provided', () => {
     const agent = new Agent()
-    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+    const event = new BeforeModelCallEvent({ agent, model: agent.model, invocationState: {} })
 
     expect(event.projectedInputTokens).toBeUndefined()
     expect(event.toJSON()).toStrictEqual({ type: 'beforeModelCallEvent' })
@@ -367,13 +381,13 @@ describe('BeforeModelCallEvent', () => {
 
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
-    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+    const event = new BeforeModelCallEvent({ agent, model: agent.model, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 
   it('allows cancel to be set to true', () => {
     const agent = new Agent()
-    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+    const event = new BeforeModelCallEvent({ agent, model: agent.model, invocationState: {} })
 
     expect(event.cancel).toBe(false)
     event.cancel = true
@@ -382,7 +396,7 @@ describe('BeforeModelCallEvent', () => {
 
   it('allows cancel to be set to a string message', () => {
     const agent = new Agent()
-    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+    const event = new BeforeModelCallEvent({ agent, model: agent.model, invocationState: {} })
 
     event.cancel = 'rate limited'
     expect(event.cancel).toBe('rate limited')
@@ -395,7 +409,7 @@ describe('AfterModelCallEvent', () => {
     const message = new Message({ role: 'assistant', content: [new TextBlock('Response')] })
     const stopReason = 'endTurn'
     const response = { message, stopReason }
-    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response })
+    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, invocationState: {} })
 
     expect(event).toEqual({
       type: 'afterModelCallEvent',
@@ -403,6 +417,7 @@ describe('AfterModelCallEvent', () => {
       model: agent.model,
       stopData: response,
       error: undefined,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -415,7 +430,7 @@ describe('AfterModelCallEvent', () => {
     const message = new Message({ role: 'assistant', content: [] })
     const error = new Error('Model failed')
     const response = { message, stopReason: 'error' }
-    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, error })
+    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, error, invocationState: {} })
 
     expect(event).toEqual({
       type: 'afterModelCallEvent',
@@ -423,6 +438,7 @@ describe('AfterModelCallEvent', () => {
       model: agent.model,
       stopData: response,
       error: error,
+      invocationState: {},
     })
   })
 
@@ -430,14 +446,14 @@ describe('AfterModelCallEvent', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
     const response = { message, stopReason: 'endTurn' }
-    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response })
+    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
   it('allows retry to be set when error is present', () => {
     const agent = new Agent()
     const error = new Error('Model failed')
-    const event = new AfterModelCallEvent({ agent, model: agent.model, error })
+    const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
 
     // Initially undefined
     expect(event.retry).toBeUndefined()
@@ -454,7 +470,7 @@ describe('AfterModelCallEvent', () => {
   it('retry is optional and defaults to undefined', () => {
     const agent = new Agent()
     const error = new Error('Model failed')
-    const event = new AfterModelCallEvent({ agent, model: agent.model, error })
+    const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
 
     expect(event.retry).toBeUndefined()
   })
@@ -467,12 +483,13 @@ describe('ModelStreamUpdateEvent', () => {
       type: 'modelMessageStartEvent' as const,
       role: 'assistant' as const,
     }
-    const hookEvent = new ModelStreamUpdateEvent({ agent, event: streamEvent })
+    const hookEvent = new ModelStreamUpdateEvent({ agent, event: streamEvent, invocationState: {} })
 
     expect(hookEvent).toEqual({
       type: 'modelStreamUpdateEvent',
       agent: agent,
       event: streamEvent,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     hookEvent.agent = new Agent()
@@ -485,12 +502,13 @@ describe('ContentBlockEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
     const contentBlock = new TextBlock('Hello')
-    const event = new ContentBlockEvent({ agent, contentBlock })
+    const event = new ContentBlockEvent({ agent, contentBlock, invocationState: {} })
 
     expect(event).toEqual({
       type: 'contentBlockEvent',
       agent: agent,
       contentBlock: contentBlock,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -503,13 +521,14 @@ describe('ModelMessageEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [new TextBlock('Hello')] })
-    const event = new ModelMessageEvent({ agent, message, stopReason: 'endTurn' })
+    const event = new ModelMessageEvent({ agent, message, stopReason: 'endTurn', invocationState: {} })
 
     expect(event).toEqual({
       type: 'modelMessageEvent',
       agent: agent,
       message: message,
       stopReason: 'endTurn',
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -528,12 +547,13 @@ describe('ToolResultEvent', () => {
       status: 'success',
       content: [new TextBlock('Result')],
     })
-    const event = new ToolResultEvent({ agent, result: toolResult })
+    const event = new ToolResultEvent({ agent, result: toolResult, invocationState: {} })
 
     expect(event).toEqual({
       type: 'toolResultEvent',
       agent: agent,
       result: toolResult,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -546,12 +566,13 @@ describe('ToolStreamUpdateEvent', () => {
   it('creates instance with correct properties', () => {
     const agent = new Agent()
     const toolStreamEvent = new ToolStreamEvent({ data: 'progress' })
-    const event = new ToolStreamUpdateEvent({ agent, event: toolStreamEvent })
+    const event = new ToolStreamUpdateEvent({ agent, event: toolStreamEvent, invocationState: {} })
 
     expect(event).toEqual({
       type: 'toolStreamUpdateEvent',
       agent: agent,
       event: toolStreamEvent,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -567,13 +588,15 @@ describe('AgentResultEvent', () => {
       stopReason: 'endTurn',
       lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Done')] }),
       metrics: new AgentMetrics(),
+      invocationState: {},
     })
-    const event = new AgentResultEvent({ agent, result })
+    const event = new AgentResultEvent({ agent, result, invocationState: {} })
 
     expect(event).toEqual({
       type: 'agentResultEvent',
       agent: agent,
       result: result,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -595,13 +618,14 @@ describe('BeforeToolsEvent', () => {
         }),
       ],
     })
-    const event = new BeforeToolsEvent({ agent, message })
+    const event = new BeforeToolsEvent({ agent, message, invocationState: {} })
 
     expect(event).toEqual({
       type: 'beforeToolsEvent',
       agent: agent,
       message: message,
       cancel: false,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -612,14 +636,14 @@ describe('BeforeToolsEvent', () => {
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
-    const event = new BeforeToolsEvent({ agent, message })
+    const event = new BeforeToolsEvent({ agent, message, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 
   it('allows cancel to be set to true', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
-    const event = new BeforeToolsEvent({ agent, message })
+    const event = new BeforeToolsEvent({ agent, message, invocationState: {} })
 
     expect(event.cancel).toBe(false)
     event.cancel = true
@@ -629,7 +653,7 @@ describe('BeforeToolsEvent', () => {
   it('allows cancel to be set to a string message', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
-    const event = new BeforeToolsEvent({ agent, message })
+    const event = new BeforeToolsEvent({ agent, message, invocationState: {} })
 
     event.cancel = 'tools not allowed'
     expect(event.cancel).toBe('tools not allowed')
@@ -649,12 +673,13 @@ describe('AfterToolsEvent', () => {
         }),
       ],
     })
-    const event = new AfterToolsEvent({ agent, message })
+    const event = new AfterToolsEvent({ agent, message, invocationState: {} })
 
     expect(event).toEqual({
       type: 'afterToolsEvent',
       agent: agent,
       message: message,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -665,7 +690,7 @@ describe('AfterToolsEvent', () => {
   it('returns true for _shouldReverseCallbacks', () => {
     const agent = new Agent()
     const message = new Message({ role: 'user', content: [] })
-    const event = new AfterToolsEvent({ agent, message })
+    const event = new AfterToolsEvent({ agent, message, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 })
@@ -686,7 +711,7 @@ describe('toJSON serialization', () => {
   describe('BeforeInvocationEvent', () => {
     it('excludes agent and returns only type', () => {
       const agent = new Agent()
-      const event = new BeforeInvocationEvent({ agent })
+      const event = new BeforeInvocationEvent({ agent, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({ type: 'beforeInvocationEvent' })
@@ -696,7 +721,7 @@ describe('toJSON serialization', () => {
   describe('AfterInvocationEvent', () => {
     it('excludes agent and returns only type', () => {
       const agent = new Agent()
-      const event = new AfterInvocationEvent({ agent })
+      const event = new AfterInvocationEvent({ agent, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({ type: 'afterInvocationEvent' })
@@ -706,7 +731,7 @@ describe('toJSON serialization', () => {
   describe('BeforeModelCallEvent', () => {
     it('excludes agent and model and returns only type', () => {
       const agent = new Agent()
-      const event = new BeforeModelCallEvent({ agent, model: agent.model })
+      const event = new BeforeModelCallEvent({ agent, model: agent.model, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({ type: 'beforeModelCallEvent' })
@@ -717,7 +742,7 @@ describe('toJSON serialization', () => {
     it('includes message and excludes agent', () => {
       const agent = new Agent()
       const message = new Message({ role: 'assistant', content: [new TextBlock('Hello')] })
-      const event = new MessageAddedEvent({ agent, message })
+      const event = new MessageAddedEvent({ agent, message, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -734,7 +759,7 @@ describe('toJSON serialization', () => {
         type: 'modelContentBlockDeltaEvent' as const,
         delta: { type: 'textDelta' as const, text: 'Hi' },
       }
-      const event = new ModelStreamUpdateEvent({ agent, event: streamEvent })
+      const event = new ModelStreamUpdateEvent({ agent, event: streamEvent, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -748,7 +773,7 @@ describe('toJSON serialization', () => {
     it('includes content block and excludes agent', () => {
       const agent = new Agent()
       const contentBlock = new TextBlock('Hello world')
-      const event = new ContentBlockEvent({ agent, contentBlock })
+      const event = new ContentBlockEvent({ agent, contentBlock, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -762,7 +787,7 @@ describe('toJSON serialization', () => {
     it('includes message and stopReason, excludes agent', () => {
       const agent = new Agent()
       const message = new Message({ role: 'assistant', content: [new TextBlock('Done')] })
-      const event = new ModelMessageEvent({ agent, message, stopReason: 'endTurn' })
+      const event = new ModelMessageEvent({ agent, message, stopReason: 'endTurn', invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -781,7 +806,7 @@ describe('toJSON serialization', () => {
         status: 'success',
         content: [new TextBlock('42')],
       })
-      const event = new ToolResultEvent({ agent, result })
+      const event = new ToolResultEvent({ agent, result, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -795,7 +820,7 @@ describe('toJSON serialization', () => {
     it('includes tool stream event and excludes agent', () => {
       const agent = new Agent()
       const toolStreamEvent = new ToolStreamEvent({ data: { progress: 50 } })
-      const event = new ToolStreamUpdateEvent({ agent, event: toolStreamEvent })
+      const event = new ToolStreamUpdateEvent({ agent, event: toolStreamEvent, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -812,8 +837,9 @@ describe('toJSON serialization', () => {
         stopReason: 'endTurn',
         lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Done')] }),
         metrics: new AgentMetrics(),
+        invocationState: {},
       })
-      const event = new AgentResultEvent({ agent, result })
+      const event = new AgentResultEvent({ agent, result, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -837,7 +863,7 @@ describe('toJSON serialization', () => {
         callback: () => 'result',
       })
       const toolUse = { name: 'testTool', toolUseId: 'id-1', input: { query: 'hello' } }
-      const event = new BeforeToolCallEvent({ agent, toolUse, tool })
+      const event = new BeforeToolCallEvent({ agent, toolUse, tool, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -856,7 +882,7 @@ describe('toJSON serialization', () => {
         status: 'success',
         content: [new TextBlock('42')],
       })
-      const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result })
+      const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -875,7 +901,7 @@ describe('toJSON serialization', () => {
         content: [new TextBlock('Error')],
       })
       const error = new Error('Tool crashed')
-      const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, error })
+      const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result, error, invocationState: {} })
       event.retry = true
       const json = JSON.parse(JSON.stringify(event))
 
@@ -893,7 +919,7 @@ describe('toJSON serialization', () => {
       const agent = new Agent()
       const message = new Message({ role: 'assistant', content: [new TextBlock('Hi')] })
       const stopData = { message, stopReason: 'endTurn' as const }
-      const event = new AfterModelCallEvent({ agent, model: agent.model, stopData })
+      const event = new AfterModelCallEvent({ agent, model: agent.model, stopData, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -908,7 +934,7 @@ describe('toJSON serialization', () => {
     it('converts error to message string and excludes retry', () => {
       const agent = new Agent()
       const error = new Error('Model failed')
-      const event = new AfterModelCallEvent({ agent, model: agent.model, error })
+      const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
       event.retry = true
       const json = JSON.parse(JSON.stringify(event))
 
@@ -926,7 +952,7 @@ describe('toJSON serialization', () => {
         role: 'assistant',
         content: [new ToolUseBlock({ name: 'calc', toolUseId: 'id-1', input: {} })],
       })
-      const event = new BeforeToolsEvent({ agent, message })
+      const event = new BeforeToolsEvent({ agent, message, invocationState: {} })
       event.cancel = 'not allowed'
       const json = JSON.parse(JSON.stringify(event))
 
@@ -950,7 +976,7 @@ describe('toJSON serialization', () => {
           }),
         ],
       })
-      const event = new AfterToolsEvent({ agent, message })
+      const event = new AfterToolsEvent({ agent, message, invocationState: {} })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -972,6 +998,7 @@ describe('toJSON serialization', () => {
       const event = new ModelStreamUpdateEvent({
         agent,
         event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Hi' } },
+        invocationState: {},
       })
       const json = JSON.stringify(event)
 
@@ -994,7 +1021,7 @@ describe('toJSON serialization completeness', () => {
    * If you add a new field to an event and it should be excluded from wire serialization,
    * add it here. Otherwise, add it to toJSON() so it gets serialized.
    */
-  const EXCLUDED_FIELDS = new Set(['agent', 'model', 'tool', 'cancel', 'retry'])
+  const EXCLUDED_FIELDS = new Set(['agent', 'model', 'tool', 'cancel', 'retry', 'invocationState'])
 
   /**
    * Fields where toJSON() transforms the value (e.g., Error to message object).
@@ -1021,34 +1048,54 @@ describe('toJSON serialization completeness', () => {
       stopReason: 'endTurn',
       lastMessage: message,
       metrics: new AgentMetrics(),
+      invocationState: {},
     })
 
     return [
       { name: 'InitializedEvent', event: new InitializedEvent({ agent }) },
-      { name: 'BeforeInvocationEvent', event: new BeforeInvocationEvent({ agent }) },
-      { name: 'AfterInvocationEvent', event: new AfterInvocationEvent({ agent }) },
+      { name: 'BeforeInvocationEvent', event: new BeforeInvocationEvent({ agent, invocationState: {} }) },
+      { name: 'AfterInvocationEvent', event: new AfterInvocationEvent({ agent, invocationState: {} }) },
       {
         name: 'BeforeModelCallEvent',
-        event: new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: 100 }),
+        event: new BeforeModelCallEvent({
+          agent,
+          model: agent.model,
+          invocationState: {},
+          projectedInputTokens: 100,
+        }),
       },
       {
         name: 'AfterModelCallEvent',
-        event: Object.assign(new AfterModelCallEvent({ agent, model: agent.model, stopData, error }), { retry: true }),
+        event: Object.assign(
+          new AfterModelCallEvent({ agent, model: agent.model, stopData, error, invocationState: {} }),
+          { retry: true }
+        ),
       },
-      { name: 'MessageAddedEvent', event: new MessageAddedEvent({ agent, message }) },
-      { name: 'ModelStreamUpdateEvent', event: new ModelStreamUpdateEvent({ agent, event: streamEvent }) },
-      { name: 'ContentBlockEvent', event: new ContentBlockEvent({ agent, contentBlock }) },
-      { name: 'ModelMessageEvent', event: new ModelMessageEvent({ agent, message, stopReason: 'endTurn' }) },
-      { name: 'ToolResultEvent', event: new ToolResultEvent({ agent, result }) },
-      { name: 'ToolStreamUpdateEvent', event: new ToolStreamUpdateEvent({ agent, event: toolStreamEvent }) },
-      { name: 'AgentResultEvent', event: new AgentResultEvent({ agent, result: agentResult }) },
-      { name: 'BeforeToolCallEvent', event: new BeforeToolCallEvent({ agent, toolUse, tool }) },
+      { name: 'MessageAddedEvent', event: new MessageAddedEvent({ agent, message, invocationState: {} }) },
+      {
+        name: 'ModelStreamUpdateEvent',
+        event: new ModelStreamUpdateEvent({ agent, event: streamEvent, invocationState: {} }),
+      },
+      { name: 'ContentBlockEvent', event: new ContentBlockEvent({ agent, contentBlock, invocationState: {} }) },
+      {
+        name: 'ModelMessageEvent',
+        event: new ModelMessageEvent({ agent, message, stopReason: 'endTurn', invocationState: {} }),
+      },
+      { name: 'ToolResultEvent', event: new ToolResultEvent({ agent, result, invocationState: {} }) },
+      {
+        name: 'ToolStreamUpdateEvent',
+        event: new ToolStreamUpdateEvent({ agent, event: toolStreamEvent, invocationState: {} }),
+      },
+      { name: 'AgentResultEvent', event: new AgentResultEvent({ agent, result: agentResult, invocationState: {} }) },
+      { name: 'BeforeToolCallEvent', event: new BeforeToolCallEvent({ agent, toolUse, tool, invocationState: {} }) },
       {
         name: 'AfterToolCallEvent',
-        event: Object.assign(new AfterToolCallEvent({ agent, toolUse, tool, result, error }), { retry: true }),
+        event: Object.assign(new AfterToolCallEvent({ agent, toolUse, tool, result, error, invocationState: {} }), {
+          retry: true,
+        }),
       },
-      { name: 'BeforeToolsEvent', event: new BeforeToolsEvent({ agent, message }) },
-      { name: 'AfterToolsEvent', event: new AfterToolsEvent({ agent, message }) },
+      { name: 'BeforeToolsEvent', event: new BeforeToolsEvent({ agent, message, invocationState: {} }) },
+      { name: 'AfterToolsEvent', event: new AfterToolsEvent({ agent, message, invocationState: {} }) },
     ]
   }
 

--- a/strands-ts/src/hooks/__tests__/registry.test.ts
+++ b/strands-ts/src/hooks/__tests__/registry.test.ts
@@ -17,7 +17,7 @@ describe('HookRegistryImplementation', () => {
       const callback = vi.fn()
       registry.addCallback(BeforeInvocationEvent, callback)
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback).toHaveBeenCalledOnce()
     })
@@ -29,7 +29,7 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, callback1)
       registry.addCallback(BeforeInvocationEvent, callback2)
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback1).toHaveBeenCalledOnce()
       expect(callback2).toHaveBeenCalledOnce()
@@ -42,12 +42,12 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, beforeCallback)
       registry.addCallback(AfterInvocationEvent, afterCallback)
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(beforeCallback).toHaveBeenCalledOnce()
       expect(afterCallback).not.toHaveBeenCalled()
 
-      await registry.invokeCallbacks(new AfterInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new AfterInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(afterCallback).toHaveBeenCalledOnce()
     })
@@ -66,7 +66,7 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, callback1)
       registry.addCallback(BeforeInvocationEvent, callback2)
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callOrder).toEqual([1, 2])
     })
@@ -83,7 +83,7 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(AfterInvocationEvent, callback1)
       registry.addCallback(AfterInvocationEvent, callback2)
 
-      await registry.invokeCallbacks(new AfterInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new AfterInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callOrder).toEqual([2, 1])
     })
@@ -97,7 +97,7 @@ describe('HookRegistryImplementation', () => {
 
       registry.addCallback(BeforeInvocationEvent, callback)
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(completed).toBe(true)
     })
@@ -109,9 +109,9 @@ describe('HookRegistryImplementation', () => {
 
       registry.addCallback(BeforeInvocationEvent, callback)
 
-      await expect(registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))).rejects.toThrow(
-        'Hook failed'
-      )
+      await expect(
+        registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
+      ).rejects.toThrow('Hook failed')
     })
 
     it('stops execution on first error', async () => {
@@ -123,9 +123,9 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, callback1)
       registry.addCallback(BeforeInvocationEvent, callback2)
 
-      await expect(registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))).rejects.toThrow(
-        'First callback failed'
-      )
+      await expect(
+        registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
+      ).rejects.toThrow('First callback failed')
 
       expect(callback2).not.toHaveBeenCalled()
     })
@@ -143,13 +143,13 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, syncCallback)
       registry.addCallback(BeforeInvocationEvent, asyncCallback)
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callOrder).toEqual(['sync', 'async'])
     })
 
     it('returns the event after invocation', async () => {
-      const event = new BeforeInvocationEvent({ agent: mockAgent })
+      const event = new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} })
       const result = await registry.invokeCallbacks(event)
       expect(result).toBe(event)
     })
@@ -162,7 +162,7 @@ describe('HookRegistryImplementation', () => {
       const cleanup = registry.addCallback(BeforeInvocationEvent, callback)
       cleanup()
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback).not.toHaveBeenCalled()
     })
@@ -175,7 +175,7 @@ describe('HookRegistryImplementation', () => {
       cleanup()
       cleanup()
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback).not.toHaveBeenCalled()
     })
@@ -188,7 +188,7 @@ describe('HookRegistryImplementation', () => {
       registry.addCallback(BeforeInvocationEvent, callback2)
       cleanup1()
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback1).not.toHaveBeenCalled()
       expect(callback2).toHaveBeenCalledOnce()
@@ -201,7 +201,7 @@ describe('HookRegistryImplementation', () => {
       cleanup()
 
       registry.addCallback(BeforeInvocationEvent, callback)
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback).toHaveBeenCalledTimes(1)
     })
@@ -214,7 +214,7 @@ describe('HookRegistryImplementation', () => {
       const cleanup2 = registry.addCallback(BeforeInvocationEvent, callback2)
       cleanup2()
 
-      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent }))
+      await registry.invokeCallbacks(new BeforeInvocationEvent({ agent: mockAgent, invocationState: {} }))
 
       expect(callback1).toHaveBeenCalledOnce()
       expect(callback2).not.toHaveBeenCalled()

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -1,4 +1,4 @@
-import type { LocalAgent, AgentResult } from '../types/agent.js'
+import type { LocalAgent, AgentResult, InvocationState } from '../types/agent.js'
 import type { ContentBlock, Message, StopReason, ToolResultBlock } from '../types/messages.js'
 import { type Tool, ToolStreamEvent } from '../tools/tool.js'
 import type { JSONValue } from '../types/json.js'
@@ -46,13 +46,29 @@ import type { Model } from '../models/model.js'
  *
  * ## Field naming conventions
  *
- * | Field           | Usage                                            |
- * |-----------------|--------------------------------------------------|
- * | `agent`         | `LocalAgent` reference on all agent-loop events  |
- * | `.event`        | Inner event in update wrappers                   |
- * | `.result`       | Finished result object                           |
- * | `.message`      | Message object                                   |
- * | `.contentBlock` | Content block object                             |
+ * | Field              | Usage                                            |
+ * |--------------------|--------------------------------------------------|
+ * | `agent`            | `LocalAgent` reference on all agent-loop events  |
+ * | `invocationState`  | Per-invocation state — see below                 |
+ * | `.event`           | Inner event in update wrappers                   |
+ * | `.result`          | Finished result object                           |
+ * | `.message`         | Message object                                   |
+ * | `.contentBlock`    | Content block object                             |
+ *
+ * ## `invocationState` on events
+ *
+ * Every hookable event that fires **during** an invocation carries
+ * {@link InvocationState} — the per-invocation mutable bag shared across hooks
+ * and tools. This lets any callback (lifecycle, data, streaming, completion)
+ * correlate back to the caller's request context (`userId`, `traceId`, etc.)
+ * without closure workarounds.
+ *
+ * The only events without `invocationState` are the ones that fire **outside**
+ * any invocation scope: {@link InitializedEvent} and `MultiAgentInitializedEvent`,
+ * both of which fire at construction.
+ *
+ * New events should follow the same rule: carry `invocationState` unless the
+ * event fires before any invocation exists.
  */
 
 /**
@@ -107,6 +123,7 @@ export class InitializedEvent extends HookableEvent {
 export class BeforeInvocationEvent extends HookableEvent {
   readonly type = 'beforeInvocationEvent' as const
   readonly agent: LocalAgent
+  readonly invocationState: InvocationState
 
   /**
    * Set by hook callbacks to cancel this invocation.
@@ -115,13 +132,14 @@ export class BeforeInvocationEvent extends HookableEvent {
    */
   cancel: boolean | string = false
 
-  constructor(data: { agent: LocalAgent }) {
+  constructor(data: { agent: LocalAgent; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<BeforeInvocationEvent, 'type'> {
@@ -137,10 +155,12 @@ export class BeforeInvocationEvent extends HookableEvent {
 export class AfterInvocationEvent extends HookableEvent {
   readonly type = 'afterInvocationEvent' as const
   readonly agent: LocalAgent
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent }) {
+  constructor(data: { agent: LocalAgent; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
+    this.invocationState = data.invocationState
   }
 
   override _shouldReverseCallbacks(): boolean {
@@ -148,7 +168,7 @@ export class AfterInvocationEvent extends HookableEvent {
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<AfterInvocationEvent, 'type'> {
@@ -165,15 +185,17 @@ export class MessageAddedEvent extends HookableEvent {
   readonly type = 'messageAddedEvent' as const
   readonly agent: LocalAgent
   readonly message: Message
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; message: Message }) {
+  constructor(data: { agent: LocalAgent; message: Message; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.message = data.message
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<MessageAddedEvent, 'type' | 'message'> {
@@ -195,6 +217,7 @@ export class BeforeToolCallEvent extends HookableEvent {
     input: JSONValue
   }
   readonly tool: Tool | undefined
+  readonly invocationState: InvocationState
 
   /**
    * Set by hook callbacks to cancel this tool call.
@@ -207,15 +230,17 @@ export class BeforeToolCallEvent extends HookableEvent {
     agent: LocalAgent
     toolUse: { name: string; toolUseId: string; input: JSONValue }
     tool: Tool | undefined
+    invocationState: InvocationState
   }) {
     super()
     this.agent = data.agent
     this.toolUse = data.toolUse
     this.tool = data.tool
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference, tool instance, and mutable cancel flag.
+   * Serializes for wire transport, excluding the agent reference, tool instance, invocationState, and mutable cancel flag.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<BeforeToolCallEvent, 'type' | 'toolUse'> {
@@ -245,6 +270,7 @@ export class AfterToolCallEvent extends HookableEvent {
   result: ToolResultBlock
 
   readonly error?: Error
+  readonly invocationState: InvocationState
 
   /**
    * Optional flag that can be set by hook callbacks to request a retry of the tool call.
@@ -257,6 +283,7 @@ export class AfterToolCallEvent extends HookableEvent {
     toolUse: { name: string; toolUseId: string; input: JSONValue }
     tool: Tool | undefined
     result: ToolResultBlock
+    invocationState: InvocationState
     error?: Error
   }) {
     super()
@@ -264,6 +291,7 @@ export class AfterToolCallEvent extends HookableEvent {
     this.toolUse = data.toolUse
     this.tool = data.tool
     this.result = data.result
+    this.invocationState = data.invocationState
     if (data.error !== undefined) {
       this.error = data.error
     }
@@ -274,7 +302,7 @@ export class AfterToolCallEvent extends HookableEvent {
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference, tool instance, and mutable retry flag.
+   * Serializes for wire transport, excluding the agent reference, tool instance, invocationState, and mutable retry flag.
    * Converts Error to an extensible object for safe wire serialization.
    * Called automatically by JSON.stringify().
    */
@@ -296,6 +324,7 @@ export class BeforeModelCallEvent extends HookableEvent {
   readonly type = 'beforeModelCallEvent' as const
   readonly agent: LocalAgent
   readonly model: Model
+  readonly invocationState: InvocationState
 
   /**
    * Set by hook callbacks to cancel this model call.
@@ -312,17 +341,23 @@ export class BeforeModelCallEvent extends HookableEvent {
    */
   readonly projectedInputTokens?: number
 
-  constructor(data: { agent: LocalAgent; model: Model; projectedInputTokens?: number }) {
+  constructor(data: {
+    agent: LocalAgent
+    model: Model
+    invocationState: InvocationState
+    projectedInputTokens?: number
+  }) {
     super()
     this.agent = data.agent
     this.model = data.model
+    this.invocationState = data.invocationState
     if (data.projectedInputTokens !== undefined) {
       this.projectedInputTokens = data.projectedInputTokens
     }
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<BeforeModelCallEvent, 'type' | 'projectedInputTokens'> {
@@ -377,6 +412,7 @@ export class AfterModelCallEvent extends HookableEvent {
   readonly model: Model
   readonly stopData?: ModelStopData
   readonly error?: Error
+  readonly invocationState: InvocationState
 
   /**
    * Optional flag that can be set by hook callbacks to request a retry of the model call.
@@ -384,10 +420,17 @@ export class AfterModelCallEvent extends HookableEvent {
    */
   retry?: boolean
 
-  constructor(data: { agent: LocalAgent; model: Model; stopData?: ModelStopData; error?: Error }) {
+  constructor(data: {
+    agent: LocalAgent
+    model: Model
+    invocationState: InvocationState
+    stopData?: ModelStopData
+    error?: Error
+  }) {
     super()
     this.agent = data.agent
     this.model = data.model
+    this.invocationState = data.invocationState
     if (data.stopData !== undefined) {
       this.stopData = data.stopData
     }
@@ -401,7 +444,7 @@ export class AfterModelCallEvent extends HookableEvent {
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference and mutable retry flag.
+   * Serializes for wire transport, excluding the agent reference, invocationState, and mutable retry flag.
    * Converts Error to an extensible object for safe wire serialization.
    * Called automatically by JSON.stringify().
    */
@@ -424,15 +467,17 @@ export class ModelStreamUpdateEvent extends HookableEvent {
   readonly type = 'modelStreamUpdateEvent' as const
   readonly agent: LocalAgent
   readonly event: ModelStreamEvent
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; event: ModelStreamEvent }) {
+  constructor(data: { agent: LocalAgent; event: ModelStreamEvent; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.event = data.event
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<ModelStreamUpdateEvent, 'type' | 'event'> {
@@ -454,15 +499,17 @@ export class ContentBlockEvent extends HookableEvent {
   readonly type = 'contentBlockEvent' as const
   readonly agent: LocalAgent
   readonly contentBlock: ContentBlock
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; contentBlock: ContentBlock }) {
+  constructor(data: { agent: LocalAgent; contentBlock: ContentBlock; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.contentBlock = data.contentBlock
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<ContentBlockEvent, 'type' | 'contentBlock'> {
@@ -479,16 +526,18 @@ export class ModelMessageEvent extends HookableEvent {
   readonly agent: LocalAgent
   readonly message: Message
   readonly stopReason: StopReason
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; message: Message; stopReason: StopReason }) {
+  constructor(data: { agent: LocalAgent; message: Message; stopReason: StopReason; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.message = data.message
     this.stopReason = data.stopReason
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<ModelMessageEvent, 'type' | 'message' | 'stopReason'> {
@@ -504,15 +553,17 @@ export class ToolResultEvent extends HookableEvent {
   readonly type = 'toolResultEvent' as const
   readonly agent: LocalAgent
   readonly result: ToolResultBlock
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; result: ToolResultBlock }) {
+  constructor(data: { agent: LocalAgent; result: ToolResultBlock; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.result = data.result
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<ToolResultEvent, 'type' | 'result'> {
@@ -533,15 +584,17 @@ export class ToolStreamUpdateEvent extends HookableEvent {
   readonly type = 'toolStreamUpdateEvent' as const
   readonly agent: LocalAgent
   readonly event: ToolStreamEvent
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; event: ToolStreamEvent }) {
+  constructor(data: { agent: LocalAgent; event: ToolStreamEvent; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.event = data.event
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<ToolStreamUpdateEvent, 'type' | 'event'> {
@@ -557,15 +610,17 @@ export class AgentResultEvent extends HookableEvent {
   readonly type = 'agentResultEvent' as const
   readonly agent: LocalAgent
   readonly result: AgentResult
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; result: AgentResult }) {
+  constructor(data: { agent: LocalAgent; result: AgentResult; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.result = data.result
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<AgentResultEvent, 'type' | 'result'> {
@@ -582,6 +637,7 @@ export class BeforeToolsEvent extends HookableEvent {
   readonly type = 'beforeToolsEvent' as const
   readonly agent: LocalAgent
   readonly message: Message
+  readonly invocationState: InvocationState
 
   /**
    * Set by hook callbacks to cancel all tool calls.
@@ -590,14 +646,15 @@ export class BeforeToolsEvent extends HookableEvent {
    */
   cancel: boolean | string = false
 
-  constructor(data: { agent: LocalAgent; message: Message }) {
+  constructor(data: { agent: LocalAgent; message: Message; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.message = data.message
+    this.invocationState = data.invocationState
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference and mutable cancel flag.
+   * Serializes for wire transport, excluding the agent reference, invocationState, and mutable cancel flag.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<BeforeToolsEvent, 'type' | 'message'> {
@@ -614,11 +671,13 @@ export class AfterToolsEvent extends HookableEvent {
   readonly type = 'afterToolsEvent' as const
   readonly agent: LocalAgent
   readonly message: Message
+  readonly invocationState: InvocationState
 
-  constructor(data: { agent: LocalAgent; message: Message }) {
+  constructor(data: { agent: LocalAgent; message: Message; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
     this.message = data.message
+    this.invocationState = data.invocationState
   }
 
   override _shouldReverseCallbacks(): boolean {
@@ -626,7 +685,7 @@ export class AfterToolsEvent extends HookableEvent {
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference.
+   * Serializes for wire transport, excluding the agent reference and invocationState.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<AfterToolsEvent, 'type' | 'message'> {

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -15,7 +15,7 @@ export { StateStore } from './state-store.js'
 export { AgentResult } from './types/agent.js'
 export type { AgentConfig, ToolList, ToolExecutorStrategy } from './agent/agent.js'
 export type { AgentAsToolOptions } from './agent/agent-as-tool.js'
-export type { LocalAgent, InvokeOptions } from './types/agent.js'
+export type { InvocationState, InvokeOptions, LocalAgent } from './types/agent.js'
 
 // Error types
 // Note: CancelledError is intentionally not exported — it is an internal

--- a/strands-ts/src/multiagent/__tests__/events.test.ts
+++ b/strands-ts/src/multiagent/__tests__/events.test.ts
@@ -59,12 +59,17 @@ describe('MultiAgentInitializedEvent', () => {
 describe('BeforeMultiAgentInvocationEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
-    const event = new BeforeMultiAgentInvocationEvent({ orchestrator: mockOrchestrator, state })
+    const event = new BeforeMultiAgentInvocationEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'beforeMultiAgentInvocationEvent',
       orchestrator: mockOrchestrator,
       state,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.orchestrator = mockOrchestrator
@@ -74,12 +79,20 @@ describe('BeforeMultiAgentInvocationEvent', () => {
 
   it('returns false for _shouldReverseCallbacks', () => {
     const state = new MultiAgentState()
-    const event = new BeforeMultiAgentInvocationEvent({ orchestrator: mockOrchestrator, state })
+    const event = new BeforeMultiAgentInvocationEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      invocationState: {},
+    })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 
   describe('toJSON', () => {
-    const event = new BeforeMultiAgentInvocationEvent({ orchestrator: mockOrchestrator, state: new MultiAgentState() })
+    const event = new BeforeMultiAgentInvocationEvent({
+      orchestrator: mockOrchestrator,
+      state: new MultiAgentState(),
+      invocationState: {},
+    })
 
     it('serializes', () => {
       expect(JSON.parse(JSON.stringify(event))).toStrictEqual({ type: 'beforeMultiAgentInvocationEvent' })
@@ -87,7 +100,7 @@ describe('BeforeMultiAgentInvocationEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state', 'invocationState'])
     })
   })
 })
@@ -95,12 +108,17 @@ describe('BeforeMultiAgentInvocationEvent', () => {
 describe('AfterMultiAgentInvocationEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
-    const event = new AfterMultiAgentInvocationEvent({ orchestrator: mockOrchestrator, state })
+    const event = new AfterMultiAgentInvocationEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'afterMultiAgentInvocationEvent',
       orchestrator: mockOrchestrator,
       state,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.orchestrator = mockOrchestrator
@@ -110,12 +128,20 @@ describe('AfterMultiAgentInvocationEvent', () => {
 
   it('returns true for _shouldReverseCallbacks', () => {
     const state = new MultiAgentState()
-    const event = new AfterMultiAgentInvocationEvent({ orchestrator: mockOrchestrator, state })
+    const event = new AfterMultiAgentInvocationEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      invocationState: {},
+    })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
   describe('toJSON', () => {
-    const event = new AfterMultiAgentInvocationEvent({ orchestrator: mockOrchestrator, state: new MultiAgentState() })
+    const event = new AfterMultiAgentInvocationEvent({
+      orchestrator: mockOrchestrator,
+      state: new MultiAgentState(),
+      invocationState: {},
+    })
 
     it('serializes', () => {
       expect(JSON.parse(JSON.stringify(event))).toStrictEqual({ type: 'afterMultiAgentInvocationEvent' })
@@ -123,7 +149,7 @@ describe('AfterMultiAgentInvocationEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state', 'invocationState'])
     })
   })
 })
@@ -131,7 +157,12 @@ describe('AfterMultiAgentInvocationEvent', () => {
 describe('BeforeNodeCallEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
-    const event = new BeforeNodeCallEvent({ orchestrator: mockOrchestrator, state, nodeId: 'node-1' })
+    const event = new BeforeNodeCallEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      nodeId: 'node-1',
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'beforeNodeCallEvent',
@@ -139,6 +170,7 @@ describe('BeforeNodeCallEvent', () => {
       state,
       nodeId: 'node-1',
       cancel: false,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.orchestrator = mockOrchestrator
@@ -150,13 +182,23 @@ describe('BeforeNodeCallEvent', () => {
 
   it('returns false for _shouldReverseCallbacks', () => {
     const state = new MultiAgentState()
-    const event = new BeforeNodeCallEvent({ orchestrator: mockOrchestrator, state, nodeId: 'node-1' })
+    const event = new BeforeNodeCallEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      nodeId: 'node-1',
+      invocationState: {},
+    })
     expect(event._shouldReverseCallbacks()).toBe(false)
   })
 
   it('allows cancel to be set to true', () => {
     const state = new MultiAgentState()
-    const event = new BeforeNodeCallEvent({ orchestrator: mockOrchestrator, state, nodeId: 'node-1' })
+    const event = new BeforeNodeCallEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      nodeId: 'node-1',
+      invocationState: {},
+    })
 
     expect(event.cancel).toBe(false)
     event.cancel = true
@@ -165,7 +207,12 @@ describe('BeforeNodeCallEvent', () => {
 
   it('allows cancel to be set to a string message', () => {
     const state = new MultiAgentState()
-    const event = new BeforeNodeCallEvent({ orchestrator: mockOrchestrator, state, nodeId: 'node-1' })
+    const event = new BeforeNodeCallEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      nodeId: 'node-1',
+      invocationState: {},
+    })
 
     event.cancel = 'node is not ready'
     expect(event.cancel).toBe('node is not ready')
@@ -176,6 +223,7 @@ describe('BeforeNodeCallEvent', () => {
       orchestrator: mockOrchestrator,
       state: new MultiAgentState(),
       nodeId: 'node-1',
+      invocationState: {},
     })
     event.cancel = true
 
@@ -188,7 +236,12 @@ describe('BeforeNodeCallEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state', 'cancel'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual([
+        'orchestrator',
+        'state',
+        'invocationState',
+        'cancel',
+      ])
     })
   })
 })
@@ -197,13 +250,20 @@ describe('AfterNodeCallEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
     const error = new Error('node failed')
-    const event = new AfterNodeCallEvent({ orchestrator: mockOrchestrator, state, nodeId: 'node-1', error })
+    const event = new AfterNodeCallEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      nodeId: 'node-1',
+      invocationState: {},
+      error,
+    })
 
     expect(event).toEqual({
       type: 'afterNodeCallEvent',
       orchestrator: mockOrchestrator,
       state,
       nodeId: 'node-1',
+      invocationState: {},
       error,
     })
     // @ts-expect-error verifying that property is readonly
@@ -216,7 +276,12 @@ describe('AfterNodeCallEvent', () => {
 
   it('returns true for _shouldReverseCallbacks', () => {
     const state = new MultiAgentState()
-    const event = new AfterNodeCallEvent({ orchestrator: mockOrchestrator, state, nodeId: 'node-1' })
+    const event = new AfterNodeCallEvent({
+      orchestrator: mockOrchestrator,
+      state,
+      nodeId: 'node-1',
+      invocationState: {},
+    })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
@@ -225,6 +290,7 @@ describe('AfterNodeCallEvent', () => {
       orchestrator: mockOrchestrator,
       state: new MultiAgentState(),
       nodeId: 'node-1',
+      invocationState: {},
       error: new Error('node failed'),
     })
 
@@ -241,6 +307,7 @@ describe('AfterNodeCallEvent', () => {
         orchestrator: mockOrchestrator,
         state: new MultiAgentState(),
         nodeId: 'node-1',
+        invocationState: {},
       })
 
       expect(JSON.parse(JSON.stringify(event))).toStrictEqual({
@@ -251,7 +318,7 @@ describe('AfterNodeCallEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['orchestrator', 'state', 'invocationState'])
     })
   })
 })
@@ -260,7 +327,13 @@ describe('NodeStreamUpdateEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
     const innerEvent = { source: 'agent', event: { type: 'beforeInvocationEvent' } as AgentStreamEvent } as const
-    const event = new NodeStreamUpdateEvent({ nodeId: 'node-1', nodeType: 'agentNode', state, inner: innerEvent })
+    const event = new NodeStreamUpdateEvent({
+      nodeId: 'node-1',
+      nodeType: 'agentNode',
+      state,
+      inner: innerEvent,
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'nodeStreamUpdateEvent',
@@ -268,6 +341,7 @@ describe('NodeStreamUpdateEvent', () => {
       nodeType: 'agentNode',
       state,
       inner: innerEvent,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.nodeId = 'node-1'
@@ -286,6 +360,7 @@ describe('NodeStreamUpdateEvent', () => {
       nodeType: 'agentNode',
       state: new MultiAgentState(),
       inner: innerEvent,
+      invocationState: {},
     })
 
     it('serializes', () => {
@@ -299,7 +374,7 @@ describe('NodeStreamUpdateEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state', 'invocationState'])
     })
   })
 })
@@ -308,7 +383,7 @@ describe('NodeResultEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
     const result = new NodeResult({ nodeId: 'node-1', status: Status.COMPLETED, duration: 100 })
-    const event = new NodeResultEvent({ nodeId: 'node-1', nodeType: 'agentNode', state, result })
+    const event = new NodeResultEvent({ nodeId: 'node-1', nodeType: 'agentNode', state, result, invocationState: {} })
 
     expect(event).toEqual({
       type: 'nodeResultEvent',
@@ -316,6 +391,7 @@ describe('NodeResultEvent', () => {
       nodeType: 'agentNode',
       state,
       result,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.nodeId = 'node-1'
@@ -333,6 +409,7 @@ describe('NodeResultEvent', () => {
       nodeType: 'agentNode',
       state: new MultiAgentState(),
       result: new NodeResult({ nodeId: 'node-1', status: Status.COMPLETED, duration: 100 }),
+      invocationState: {},
     })
 
     it('serializes', () => {
@@ -352,7 +429,7 @@ describe('NodeResultEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state', 'invocationState'])
     })
   })
 })
@@ -360,13 +437,14 @@ describe('NodeResultEvent', () => {
 describe('NodeCancelEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
-    const event = new NodeCancelEvent({ nodeId: 'node-1', state, message: 'cancelled by hook' })
+    const event = new NodeCancelEvent({ nodeId: 'node-1', state, message: 'cancelled by hook', invocationState: {} })
 
     expect(event).toEqual({
       type: 'nodeCancelEvent',
       nodeId: 'node-1',
       state,
       message: 'cancelled by hook',
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.nodeId = 'node-1'
@@ -377,7 +455,12 @@ describe('NodeCancelEvent', () => {
   })
 
   describe('toJSON', () => {
-    const event = new NodeCancelEvent({ nodeId: 'node-1', state: new MultiAgentState(), message: 'cancelled by hook' })
+    const event = new NodeCancelEvent({
+      nodeId: 'node-1',
+      state: new MultiAgentState(),
+      message: 'cancelled by hook',
+      invocationState: {},
+    })
 
     it('serializes', () => {
       expect(JSON.parse(JSON.stringify(event))).toStrictEqual({
@@ -389,7 +472,7 @@ describe('NodeCancelEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state', 'invocationState'])
     })
   })
 })
@@ -397,13 +480,19 @@ describe('NodeCancelEvent', () => {
 describe('MultiAgentHandoffEvent', () => {
   it('creates instance with correct properties', () => {
     const state = new MultiAgentState()
-    const event = new MultiAgentHandoffEvent({ source: 'node-a', targets: ['node-b', 'node-c'], state })
+    const event = new MultiAgentHandoffEvent({
+      source: 'node-a',
+      targets: ['node-b', 'node-c'],
+      state,
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'multiAgentHandoffEvent',
       source: 'node-a',
       targets: ['node-b', 'node-c'],
       state,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.source = 'node-a'
@@ -418,6 +507,7 @@ describe('MultiAgentHandoffEvent', () => {
       source: 'node-a',
       targets: ['node-b', 'node-c'],
       state: new MultiAgentState(),
+      invocationState: {},
     })
 
     it('serializes', () => {
@@ -430,7 +520,7 @@ describe('MultiAgentHandoffEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state'])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['state', 'invocationState'])
     })
   })
 })
@@ -438,18 +528,22 @@ describe('MultiAgentHandoffEvent', () => {
 describe('MultiAgentResultEvent', () => {
   it('creates instance with correct properties', () => {
     const result = new MultiAgentResult({ results: [], duration: 0 })
-    const event = new MultiAgentResultEvent({ result })
+    const event = new MultiAgentResultEvent({ result, invocationState: {} })
 
     expect(event).toEqual({
       type: 'multiAgentResultEvent',
       result,
+      invocationState: {},
     })
     // @ts-expect-error verifying that property is readonly
     event.result = result
   })
 
   describe('toJSON', () => {
-    const event = new MultiAgentResultEvent({ result: new MultiAgentResult({ results: [], duration: 500 }) })
+    const event = new MultiAgentResultEvent({
+      result: new MultiAgentResult({ results: [], duration: 500 }),
+      invocationState: {},
+    })
 
     it('serializes', () => {
       expect(JSON.parse(JSON.stringify(event))).toStrictEqual({
@@ -467,7 +561,7 @@ describe('MultiAgentResultEvent', () => {
 
     it('only excludes expected fields', () => {
       const json = event.toJSON()
-      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual([])
+      expect(Object.keys(event).filter((k) => !(k in json))).toStrictEqual(['invocationState'])
     })
   })
 })

--- a/strands-ts/src/multiagent/__tests__/graph.invocation-state.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.invocation-state.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { BeforeModelCallEvent } from '../../hooks/events.js'
+import { TextBlock } from '../../types/messages.js'
+import { Graph } from '../graph.js'
+import {
+  AfterMultiAgentInvocationEvent,
+  AfterNodeCallEvent,
+  BeforeMultiAgentInvocationEvent,
+  BeforeNodeCallEvent,
+  MultiAgentHandoffEvent,
+  MultiAgentResultEvent,
+  NodeResultEvent,
+  NodeStreamUpdateEvent,
+} from '../events.js'
+import type { InvocationState } from '../../types/agent.js'
+
+describe('Graph invocationState forwarding', () => {
+  it('forwards invocationState to every node and mutations from one node are visible to the next', async () => {
+    const nodeAObserved: InvocationState[] = []
+    const nodeBObserved: InvocationState[] = []
+
+    const agentA = new Agent({
+      model: new MockMessageModel().addTurn(new TextBlock('A done')),
+      printer: false,
+      id: 'a',
+    })
+    agentA.addHook(BeforeModelCallEvent, (event) => {
+      nodeAObserved.push(event.invocationState)
+      event.invocationState.touchedByA = true
+    })
+
+    const agentB = new Agent({
+      model: new MockMessageModel().addTurn(new TextBlock('B done')),
+      printer: false,
+      id: 'b',
+    })
+    agentB.addHook(BeforeModelCallEvent, (event) => {
+      nodeBObserved.push(event.invocationState)
+    })
+
+    const graph = new Graph({
+      nodes: [agentA, agentB],
+      edges: [{ source: 'a', target: 'b' }],
+    })
+
+    const state: InvocationState = { requestId: 'r-1' }
+    await graph.invoke('hello', { invocationState: state })
+
+    // Both nodes observe the same object reference.
+    expect(nodeAObserved[0]).toBe(state)
+    expect(nodeBObserved[0]).toBe(state)
+
+    // Node B sees node A's mutation.
+    expect(nodeBObserved[0]?.touchedByA).toBe(true)
+    expect(state.touchedByA).toBe(true)
+  })
+
+  it('defaults invocationState to {} when none is passed', async () => {
+    let observed: InvocationState | undefined
+
+    const agentA = new Agent({
+      model: new MockMessageModel().addTurn(new TextBlock('A done')),
+      printer: false,
+      id: 'a',
+    })
+    agentA.addHook(BeforeModelCallEvent, (event) => {
+      observed = event.invocationState
+    })
+
+    const graph = new Graph({
+      nodes: [agentA],
+      edges: [],
+    })
+
+    await graph.invoke('hello')
+
+    expect(observed).toEqual({})
+  })
+
+  it('every orchestrator and node event in a run carries the same invocationState reference', async () => {
+    const agentA = new Agent({
+      model: new MockMessageModel().addTurn(new TextBlock('A done')),
+      printer: false,
+      id: 'a',
+    })
+    const agentB = new Agent({
+      model: new MockMessageModel().addTurn(new TextBlock('B done')),
+      printer: false,
+      id: 'b',
+    })
+
+    const graph = new Graph({
+      nodes: [agentA, agentB],
+      edges: [{ source: 'a', target: 'b' }],
+    })
+
+    const state: InvocationState = { requestId: 'r-1' }
+    const observed: { label: string; ref: InvocationState }[] = []
+
+    const record = (label: string, ref: InvocationState): void => {
+      observed.push({ label, ref })
+    }
+    graph.addHook(BeforeMultiAgentInvocationEvent, (e) => record('BeforeMultiAgentInvocation', e.invocationState))
+    graph.addHook(AfterMultiAgentInvocationEvent, (e) => record('AfterMultiAgentInvocation', e.invocationState))
+    graph.addHook(BeforeNodeCallEvent, (e) => record(`BeforeNodeCall:${e.nodeId}`, e.invocationState))
+    graph.addHook(AfterNodeCallEvent, (e) => record(`AfterNodeCall:${e.nodeId}`, e.invocationState))
+    graph.addHook(NodeStreamUpdateEvent, (e) => record(`NodeStreamUpdate:${e.nodeId}`, e.invocationState))
+    graph.addHook(NodeResultEvent, (e) => record(`NodeResult:${e.nodeId}`, e.invocationState))
+    graph.addHook(MultiAgentHandoffEvent, (e) => record('MultiAgentHandoff', e.invocationState))
+    graph.addHook(MultiAgentResultEvent, (e) => record('MultiAgentResult', e.invocationState))
+
+    await graph.invoke('hello', { invocationState: state })
+
+    // Every event observed at the orchestrator level must share the caller's reference.
+    expect(observed.length).toBeGreaterThan(0)
+    for (const { label, ref } of observed) {
+      expect(ref, `event=${label} saw a different invocationState object`).toBe(state)
+    }
+  })
+})

--- a/strands-ts/src/multiagent/__tests__/nodes.test.ts
+++ b/strands-ts/src/multiagent/__tests__/nodes.test.ts
@@ -64,6 +64,7 @@ describe('Node', () => {
         nodeType: 'node',
         state,
         result,
+        invocationState: {},
       })
 
       expect(result).toEqual({
@@ -90,6 +91,7 @@ describe('Node', () => {
         nodeType: 'node',
         state,
         result,
+        invocationState: {},
       })
 
       expect(result).toEqual({
@@ -223,12 +225,13 @@ describe('MultiAgentNode', () => {
 
   describe('handle', () => {
     it('passes through inner NodeStreamUpdateEvents', async () => {
-      const innerUpdate = new MultiAgentHandoffEvent({ source: 'x', targets: ['y'], state })
+      const innerUpdate = new MultiAgentHandoffEvent({ source: 'x', targets: ['y'], state, invocationState: {} })
       const innerEvent = new NodeStreamUpdateEvent({
         nodeId: 'deep-node',
         nodeType: 'agentNode',
         state,
         inner: { source: 'multiAgent', event: innerUpdate },
+        invocationState: {},
       })
       const orchestrator = mockOrchestrator('inner', [innerEvent])
       node = new MultiAgentNode({ orchestrator })
@@ -241,7 +244,7 @@ describe('MultiAgentNode', () => {
     })
 
     it('wraps non-NodeStreamUpdateEvents with this node identity', async () => {
-      const handoff = new MultiAgentHandoffEvent({ source: 'a', targets: ['b'], state })
+      const handoff = new MultiAgentHandoffEvent({ source: 'a', targets: ['b'], state, invocationState: {} })
       const orchestrator = mockOrchestrator('inner', [handoff])
       node = new MultiAgentNode({ orchestrator })
 

--- a/strands-ts/src/multiagent/__tests__/swarm.invocation-state.test.ts
+++ b/strands-ts/src/multiagent/__tests__/swarm.invocation-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { BeforeModelCallEvent } from '../../hooks/events.js'
+import type { JSONValue } from '../../types/json.js'
+import { Swarm } from '../swarm.js'
+import type { InvocationState } from '../../types/agent.js'
+
+/**
+ * Agent that hands off to `nextAgentId` via the structured-output tool, or
+ * terminates when `nextAgentId` is undefined.
+ */
+function makeHandoffAgent(id: string, nextAgentId: string | undefined, message: string): Agent {
+  const handoff: { agentId?: string; message: string } = { message }
+  if (nextAgentId !== undefined) handoff.agentId = nextAgentId
+
+  const model = new MockMessageModel().addTurn({
+    type: 'toolUseBlock',
+    name: 'strands_structured_output',
+    toolUseId: `tool-${id}`,
+    input: handoff as JSONValue,
+  })
+  return new Agent({ model, printer: false, id, description: `Agent ${id}` })
+}
+
+describe('Swarm invocationState forwarding', () => {
+  it('forwards invocationState to every node and mutations from one node are visible to the next', async () => {
+    const nodeAObserved: InvocationState[] = []
+    const nodeBObserved: InvocationState[] = []
+
+    const agentA = makeHandoffAgent('a', 'b', 'to b')
+    agentA.addHook(BeforeModelCallEvent, (event) => {
+      nodeAObserved.push(event.invocationState)
+      event.invocationState.touchedByA = true
+    })
+
+    const agentB = makeHandoffAgent('b', undefined, 'done')
+    agentB.addHook(BeforeModelCallEvent, (event) => {
+      nodeBObserved.push(event.invocationState)
+    })
+
+    const swarm = new Swarm({ nodes: [agentA, agentB], start: 'a' })
+
+    const state: InvocationState = { requestId: 'r-1' }
+    await swarm.invoke('hello', { invocationState: state })
+
+    // Both nodes observe the same object reference.
+    expect(nodeAObserved[0]).toBe(state)
+    expect(nodeBObserved[0]).toBe(state)
+
+    // Node B sees node A's mutation.
+    expect(nodeBObserved[0]?.touchedByA).toBe(true)
+    expect(state.touchedByA).toBe(true)
+  })
+
+  it('defaults invocationState to {} when none is passed', async () => {
+    let observed: InvocationState | undefined
+
+    const agentA = makeHandoffAgent('a', undefined, 'done')
+    agentA.addHook(BeforeModelCallEvent, (event) => {
+      observed = event.invocationState
+    })
+
+    const swarm = new Swarm({ nodes: [agentA], start: 'a' })
+
+    await swarm.invoke('hello')
+
+    expect(observed).toEqual({})
+  })
+})

--- a/strands-ts/src/multiagent/events.ts
+++ b/strands-ts/src/multiagent/events.ts
@@ -1,5 +1,5 @@
 import { HookableEvent, StreamEvent } from '../hooks/events.js'
-import type { AgentStreamEvent } from '../types/agent.js'
+import type { AgentStreamEvent, InvocationState } from '../types/agent.js'
 import type { MultiAgentResult, MultiAgentState, NodeResult } from './state.js'
 import type { MultiAgent } from './multiagent.js'
 import type { NodeType } from './nodes.js'
@@ -28,11 +28,13 @@ export class BeforeMultiAgentInvocationEvent extends HookableEvent {
   readonly type = 'beforeMultiAgentInvocationEvent' as const
   readonly orchestrator: MultiAgent
   readonly state: MultiAgentState
+  readonly invocationState: InvocationState
 
-  constructor(data: { orchestrator: MultiAgent; state: MultiAgentState }) {
+  constructor(data: { orchestrator: MultiAgent; state: MultiAgentState; invocationState: InvocationState }) {
     super()
     this.orchestrator = data.orchestrator
     this.state = data.state
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<BeforeMultiAgentInvocationEvent, 'type'> {
@@ -47,11 +49,13 @@ export class AfterMultiAgentInvocationEvent extends HookableEvent {
   readonly type = 'afterMultiAgentInvocationEvent' as const
   readonly orchestrator: MultiAgent
   readonly state: MultiAgentState
+  readonly invocationState: InvocationState
 
-  constructor(data: { orchestrator: MultiAgent; state: MultiAgentState }) {
+  constructor(data: { orchestrator: MultiAgent; state: MultiAgentState; invocationState: InvocationState }) {
     super()
     this.orchestrator = data.orchestrator
     this.state = data.state
+    this.invocationState = data.invocationState
   }
 
   override _shouldReverseCallbacks(): boolean {
@@ -72,6 +76,7 @@ export class BeforeNodeCallEvent extends HookableEvent {
   readonly orchestrator: MultiAgent
   readonly state: MultiAgentState
   readonly nodeId: string
+  readonly invocationState: InvocationState
 
   /**
    * Set by hook callbacks to cancel node execution.
@@ -80,11 +85,17 @@ export class BeforeNodeCallEvent extends HookableEvent {
    */
   cancel: boolean | string = false
 
-  constructor(data: { orchestrator: MultiAgent; state: MultiAgentState; nodeId: string }) {
+  constructor(data: {
+    orchestrator: MultiAgent
+    state: MultiAgentState
+    nodeId: string
+    invocationState: InvocationState
+  }) {
     super()
     this.orchestrator = data.orchestrator
     this.state = data.state
     this.nodeId = data.nodeId
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<BeforeNodeCallEvent, 'type' | 'nodeId'> {
@@ -100,13 +111,21 @@ export class AfterNodeCallEvent extends HookableEvent {
   readonly orchestrator: MultiAgent
   readonly state: MultiAgentState
   readonly nodeId: string
+  readonly invocationState: InvocationState
   readonly error?: Error
 
-  constructor(data: { orchestrator: MultiAgent; state: MultiAgentState; nodeId: string; error?: Error }) {
+  constructor(data: {
+    orchestrator: MultiAgent
+    state: MultiAgentState
+    nodeId: string
+    invocationState: InvocationState
+    error?: Error
+  }) {
     super()
     this.orchestrator = data.orchestrator
     this.state = data.state
     this.nodeId = data.nodeId
+    this.invocationState = data.invocationState
     if (data.error !== undefined) {
       this.error = data.error
     }
@@ -157,13 +176,21 @@ export class NodeStreamUpdateEvent extends HookableEvent {
   readonly nodeType: NodeType
   readonly state: MultiAgentState
   readonly inner: NodeStreamUpdateInnerEvent
+  readonly invocationState: InvocationState
 
-  constructor(data: { nodeId: string; nodeType: NodeType; state: MultiAgentState; inner: NodeStreamUpdateInnerEvent }) {
+  constructor(data: {
+    nodeId: string
+    nodeType: NodeType
+    state: MultiAgentState
+    inner: NodeStreamUpdateInnerEvent
+    invocationState: InvocationState
+  }) {
     super()
     this.nodeId = data.nodeId
     this.nodeType = data.nodeType
     this.state = data.state
     this.inner = data.inner
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<NodeStreamUpdateEvent, 'type' | 'nodeId' | 'nodeType' | 'inner'> {
@@ -181,13 +208,21 @@ export class NodeResultEvent extends HookableEvent {
   readonly nodeType: NodeType
   readonly state: MultiAgentState
   readonly result: NodeResult
+  readonly invocationState: InvocationState
 
-  constructor(data: { nodeId: string; nodeType: NodeType; state: MultiAgentState; result: NodeResult }) {
+  constructor(data: {
+    nodeId: string
+    nodeType: NodeType
+    state: MultiAgentState
+    result: NodeResult
+    invocationState: InvocationState
+  }) {
     super()
     this.nodeId = data.nodeId
     this.nodeType = data.nodeType
     this.state = data.state
     this.result = data.result
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<NodeResultEvent, 'type' | 'nodeId' | 'nodeType' | 'result'> {
@@ -203,12 +238,14 @@ export class MultiAgentHandoffEvent extends HookableEvent {
   readonly source: string
   readonly targets: string[]
   readonly state: MultiAgentState
+  readonly invocationState: InvocationState
 
-  constructor(data: { source: string; targets: string[]; state: MultiAgentState }) {
+  constructor(data: { source: string; targets: string[]; state: MultiAgentState; invocationState: InvocationState }) {
     super()
     this.source = data.source
     this.targets = data.targets
     this.state = data.state
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<MultiAgentHandoffEvent, 'type' | 'source' | 'targets'> {
@@ -224,12 +261,14 @@ export class NodeCancelEvent extends HookableEvent {
   readonly nodeId: string
   readonly state: MultiAgentState
   readonly message: string
+  readonly invocationState: InvocationState
 
-  constructor(data: { nodeId: string; state: MultiAgentState; message: string }) {
+  constructor(data: { nodeId: string; state: MultiAgentState; message: string; invocationState: InvocationState }) {
     super()
     this.nodeId = data.nodeId
     this.state = data.state
     this.message = data.message
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<NodeCancelEvent, 'type' | 'nodeId' | 'message'> {
@@ -244,10 +283,12 @@ export class NodeCancelEvent extends HookableEvent {
 export class MultiAgentResultEvent extends HookableEvent {
   readonly type = 'multiAgentResultEvent' as const
   readonly result: MultiAgentResult
+  readonly invocationState: InvocationState
 
-  constructor(data: { result: MultiAgentResult }) {
+  constructor(data: { result: MultiAgentResult; invocationState: InvocationState }) {
     super()
     this.result = data.result
+    this.invocationState = data.invocationState
   }
 
   toJSON(): Pick<MultiAgentResultEvent, 'type' | 'result'> {

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -1,6 +1,6 @@
 import type { AttributeValue } from '@opentelemetry/api'
-import type { InvokableAgent } from '../types/agent.js'
-import type { MultiAgentInput } from './multiagent.js'
+import type { InvocationState, InvokableAgent } from '../types/agent.js'
+import type { MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
 import type { ContentBlock } from '../types/messages.js'
 import { TextBlock, contentBlockFromData } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
@@ -155,10 +155,11 @@ export class Graph implements MultiAgent {
    * Invoke graph and return final result (consumes stream).
    *
    * @param input - The input to pass to entry point nodes
+   * @param options - Optional per-invocation options (e.g., {@link InvocationState})
    * @returns Promise resolving to the final MultiAgentResult
    */
-  async invoke(input: MultiAgentInput): Promise<MultiAgentResult> {
-    const gen = this.stream(input)
+  async invoke(input: MultiAgentInput, options?: MultiAgentInvokeOptions): Promise<MultiAgentResult> {
+    const gen = this.stream(input, options)
     let next = await gen.next()
     while (!next.done) {
       next = await gen.next()
@@ -182,12 +183,20 @@ export class Graph implements MultiAgent {
    * Invokes hook callbacks for each event before yielding.
    *
    * @param input - The input to pass to entry nodes
+   * @param options - Optional per-invocation options (e.g., {@link InvocationState})
    * @returns Async generator yielding streaming events and returning a MultiAgentResult
    */
-  async *stream(input: MultiAgentInput): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
+  async *stream(
+    input: MultiAgentInput,
+    options?: MultiAgentInvokeOptions
+  ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
     await this.initialize()
 
-    const gen = this._stream(input)
+    // Resolve invocationState once; the same object is threaded to every node's
+    // child agent so mutations in one node are visible in the next.
+    const invocationState: InvocationState = options?.invocationState ?? {}
+
+    const gen = this._stream(input, invocationState)
     try {
       let next = await gen.next()
       while (!next.done) {
@@ -203,7 +212,10 @@ export class Graph implements MultiAgent {
     }
   }
 
-  private async *_stream(input: MultiAgentInput): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
+  private async *_stream(
+    input: MultiAgentInput,
+    invocationState: InvocationState
+  ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
     const state = new MultiAgentState({ nodeIds: [...this.nodes.keys()] })
 
     const queue = new Queue()
@@ -216,7 +228,7 @@ export class Graph implements MultiAgent {
     })
 
     // SessionManager (or plugins) may restore state.results here via the hook
-    yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state })
+    yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
 
     // Resume: if state was restored, find nodes that are ready but haven't completed otherwise start from source nodes
     const targets = (await this._findResumeTargets(state)) ?? [...this._sources]
@@ -231,7 +243,7 @@ export class Graph implements MultiAgent {
           this._checkSteps(state)
           state.steps++
 
-          streams.set(node.id, this._streamNode(node, input, state, queue, multiAgentSpan))
+          streams.set(node.id, this._streamNode(node, input, state, queue, multiAgentSpan, invocationState))
         }
 
         await queue.wait()
@@ -262,6 +274,7 @@ export class Graph implements MultiAgent {
               source: node.id,
               targets: ready.map((n) => n.id),
               state,
+              invocationState,
             })
             targets.push(...ready)
           }
@@ -286,10 +299,10 @@ export class Graph implements MultiAgent {
         ...(caughtError && { error: caughtError }),
       })
 
-      yield new AfterMultiAgentInvocationEvent({ orchestrator: this, state })
+      yield new AfterMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
     }
 
-    yield new MultiAgentResultEvent({ result })
+    yield new MultiAgentResultEvent({ result, invocationState })
     return result
   }
 
@@ -301,7 +314,8 @@ export class Graph implements MultiAgent {
     input: MultiAgentInput,
     state: MultiAgentState,
     queue: Queue,
-    multiAgentSpan: Span | null
+    multiAgentSpan: Span | null,
+    invocationState: InvocationState
   ): Promise<void> {
     const nodeState = state.node(node.id)!
 
@@ -309,7 +323,7 @@ export class Graph implements MultiAgent {
       this._tracer.startNodeSpan({ nodeId: node.id, nodeType: node.type })
     )
 
-    const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id })
+    const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
     await queue.send({ type: 'event', node, event: beforeEvent })
 
     if (beforeEvent.cancel) {
@@ -321,12 +335,12 @@ export class Graph implements MultiAgent {
       await queue.send({
         type: 'event',
         node,
-        event: new NodeCancelEvent({ nodeId: node.id, state, message }),
+        event: new NodeCancelEvent({ nodeId: node.id, state, message, invocationState }),
       })
       await queue.send({
         type: 'event',
         node,
-        event: new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id }),
+        event: new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }),
       })
       this._tracer.endNodeSpan(nodeSpan, { status: Status.CANCELLED, duration: 0 })
       queue.push({ type: 'result', node, result })
@@ -336,7 +350,7 @@ export class Graph implements MultiAgent {
     try {
       const nodeInput = this._resolveNodeInput(node, input, state)
 
-      const gen = this._tracer.withSpanContext(nodeSpan, () => node.stream(nodeInput, state))
+      const gen = this._tracer.withSpanContext(nodeSpan, () => node.stream(nodeInput, state, { invocationState }))
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       while (!next.done) {
         await queue.send({ type: 'event', node, event: next.value })
@@ -349,7 +363,7 @@ export class Graph implements MultiAgent {
       await queue.send({
         type: 'event',
         node,
-        event: new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id }),
+        event: new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }),
       })
     } catch (error) {
       const nodeError = normalizeError(error)
@@ -362,6 +376,7 @@ export class Graph implements MultiAgent {
           orchestrator: this,
           state,
           nodeId: node.id,
+          invocationState,
           error: nodeError,
         }),
       })

--- a/strands-ts/src/multiagent/index.ts
+++ b/strands-ts/src/multiagent/index.ts
@@ -40,4 +40,4 @@ export type { SwarmConfig, SwarmNodeDefinition, SwarmOptions } from './swarm.js'
 
 export type { MultiAgentPlugin } from './plugins.js'
 
-export type { MultiAgent, MultiAgentInput } from './multiagent.js'
+export type { MultiAgent, MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'

--- a/strands-ts/src/multiagent/multiagent.ts
+++ b/strands-ts/src/multiagent/multiagent.ts
@@ -1,4 +1,4 @@
-import type { InvokeArgs } from '../types/agent.js'
+import type { InvocationState, InvokeArgs } from '../types/agent.js'
 import type { Message, MessageData } from '../types/messages.js'
 import type { HookableEvent } from '../hooks/events.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
@@ -12,6 +12,18 @@ import type { MultiAgentResult } from './state.js'
 export type MultiAgentInput = Exclude<InvokeArgs, Message[] | MessageData[]>
 
 /**
+ * Options for a single multi-agent orchestrator invocation.
+ */
+export interface MultiAgentInvokeOptions {
+  /**
+   * Per-invocation state forwarded to every node's child agent. Mutable —
+   * one node's hooks/tools can read state written by a previous node. See
+   * {@link InvocationState} for details. Defaults to `{}` when omitted.
+   */
+  invocationState?: InvocationState
+}
+
+/**
  * Interface for any multi-agent orchestrator that can stream execution.
  * Implement this interface to create custom orchestration patterns that can be
  * composed as nodes within other orchestrators via {@link MultiAgentNode}.
@@ -23,16 +35,21 @@ export interface MultiAgent {
   /**
    * Execute the orchestrator and return the final result.
    * @param input - Input to pass to the orchestrator
+   * @param options - Optional per-invocation options
    * @returns The aggregate result from all executed nodes
    */
-  invoke(input: MultiAgentInput): Promise<MultiAgentResult>
+  invoke(input: MultiAgentInput, options?: MultiAgentInvokeOptions): Promise<MultiAgentResult>
 
   /**
    * Execute the orchestrator and stream events as they occur.
    * @param input - Input to pass to the orchestrator
+   * @param options - Optional per-invocation options
    * @returns Async generator yielding events and returning the final result
    */
-  stream(input: MultiAgentInput): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined>
+  stream(
+    input: MultiAgentInput,
+    options?: MultiAgentInvokeOptions
+  ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined>
 
   /**
    * Register a hook callback for a specific orchestrator event type.

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -1,5 +1,5 @@
 import { Agent } from '../agent/agent.js'
-import type { InvokeOptions, InvokableAgent, AgentStreamEvent } from '../types/agent.js'
+import type { InvocationState, InvokeOptions, InvokableAgent, AgentStreamEvent } from '../types/agent.js'
 import type { MultiAgentInput } from './multiagent.js'
 import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
 import type { MultiAgentStreamEvent } from './events.js'
@@ -34,6 +34,13 @@ export interface NodeInputOptions {
    * Structured output schema for this node invocation.
    */
   structuredOutputSchema?: z.ZodSchema
+
+  /**
+   * Per-invocation state forwarded to the node's underlying agent. See
+   * {@link InvocationState}. Shared by reference across all nodes so one node's
+   * hooks/tools can read state written by a previous node.
+   */
+  invocationState?: InvocationState
 }
 
 /**
@@ -77,9 +84,14 @@ export abstract class Node {
     nodeState.status = Status.EXECUTING
     nodeState.startTime = Date.now()
 
+    // Resolve invocationState once — the same reference is threaded into handle()
+    // and into NodeResultEvent so callbacks see one object for the whole node run.
+    const invocationState: InvocationState = options?.invocationState ?? {}
+    const resolvedOptions: NodeInputOptions = { ...options, invocationState }
+
     let result: NodeResult
     try {
-      const update = yield* this.handle(input, state, options)
+      const update = yield* this.handle(input, state, resolvedOptions)
       result = new NodeResult({
         nodeId: this.id,
         status: Status.COMPLETED,
@@ -100,7 +112,13 @@ export abstract class Node {
       nodeState.results.push(result!)
     }
 
-    yield new NodeResultEvent({ nodeId: this.id, nodeType: this.type, state, result })
+    yield new NodeResultEvent({
+      nodeId: this.id,
+      nodeType: this.type,
+      state,
+      result,
+      invocationState,
+    })
     return result
   }
 
@@ -166,12 +184,19 @@ export class AgentNode extends Node {
     state: MultiAgentState,
     options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
+    // Resolve invocationState once so every NodeStreamUpdateEvent and the
+    // inner agent's invocation share one reference. Node.stream normally
+    // passes this through already, but resolving here makes handle() safe to
+    // call directly.
+    const invocationState: InvocationState = options?.invocationState ?? {}
+
     // Only Agent instances support snapshot/restore for state isolation
     const snapshot =
       this._agent instanceof Agent ? takeSnapshot(this._agent, { include: ['messages', 'state'] }) : undefined
     try {
       const invokeOptions: InvokeOptions = {
         ...(options?.structuredOutputSchema && { structuredOutputSchema: options.structuredOutputSchema }),
+        invocationState,
       }
 
       const gen = this._agent.stream(input, invokeOptions)
@@ -185,6 +210,7 @@ export class AgentNode extends Node {
             this._agent instanceof Agent
               ? { source: 'agent', event: next.value as AgentStreamEvent }
               : { source: 'custom', event: next.value },
+          invocationState,
         })
         next = await gen.next()
       }
@@ -238,15 +264,20 @@ export class MultiAgentNode extends Node {
    *
    * @param input - Input to pass to the orchestrator
    * @param state - The current multi-agent state
-   * @param _options - Per-invocation options (unused by orchestrator nodes)
+   * @param options - Per-invocation options. `invocationState` is forwarded to the
+   *   nested orchestrator; `structuredOutputSchema` is not applicable here.
    * @returns Async generator yielding streaming events and returning the orchestrator's content
    */
   async *handle(
     input: MultiAgentInput,
     state: MultiAgentState,
-    _options?: NodeInputOptions
+    options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
-    const gen = this._orchestrator.stream(input)
+    // Resolve once so every wrapped NodeStreamUpdateEvent and the nested
+    // orchestrator's invocation share the same reference.
+    const invocationState: InvocationState = options?.invocationState ?? {}
+
+    const gen = this._orchestrator.stream(input, { invocationState })
     let next = await gen.next()
     while (!next.done) {
       const event = next.value
@@ -258,6 +289,7 @@ export class MultiAgentNode extends Node {
           nodeType: this.type,
           state,
           inner: { source: 'multiAgent', event },
+          invocationState,
         })
       }
       next = await gen.next()

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -184,10 +184,8 @@ export class AgentNode extends Node {
     state: MultiAgentState,
     options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
-    // Resolve invocationState once so every NodeStreamUpdateEvent and the
-    // inner agent's invocation share one reference. Node.stream normally
-    // passes this through already, but resolving here makes handle() safe to
-    // call directly.
+    // Resolve once per handle() call — Node.stream() normally supplies this;
+    // handle() is public API, so direct callers get per-call state.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
     // Only Agent instances support snapshot/restore for state isolation
@@ -273,8 +271,8 @@ export class MultiAgentNode extends Node {
     state: MultiAgentState,
     options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResultUpdate, undefined> {
-    // Resolve once so every wrapped NodeStreamUpdateEvent and the nested
-    // orchestrator's invocation share the same reference.
+    // Resolve once per handle() call — Node.stream() normally supplies this;
+    // handle() is public API, so direct callers get per-call state.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
     const gen = this._orchestrator.stream(input, { invocationState })

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -1,7 +1,7 @@
 import { logger } from '../logging/logger.js'
 import type { AttributeValue, Span } from '@opentelemetry/api'
-import type { InvokableAgent } from '../types/agent.js'
-import type { MultiAgentInput } from './multiagent.js'
+import type { InvocationState, InvokableAgent } from '../types/agent.js'
+import type { MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
 import { z } from 'zod'
 import { HookableEvent } from '../hooks/events.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
@@ -166,10 +166,11 @@ export class Swarm implements MultiAgent {
    * Invoke swarm and return final result (consumes stream).
    *
    * @param input - The input to pass to the start agent
+   * @param options - Optional per-invocation options (e.g., {@link InvocationState})
    * @returns Promise resolving to the final MultiAgentResult
    */
-  async invoke(input: MultiAgentInput): Promise<MultiAgentResult> {
-    const gen = this.stream(input)
+  async invoke(input: MultiAgentInput, options?: MultiAgentInvokeOptions): Promise<MultiAgentResult> {
+    const gen = this.stream(input, options)
     let next = await gen.next()
     while (!next.done) {
       next = await gen.next()
@@ -182,12 +183,20 @@ export class Swarm implements MultiAgent {
    * Invokes hook callbacks for each event before yielding.
    *
    * @param input - The input to pass to the start agent
+   * @param options - Optional per-invocation options (e.g., {@link InvocationState})
    * @returns Async generator yielding streaming events and returning a MultiAgentResult
    */
-  async *stream(input: MultiAgentInput): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
+  async *stream(
+    input: MultiAgentInput,
+    options?: MultiAgentInvokeOptions
+  ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
     await this.initialize()
 
-    const gen = this._stream(input)
+    // Shared by reference across every node so mutations in one node's agent
+    // are visible to the next.
+    const invocationState: InvocationState = options?.invocationState ?? {}
+
+    const gen = this._stream(input, invocationState)
     let next = await gen.next()
     while (!next.done) {
       if (next.value instanceof HookableEvent) {
@@ -199,7 +208,10 @@ export class Swarm implements MultiAgent {
     return next.value
   }
 
-  private async *_stream(input: MultiAgentInput): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
+  private async *_stream(
+    input: MultiAgentInput,
+    invocationState: InvocationState
+  ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
     const state = new MultiAgentState({
       nodeIds: [...this.nodes.keys()],
     })
@@ -211,7 +223,7 @@ export class Swarm implements MultiAgent {
     })
 
     // SessionManager (or plugins) may restore state.results here via the hook
-    yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state })
+    yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
 
     // Resume: if state was restored from a snapshot, derive the next node from the last handoff
     const resumeNode = this._findResumeNode(state)
@@ -225,7 +237,7 @@ export class Swarm implements MultiAgent {
         state.steps++
 
         // Execute current node
-        const nodeResult = yield* this._streamNode(node, input, state, handoff, multiAgentSpan)
+        const nodeResult = yield* this._streamNode(node, input, state, handoff, multiAgentSpan, invocationState)
         handoff = nodeResult.structuredOutput as HandoffResult | undefined
 
         // Check for terminal conditions
@@ -235,7 +247,7 @@ export class Swarm implements MultiAgent {
 
         // Hand off to next agent
         const target = this.nodes.get(handoff.agentId)!
-        yield new MultiAgentHandoffEvent({ source: node.id, targets: [target.id], state })
+        yield new MultiAgentHandoffEvent({ source: node.id, targets: [target.id], state, invocationState })
         logger.debug(`source=<${node.id}>, target=<${target.id}> | swarm handoff`)
         node = target
       }
@@ -257,10 +269,10 @@ export class Swarm implements MultiAgent {
         ...(caughtError && { error: caughtError }),
       })
 
-      yield new AfterMultiAgentInvocationEvent({ orchestrator: this, state })
+      yield new AfterMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
     }
 
-    yield new MultiAgentResultEvent({ result })
+    yield new MultiAgentResultEvent({ result, invocationState })
     return result
   }
 
@@ -269,7 +281,8 @@ export class Swarm implements MultiAgent {
     input: MultiAgentInput,
     state: MultiAgentState,
     handoff: HandoffResult | undefined,
-    multiAgentSpan: Span | null
+    multiAgentSpan: Span | null,
+    invocationState: InvocationState
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResult, undefined> {
     const nodeState = state.node(node.id)!
     const handoffSchema = this._buildHandoffSchema(node.id)
@@ -277,7 +290,7 @@ export class Swarm implements MultiAgent {
       this._tracer.startNodeSpan({ nodeId: node.id, nodeType: node.type })
     )
 
-    const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id })
+    const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
     yield beforeEvent
 
     if (beforeEvent.cancel) {
@@ -286,8 +299,8 @@ export class Swarm implements MultiAgent {
       nodeState.status = Status.CANCELLED
       nodeState.results.push(result)
       state.results.push(result)
-      yield new NodeCancelEvent({ nodeId: node.id, state, message })
-      yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id })
+      yield new NodeCancelEvent({ nodeId: node.id, state, message, invocationState })
+      yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
       this._tracer.endNodeSpan(nodeSpan, { status: Status.CANCELLED, duration: 0 })
       return result
     }
@@ -296,7 +309,7 @@ export class Swarm implements MultiAgent {
 
     try {
       const gen = this._tracer.withSpanContext(nodeSpan, () =>
-        node.stream(nodeInput, state, { structuredOutputSchema: handoffSchema })
+        node.stream(nodeInput, state, { structuredOutputSchema: handoffSchema, invocationState })
       )
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       while (!next.done) {
@@ -308,7 +321,7 @@ export class Swarm implements MultiAgent {
       this._tracer.endNodeSpan(nodeSpan, { status: result.status, duration: result.duration, usage: result.usage })
       state.results.push(result)
 
-      yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id })
+      yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
       return result
     } catch (error) {
       const nodeError = normalizeError(error)
@@ -318,6 +331,7 @@ export class Swarm implements MultiAgent {
         orchestrator: this,
         state,
         nodeId: node.id,
+        invocationState,
         error: nodeError,
       })
       throw nodeError

--- a/strands-ts/src/plugins/__tests__/registry.test.ts
+++ b/strands-ts/src/plugins/__tests__/registry.test.ts
@@ -182,7 +182,7 @@ describe('PluginRegistry', () => {
 
       const callback = registeredHooks[0]?.callback
       const mockAgentData = {} as LocalAgent
-      callback?.(new BeforeInvocationEvent({ agent: mockAgentData }))
+      callback?.(new BeforeInvocationEvent({ agent: mockAgentData, invocationState: {} }))
 
       expect(plugin.hookRegistered).toBe(true)
     })

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -59,11 +59,11 @@ function createMockAgent(id = 'agent'): Agent {
 const MOCK_MESSAGE = new Message({ role: 'user', content: [new TextBlock('test')] })
 
 function createMockEvent(agent: Agent) {
-  return { agent }
+  return { agent, invocationState: {} }
 }
 
 function createMockMessageEvent(agent: Agent) {
-  return { agent, message: MOCK_MESSAGE }
+  return { agent, message: MOCK_MESSAGE, invocationState: {} }
 }
 
 async function initPluginAndInvokeHook<T extends HookableEvent>(
@@ -766,7 +766,10 @@ describe('SessionManager — multi-agent', () => {
       sessionManager.initMultiAgent(orchestrator)
 
       const state = new MultiAgentState({ nodeIds: ['a'] })
-      await invokeOrchestratorHook(orchestrator, new AfterNodeCallEvent({ orchestrator, state, nodeId: 'a' }))
+      await invokeOrchestratorHook(
+        orchestrator,
+        new AfterNodeCallEvent({ orchestrator, state, nodeId: 'a', invocationState: {} })
+      )
 
       const snapshot = await storage.loadSnapshot({
         location: { sessionId: 'test-session', scope: 'multiAgent', scopeId: 'test-graph' },
@@ -784,7 +787,10 @@ describe('SessionManager — multi-agent', () => {
       sessionManager.initMultiAgent(orchestrator)
 
       const state = new MultiAgentState({ nodeIds: ['a'] })
-      await invokeOrchestratorHook(orchestrator, new AfterMultiAgentInvocationEvent({ orchestrator, state }))
+      await invokeOrchestratorHook(
+        orchestrator,
+        new AfterMultiAgentInvocationEvent({ orchestrator, state, invocationState: {} })
+      )
 
       const snapshot = await storage.loadSnapshot({
         location: { sessionId: 'test-session', scope: 'multiAgent', scopeId: 'test-graph' },
@@ -803,7 +809,10 @@ describe('SessionManager — multi-agent', () => {
       sessionManager.initMultiAgent(orchestrator)
 
       const state = new MultiAgentState({ nodeIds: ['a'] })
-      await invokeOrchestratorHook(orchestrator, new AfterMultiAgentInvocationEvent({ orchestrator, state }))
+      await invokeOrchestratorHook(
+        orchestrator,
+        new AfterMultiAgentInvocationEvent({ orchestrator, state, invocationState: {} })
+      )
 
       const snapshot = await storage.loadSnapshot({
         location: { sessionId: 'test-session', scope: 'multiAgent', scopeId: 'test-graph' },
@@ -864,7 +873,7 @@ describe('SessionManager — multi-agent', () => {
       const freshState = new MultiAgentState({ nodeIds: ['a'] })
       await invokeOrchestratorHook(
         orchestrator,
-        new BeforeMultiAgentInvocationEvent({ orchestrator, state: freshState })
+        new BeforeMultiAgentInvocationEvent({ orchestrator, state: freshState, invocationState: {} })
       )
 
       expect(freshState.steps).toBe(7)
@@ -882,7 +891,7 @@ describe('SessionManager — multi-agent', () => {
       const freshState = new MultiAgentState({ nodeIds: ['a'] })
       await invokeOrchestratorHook(
         orchestrator,
-        new BeforeMultiAgentInvocationEvent({ orchestrator, state: freshState })
+        new BeforeMultiAgentInvocationEvent({ orchestrator, state: freshState, invocationState: {} })
       )
 
       expect(freshState.steps).toBe(0)
@@ -919,7 +928,7 @@ describe('SessionManager — multi-agent', () => {
       const stateA = new MultiAgentState({ nodeIds: ['x'] })
       await invokeOrchestratorHook(
         orchestratorA,
-        new BeforeMultiAgentInvocationEvent({ orchestrator: orchestratorA, state: stateA })
+        new BeforeMultiAgentInvocationEvent({ orchestrator: orchestratorA, state: stateA, invocationState: {} })
       )
       expect(stateA.steps).toBe(3)
 
@@ -927,7 +936,7 @@ describe('SessionManager — multi-agent', () => {
       const stateB = new MultiAgentState({ nodeIds: ['x'] })
       await invokeOrchestratorHook(
         orchestratorB,
-        new BeforeMultiAgentInvocationEvent({ orchestrator: orchestratorB, state: stateB })
+        new BeforeMultiAgentInvocationEvent({ orchestrator: orchestratorB, state: stateB, invocationState: {} })
       )
       expect(stateB.steps).toBe(5)
     })
@@ -953,7 +962,7 @@ describe('SessionManager — multi-agent', () => {
       const firstState = new MultiAgentState({ nodeIds: ['a'] })
       await invokeOrchestratorHook(
         orchestrator,
-        new BeforeMultiAgentInvocationEvent({ orchestrator, state: firstState })
+        new BeforeMultiAgentInvocationEvent({ orchestrator, state: firstState, invocationState: {} })
       )
       expect(firstState.steps).toBe(7)
 
@@ -961,7 +970,7 @@ describe('SessionManager — multi-agent', () => {
       const secondState = new MultiAgentState({ nodeIds: ['a'] })
       await invokeOrchestratorHook(
         orchestrator,
-        new BeforeMultiAgentInvocationEvent({ orchestrator, state: secondState })
+        new BeforeMultiAgentInvocationEvent({ orchestrator, state: secondState, invocationState: {} })
       )
       expect(secondState.steps).toBe(0)
     })

--- a/strands-ts/src/tools/tool.ts
+++ b/strands-ts/src/tools/tool.ts
@@ -1,6 +1,6 @@
 import type { ToolSpec, ToolUse } from './types.js'
 import { TextBlock, ToolResultBlock } from '../types/messages.js'
-import type { LocalAgent } from '../types/agent.js'
+import type { InvocationState, LocalAgent } from '../types/agent.js'
 import { normalizeError } from '../errors.js'
 
 export type { ToolSpec } from './types.js'
@@ -21,6 +21,17 @@ export interface ToolContext {
    * Provides access to agent state, conversation history, and cancellation state.
    */
   agent: LocalAgent
+
+  /**
+   * Per-invocation state shared across hooks and tools for the current
+   * agent invocation. Mutable — read and write freely; changes are visible to
+   * subsequent hooks, tools, and on {@link AgentResult.invocationState}.
+   *
+   * Distinct from `agent.appState`: `invocationState` is ephemeral and accepts
+   * arbitrary values, while `appState` is durable, JSON-serializable, and
+   * deep-copied on read/write.
+   */
+  invocationState: InvocationState
 }
 
 /**

--- a/strands-ts/src/types/__tests__/agent.test.ts
+++ b/strands-ts/src/types/__tests__/agent.test.ts
@@ -18,6 +18,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('')
@@ -35,6 +36,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('Hello, world!')
@@ -52,6 +54,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('First line\nSecond line\nThird line')
@@ -69,6 +72,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('💭 Reasoning:\n   Let me think about this...')
@@ -86,6 +90,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('')
@@ -107,6 +112,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe(
@@ -134,6 +140,7 @@ describe('AgentResult', () => {
           stopReason: 'toolUse',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('')
@@ -157,6 +164,7 @@ describe('AgentResult', () => {
           stopReason: 'toolUse',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(result.toString()).toBe('Before tool\n💭 Reasoning:\n   Thinking...\nAfter tool')
@@ -174,6 +182,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(String(result)).toBe('Hello')
@@ -189,6 +198,7 @@ describe('AgentResult', () => {
           stopReason: 'endTurn',
           lastMessage: message,
           metrics: new AgentMetrics(),
+          invocationState: {},
         })
 
         expect(`Response: ${result}`).toBe('Response: World')
@@ -209,6 +219,7 @@ describe('AgentResult', () => {
         stopReason: 'endTurn',
         lastMessage: message,
         metrics,
+        invocationState: {},
       })
 
       expect(result.contextSize).toBe(500)
@@ -224,6 +235,7 @@ describe('AgentResult', () => {
         stopReason: 'endTurn',
         lastMessage: message,
         metrics: new AgentMetrics(),
+        invocationState: {},
       })
 
       expect(result.contextSize).toBeUndefined()
@@ -238,6 +250,7 @@ describe('AgentResult', () => {
       const result = new AgentResult({
         stopReason: 'endTurn',
         lastMessage: message,
+        invocationState: {},
       })
 
       expect(result.contextSize).toBeUndefined()
@@ -257,6 +270,7 @@ describe('AgentResult', () => {
         stopReason: 'endTurn',
         lastMessage: message,
         metrics,
+        invocationState: {},
       })
 
       expect(result.projectedContextSize).toBe(750)
@@ -272,6 +286,7 @@ describe('AgentResult', () => {
         stopReason: 'endTurn',
         lastMessage: message,
         metrics: new AgentMetrics(),
+        invocationState: {},
       })
 
       expect(result.projectedContextSize).toBeUndefined()
@@ -293,6 +308,7 @@ describe('AgentResult', () => {
         lastMessage: message,
         traces,
         metrics,
+        invocationState: {},
       })
 
       const json = result.toJSON()
@@ -316,6 +332,7 @@ describe('AgentResult', () => {
         stopReason: 'endTurn',
         lastMessage: message,
         structuredOutput,
+        invocationState: {},
       })
 
       const json = result.toJSON()
@@ -332,6 +349,7 @@ describe('AgentResult', () => {
       const result = new AgentResult({
         stopReason: 'endTurn',
         lastMessage: message,
+        invocationState: {},
       })
 
       const json = result.toJSON()
@@ -353,6 +371,7 @@ describe('AgentResult', () => {
         lastMessage: message,
         traces,
         metrics,
+        invocationState: {},
       })
 
       const jsonString = JSON.stringify(result)
@@ -382,6 +401,7 @@ describe('AgentResult', () => {
         lastMessage: message,
         traces,
         metrics,
+        invocationState: {},
       })
 
       // Properties are still accessible
@@ -414,6 +434,7 @@ describe('AgentResult', () => {
         lastMessage: message,
         traces,
         metrics,
+        invocationState: {},
       })
 
       // Simulate what happens in Express/Next.js: res.json(result)

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -36,6 +36,26 @@ import { AgentMetrics } from '../telemetry/meter.js'
 export type InvokeArgs = string | ContentBlock[] | ContentBlockData[] | Message[] | MessageData[]
 
 /**
+ * Per-invocation state threaded through hooks and tools for a single agent
+ * invocation, and returned on {@link AgentResult.invocationState}. One object
+ * per invocation, shared by reference; mutations by hooks or tools are visible
+ * to subsequent hooks, tools, and recursive loop cycles.
+ *
+ * Typically used for request-scoped context (`userId`, `requestId`, `traceId`)
+ * or cross-hook counters. The SDK writes no keys into it — the key space is
+ * entirely the caller's.
+ *
+ * Distinct from {@link LocalAgent.appState}: `appState` is durable across
+ * invocations, JSON-serializable, and deep-copied. `invocationState` is
+ * ephemeral and accepts arbitrary values.
+ *
+ * Excluded from `toJSON()` on {@link AgentResult} and all hook events because
+ * values may not be serializable; callers produce a serialized form explicitly
+ * if needed.
+ */
+export type InvocationState = Record<string, unknown>
+
+/**
  * Options for a single agent invocation.
  */
 export interface InvokeOptions {
@@ -43,6 +63,15 @@ export interface InvokeOptions {
    * Zod schema for structured output validation, overriding the constructor-provided schema for this invocation only.
    */
   structuredOutputSchema?: z.ZodSchema
+
+  /**
+   * Per-invocation state. Passed to lifecycle hook events and tools, and
+   * returned on {@link AgentResult.invocationState}. Mutable — hooks and tools
+   * may read and write. See {@link InvocationState} for details.
+   *
+   * Defaults to an empty object when omitted.
+   */
+  invocationState?: InvocationState
 
   /**
    * External AbortSignal for cancelling the agent invocation.
@@ -240,15 +269,25 @@ export class AgentResult {
    */
   readonly metrics?: AgentMetrics
 
+  /**
+   * Per-invocation state passed into the agent, threaded through hooks and
+   * tools, and surfaced here at the end of the invocation. See
+   * {@link InvocationState} for details. Always defined — defaults to `{}` when
+   * no `invocationState` was provided in {@link InvokeOptions}.
+   */
+  readonly invocationState: InvocationState
+
   constructor(data: {
     stopReason: StopReason
     lastMessage: Message
+    invocationState: InvocationState
     traces?: AgentTrace[]
     metrics?: AgentMetrics
     structuredOutput?: z.output<z.ZodType>
   }) {
     this.stopReason = data.stopReason
     this.lastMessage = data.lastMessage
+    this.invocationState = data.invocationState
     if (data.traces !== undefined) {
       this.traces = data.traces
     }
@@ -279,14 +318,14 @@ export class AgentResult {
   }
 
   /**
-   * Custom JSON serialization that excludes traces and metrics by default.
-   * This prevents accidentally sending large trace/metric data over the wire
-   * when serializing AgentResult for API responses.
+   * Custom JSON serialization that excludes traces, metrics, and invocationState.
+   * Traces and metrics are excluded to avoid sending large payloads over the wire
+   * in API responses; `invocationState` is excluded because its values are
+   * caller-owned and may not be serializable (see {@link InvocationState}).
    *
-   * Traces and metrics remain accessible via their properties for debugging,
-   * but won't be included in JSON.stringify() output.
+   * All three remain accessible via their properties for debugging.
    *
-   * @returns Object representation without traces/metrics for safe serialization
+   * @returns Object representation for safe serialization
    */
   public toJSON(): object {
     return {

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -42,8 +42,10 @@ export type InvokeArgs = string | ContentBlock[] | ContentBlockData[] | Message[
  * to subsequent hooks, tools, and recursive loop cycles.
  *
  * Typically used for request-scoped context (`userId`, `requestId`, `traceId`)
- * or cross-hook counters. The SDK writes no keys into it — the key space is
- * entirely the caller's.
+ * or cross-hook counters. The core agent loop writes no keys into it — the
+ * key space is the caller's. Transport bridges may populate reserved keys
+ * (e.g. `A2AExecutor` sets `a2aRequestContext`); those bridges document their
+ * own reserved keys.
  *
  * Distinct from {@link LocalAgent.appState}: `appState` is durable across
  * invocations, JSON-serializable, and deep-copied. `invocationState` is

--- a/strands-ts/src/vended-plugins/skills/__tests__/agent-skills.test.node.ts
+++ b/strands-ts/src/vended-plugins/skills/__tests__/agent-skills.test.node.ts
@@ -151,7 +151,7 @@ describe('AgentSkills', () => {
     })
 
     const fireBeforeInvocation = async () => {
-      await invokeTrackedHook(agent, new BeforeInvocationEvent({ agent: agent as any }))
+      await invokeTrackedHook(agent, new BeforeInvocationEvent({ agent: agent as any, invocationState: {} }))
     }
 
     it('injects into undefined system prompt', async () => {
@@ -231,7 +231,7 @@ describe('AgentSkills', () => {
       await plugin2.initAgent(agent2)
 
       const hook = agent2.trackedHooks[0]!
-      await hook.callback(new BeforeInvocationEvent({ agent: agent2 as any }))
+      await hook.callback(new BeforeInvocationEvent({ agent: agent2 as any, invocationState: {} }))
 
       const prompt = agent2.systemPrompt as string
       expect(prompt).toContain('&lt;hello&gt;')
@@ -247,7 +247,7 @@ describe('AgentSkills', () => {
       const filePlugin = new AgentSkills({ skills: [dirPath] })
       const fileAgent = createMockAgent()
       await filePlugin.initAgent(fileAgent)
-      await invokeTrackedHook(fileAgent, new BeforeInvocationEvent({ agent: fileAgent as any }))
+      await invokeTrackedHook(fileAgent, new BeforeInvocationEvent({ agent: fileAgent as any, invocationState: {} }))
 
       const prompt = fileAgent.systemPrompt as string
       expect(prompt).toContain('<location>')
@@ -258,7 +258,7 @@ describe('AgentSkills', () => {
       const emptyPlugin = new AgentSkills({ skills: [] })
       const emptyAgent = createMockAgent()
       await emptyPlugin.initAgent(emptyAgent)
-      await invokeTrackedHook(emptyAgent, new BeforeInvocationEvent({ agent: emptyAgent as any }))
+      await invokeTrackedHook(emptyAgent, new BeforeInvocationEvent({ agent: emptyAgent as any, invocationState: {} }))
 
       const prompt = emptyAgent.systemPrompt as string
       expect(prompt).toContain('No skills are currently available.')
@@ -291,7 +291,7 @@ describe('AgentSkills', () => {
       })
       const multiAgent = createMockAgent()
       await multiPlugin.initAgent(multiAgent)
-      await invokeTrackedHook(multiAgent, new BeforeInvocationEvent({ agent: multiAgent as any }))
+      await invokeTrackedHook(multiAgent, new BeforeInvocationEvent({ agent: multiAgent as any, invocationState: {} }))
 
       const prompt = multiAgent.systemPrompt as string
       expect(prompt).toContain('skill-a')
@@ -332,6 +332,7 @@ describe('AgentSkills', () => {
       const gen = skillsTool.stream({
         toolUse: { name: 'skills', toolUseId: 'test-id', input: { skill_name: skillName } },
         agent: agent as any,
+        invocationState: {},
       })
       let result = await gen.next()
       while (!result.done) {
@@ -412,6 +413,7 @@ describe('AgentSkills', () => {
       const gen = tools[0]!.stream({
         toolUse: { name: 'skills', toolUseId: 'id', input: { skill_name: 'resource-skill' } },
         agent: agent2 as any,
+        invocationState: {},
       })
       let result = await gen.next()
       while (!result.done) result = await gen.next()
@@ -435,6 +437,7 @@ describe('AgentSkills', () => {
       const gen = tools[0]!.stream({
         toolUse: { name: 'skills', toolUseId: 'id', input: { skill_name: 'no-resources' } },
         agent: agent2 as any,
+        invocationState: {},
       })
       let result = await gen.next()
       while (!result.done) result = await gen.next()
@@ -462,6 +465,7 @@ describe('AgentSkills', () => {
       const gen = tools[0]!.stream({
         toolUse: { name: 'skills', toolUseId: 'id', input: { skill_name: 'many-files' } },
         agent: agent2 as any,
+        invocationState: {},
       })
       let result = await gen.next()
       while (!result.done) result = await gen.next()

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -18,6 +18,7 @@ describe.skipIf(process.platform === 'win32')('bash tool', () => {
         input: {},
       },
       agent,
+      invocationState: {},
     }
     return { state: agent.appState, context }
   }

--- a/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
+++ b/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
@@ -21,6 +21,7 @@ describe('fileEditor tool', () => {
         input: {},
       },
       agent,
+      invocationState: {},
     }
     return { state: agent.appState, context: toolContext }
   }

--- a/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -16,6 +16,7 @@ describe('notebook tool', () => {
         input: {},
       },
       agent,
+      invocationState: {},
     }
     return { state: agent.appState, context }
   }


### PR DESCRIPTION
## Description

Adds `invocationState`: a per-invocation, mutable `Record<string, unknown>` that callers pass into `agent.invoke()` / `agent.stream()`, threaded through every hookable event and every tool, and returned on `AgentResult.invocationState`. Ports Python's `request_state` concept to TS, letting callers thread request-scoped context (`userId`, `requestId`, `traceId`, custom counters) through a single run without polluting model context or leaking into durable agent state.

Part of this PR adds invocationState to all of the events in the SDK. We are aligned that we own these events and prefer to make breaking changes to custom plugins by adding events instead of introducing a sea of ?

```typescript
// Pass state in, read it back on the result
const result = await agent.invoke('Hi', {
  invocationState: { userId: 'u-1', requestId: 'r-42' },
})
result.invocationState.userId // 'u-1' — same object round-trips

// Hook callbacks can read and mutate
agent.addHook(BeforeModelCallEvent, (event) => {
  event.invocationState.modelCalls = (event.invocationState.modelCalls ?? 0) + 1
})

// Tools see it via ToolContext
tool({
  name: 'getUser',
  callback: (_input, ctx) => `User: ${ctx.invocationState.userId}`,
})

// Forwarded through multi-agent orchestration and agent-as-tool composition
await graph.invoke('hello', { invocationState: { traceId: 't-1' } })
const writer = new Agent({ tools: [researcher.asTool()] })
await writer.invoke('...', { invocationState }) // flows into researcher
```

**Shape**: `type InvocationState = Record<string, unknown>`. One object per invocation, shared by reference across every hook event, every tool, and every recursive loop cycle. Mutations are visible to subsequent hooks and tools. Defaults to `{}` when omitted. Excluded from `toJSON()` because values are caller-owned and may not be serializable. Distinct from `agent.appState` (durable, JSON-validated, deep-copied, session-persistent).

**Key design decisions diverging from Python:**

1. **Flattened Python's two-layer shape into one.** Python exposes `invocation_state` (outer) containing `request_state` (inner, returned on the result). That split exists because Python also writes SDK-internal keys into `invocation_state` — `"agent"`, `"event_loop_cycle_id"`, cycle traces, spans, etc. — so `request_state` got carved out as "this is yours, not the SDK's". TS has typed homes for all of those (`ToolContext.agent`, `Tracer`, `Meter`, typed hook event fields), so the pollution problem doesn't exist and the carveout isn't needed. One flat `invocationState`, zero SDK-written keys, the entire key space belongs to the caller.

2. **`invocationState` on every event that fires during an invocation, not just lifecycle ones.** The first draft only put it on lifecycle and state-change events (Before/After Invocation/Model/Tools/ToolCall, MessageAdded), mirroring Python's hook event surface. Python doesn't expose data/streaming events as hook events at all — callers can't subscribe to per-chunk model streaming in Python. TS has a richer hookable surface, and the callbacks that most need request-identity context are exactly the streaming ones: token-fanning to per-user UI panels, per-chunk distributed-trace spans, per-content-block audit logging. Omitting `invocationState` from those events would push callers into closure workarounds for the feature's main use case. Final rule: every hookable event that fires during an invocation carries `invocationState`. Only `InitializedEvent` and `MultiAgentInitializedEvent` don't — they fire at construction, before any invocation exists.

3. **No `stopEventLoop` control flag.** Python reserves `request_state["stop_event_loop"] = True` as an in-loop stop signal (experimental, bidi-only). TS already has `agent.cancel()` / `InvokeOptions.cancelSignal` — structured, propagates into in-flight model streams, produces `stopReason: 'cancelled'`. Adding a magic dict key would give two ways to stop with the lossier one polluting `invocationState`. If TS later needs a graceful "stop after this cycle" signal, it gets its own typed mechanism.

4. **`Record<string, unknown>`, not generic `Agent<TState>`.** Matches Python's untyped-bag contract. A generic `TState` would virus through `Agent`, `AgentResult`, `InvokeOptions`, every hook event, `ToolContext`, `Node`, `MultiAgent` — large surface change for a feature most callers won't parameterize. Adding a generic default later is non-breaking.

## Related Issues

#772 

## Documentation PR

will follow up 

## Type of Change

Breaking change

## Testing

How have you tested the change?

- [x] I ran `npm run check`

Added dedicated tests for: round-trip, reference identity across all hook events, hook mutation visibility, multi-cycle persistence through tool-use loops, retry-path reference preservation (`AfterModelCallEvent.retry` and `AfterToolCallEvent.retry`), isolation from `appState`, cross-invocation isolation, tool access via `ToolContext`, agent-as-tool forwarding, Graph and Swarm multi-node forwarding, and an identity sweep across every orchestrator-and-node-level event in a Graph run.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Breaking Changes

Constructors for hook events and `AgentResult` now require `invocationState` in their data object. External code constructing these directly (custom plugins, test fixtures) will fail to compile until updated. Normal usage — invoking agents, registering hooks, writing tools — is unaffected.

### Migration

```typescript
// Before
new BeforeInvocationEvent({ agent })
new AgentResult({ stopReason, lastMessage, metrics })

// After
new BeforeInvocationEvent({ agent, invocationState })
new AgentResult({ stopReason, lastMessage, metrics, invocationState })
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
