### PR TITLE
feat: add DefaultModelRetryStrategy, ModelRetryStrategy, and BackoffStrategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ sdk-typescript/
 │   │   │   ├── __tests__/
 │   │   │   └── tool-registry.ts
 │   │   │
+│   │   ├── retry/                # Retry strategies for model calls
+│   │   │   ├── __tests__/
+│   │   │   ├── backoff-strategy.ts
+│   │   │   ├── model-retry-strategy.ts
+│   │   │   └── index.ts
+│   │   │
 │   │   ├── session/              # Session management
 │   │   │   ├── __tests__/
 │   │   │   ├── session-manager.ts
@@ -266,6 +272,7 @@ sdk-typescript/
 - **`strands-ts/src/multiagent/`**: Multi-agent orchestration patterns (Graph for DAG execution, Swarm for handoff-based routing)
 - **`strands-ts/src/plugins/`**: Plugin system for extending agent functionality
 - **`strands-ts/src/registry/`**: Tool registry implementation
+- **`strands-ts/src/retry/`**: Retry strategies for model calls (backoff strategies, `ModelRetryStrategy` plugin)
 - **`strands-ts/src/session/`**: Session management (file, S3, custom storage)
 - **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
 - **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,9 @@ sdk-typescript/
 │   │   ├── retry/                # Retry strategies for model calls
 │   │   │   ├── __tests__/
 │   │   │   ├── backoff-strategy.ts
-│   │   │   ├── retry-strategy.ts         # Abstract RetryStrategy base class
-│   │   │   ├── model-retry-strategy.ts
+│   │   │   ├── model-retry-strategy.ts         # Abstract ModelRetryStrategy base class
+│   │   │   ├── default-model-retry-strategy.ts
+│   │   │   ├── retry-strategy.ts               # RetryStrategy union type + dedup helper
 │   │   │   └── index.ts
 │   │   │
 │   │   ├── session/              # Session management
@@ -273,7 +274,7 @@ sdk-typescript/
 - **`strands-ts/src/multiagent/`**: Multi-agent orchestration patterns (Graph for DAG execution, Swarm for handoff-based routing)
 - **`strands-ts/src/plugins/`**: Plugin system for extending agent functionality
 - **`strands-ts/src/registry/`**: Tool registry implementation
-- **`strands-ts/src/retry/`**: Retry strategies for model calls (backoff strategies, abstract `RetryStrategy` plugin base class, concrete `ModelRetryStrategy`)
+- **`strands-ts/src/retry/`**: Retry strategies for model calls (backoff strategies, abstract `ModelRetryStrategy` plugin base class, concrete `DefaultModelRetryStrategy`)
 - **`strands-ts/src/session/`**: Session management (file, S3, custom storage)
 - **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
 - **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas
@@ -563,11 +564,11 @@ Name plugins for what they do, not for the `Plugin` interface they implement.
 ```typescript
 // Good
 export class AgentSkills implements Plugin { ... }
-export class ModelRetryStrategy implements Plugin { ... }
+export class DefaultModelRetryStrategy implements Plugin { ... }
 
 // Bad
 export class AgentSkillsPlugin implements Plugin { ... }
-export class ModelRetryStrategyPlugin implements Plugin { ... }
+export class DefaultModelRetryStrategyPlugin implements Plugin { ... }
 ```
 
 Same rule for the associated config (`AgentSkillsConfig`, not `AgentSkillsPluginConfig`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ sdk-typescript/
 │   │   ├── retry/                # Retry strategies for model calls
 │   │   │   ├── __tests__/
 │   │   │   ├── backoff-strategy.ts
+│   │   │   ├── retry-strategy.ts         # Abstract RetryStrategy base class
 │   │   │   ├── model-retry-strategy.ts
 │   │   │   └── index.ts
 │   │   │
@@ -272,7 +273,7 @@ sdk-typescript/
 - **`strands-ts/src/multiagent/`**: Multi-agent orchestration patterns (Graph for DAG execution, Swarm for handoff-based routing)
 - **`strands-ts/src/plugins/`**: Plugin system for extending agent functionality
 - **`strands-ts/src/registry/`**: Tool registry implementation
-- **`strands-ts/src/retry/`**: Retry strategies for model calls (backoff strategies, `ModelRetryStrategy` plugin)
+- **`strands-ts/src/retry/`**: Retry strategies for model calls (backoff strategies, abstract `RetryStrategy` plugin base class, concrete `ModelRetryStrategy`)
 - **`strands-ts/src/session/`**: Session management (file, S3, custom storage)
 - **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
 - **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -63,11 +63,8 @@ describe('Agent Hooks Integration', () => {
         new AfterModelCallEvent({
           agent,
           model: agent.model,
-<<<<<<< HEAD
           invocationState: {},
-=======
           attemptCount: 1,
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
           stopData: {
             stopReason: 'endTurn',
             message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
@@ -114,11 +111,8 @@ describe('Agent Hooks Integration', () => {
         new AfterModelCallEvent({
           agent,
           model: agent.model,
-<<<<<<< HEAD
           invocationState: {},
-=======
           attemptCount: 1,
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
           stopData: {
             stopReason: 'endTurn',
             message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -63,7 +63,11 @@ describe('Agent Hooks Integration', () => {
         new AfterModelCallEvent({
           agent,
           model: agent.model,
+<<<<<<< HEAD
           invocationState: {},
+=======
+          attemptCount: 1,
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
           stopData: {
             stopReason: 'endTurn',
             message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),
@@ -110,7 +114,11 @@ describe('Agent Hooks Integration', () => {
         new AfterModelCallEvent({
           agent,
           model: agent.model,
+<<<<<<< HEAD
           invocationState: {},
+=======
+          attemptCount: 1,
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
           stopData: {
             stopReason: 'endTurn',
             message: new Message({ role: 'assistant', content: [new TextBlock('Hello')] }),

--- a/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
@@ -1,0 +1,144 @@
+// End-to-end wiring test for ModelRetryStrategy on the Agent constructor.
+// Uses fake timers so the retry backoff never waits real wall time.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { Agent } from '../agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { ModelRetryStrategy } from '../../retry/model-retry-strategy.js'
+import { ConstantBackoff } from '../../retry/backoff-strategy.js'
+import { ModelThrottledError } from '../../errors.js'
+import { AfterModelCallEvent } from '../../hooks/events.js'
+
+describe('Agent modelRetryStrategy wiring', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retries model calls that throw ModelThrottledError', async () => {
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('rate limited'))
+      .addTurn({ type: 'textBlock', text: 'ok' })
+
+    const agent = new Agent({
+      model,
+      modelRetryStrategy: new ModelRetryStrategy({
+        maxAttempts: 3,
+        backoff: new ConstantBackoff({ delayMs: 1 }),
+      }),
+    })
+
+    const invokePromise = agent.invoke('hi')
+    // Flush any pending timers the retry scheduled.
+    await vi.runAllTimersAsync()
+    const result = await invokePromise
+
+    expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
+  })
+
+  it('does not retry non-throttling errors', async () => {
+    const model = new MockMessageModel().addTurn(new Error('boom'))
+
+    const agent = new Agent({
+      model,
+      modelRetryStrategy: new ModelRetryStrategy({
+        maxAttempts: 3,
+        backoff: new ConstantBackoff({ delayMs: 1 }),
+      }),
+    })
+
+    const invokePromise = agent.invoke('hi')
+    const assertion = expect(invokePromise).rejects.toThrow('boom')
+    await vi.runAllTimersAsync()
+    await assertion
+  })
+
+  it('installs a default ModelRetryStrategy when none is provided', async () => {
+    // With no override, two ModelThrottledErrors in a row should still succeed
+    // because the defaults allow multiple attempts.
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('throttled 1'))
+      .addTurn(new ModelThrottledError('throttled 2'))
+      .addTurn({ type: 'textBlock', text: 'ok' })
+
+    const agent = new Agent({ model })
+    const invokePromise = agent.invoke('hi')
+    await vi.runAllTimersAsync()
+    const result = await invokePromise
+
+    expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
+  })
+
+  it('gives up once maxAttempts is exceeded', async () => {
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('throttled 1'))
+      .addTurn(new ModelThrottledError('throttled 2'))
+      .addTurn(new ModelThrottledError('throttled 3'))
+
+    const agent = new Agent({
+      model,
+      modelRetryStrategy: new ModelRetryStrategy({
+        maxAttempts: 2,
+        backoff: new ConstantBackoff({ delayMs: 1 }),
+      }),
+    })
+
+    const invokePromise = agent.invoke('hi')
+    const assertion = expect(invokePromise).rejects.toThrow(ModelThrottledError)
+    await vi.runAllTimersAsync()
+    await assertion
+  })
+
+  it('disables retries when modelRetryStrategy is null', async () => {
+    const model = new MockMessageModel().addTurn(new ModelThrottledError('throttled'))
+
+    const agent = new Agent({ model, modelRetryStrategy: null })
+
+    const invokePromise = agent.invoke('hi')
+    const assertion = expect(invokePromise).rejects.toThrow(ModelThrottledError)
+    await vi.runAllTimersAsync()
+    await assertion
+  })
+
+  it('respects a user hook that already set retry=true (no double wait, no double increment)', async () => {
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('throttled'))
+      .addTurn({ type: 'textBlock', text: 'ok' })
+
+    const strategy = new ModelRetryStrategy({
+      maxAttempts: 2, // only 1 retry allowed — if our strategy also incremented, we'd exceed
+      backoff: new ConstantBackoff({ delayMs: 10_000 }), // huge delay — if we slept on top, test would time out
+    })
+
+    const agent = new Agent({ model, modelRetryStrategy: strategy })
+    agent.addHook(AfterModelCallEvent, (event) => {
+      if (event.error instanceof ModelThrottledError) {
+        event.retry = true
+      }
+    })
+
+    const invokePromise = agent.invoke('hi')
+    await vi.runAllTimersAsync()
+    const result = await invokePromise
+
+    expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
+  })
+
+  it('throws if the same instance is attached to two agents', async () => {
+    const strategy = new ModelRetryStrategy()
+
+    const agent1 = new Agent({
+      model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' }),
+      modelRetryStrategy: strategy,
+    })
+    await agent1.invoke('hi')
+
+    const agent2 = new Agent({
+      model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' }),
+      modelRetryStrategy: strategy,
+    })
+    await expect(agent2.invoke('hi')).rejects.toThrow(/already attached to another agent/)
+  })
+})

--- a/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
@@ -9,7 +9,7 @@ import { ConstantBackoff } from '../../retry/backoff-strategy.js'
 import { ModelThrottledError } from '../../errors.js'
 import { AfterModelCallEvent } from '../../hooks/events.js'
 
-describe('Agent modelRetryStrategy wiring', () => {
+describe('Agent retryStrategy wiring', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -24,7 +24,7 @@ describe('Agent modelRetryStrategy wiring', () => {
 
     const agent = new Agent({
       model,
-      modelRetryStrategy: new ModelRetryStrategy({
+      retryStrategy: new ModelRetryStrategy({
         maxAttempts: 3,
         backoff: new ConstantBackoff({ delayMs: 1 }),
       }),
@@ -43,7 +43,7 @@ describe('Agent modelRetryStrategy wiring', () => {
 
     const agent = new Agent({
       model,
-      modelRetryStrategy: new ModelRetryStrategy({
+      retryStrategy: new ModelRetryStrategy({
         maxAttempts: 3,
         backoff: new ConstantBackoff({ delayMs: 1 }),
       }),
@@ -79,7 +79,7 @@ describe('Agent modelRetryStrategy wiring', () => {
 
     const agent = new Agent({
       model,
-      modelRetryStrategy: new ModelRetryStrategy({
+      retryStrategy: new ModelRetryStrategy({
         maxAttempts: 2,
         backoff: new ConstantBackoff({ delayMs: 1 }),
       }),
@@ -91,10 +91,10 @@ describe('Agent modelRetryStrategy wiring', () => {
     await assertion
   })
 
-  it('disables retries when modelRetryStrategy is null', async () => {
+  it('disables retries when retryStrategy is null', async () => {
     const model = new MockMessageModel().addTurn(new ModelThrottledError('throttled'))
 
-    const agent = new Agent({ model, modelRetryStrategy: null })
+    const agent = new Agent({ model, retryStrategy: null })
 
     const invokePromise = agent.invoke('hi')
     const assertion = expect(invokePromise).rejects.toThrow(ModelThrottledError)
@@ -112,7 +112,7 @@ describe('Agent modelRetryStrategy wiring', () => {
       backoff: new ConstantBackoff({ delayMs: 10_000 }), // huge delay — if we slept on top, test would time out
     })
 
-    const agent = new Agent({ model, modelRetryStrategy: strategy })
+    const agent = new Agent({ model, retryStrategy: strategy })
     agent.addHook(AfterModelCallEvent, (event) => {
       if (event.error instanceof ModelThrottledError) {
         event.retry = true
@@ -131,13 +131,13 @@ describe('Agent modelRetryStrategy wiring', () => {
 
     const agent1 = new Agent({
       model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' }),
-      modelRetryStrategy: strategy,
+      retryStrategy: strategy,
     })
     await agent1.invoke('hi')
 
     const agent2 = new Agent({
       model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' }),
-      modelRetryStrategy: strategy,
+      retryStrategy: strategy,
     })
     await expect(agent2.invoke('hi')).rejects.toThrow(/already attached to another agent/)
   })

--- a/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
@@ -141,28 +141,15 @@ describe('Agent retryStrategy wiring', () => {
     expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
   })
 
-  it('warns and drops duplicates when two retry strategies of the same type are provided', async () => {
+  it('warns when two retry strategies of the same type are provided', () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
 
-    const model = new MockMessageModel()
-      .addTurn(new ModelThrottledError('throttled'))
-      .addTurn({ type: 'textBlock', text: 'ok' })
-
-    const agent = new Agent({
-      model,
-      retryStrategy: [
-        new DefaultModelRetryStrategy({ maxAttempts: 3, backoff: new ConstantBackoff({ delayMs: 1 }) }),
-        new DefaultModelRetryStrategy({ maxAttempts: 3, backoff: new ConstantBackoff({ delayMs: 1 }) }),
-      ],
+    new Agent({
+      model: new MockMessageModel(),
+      retryStrategy: [new DefaultModelRetryStrategy(), new DefaultModelRetryStrategy()],
     })
 
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('DefaultModelRetryStrategy'))
-
-    // Agent still functions: the first strategy handled the throttling error.
-    const invokePromise = agent.invoke('hi')
-    await vi.runAllTimersAsync()
-    const result = await invokePromise
-    expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
 
     warn.mockRestore()
   })

--- a/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
@@ -6,6 +6,7 @@ import { Agent } from '../agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { DefaultModelRetryStrategy } from '../../retry/default-model-retry-strategy.js'
 import { ModelRetryStrategy } from '../../retry/model-retry-strategy.js'
+import type { RetryDecision } from '../../retry/retry-strategy.js'
 import { ConstantBackoff } from '../../retry/backoff-strategy.js'
 import { ModelThrottledError } from '../../errors.js'
 import { AfterModelCallEvent } from '../../hooks/events.js'
@@ -121,7 +122,9 @@ describe('Agent retryStrategy wiring', () => {
     // with a second instance of itself — see the fail-fast test below).
     class NoopRetryStrategy extends ModelRetryStrategy {
       readonly name = 'test:noop-retry-strategy'
-      override retryModel(): void {}
+      protected override computeRetryDecision(): RetryDecision {
+        return { retry: false }
+      }
     }
 
     const model = new MockMessageModel()

--- a/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
@@ -1,13 +1,15 @@
-// End-to-end wiring test for ModelRetryStrategy on the Agent constructor.
+// End-to-end wiring test for DefaultModelRetryStrategy on the Agent constructor.
 // Uses fake timers so the retry backoff never waits real wall time.
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { Agent } from '../agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { DefaultModelRetryStrategy } from '../../retry/default-model-retry-strategy.js'
 import { ModelRetryStrategy } from '../../retry/model-retry-strategy.js'
 import { ConstantBackoff } from '../../retry/backoff-strategy.js'
 import { ModelThrottledError } from '../../errors.js'
 import { AfterModelCallEvent } from '../../hooks/events.js'
+import { logger } from '../../logging/logger.js'
 
 describe('Agent retryStrategy wiring', () => {
   beforeEach(() => {
@@ -24,7 +26,7 @@ describe('Agent retryStrategy wiring', () => {
 
     const agent = new Agent({
       model,
-      retryStrategy: new ModelRetryStrategy({
+      retryStrategy: new DefaultModelRetryStrategy({
         maxAttempts: 3,
         backoff: new ConstantBackoff({ delayMs: 1 }),
       }),
@@ -43,7 +45,7 @@ describe('Agent retryStrategy wiring', () => {
 
     const agent = new Agent({
       model,
-      retryStrategy: new ModelRetryStrategy({
+      retryStrategy: new DefaultModelRetryStrategy({
         maxAttempts: 3,
         backoff: new ConstantBackoff({ delayMs: 1 }),
       }),
@@ -55,7 +57,7 @@ describe('Agent retryStrategy wiring', () => {
     await assertion
   })
 
-  it('installs a default ModelRetryStrategy when none is provided', async () => {
+  it('installs a default DefaultModelRetryStrategy when none is provided', async () => {
     // With no override, two ModelThrottledErrors in a row should still succeed
     // because the defaults allow multiple attempts.
     const model = new MockMessageModel()
@@ -79,7 +81,7 @@ describe('Agent retryStrategy wiring', () => {
 
     const agent = new Agent({
       model,
-      retryStrategy: new ModelRetryStrategy({
+      retryStrategy: new DefaultModelRetryStrategy({
         maxAttempts: 2,
         backoff: new ConstantBackoff({ delayMs: 1 }),
       }),
@@ -102,12 +104,75 @@ describe('Agent retryStrategy wiring', () => {
     await assertion
   })
 
+  it('disables retries when retryStrategy is an empty array', async () => {
+    const model = new MockMessageModel().addTurn(new ModelThrottledError('throttled'))
+
+    const agent = new Agent({ model, retryStrategy: [] })
+
+    const invokePromise = agent.invoke('hi')
+    const assertion = expect(invokePromise).rejects.toThrow(ModelThrottledError)
+    await vi.runAllTimersAsync()
+    await assertion
+  })
+
+  it('accepts an array of distinct retry strategy types', async () => {
+    // A trivial secondary strategy subclass so the two entries have different
+    // constructors (the default DefaultModelRetryStrategy cannot be paired
+    // with a second instance of itself — see the fail-fast test below).
+    class NoopRetryStrategy extends ModelRetryStrategy {
+      readonly name = 'test:noop-retry-strategy'
+      override retryModel(): void {}
+    }
+
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('throttled'))
+      .addTurn({ type: 'textBlock', text: 'ok' })
+
+    const primary = new DefaultModelRetryStrategy({
+      maxAttempts: 3,
+      backoff: new ConstantBackoff({ delayMs: 1 }),
+    })
+
+    const agent = new Agent({ model, retryStrategy: [primary, new NoopRetryStrategy()] })
+    const invokePromise = agent.invoke('hi')
+    await vi.runAllTimersAsync()
+    const result = await invokePromise
+
+    expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
+  })
+
+  it('warns and drops duplicates when two retry strategies of the same type are provided', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('throttled'))
+      .addTurn({ type: 'textBlock', text: 'ok' })
+
+    const agent = new Agent({
+      model,
+      retryStrategy: [
+        new DefaultModelRetryStrategy({ maxAttempts: 3, backoff: new ConstantBackoff({ delayMs: 1 }) }),
+        new DefaultModelRetryStrategy({ maxAttempts: 3, backoff: new ConstantBackoff({ delayMs: 1 }) }),
+      ],
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('DefaultModelRetryStrategy'))
+
+    // Agent still functions: the first strategy handled the throttling error.
+    const invokePromise = agent.invoke('hi')
+    await vi.runAllTimersAsync()
+    const result = await invokePromise
+    expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
+
+    warn.mockRestore()
+  })
+
   it('respects a user hook that already set retry=true (no double wait, no double increment)', async () => {
     const model = new MockMessageModel()
       .addTurn(new ModelThrottledError('throttled'))
       .addTurn({ type: 'textBlock', text: 'ok' })
 
-    const strategy = new ModelRetryStrategy({
+    const strategy = new DefaultModelRetryStrategy({
       maxAttempts: 2, // only 1 retry allowed — if our strategy also incremented, we'd exceed
       backoff: new ConstantBackoff({ delayMs: 10_000 }), // huge delay — if we slept on top, test would time out
     })
@@ -127,7 +192,7 @@ describe('Agent retryStrategy wiring', () => {
   })
 
   it('throws if the same instance is attached to two agents', async () => {
-    const strategy = new ModelRetryStrategy()
+    const strategy = new DefaultModelRetryStrategy()
 
     const agent1 = new Agent({
       model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' }),

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -167,11 +167,10 @@ export type AgentConfig = {
    *
    * - Omitted: a sensible default {@link DefaultModelRetryStrategy} with exponential backoff is used.
    * - Single strategy: the given strategy is used.
-   * - Array of strategies: all are registered, in the given order. Hooks fire
-   *   in reverse registration order, so later entries in the array take
-   *   priority. Duplicates of the same concrete class are dropped (only the
-   *   first of each type is kept) with a logger warning.
-   * - `[]` or `null`: retries are explicitly disabled; failures propagate to the caller.
+   * - Array of strategies: all are registered, in the given order. Passing two
+   *   instances of the same concrete class logs a warning — they will collide
+   *   on `plugin.name` when the plugin registry initializes.
+   * - `null` or `[]`: retries are explicitly disabled; failures propagate to the caller.
    */
   retryStrategy?: RetryStrategy | RetryStrategy[] | null
   /**
@@ -327,7 +326,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     this._hooksRegistry = new HookRegistryImplementation()
 
     // `undefined` (omitted) → install the default; `null`/`[]` → explicit opt-out.
-    const rawRetryStrategies: RetryStrategy[] =
+    const retryStrategies: RetryStrategy[] =
       config?.retryStrategy === null
         ? []
         : config?.retryStrategy === undefined
@@ -335,29 +334,16 @@ export class Agent implements LocalAgent, InvokableAgent {
           : Array.isArray(config.retryStrategy)
             ? config.retryStrategy
             : [config.retryStrategy]
-    warnOnDuplicateRetryStrategyTypes(rawRetryStrategies)
-    const seenStrategyTypes = new Set<new (...args: never[]) => RetryStrategy>()
-    const retryStrategies = rawRetryStrategies.filter((s) => {
-      const ctor = s.constructor as new (...args: never[]) => RetryStrategy
-      if (seenStrategyTypes.has(ctor)) return false
-      seenStrategyTypes.add(ctor)
-      return true
-    })
+    warnOnDuplicateRetryStrategyTypes(retryStrategies)
 
     // Initialize plugin registry with all plugins to be initialized during initialize().
-<<<<<<< HEAD
     // Ordering notes:
     // - ModelPlugin is registered last so that on AfterInvocationEvent (which uses
     //   reverse callback ordering), it runs first — clearing messages before
     //   SessionManager saves.
-    // - Retry-strategy ordering is not load-bearing for correctness: `ModelRetryStrategy`
+    // - Retry-strategy ordering is not load-bearing for correctness: `DefaultModelRetryStrategy`
     //   guards on `event.retry`, so a user hook that already set it short-circuits
     //   the strategy regardless of registration order.
-=======
-    // Ordering is not load-bearing for retry correctness: `DefaultModelRetryStrategy`
-    // guards on `event.retry` so a user hook that already set it short-circuits
-    // the strategy regardless of registration order.
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     this._pluginRegistry = new PluginRegistry([
       this._conversationManager,
       ...retryStrategies,
@@ -1051,77 +1037,45 @@ export class Agent implements LocalAgent, InvokableAgent {
       streamOptions.toolChoice = toolChoice
     }
 
-<<<<<<< HEAD
-    // Estimate input tokens for the upcoming model call (non-fatal if estimation fails)
-    let projectedInputTokens: number | undefined
-    try {
-      projectedInputTokens = await this._estimateInputTokens(streamOptions)
-    } catch (e) {
-      logger.debug(`error=<${e}> | token estimation failed, proceeding without estimate`)
-    }
-
-    const beforeModelCallEvent = new BeforeModelCallEvent({
-      agent: this,
-      model: this.model,
-      invocationState,
-      ...(projectedInputTokens !== undefined && { projectedInputTokens }),
-    })
-    yield beforeModelCallEvent
-
-    if (beforeModelCallEvent.cancel) {
-      const cancelText =
-        typeof beforeModelCallEvent.cancel === 'string' ? beforeModelCallEvent.cancel : 'model call denied by hook'
-      const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
-      const stopData: ModelStopData = { message, stopReason: 'endTurn' }
-      const afterModelCallEvent = new AfterModelCallEvent({
-        agent: this,
-        model: this.model,
-        stopData,
-        invocationState,
-      })
-      yield afterModelCallEvent
-
-      if (afterModelCallEvent.retry) {
-        return yield* this._invokeModel(invocationState, toolChoice)
-      }
-
-      return { message, stopReason: 'endTurn' }
-    }
-
-    // Start model span within loop span context
-    const modelId = this.model.modelId
-    const modelSpan = this._tracer.startModelInvokeSpan({
-      messages: this.messages,
-      ...(modelId && { modelId }),
-      ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
-    })
-
-    try {
-      const result = yield* this._streamFromModel(this.messages, streamOptions, invocationState)
-
-      // Accumulate token usage and model latency metrics
-      this._meter.updateCycle(result.metadata)
-
-      // End model span with usage
-      const usage = result.metadata?.usage
-      const metrics = result.metadata?.metrics
-      this._tracer.endModelInvokeSpan(modelSpan, {
-        output: result.message,
-        stopReason: result.stopReason,
-        ...(usage && { usage }),
-        ...(metrics && { metrics }),
-      })
-
-      yield new ModelMessageEvent({
-        agent: this,
-        message: result.message,
-        stopReason: result.stopReason,
-        invocationState,
-      })
-=======
     let attemptCount = 1
     while (true) {
-      yield new BeforeModelCallEvent({ agent: this, model: this.model })
+      // Estimate input tokens for the upcoming model call (non-fatal if estimation fails)
+      let projectedInputTokens: number | undefined
+      try {
+        projectedInputTokens = await this._estimateInputTokens(streamOptions)
+      } catch (e) {
+        logger.debug(`error=<${e}> | token estimation failed, proceeding without estimate`)
+      }
+
+      const beforeModelCallEvent = new BeforeModelCallEvent({
+        agent: this,
+        model: this.model,
+        invocationState,
+        ...(projectedInputTokens !== undefined && { projectedInputTokens }),
+      })
+      yield beforeModelCallEvent
+
+      if (beforeModelCallEvent.cancel) {
+        const cancelText =
+          typeof beforeModelCallEvent.cancel === 'string' ? beforeModelCallEvent.cancel : 'model call denied by hook'
+        const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
+        const stopData: ModelStopData = { message, stopReason: 'endTurn' }
+        const afterModelCallEvent = new AfterModelCallEvent({
+          agent: this,
+          model: this.model,
+          attemptCount,
+          stopData,
+          invocationState,
+        })
+        yield afterModelCallEvent
+
+        if (afterModelCallEvent.retry) {
+          attemptCount += 1
+          continue
+        }
+
+        return { message, stopReason: 'endTurn' }
+      }
 
       // Start model span within loop span context
       const modelId = this.model.modelId
@@ -1132,8 +1086,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       })
 
       try {
-        const result = yield* this._streamFromModel(this.messages, streamOptions)
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+        const result = yield* this._streamFromModel(this.messages, streamOptions, invocationState)
 
         // Accumulate token usage and model latency metrics
         this._meter.updateCycle(result.metadata)
@@ -1148,26 +1101,17 @@ export class Agent implements LocalAgent, InvokableAgent {
           ...(metrics && { metrics }),
         })
 
-<<<<<<< HEAD
-      const afterModelCallEvent = new AfterModelCallEvent({
-        agent: this,
-        model: this.model,
-        stopData,
-        invocationState,
-      })
-      yield afterModelCallEvent
-
-      if (afterModelCallEvent.retry) {
-        return yield* this._invokeModel(invocationState, toolChoice)
-      }
-=======
-        yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
+        yield new ModelMessageEvent({
+          agent: this,
+          message: result.message,
+          stopReason: result.stopReason,
+          invocationState,
+        })
 
         // Handle user content redaction if guardrails blocked input
         if (result.redaction?.userMessage) {
           this._redactLastMessage(result.redaction.userMessage)
         }
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
         const stopData: ModelStopData = {
           message: result.message,
@@ -1175,23 +1119,19 @@ export class Agent implements LocalAgent, InvokableAgent {
           ...(result.redaction && { redaction: result.redaction }),
         }
 
-        const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, attemptCount, stopData })
+        const afterModelCallEvent = new AfterModelCallEvent({
+          agent: this,
+          model: this.model,
+          attemptCount,
+          stopData,
+          invocationState,
+        })
         yield afterModelCallEvent
 
-<<<<<<< HEAD
-      // Create error event
-      const errorEvent = new AfterModelCallEvent({
-        agent: this,
-        model: this.model,
-        error: modelError,
-        invocationState,
-      })
-=======
         if (afterModelCallEvent.retry) {
           attemptCount += 1
           continue
         }
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
         return result
       } catch (error) {
@@ -1206,6 +1146,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           model: this.model,
           attemptCount,
           error: modelError,
+          invocationState,
         })
 
         // Yield error event - stream will invoke hooks
@@ -1226,17 +1167,6 @@ export class Agent implements LocalAgent, InvokableAgent {
         // Re-throw error
         throw error
       }
-<<<<<<< HEAD
-
-      // After yielding, hooks have been invoked and may have set retry
-      if (errorEvent.retry) {
-        return yield* this._invokeModel(invocationState, toolChoice)
-      }
-
-      // Re-throw error
-      throw error
-=======
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     }
   }
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -72,8 +72,9 @@ import { Meter } from '../telemetry/meter.js'
 import type { AttributeValue } from '@opentelemetry/api'
 import { logger } from '../logging/logger.js'
 import { CancelledError } from '../errors.js'
-import { ModelRetryStrategy } from '../retry/model-retry-strategy.js'
+import { DefaultModelRetryStrategy } from '../retry/default-model-retry-strategy.js'
 import type { RetryStrategy } from '../retry/retry-strategy.js'
+import { warnOnDuplicateRetryStrategyTypes } from '../retry/retry-strategy.js'
 
 /**
  * Recursive type definition for nested tool arrays.
@@ -162,13 +163,17 @@ export type AgentConfig = {
    */
   plugins?: Plugin[]
   /**
-   * Retry strategy for failed model/tool calls.
+   * Retry strategy (or strategies) for failed model/tool calls.
    *
-   * - Omitted: a sensible default {@link ModelRetryStrategy} with exponential backoff is used.
-   * - Provided: the given strategy is used.
-   * - `null`: retries are explicitly disabled; failures propagate to the caller.
+   * - Omitted: a sensible default {@link DefaultModelRetryStrategy} with exponential backoff is used.
+   * - Single strategy: the given strategy is used.
+   * - Array of strategies: all are registered, in the given order. Hooks fire
+   *   in reverse registration order, so later entries in the array take
+   *   priority. Duplicates of the same concrete class are dropped (only the
+   *   first of each type is kept) with a logger warning.
+   * - `[]` or `null`: retries are explicitly disabled; failures propagate to the caller.
    */
-  retryStrategy?: RetryStrategy | null
+  retryStrategy?: RetryStrategy | RetryStrategy[] | null
   /**
    * Zod schema for structured output validation.
    */
@@ -321,11 +326,26 @@ export class Agent implements LocalAgent, InvokableAgent {
     // Initialize hooks registry
     this._hooksRegistry = new HookRegistryImplementation()
 
-    // `undefined` (omitted) → install the default; `null` → explicit opt-out.
-    const retryStrategy =
-      config?.retryStrategy === null ? undefined : (config?.retryStrategy ?? new ModelRetryStrategy())
+    // `undefined` (omitted) → install the default; `null`/`[]` → explicit opt-out.
+    const rawRetryStrategies: RetryStrategy[] =
+      config?.retryStrategy === null
+        ? []
+        : config?.retryStrategy === undefined
+          ? [new DefaultModelRetryStrategy()]
+          : Array.isArray(config.retryStrategy)
+            ? config.retryStrategy
+            : [config.retryStrategy]
+    warnOnDuplicateRetryStrategyTypes(rawRetryStrategies)
+    const seenStrategyTypes = new Set<new (...args: never[]) => RetryStrategy>()
+    const retryStrategies = rawRetryStrategies.filter((s) => {
+      const ctor = s.constructor as new (...args: never[]) => RetryStrategy
+      if (seenStrategyTypes.has(ctor)) return false
+      seenStrategyTypes.add(ctor)
+      return true
+    })
 
     // Initialize plugin registry with all plugins to be initialized during initialize().
+<<<<<<< HEAD
     // Ordering notes:
     // - ModelPlugin is registered last so that on AfterInvocationEvent (which uses
     //   reverse callback ordering), it runs first — clearing messages before
@@ -333,9 +353,14 @@ export class Agent implements LocalAgent, InvokableAgent {
     // - Retry-strategy ordering is not load-bearing for correctness: `ModelRetryStrategy`
     //   guards on `event.retry`, so a user hook that already set it short-circuits
     //   the strategy regardless of registration order.
+=======
+    // Ordering is not load-bearing for retry correctness: `DefaultModelRetryStrategy`
+    // guards on `event.retry` so a user hook that already set it short-circuits
+    // the strategy regardless of registration order.
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     this._pluginRegistry = new PluginRegistry([
       this._conversationManager,
-      ...(retryStrategy ? [retryStrategy] : []),
+      ...retryStrategies,
       ...(config?.plugins ?? []),
       ...(config?.sessionManager ? [config.sessionManager] : []),
       new ModelPlugin(this.model),
@@ -1026,6 +1051,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       streamOptions.toolChoice = toolChoice
     }
 
+<<<<<<< HEAD
     // Estimate input tokens for the upcoming model call (non-fatal if estimation fails)
     let projectedInputTokens: number | undefined
     try {
@@ -1092,18 +1118,37 @@ export class Agent implements LocalAgent, InvokableAgent {
         stopReason: result.stopReason,
         invocationState,
       })
+=======
+    let attemptCount = 1
+    while (true) {
+      yield new BeforeModelCallEvent({ agent: this, model: this.model })
 
-      // Handle user content redaction if guardrails blocked input
-      if (result.redaction?.userMessage) {
-        this._redactLastMessage(result.redaction.userMessage)
-      }
+      // Start model span within loop span context
+      const modelId = this.model.modelId
+      const modelSpan = this._tracer.startModelInvokeSpan({
+        messages: this.messages,
+        ...(modelId && { modelId }),
+        ...(this.systemPrompt !== undefined && { systemPrompt: this.systemPrompt }),
+      })
 
-      const stopData: ModelStopData = {
-        message: result.message,
-        stopReason: result.stopReason,
-        ...(result.redaction && { redaction: result.redaction }),
-      }
+      try {
+        const result = yield* this._streamFromModel(this.messages, streamOptions)
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
+        // Accumulate token usage and model latency metrics
+        this._meter.updateCycle(result.metadata)
+
+        // End model span with usage
+        const usage = result.metadata?.usage
+        const metrics = result.metadata?.metrics
+        this._tracer.endModelInvokeSpan(modelSpan, {
+          output: result.message,
+          stopReason: result.stopReason,
+          ...(usage && { usage }),
+          ...(metrics && { metrics }),
+        })
+
+<<<<<<< HEAD
       const afterModelCallEvent = new AfterModelCallEvent({
         agent: this,
         model: this.model,
@@ -1115,14 +1160,25 @@ export class Agent implements LocalAgent, InvokableAgent {
       if (afterModelCallEvent.retry) {
         return yield* this._invokeModel(invocationState, toolChoice)
       }
+=======
+        yield new ModelMessageEvent({ agent: this, message: result.message, stopReason: result.stopReason })
 
-      return result
-    } catch (error) {
-      const modelError = normalizeError(error)
+        // Handle user content redaction if guardrails blocked input
+        if (result.redaction?.userMessage) {
+          this._redactLastMessage(result.redaction.userMessage)
+        }
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
-      // End model span with error
-      this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
+        const stopData: ModelStopData = {
+          message: result.message,
+          stopReason: result.stopReason,
+          ...(result.redaction && { redaction: result.redaction }),
+        }
 
+        const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, attemptCount, stopData })
+        yield afterModelCallEvent
+
+<<<<<<< HEAD
       // Create error event
       const errorEvent = new AfterModelCallEvent({
         agent: this,
@@ -1130,15 +1186,47 @@ export class Agent implements LocalAgent, InvokableAgent {
         error: modelError,
         invocationState,
       })
+=======
+        if (afterModelCallEvent.retry) {
+          attemptCount += 1
+          continue
+        }
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
-      // Yield error event - stream will invoke hooks
-      yield errorEvent
+        return result
+      } catch (error) {
+        const modelError = normalizeError(error)
 
-      // Let CancelledError propagate directly — no retry
-      // (we emit the AfterModelCall because we already emitted Before and we guarentee the pair)
-      if (error instanceof CancelledError) {
+        // End model span with error
+        this._tracer.endModelInvokeSpan(modelSpan, { error: modelError })
+
+        // Create error event
+        const errorEvent = new AfterModelCallEvent({
+          agent: this,
+          model: this.model,
+          attemptCount,
+          error: modelError,
+        })
+
+        // Yield error event - stream will invoke hooks
+        yield errorEvent
+
+        // Let CancelledError propagate directly — no retry
+        // (we emit the AfterModelCall because we already emitted Before and we guarentee the pair)
+        if (error instanceof CancelledError) {
+          throw error
+        }
+
+        // After yielding, hooks have been invoked and may have set retry
+        if (errorEvent.retry) {
+          attemptCount += 1
+          continue
+        }
+
+        // Re-throw error
         throw error
       }
+<<<<<<< HEAD
 
       // After yielding, hooks have been invoked and may have set retry
       if (errorEvent.retry) {
@@ -1147,6 +1235,8 @@ export class Agent implements LocalAgent, InvokableAgent {
 
       // Re-throw error
       throw error
+=======
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     }
   }
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -324,9 +324,14 @@ export class Agent implements LocalAgent, InvokableAgent {
     const modelRetryStrategy =
       config?.modelRetryStrategy === null ? undefined : (config?.modelRetryStrategy ?? new ModelRetryStrategy())
 
-    // Initialize plugin registry with all plugins to be initialized during initialize()
-    // ModelPlugin is registered last so that on AfterInvocationEvent (which uses reverse
-    // callback ordering), it runs first — clearing messages before SessionManager saves.
+    // Initialize plugin registry with all plugins to be initialized during initialize().
+    // Ordering notes:
+    // - ModelPlugin is registered last so that on AfterInvocationEvent (which uses
+    //   reverse callback ordering), it runs first — clearing messages before
+    //   SessionManager saves.
+    // - Retry-strategy ordering is not load-bearing for correctness: `ModelRetryStrategy`
+    //   guards on `event.retry`, so a user hook that already set it short-circuits
+    //   the strategy regardless of registration order.
     this._pluginRegistry = new PluginRegistry([
       this._conversationManager,
       ...(modelRetryStrategy ? [modelRetryStrategy] : []),

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -72,6 +72,7 @@ import { Meter } from '../telemetry/meter.js'
 import type { AttributeValue } from '@opentelemetry/api'
 import { logger } from '../logging/logger.js'
 import { CancelledError } from '../errors.js'
+import { ModelRetryStrategy } from '../retry/model-retry-strategy.js'
 
 /**
  * Recursive type definition for nested tool arrays.
@@ -159,6 +160,14 @@ export type AgentConfig = {
    * Plugins to register with the agent.
    */
   plugins?: Plugin[]
+  /**
+   * Retry strategy for failed model calls (e.g. throttling).
+   *
+   * - Omitted: a sensible default {@link ModelRetryStrategy} with exponential backoff is used.
+   * - Provided: the given strategy is used.
+   * - `null`: retries are explicitly disabled; failures propagate to the caller.
+   */
+  modelRetryStrategy?: ModelRetryStrategy | null
   /**
    * Zod schema for structured output validation.
    */
@@ -311,11 +320,16 @@ export class Agent implements LocalAgent, InvokableAgent {
     // Initialize hooks registry
     this._hooksRegistry = new HookRegistryImplementation()
 
+    // `undefined` (omitted) → install the default; `null` → explicit opt-out.
+    const modelRetryStrategy =
+      config?.modelRetryStrategy === null ? undefined : (config?.modelRetryStrategy ?? new ModelRetryStrategy())
+
     // Initialize plugin registry with all plugins to be initialized during initialize()
     // ModelPlugin is registered last so that on AfterInvocationEvent (which uses reverse
     // callback ordering), it runs first — clearing messages before SessionManager saves.
     this._pluginRegistry = new PluginRegistry([
       this._conversationManager,
+      ...(modelRetryStrategy ? [modelRetryStrategy] : []),
       ...(config?.plugins ?? []),
       ...(config?.sessionManager ? [config.sessionManager] : []),
       new ModelPlugin(this.model),

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -73,6 +73,7 @@ import type { AttributeValue } from '@opentelemetry/api'
 import { logger } from '../logging/logger.js'
 import { CancelledError } from '../errors.js'
 import { ModelRetryStrategy } from '../retry/model-retry-strategy.js'
+import type { RetryStrategy } from '../retry/retry-strategy.js'
 
 /**
  * Recursive type definition for nested tool arrays.
@@ -161,13 +162,13 @@ export type AgentConfig = {
    */
   plugins?: Plugin[]
   /**
-   * Retry strategy for failed model calls (e.g. throttling).
+   * Retry strategy for failed model/tool calls.
    *
    * - Omitted: a sensible default {@link ModelRetryStrategy} with exponential backoff is used.
    * - Provided: the given strategy is used.
    * - `null`: retries are explicitly disabled; failures propagate to the caller.
    */
-  modelRetryStrategy?: ModelRetryStrategy | null
+  retryStrategy?: RetryStrategy | null
   /**
    * Zod schema for structured output validation.
    */
@@ -321,8 +322,8 @@ export class Agent implements LocalAgent, InvokableAgent {
     this._hooksRegistry = new HookRegistryImplementation()
 
     // `undefined` (omitted) → install the default; `null` → explicit opt-out.
-    const modelRetryStrategy =
-      config?.modelRetryStrategy === null ? undefined : (config?.modelRetryStrategy ?? new ModelRetryStrategy())
+    const retryStrategy =
+      config?.retryStrategy === null ? undefined : (config?.retryStrategy ?? new ModelRetryStrategy())
 
     // Initialize plugin registry with all plugins to be initialized during initialize().
     // Ordering notes:
@@ -334,7 +335,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     //   the strategy regardless of registration order.
     this._pluginRegistry = new PluginRegistry([
       this._conversationManager,
-      ...(modelRetryStrategy ? [modelRetryStrategy] : []),
+      ...(retryStrategy ? [retryStrategy] : []),
       ...(config?.plugins ?? []),
       ...(config?.sessionManager ? [config.sessionManager] : []),
       new ModelPlugin(this.model),

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -42,11 +42,13 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        attemptCount: 1,
+        error,
+        invocationState: {},
+      })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(1)
@@ -61,11 +63,13 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        attemptCount: 1,
+        error,
+        invocationState: {},
+      })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(1)
@@ -78,11 +82,13 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new Error('some other error')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        attemptCount: 1,
+        error,
+        invocationState: {},
+      })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(0)
@@ -104,11 +110,13 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        attemptCount: 1,
+        error,
+        invocationState: {},
+      })
       await invokeTrackedHook(mockAgent, event)
 
       expect(receivedArgs).toHaveLength(1)

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -42,7 +42,11 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(1)
@@ -57,7 +61,11 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(1)
@@ -70,7 +78,11 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new Error('some other error')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceCallCount).toBe(0)
@@ -92,7 +104,11 @@ describe('ConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('overflow')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       await invokeTrackedHook(mockAgent, event)
 
       expect(receivedArgs).toHaveLength(1)

--- a/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
@@ -17,7 +17,11 @@ describe('NullConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('Context overflow')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       await invokeTrackedHook(mockAgent, event)
 
       // Messages should be unchanged — NullConversationManager never reduces
@@ -32,7 +36,11 @@ describe('NullConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('Context overflow')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       await invokeTrackedHook(mockAgent, event)
 
       // reduce() returns false, so retry should not be set

--- a/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
@@ -17,11 +17,13 @@ describe('NullConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('Context overflow')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        attemptCount: 1,
+        error,
+        invocationState: {},
+      })
       await invokeTrackedHook(mockAgent, event)
 
       // Messages should be unchanged — NullConversationManager never reduces
@@ -36,11 +38,13 @@ describe('NullConversationManager', () => {
       manager.initAgent(mockAgent)
 
       const error = new ContextWindowOverflowError('Context overflow')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent: mockAgent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent: mockAgent,
+        model: {} as any,
+        attemptCount: 1,
+        error,
+        invocationState: {},
+      })
       await invokeTrackedHook(mockAgent, event)
 
       // reduce() returns false, so retry should not be set

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -26,11 +26,7 @@ async function triggerContextOverflow(
 ): Promise<{ retry?: boolean }> {
   const pluginAgent = createMockAgent()
   manager.initAgent(pluginAgent)
-<<<<<<< HEAD
-  const event = new AfterModelCallEvent({ agent, model: {} as any, error, invocationState: {} })
-=======
-  const event = new AfterModelCallEvent({ agent, model: {} as any, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+  const event = new AfterModelCallEvent({ agent, model: {} as any, attemptCount: 1, error, invocationState: {} })
   await invokeTrackedHook(pluginAgent, event)
   return event
 }
@@ -640,13 +636,9 @@ describe('SlidingWindowConversationManager', () => {
       const event = new AfterModelCallEvent({
         agent: mockAgent,
         model: {} as any,
-<<<<<<< HEAD
-        error: originalError,
-        invocationState: {},
-=======
         attemptCount: 1,
         error: originalError,
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+        invocationState: {},
       })
       const pluginAgent = createMockAgent()
       manager.initAgent(pluginAgent)

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -26,7 +26,11 @@ async function triggerContextOverflow(
 ): Promise<{ retry?: boolean }> {
   const pluginAgent = createMockAgent()
   manager.initAgent(pluginAgent)
+<<<<<<< HEAD
   const event = new AfterModelCallEvent({ agent, model: {} as any, error, invocationState: {} })
+=======
+  const event = new AfterModelCallEvent({ agent, model: {} as any, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
   await invokeTrackedHook(pluginAgent, event)
   return event
 }
@@ -636,8 +640,13 @@ describe('SlidingWindowConversationManager', () => {
       const event = new AfterModelCallEvent({
         agent: mockAgent,
         model: {} as any,
+<<<<<<< HEAD
         error: originalError,
         invocationState: {},
+=======
+        attemptCount: 1,
+        error: originalError,
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       })
       const pluginAgent = createMockAgent()
       manager.initAgent(pluginAgent)

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -308,6 +308,7 @@ describe('SummarizingConversationManager', () => {
       const event = new AfterModelCallEvent({
         agent,
         model: model as unknown as Model,
+        attemptCount: 1,
         error: new ContextWindowOverflowError('overflow'),
         invocationState: {},
       })

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -456,12 +456,17 @@ describe('AfterModelCallEvent', () => {
     const message = new Message({ role: 'assistant', content: [new TextBlock('Response')] })
     const stopReason = 'endTurn'
     const response = { message, stopReason }
+<<<<<<< HEAD
     const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, invocationState: {} })
+=======
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData: response })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
     expect(event).toEqual({
       type: 'afterModelCallEvent',
       agent: agent,
       model: agent.model,
+      attemptCount: 1,
       stopData: response,
       error: undefined,
       invocationState: {},
@@ -477,12 +482,17 @@ describe('AfterModelCallEvent', () => {
     const message = new Message({ role: 'assistant', content: [] })
     const error = new Error('Model failed')
     const response = { message, stopReason: 'error' }
+<<<<<<< HEAD
     const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, error, invocationState: {} })
+=======
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData: response, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
     expect(event).toEqual({
       type: 'afterModelCallEvent',
       agent: agent,
       model: agent.model,
+      attemptCount: 1,
       stopData: response,
       error: error,
       invocationState: {},
@@ -493,14 +503,22 @@ describe('AfterModelCallEvent', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
     const response = { message, stopReason: 'endTurn' }
+<<<<<<< HEAD
     const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, invocationState: {} })
+=======
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData: response })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
   it('allows retry to be set when error is present', () => {
     const agent = new Agent()
     const error = new Error('Model failed')
+<<<<<<< HEAD
     const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
+=======
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
     // Initially undefined
     expect(event.retry).toBeUndefined()
@@ -517,7 +535,11 @@ describe('AfterModelCallEvent', () => {
   it('retry is optional and defaults to undefined', () => {
     const agent = new Agent()
     const error = new Error('Model failed')
+<<<<<<< HEAD
     const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
+=======
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
 
     expect(event.retry).toBeUndefined()
   })
@@ -962,15 +984,20 @@ describe('toJSON serialization', () => {
   })
 
   describe('AfterModelCallEvent', () => {
-    it('includes stopData and excludes agent and model on success', () => {
+    it('includes stopData and attemptCount and excludes agent and model on success', () => {
       const agent = new Agent()
       const message = new Message({ role: 'assistant', content: [new TextBlock('Hi')] })
       const stopData = { message, stopReason: 'endTurn' as const }
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent, model: agent.model, stopData, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 2, stopData })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
         type: 'afterModelCallEvent',
+        attemptCount: 2,
         stopData: {
           message: { role: 'assistant', content: [{ text: 'Hi' }] },
           stopReason: 'endTurn',
@@ -981,12 +1008,17 @@ describe('toJSON serialization', () => {
     it('converts error to message string and excludes retry', () => {
       const agent = new Agent()
       const error = new Error('Model failed')
+<<<<<<< HEAD
       const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
+=======
+      const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error })
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       event.retry = true
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
         type: 'afterModelCallEvent',
+        attemptCount: 1,
         error: { message: 'Model failed' },
       })
     })
@@ -1122,10 +1154,16 @@ describe('toJSON serialization completeness', () => {
       },
       {
         name: 'AfterModelCallEvent',
+<<<<<<< HEAD
         event: Object.assign(
           new AfterModelCallEvent({ agent, model: agent.model, stopData, error, invocationState: {} }),
           { retry: true }
         ),
+=======
+        event: Object.assign(new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData, error }), {
+          retry: true,
+        }),
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       },
       { name: 'MessageAddedEvent', event: new MessageAddedEvent({ agent, message, invocationState: {} }) },
       {

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -456,11 +456,13 @@ describe('AfterModelCallEvent', () => {
     const message = new Message({ role: 'assistant', content: [new TextBlock('Response')] })
     const stopReason = 'endTurn'
     const response = { message, stopReason }
-<<<<<<< HEAD
-    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, invocationState: {} })
-=======
-    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData: response })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+    const event = new AfterModelCallEvent({
+      agent,
+      model: agent.model,
+      attemptCount: 1,
+      stopData: response,
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'afterModelCallEvent',
@@ -482,11 +484,14 @@ describe('AfterModelCallEvent', () => {
     const message = new Message({ role: 'assistant', content: [] })
     const error = new Error('Model failed')
     const response = { message, stopReason: 'error' }
-<<<<<<< HEAD
-    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, error, invocationState: {} })
-=======
-    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData: response, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+    const event = new AfterModelCallEvent({
+      agent,
+      model: agent.model,
+      attemptCount: 1,
+      stopData: response,
+      error,
+      invocationState: {},
+    })
 
     expect(event).toEqual({
       type: 'afterModelCallEvent',
@@ -503,22 +508,20 @@ describe('AfterModelCallEvent', () => {
     const agent = new Agent()
     const message = new Message({ role: 'assistant', content: [] })
     const response = { message, stopReason: 'endTurn' }
-<<<<<<< HEAD
-    const event = new AfterModelCallEvent({ agent, model: agent.model, stopData: response, invocationState: {} })
-=======
-    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData: response })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+    const event = new AfterModelCallEvent({
+      agent,
+      model: agent.model,
+      attemptCount: 1,
+      stopData: response,
+      invocationState: {},
+    })
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
   it('allows retry to be set when error is present', () => {
     const agent = new Agent()
     const error = new Error('Model failed')
-<<<<<<< HEAD
-    const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
-=======
-    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error, invocationState: {} })
 
     // Initially undefined
     expect(event.retry).toBeUndefined()
@@ -535,11 +538,7 @@ describe('AfterModelCallEvent', () => {
   it('retry is optional and defaults to undefined', () => {
     const agent = new Agent()
     const error = new Error('Model failed')
-<<<<<<< HEAD
-    const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
-=======
-    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+    const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error, invocationState: {} })
 
     expect(event.retry).toBeUndefined()
   })
@@ -988,11 +987,13 @@ describe('toJSON serialization', () => {
       const agent = new Agent()
       const message = new Message({ role: 'assistant', content: [new TextBlock('Hi')] })
       const stopData = { message, stopReason: 'endTurn' as const }
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent, model: agent.model, stopData, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 2, stopData })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({
+        agent,
+        model: agent.model,
+        attemptCount: 2,
+        stopData,
+        invocationState: {},
+      })
       const json = JSON.parse(JSON.stringify(event))
 
       expect(json).toStrictEqual({
@@ -1008,11 +1009,7 @@ describe('toJSON serialization', () => {
     it('converts error to message string and excludes retry', () => {
       const agent = new Agent()
       const error = new Error('Model failed')
-<<<<<<< HEAD
-      const event = new AfterModelCallEvent({ agent, model: agent.model, error, invocationState: {} })
-=======
-      const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error })
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
+      const event = new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, error, invocationState: {} })
       event.retry = true
       const json = JSON.parse(JSON.stringify(event))
 
@@ -1154,16 +1151,10 @@ describe('toJSON serialization completeness', () => {
       },
       {
         name: 'AfterModelCallEvent',
-<<<<<<< HEAD
         event: Object.assign(
-          new AfterModelCallEvent({ agent, model: agent.model, stopData, error, invocationState: {} }),
+          new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData, error, invocationState: {} }),
           { retry: true }
         ),
-=======
-        event: Object.assign(new AfterModelCallEvent({ agent, model: agent.model, attemptCount: 1, stopData, error }), {
-          retry: true,
-        }),
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
       },
       { name: 'MessageAddedEvent', event: new MessageAddedEvent({ agent, message, invocationState: {} }) },
       {

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -472,22 +472,16 @@ export class AfterModelCallEvent extends HookableEvent {
   constructor(data: {
     agent: LocalAgent
     model: Model
-<<<<<<< HEAD
     invocationState: InvocationState
-=======
     attemptCount: number
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     stopData?: ModelStopData
     error?: Error
   }) {
     super()
     this.agent = data.agent
     this.model = data.model
-<<<<<<< HEAD
     this.invocationState = data.invocationState
-=======
     this.attemptCount = data.attemptCount
->>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     if (data.stopData !== undefined) {
       this.stopData = data.stopData
     }

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -453,6 +453,17 @@ export class AfterModelCallEvent extends HookableEvent {
   readonly invocationState: InvocationState
 
   /**
+   * 1-indexed count of model attempts for this turn, including the attempt
+   * that just completed (or failed). The first call in a turn is `1`; each
+   * subsequent retry increments by one.
+   *
+   * Retry strategies may rely on `attemptCount === 1` to mark the start of a
+   * new retry sequence (e.g. to clear per-turn state carried over from a
+   * previous turn). The agent loop guarantees this marker on every fresh turn.
+   */
+  readonly attemptCount: number
+
+  /**
    * Optional flag that can be set by hook callbacks to request a retry of the model call.
    * When set to true, the agent will retry the model invocation.
    */
@@ -461,14 +472,22 @@ export class AfterModelCallEvent extends HookableEvent {
   constructor(data: {
     agent: LocalAgent
     model: Model
+<<<<<<< HEAD
     invocationState: InvocationState
+=======
+    attemptCount: number
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     stopData?: ModelStopData
     error?: Error
   }) {
     super()
     this.agent = data.agent
     this.model = data.model
+<<<<<<< HEAD
     this.invocationState = data.invocationState
+=======
+    this.attemptCount = data.attemptCount
+>>>>>>> b4a1aba (feat: re-design retries as one abstract class per retry type. add attemptCount to AfterModelCallEvent hook)
     if (data.stopData !== undefined) {
       this.stopData = data.stopData
     }
@@ -486,9 +505,10 @@ export class AfterModelCallEvent extends HookableEvent {
    * Converts Error to an extensible object for safe wire serialization.
    * Called automatically by JSON.stringify().
    */
-  toJSON(): Pick<AfterModelCallEvent, 'type' | 'stopData'> & { error?: { message?: string } } {
+  toJSON(): Pick<AfterModelCallEvent, 'type' | 'stopData' | 'attemptCount'> & { error?: { message?: string } } {
     return {
       type: this.type,
+      attemptCount: this.attemptCount,
       ...(this.stopData !== undefined && { stopData: this.stopData }),
       ...(this.error !== undefined && { error: { message: this.error.message } }),
     }

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -211,6 +211,21 @@ export type {
 // Plugin system
 export type { Plugin } from './plugins/index.js'
 
+// Retry
+export {
+  type BackoffContext,
+  type BackoffStrategy,
+  type JitterKind,
+  type ConstantBackoffOptions,
+  type LinearBackoffOptions,
+  type ExponentialBackoffOptions,
+  ConstantBackoff,
+  LinearBackoff,
+  ExponentialBackoff,
+  ModelRetryStrategy,
+  type ModelRetryStrategyOptions,
+} from './retry/index.js'
+
 // Conversation Manager
 export {
   ConversationManager,

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -222,6 +222,7 @@ export {
   ConstantBackoff,
   LinearBackoff,
   ExponentialBackoff,
+  RetryStrategy,
   ModelRetryStrategy,
   type ModelRetryStrategyOptions,
 } from './retry/index.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -222,9 +222,10 @@ export {
   ConstantBackoff,
   LinearBackoff,
   ExponentialBackoff,
-  RetryStrategy,
   ModelRetryStrategy,
-  type ModelRetryStrategyOptions,
+  DefaultModelRetryStrategy,
+  type DefaultModelRetryStrategyOptions,
+  type RetryStrategy,
 } from './retry/index.js'
 
 // Conversation Manager

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -226,6 +226,7 @@ export {
   DefaultModelRetryStrategy,
   type DefaultModelRetryStrategyOptions,
   type RetryStrategy,
+  type RetryDecision,
 } from './retry/index.js'
 
 // Conversation Manager

--- a/strands-ts/src/retry/__tests__/backoff-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/backoff-strategy.test.ts
@@ -1,0 +1,138 @@
+// All tests here are purely synchronous — strategies compute a delay number;
+// no timers fire and nothing is awaited, so tests never wait real wall time.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ConstantBackoff, LinearBackoff, ExponentialBackoff, type BackoffContext } from '../backoff-strategy.js'
+
+function ctx(partial: Partial<BackoffContext> = {}): BackoffContext {
+  return { attempt: 1, elapsedMs: 0, ...partial }
+}
+
+describe('ConstantBackoff', () => {
+  it('returns the configured delay regardless of attempt', () => {
+    const bo = new ConstantBackoff({ delayMs: 250 })
+    expect(bo.nextDelay(ctx({ attempt: 1 }))).toBe(250)
+    expect(bo.nextDelay(ctx({ attempt: 5 }))).toBe(250)
+  })
+
+  it('defaults delayMs to 1000', () => {
+    expect(new ConstantBackoff().nextDelay(ctx())).toBe(1000)
+  })
+
+  it('rejects attempts below 1', () => {
+    const bo = new ConstantBackoff()
+    expect(() => bo.nextDelay(ctx({ attempt: 0 }))).toThrow(/attempt must be an integer/)
+  })
+})
+
+describe('LinearBackoff', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('grows as baseMs * attempt', () => {
+    const bo = new LinearBackoff({ baseMs: 100, jitter: 'none' })
+    expect(bo.nextDelay(ctx({ attempt: 1 }))).toBe(100)
+    expect(bo.nextDelay(ctx({ attempt: 2 }))).toBe(200)
+    expect(bo.nextDelay(ctx({ attempt: 3 }))).toBe(300)
+  })
+
+  it('clamps to maxMs before jitter', () => {
+    const bo = new LinearBackoff({ baseMs: 1000, maxMs: 2500, jitter: 'none' })
+    expect(bo.nextDelay(ctx({ attempt: 10 }))).toBe(2500)
+  })
+
+  it('applies full jitter by default (Math.random() * raw)', () => {
+    const bo = new LinearBackoff({ baseMs: 100 })
+    // attempt 4 → raw 400, Math.random() mocked to 0.5 → 200
+    expect(bo.nextDelay(ctx({ attempt: 4 }))).toBe(200)
+  })
+
+  it('rejects attempts below 1', () => {
+    const bo = new LinearBackoff()
+    expect(() => bo.nextDelay(ctx({ attempt: 0 }))).toThrow(/attempt must be an integer/)
+  })
+})
+
+describe('ExponentialBackoff', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('grows as baseMs * multiplier^(attempt-1)', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, jitter: 'none' })
+    expect(bo.nextDelay(ctx({ attempt: 1 }))).toBe(100)
+    expect(bo.nextDelay(ctx({ attempt: 2 }))).toBe(200)
+    expect(bo.nextDelay(ctx({ attempt: 3 }))).toBe(400)
+    expect(bo.nextDelay(ctx({ attempt: 4 }))).toBe(800)
+  })
+
+  it('honors custom multiplier', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, multiplier: 3, jitter: 'none' })
+    expect(bo.nextDelay(ctx({ attempt: 3 }))).toBe(900)
+  })
+
+  it('clamps to maxMs', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, maxMs: 500, jitter: 'none' })
+    expect(bo.nextDelay(ctx({ attempt: 10 }))).toBe(500)
+  })
+
+  it('applies full jitter by default', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100 })
+    // attempt 3 → raw 400, Math.random() mocked to 0.5 → 200
+    expect(bo.nextDelay(ctx({ attempt: 3 }))).toBe(200)
+  })
+
+  it('applies equal jitter as raw/2 + random*raw/2', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, jitter: 'equal' })
+    // attempt 2 → raw 200, equal → 100 + 0.5*100 = 150
+    expect(bo.nextDelay(ctx({ attempt: 2 }))).toBe(150)
+  })
+
+  it('applies no jitter when set to none', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, jitter: 'none' })
+    expect(bo.nextDelay(ctx({ attempt: 3 }))).toBe(400)
+  })
+
+  it('falls back to full jitter for decorrelated when lastDelayMs missing', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, jitter: 'decorrelated' })
+    expect(bo.nextDelay(ctx({ attempt: 3 }))).toBe(200)
+  })
+
+  it('applies decorrelated jitter as uniform(baseMs, min(maxMs, lastDelayMs*3))', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, maxMs: 10_000, jitter: 'decorrelated' })
+    // lastDelayMs=200 → upper=min(10_000, 600)=600
+    // random=0.5 → 100 + 0.5 * (600-100) = 350
+    expect(bo.nextDelay(ctx({ attempt: 2, lastDelayMs: 200 }))).toBe(350)
+  })
+
+  it('caps decorrelated upper at maxMs', () => {
+    const bo = new ExponentialBackoff({ baseMs: 100, maxMs: 500, jitter: 'decorrelated' })
+    // lastDelayMs=1000 → upper=min(500, 3000)=500
+    // random=0.5 → 100 + 0.5 * (500-100) = 300
+    expect(bo.nextDelay(ctx({ attempt: 2, lastDelayMs: 1000 }))).toBe(300)
+  })
+
+  it('floors decorrelated upper at baseMs when lastDelay*3 < baseMs', () => {
+    // Guards against inverted range: without max(baseMs, ...), upper=30 would be
+    // below lower=100. The max clamp yields upper=baseMs, so delay stays at baseMs.
+    const bo = new ExponentialBackoff({ baseMs: 100, maxMs: 500, jitter: 'decorrelated' })
+    expect(bo.nextDelay(ctx({ attempt: 2, lastDelayMs: 10 }))).toBe(100)
+  })
+
+  it('rejects attempts below 1', () => {
+    const bo = new ExponentialBackoff()
+    expect(() => bo.nextDelay(ctx({ attempt: 0 }))).toThrow(/attempt must be an integer/)
+  })
+
+  it('rejects non-integer attempts', () => {
+    const bo = new ExponentialBackoff()
+    expect(() => bo.nextDelay(ctx({ attempt: 1.5 }))).toThrow(/attempt must be an integer/)
+  })
+})

--- a/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { DefaultModelRetryStrategy } from '../default-model-retry-strategy.js'
 import { ModelRetryStrategy } from '../model-retry-strategy.js'
+import type { RetryDecision } from '../retry-strategy.js'
 import { ConstantBackoff, type BackoffStrategy } from '../backoff-strategy.js'
 import { AfterModelCallEvent } from '../../hooks/events.js'
 import { ModelThrottledError } from '../../errors.js'
@@ -30,7 +31,7 @@ describe('DefaultModelRetryStrategy', () => {
   })
 
   it('exposes the plugin name', () => {
-    expect(new DefaultModelRetryStrategy().name).toBe('strands:model-retry-strategy')
+    expect(new DefaultModelRetryStrategy().name).toBe('strands:default-model-retry-strategy')
   })
 
   it('is a ModelRetryStrategy', () => {
@@ -176,5 +177,89 @@ describe('DefaultModelRetryStrategy', () => {
       elapsedMs: expect.any(Number),
       lastDelayMs: 5,
     })
+  })
+
+  it('clears per-turn state on attempt 1 even when a prior hook already set event.retry', async () => {
+    // Regression: onFirstModelAttempt must fire before the event.retry short-circuit.
+    // Otherwise state from a prior turn leaks into the new turn's BackoffContext.
+    const nextDelay = vi.fn<BackoffStrategy['nextDelay']>().mockReturnValue(5)
+    const backoff: BackoffStrategy = { nextDelay }
+    const strategy = new DefaultModelRetryStrategy({ maxAttempts: 5, backoff })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    // Turn 1 → fail → lastDelayMs gets set to 5.
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
+    const p1 = invokeTrackedHook(agent, e1)
+    await vi.advanceTimersByTimeAsync(5)
+    await p1
+
+    // Turn 2 → attempt 1 → another hook already set retry=true before us.
+    // We should still clear state (onFirstModelAttempt runs first), even though
+    // we short-circuit and don't call computeRetryDecision.
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
+    e2.retry = true
+    await invokeTrackedHook(agent, e2)
+
+    // Turn 2 → attempt 2 → backoff should see no lastDelayMs from turn 1.
+    const e3 = makeErrorEvent(agent, new ModelThrottledError('x'), 2)
+    const p3 = invokeTrackedHook(agent, e3)
+    await vi.advanceTimersByTimeAsync(5)
+    await p3
+
+    // Second call is turn 2 attempt 2; must not carry turn 1's lastDelayMs.
+    expect(nextDelay.mock.calls[1]![0]).toEqual({
+      attempt: 2,
+      elapsedMs: expect.any(Number),
+    })
+  })
+
+  it('lets subclasses expand the retryable set by overriding isRetryable', async () => {
+    class CustomError extends Error {}
+
+    class PermissiveStrategy extends DefaultModelRetryStrategy {
+      override readonly name = 'test:permissive'
+      override isRetryable(error: Error): boolean {
+        return super.isRetryable(error) || error instanceof CustomError
+      }
+    }
+
+    const strategy = new PermissiveStrategy({
+      maxAttempts: 3,
+      backoff: new ConstantBackoff({ delayMs: 10 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    const event = makeErrorEvent(agent, new CustomError('custom'), 1)
+    const pending = invokeTrackedHook(agent, event)
+    await vi.advanceTimersByTimeAsync(10)
+    await pending
+
+    expect(event.retry).toBe(true)
+  })
+
+  it('short-circuits without retry when computeRetryDecision returns retry:false for a non-max reason', async () => {
+    // Exercises the computeRetryDecision "return { retry: false }" branch that
+    // isn't about maxAttempts. A subclass declines to retry a specific error
+    // instance even though the classifier said it was retryable in principle.
+    class PickyStrategy extends DefaultModelRetryStrategy {
+      override readonly name = 'test:picky'
+      protected override computeRetryDecision(event: AfterModelCallEvent): RetryDecision {
+        if ((event.error as Error).message === 'skip') return { retry: false }
+        return super.computeRetryDecision(event)
+      }
+    }
+
+    const strategy = new PickyStrategy({
+      maxAttempts: 5,
+      backoff: new ConstantBackoff({ delayMs: 10 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    const event = makeErrorEvent(agent, new ModelThrottledError('skip'), 1)
+    await invokeTrackedHook(agent, event)
+    expect(event.retry).toBeUndefined()
   })
 })

--- a/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
@@ -10,7 +10,7 @@ import { ModelThrottledError } from '../../errors.js'
 import { createMockAgent, invokeTrackedHook, type MockAgent } from '../../__fixtures__/agent-helpers.js'
 
 function makeErrorEvent(agent: MockAgent, error: Error, attemptCount: number): AfterModelCallEvent {
-  return new AfterModelCallEvent({ agent, model: {} as never, attemptCount, error })
+  return new AfterModelCallEvent({ agent, model: {} as never, attemptCount, error, invocationState: {} })
 }
 
 describe('DefaultModelRetryStrategy', () => {

--- a/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
@@ -2,26 +2,18 @@
 // real wall time — timers are advanced manually with vi.advanceTimersByTimeAsync.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { DefaultModelRetryStrategy } from '../default-model-retry-strategy.js'
 import { ModelRetryStrategy } from '../model-retry-strategy.js'
-import { RetryStrategy } from '../retry-strategy.js'
 import { ConstantBackoff, type BackoffStrategy } from '../backoff-strategy.js'
-import { AfterInvocationEvent, AfterModelCallEvent } from '../../hooks/events.js'
+import { AfterModelCallEvent } from '../../hooks/events.js'
 import { ModelThrottledError } from '../../errors.js'
 import { createMockAgent, invokeTrackedHook, type MockAgent } from '../../__fixtures__/agent-helpers.js'
 
-function makeErrorEvent(agent: MockAgent, error: Error): AfterModelCallEvent {
-  return new AfterModelCallEvent({ agent, model: {} as never, error })
+function makeErrorEvent(agent: MockAgent, error: Error, attemptCount: number): AfterModelCallEvent {
+  return new AfterModelCallEvent({ agent, model: {} as never, attemptCount, error })
 }
 
-function makeSuccessEvent(agent: MockAgent): AfterModelCallEvent {
-  return new AfterModelCallEvent({
-    agent,
-    model: {} as never,
-    stopData: { message: {} as never, stopReason: 'endTurn' },
-  })
-}
-
-describe('ModelRetryStrategy', () => {
+describe('DefaultModelRetryStrategy', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -29,36 +21,35 @@ describe('ModelRetryStrategy', () => {
     vi.useRealTimers()
   })
 
-  it('registers AfterModelCallEvent and AfterInvocationEvent hooks', () => {
-    const strategy = new ModelRetryStrategy()
+  it('registers an AfterModelCallEvent hook', () => {
+    const strategy = new DefaultModelRetryStrategy()
     const agent = createMockAgent()
     strategy.initAgent(agent)
     const types = agent.trackedHooks.map((h) => h.eventType)
     expect(types).toContain(AfterModelCallEvent)
-    expect(types).toContain(AfterInvocationEvent)
   })
 
   it('exposes the plugin name', () => {
-    expect(new ModelRetryStrategy().name).toBe('strands:model-retry-strategy')
+    expect(new DefaultModelRetryStrategy().name).toBe('strands:model-retry-strategy')
   })
 
-  it('is a RetryStrategy', () => {
-    expect(new ModelRetryStrategy()).toBeInstanceOf(RetryStrategy)
+  it('is a ModelRetryStrategy', () => {
+    expect(new DefaultModelRetryStrategy()).toBeInstanceOf(ModelRetryStrategy)
   })
 
   it('rejects maxAttempts below 1', () => {
-    expect(() => new ModelRetryStrategy({ maxAttempts: 0 })).toThrow(/maxAttempts/)
+    expect(() => new DefaultModelRetryStrategy({ maxAttempts: 0 })).toThrow(/maxAttempts/)
   })
 
   it('sets retry=true on ModelThrottledError and sleeps for the configured delay', async () => {
-    const strategy = new ModelRetryStrategy({
+    const strategy = new DefaultModelRetryStrategy({
       maxAttempts: 3,
       backoff: new ConstantBackoff({ delayMs: 500 }),
     })
     const agent = createMockAgent()
     strategy.initAgent(agent)
 
-    const event = makeErrorEvent(agent, new ModelThrottledError('rate limited'))
+    const event = makeErrorEvent(agent, new ModelThrottledError('rate limited'), 1)
     const pending = invokeTrackedHook(agent, event)
 
     // Before the timer advances, the hook is still awaiting sleep — retry not yet set.
@@ -71,19 +62,19 @@ describe('ModelRetryStrategy', () => {
   })
 
   it('does not retry non-retryable errors', async () => {
-    const strategy = new ModelRetryStrategy({
+    const strategy = new DefaultModelRetryStrategy({
       backoff: new ConstantBackoff({ delayMs: 10 }),
     })
     const agent = createMockAgent()
     strategy.initAgent(agent)
 
-    const event = makeErrorEvent(agent, new Error('boom'))
+    const event = makeErrorEvent(agent, new Error('boom'), 1)
     await invokeTrackedHook(agent, event)
     expect(event.retry).toBeUndefined()
   })
 
   it('stops retrying once maxAttempts is reached', async () => {
-    const strategy = new ModelRetryStrategy({
+    const strategy = new DefaultModelRetryStrategy({
       maxAttempts: 3,
       backoff: new ConstantBackoff({ delayMs: 1 }),
     })
@@ -91,34 +82,34 @@ describe('ModelRetryStrategy', () => {
     strategy.initAgent(agent)
 
     // Attempt 1 → retry
-    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
     const p1 = invokeTrackedHook(agent, e1)
     await vi.advanceTimersByTimeAsync(1)
     await p1
     expect(e1.retry).toBe(true)
 
     // Attempt 2 → retry
-    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'), 2)
     const p2 = invokeTrackedHook(agent, e2)
     await vi.advanceTimersByTimeAsync(1)
     await p2
     expect(e2.retry).toBe(true)
 
-    // Attempt 3 → exceeds max, should not retry
-    const e3 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    // Attempt 3 → at max, should not retry
+    const e3 = makeErrorEvent(agent, new ModelThrottledError('x'), 3)
     await invokeTrackedHook(agent, e3)
     expect(e3.retry).toBeUndefined()
   })
 
   it('skips work if another hook already requested retry', async () => {
-    const strategy = new ModelRetryStrategy({
+    const strategy = new DefaultModelRetryStrategy({
       maxAttempts: 5,
       backoff: new ConstantBackoff({ delayMs: 1000 }),
     })
     const agent = createMockAgent()
     strategy.initAgent(agent)
 
-    const event = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const event = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
     event.retry = true
 
     // Should return immediately with no sleep — if it tried to sleep we'd see
@@ -127,66 +118,43 @@ describe('ModelRetryStrategy', () => {
     expect(event.retry).toBe(true)
   })
 
-  it('resets state after a successful model call', async () => {
-    const strategy = new ModelRetryStrategy({
-      maxAttempts: 2,
-      backoff: new ConstantBackoff({ delayMs: 1 }),
-    })
+  it('clears backoff state at the start of each new turn', async () => {
+    // The strategy resets state on `attemptCount === 1` regardless of how
+    // the prior turn ended. This exercises that: a turn racks up a retry
+    // (lastDelayMs = 5), then the next turn's first attempt must see a
+    // fresh BackoffContext (no lastDelayMs).
+    const nextDelay = vi.fn<BackoffStrategy['nextDelay']>().mockReturnValue(5)
+    const backoff: BackoffStrategy = { nextDelay }
+    const strategy = new DefaultModelRetryStrategy({ maxAttempts: 5, backoff })
     const agent = createMockAgent()
     strategy.initAgent(agent)
 
-    // Fail once — currentAttempt becomes 1
-    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    // Turn 1 → fail → lastDelayMs gets set to 5.
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
     const p1 = invokeTrackedHook(agent, e1)
-    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(5)
     await p1
-    expect(e1.retry).toBe(true)
 
-    // Success — should reset the counter
-    const ok = makeSuccessEvent(agent)
-    await invokeTrackedHook(agent, ok)
-
-    // Next failure should still retry (counter was reset, so we're back at attempt 1)
-    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    // Turn 2 → fail on first attempt → should see no lastDelayMs.
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
     const p2 = invokeTrackedHook(agent, e2)
-    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(5)
     await p2
-    expect(e2.retry).toBe(true)
-  })
 
-  it('resets state on AfterInvocationEvent', async () => {
-    const strategy = new ModelRetryStrategy({
-      maxAttempts: 2,
-      backoff: new ConstantBackoff({ delayMs: 1 }),
+    expect(nextDelay.mock.calls[1]![0]).toEqual({
+      attempt: 1,
+      elapsedMs: expect.any(Number),
     })
-    const agent = createMockAgent()
-    strategy.initAgent(agent)
-
-    // Fail once → counter = 1
-    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
-    const p1 = invokeTrackedHook(agent, e1)
-    await vi.advanceTimersByTimeAsync(1)
-    await p1
-
-    // Invocation ends → counter reset
-    await invokeTrackedHook(agent, new AfterInvocationEvent({ agent }))
-
-    // Next invocation's first failure should retry (would not if counter was 1 with maxAttempts=2)
-    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
-    const p2 = invokeTrackedHook(agent, e2)
-    await vi.advanceTimersByTimeAsync(1)
-    await p2
-    expect(e2.retry).toBe(true)
   })
 
   it('passes BackoffContext with attempt and lastDelayMs to the backoff strategy', async () => {
     const nextDelay = vi.fn<BackoffStrategy['nextDelay']>().mockReturnValue(5)
     const backoff: BackoffStrategy = { nextDelay }
-    const strategy = new ModelRetryStrategy({ maxAttempts: 5, backoff })
+    const strategy = new DefaultModelRetryStrategy({ maxAttempts: 5, backoff })
     const agent = createMockAgent()
     strategy.initAgent(agent)
 
-    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'), 1)
     const p1 = invokeTrackedHook(agent, e1)
     await vi.advanceTimersByTimeAsync(5)
     await p1
@@ -197,7 +165,7 @@ describe('ModelRetryStrategy', () => {
       elapsedMs: expect.any(Number),
     })
 
-    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'), 2)
     const p2 = invokeTrackedHook(agent, e2)
     await vi.advanceTimersByTimeAsync(5)
     await p2

--- a/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
@@ -219,7 +219,7 @@ describe('DefaultModelRetryStrategy', () => {
 
     class PermissiveStrategy extends DefaultModelRetryStrategy {
       override readonly name = 'test:permissive'
-      override isRetryable(error: Error): boolean {
+      protected override isRetryable(error: Error): boolean {
         return super.isRetryable(error) || error instanceof CustomError
       }
     }

--- a/strands-ts/src/retry/__tests__/model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/model-retry-strategy.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ModelRetryStrategy } from '../model-retry-strategy.js'
+import { RetryStrategy } from '../retry-strategy.js'
 import { ConstantBackoff, type BackoffStrategy } from '../backoff-strategy.js'
 import { AfterInvocationEvent, AfterModelCallEvent } from '../../hooks/events.js'
 import { ModelThrottledError } from '../../errors.js'
@@ -39,6 +40,10 @@ describe('ModelRetryStrategy', () => {
 
   it('exposes the plugin name', () => {
     expect(new ModelRetryStrategy().name).toBe('strands:model-retry-strategy')
+  })
+
+  it('is a RetryStrategy', () => {
+    expect(new ModelRetryStrategy()).toBeInstanceOf(RetryStrategy)
   })
 
   it('rejects maxAttempts below 1', () => {

--- a/strands-ts/src/retry/__tests__/model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/model-retry-strategy.test.ts
@@ -1,0 +1,202 @@
+// Tests use vi.useFakeTimers() so the internal `await sleep(...)` never waits
+// real wall time — timers are advanced manually with vi.advanceTimersByTimeAsync.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ModelRetryStrategy } from '../model-retry-strategy.js'
+import { ConstantBackoff, type BackoffStrategy } from '../backoff-strategy.js'
+import { AfterInvocationEvent, AfterModelCallEvent } from '../../hooks/events.js'
+import { ModelThrottledError } from '../../errors.js'
+import { createMockAgent, invokeTrackedHook, type MockAgent } from '../../__fixtures__/agent-helpers.js'
+
+function makeErrorEvent(agent: MockAgent, error: Error): AfterModelCallEvent {
+  return new AfterModelCallEvent({ agent, model: {} as never, error })
+}
+
+function makeSuccessEvent(agent: MockAgent): AfterModelCallEvent {
+  return new AfterModelCallEvent({
+    agent,
+    model: {} as never,
+    stopData: { message: {} as never, stopReason: 'endTurn' },
+  })
+}
+
+describe('ModelRetryStrategy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('registers AfterModelCallEvent and AfterInvocationEvent hooks', () => {
+    const strategy = new ModelRetryStrategy()
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+    const types = agent.trackedHooks.map((h) => h.eventType)
+    expect(types).toContain(AfterModelCallEvent)
+    expect(types).toContain(AfterInvocationEvent)
+  })
+
+  it('exposes the plugin name', () => {
+    expect(new ModelRetryStrategy().name).toBe('strands:model-retry-strategy')
+  })
+
+  it('rejects maxAttempts below 1', () => {
+    expect(() => new ModelRetryStrategy({ maxAttempts: 0 })).toThrow(/maxAttempts/)
+  })
+
+  it('sets retry=true on ModelThrottledError and sleeps for the configured delay', async () => {
+    const strategy = new ModelRetryStrategy({
+      maxAttempts: 3,
+      backoff: new ConstantBackoff({ delayMs: 500 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    const event = makeErrorEvent(agent, new ModelThrottledError('rate limited'))
+    const pending = invokeTrackedHook(agent, event)
+
+    // Before the timer advances, the hook is still awaiting sleep — retry not yet set.
+    await vi.advanceTimersByTimeAsync(499)
+    expect(event.retry).toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await pending
+    expect(event.retry).toBe(true)
+  })
+
+  it('does not retry non-retryable errors', async () => {
+    const strategy = new ModelRetryStrategy({
+      backoff: new ConstantBackoff({ delayMs: 10 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    const event = makeErrorEvent(agent, new Error('boom'))
+    await invokeTrackedHook(agent, event)
+    expect(event.retry).toBeUndefined()
+  })
+
+  it('stops retrying once maxAttempts is reached', async () => {
+    const strategy = new ModelRetryStrategy({
+      maxAttempts: 3,
+      backoff: new ConstantBackoff({ delayMs: 1 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    // Attempt 1 → retry
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p1 = invokeTrackedHook(agent, e1)
+    await vi.advanceTimersByTimeAsync(1)
+    await p1
+    expect(e1.retry).toBe(true)
+
+    // Attempt 2 → retry
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p2 = invokeTrackedHook(agent, e2)
+    await vi.advanceTimersByTimeAsync(1)
+    await p2
+    expect(e2.retry).toBe(true)
+
+    // Attempt 3 → exceeds max, should not retry
+    const e3 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    await invokeTrackedHook(agent, e3)
+    expect(e3.retry).toBeUndefined()
+  })
+
+  it('skips work if another hook already requested retry', async () => {
+    const strategy = new ModelRetryStrategy({
+      maxAttempts: 5,
+      backoff: new ConstantBackoff({ delayMs: 1000 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    const event = makeErrorEvent(agent, new ModelThrottledError('x'))
+    event.retry = true
+
+    // Should return immediately with no sleep — if it tried to sleep we'd see
+    // hung test state; resolving without advancing timers proves the skip.
+    await invokeTrackedHook(agent, event)
+    expect(event.retry).toBe(true)
+  })
+
+  it('resets state after a successful model call', async () => {
+    const strategy = new ModelRetryStrategy({
+      maxAttempts: 2,
+      backoff: new ConstantBackoff({ delayMs: 1 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    // Fail once — currentAttempt becomes 1
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p1 = invokeTrackedHook(agent, e1)
+    await vi.advanceTimersByTimeAsync(1)
+    await p1
+    expect(e1.retry).toBe(true)
+
+    // Success — should reset the counter
+    const ok = makeSuccessEvent(agent)
+    await invokeTrackedHook(agent, ok)
+
+    // Next failure should still retry (counter was reset, so we're back at attempt 1)
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p2 = invokeTrackedHook(agent, e2)
+    await vi.advanceTimersByTimeAsync(1)
+    await p2
+    expect(e2.retry).toBe(true)
+  })
+
+  it('resets state on AfterInvocationEvent', async () => {
+    const strategy = new ModelRetryStrategy({
+      maxAttempts: 2,
+      backoff: new ConstantBackoff({ delayMs: 1 }),
+    })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    // Fail once → counter = 1
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p1 = invokeTrackedHook(agent, e1)
+    await vi.advanceTimersByTimeAsync(1)
+    await p1
+
+    // Invocation ends → counter reset
+    await invokeTrackedHook(agent, new AfterInvocationEvent({ agent }))
+
+    // Next invocation's first failure should retry (would not if counter was 1 with maxAttempts=2)
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p2 = invokeTrackedHook(agent, e2)
+    await vi.advanceTimersByTimeAsync(1)
+    await p2
+    expect(e2.retry).toBe(true)
+  })
+
+  it('passes BackoffContext with attempt and lastDelayMs to the backoff strategy', async () => {
+    const nextDelay = vi.fn<BackoffStrategy['nextDelay']>().mockReturnValue(5)
+    const backoff: BackoffStrategy = { nextDelay }
+    const strategy = new ModelRetryStrategy({ maxAttempts: 5, backoff })
+    const agent = createMockAgent()
+    strategy.initAgent(agent)
+
+    const e1 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p1 = invokeTrackedHook(agent, e1)
+    await vi.advanceTimersByTimeAsync(5)
+    await p1
+
+    expect(nextDelay).toHaveBeenCalledTimes(1)
+    expect(nextDelay.mock.calls[0]![0]!.attempt).toBe(1)
+    expect(nextDelay.mock.calls[0]![0]!.lastDelayMs).toBeUndefined()
+
+    const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
+    const p2 = invokeTrackedHook(agent, e2)
+    await vi.advanceTimersByTimeAsync(5)
+    await p2
+
+    expect(nextDelay).toHaveBeenCalledTimes(2)
+    expect(nextDelay.mock.calls[1]![0]!.attempt).toBe(2)
+    expect(nextDelay.mock.calls[1]![0]!.lastDelayMs).toBe(5)
+  })
+})

--- a/strands-ts/src/retry/__tests__/model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/model-retry-strategy.test.ts
@@ -187,8 +187,10 @@ describe('ModelRetryStrategy', () => {
     await p1
 
     expect(nextDelay).toHaveBeenCalledTimes(1)
-    expect(nextDelay.mock.calls[0]![0]!.attempt).toBe(1)
-    expect(nextDelay.mock.calls[0]![0]!.lastDelayMs).toBeUndefined()
+    expect(nextDelay.mock.calls[0]![0]).toEqual({
+      attempt: 1,
+      elapsedMs: expect.any(Number),
+    })
 
     const e2 = makeErrorEvent(agent, new ModelThrottledError('x'))
     const p2 = invokeTrackedHook(agent, e2)
@@ -196,7 +198,10 @@ describe('ModelRetryStrategy', () => {
     await p2
 
     expect(nextDelay).toHaveBeenCalledTimes(2)
-    expect(nextDelay.mock.calls[1]![0]!.attempt).toBe(2)
-    expect(nextDelay.mock.calls[1]![0]!.lastDelayMs).toBe(5)
+    expect(nextDelay.mock.calls[1]![0]).toEqual({
+      attempt: 2,
+      elapsedMs: expect.any(Number),
+      lastDelayMs: 5,
+    })
   })
 })

--- a/strands-ts/src/retry/backoff-strategy.ts
+++ b/strands-ts/src/retry/backoff-strategy.ts
@@ -66,15 +66,15 @@ export interface ConstantBackoffOptions {
  * Constant backoff: returns the same delay for every retry.
  */
 export class ConstantBackoff implements BackoffStrategy {
-  private readonly delayMs: number
+  private readonly _delayMs: number
 
   constructor(opts: ConstantBackoffOptions = {}) {
-    this.delayMs = opts.delayMs ?? 1000
+    this._delayMs = opts.delayMs ?? 1000
   }
 
   nextDelay(ctx: BackoffContext): number {
     validateAttempt(ctx.attempt, 'ConstantBackoff')
-    return this.delayMs
+    return this._delayMs
   }
 }
 
@@ -94,20 +94,20 @@ export interface LinearBackoffOptions {
  * Linear backoff: delay grows as `baseMs * attempt`, capped at `maxMs`, then jittered.
  */
 export class LinearBackoff implements BackoffStrategy {
-  private readonly baseMs: number
-  private readonly maxMs: number
-  private readonly jitter: JitterKind
+  private readonly _baseMs: number
+  private readonly _maxMs: number
+  private readonly _jitter: JitterKind
 
   constructor(opts: LinearBackoffOptions = {}) {
-    this.baseMs = opts.baseMs ?? 1000
-    this.maxMs = opts.maxMs ?? 30_000
-    this.jitter = opts.jitter ?? 'full'
+    this._baseMs = opts.baseMs ?? 1000
+    this._maxMs = opts.maxMs ?? 30_000
+    this._jitter = opts.jitter ?? 'full'
   }
 
   nextDelay(ctx: BackoffContext): number {
     validateAttempt(ctx.attempt, 'LinearBackoff')
-    const raw = Math.min(this.maxMs, this.baseMs * ctx.attempt)
-    return jitter(raw, this.jitter, this.baseMs, this.maxMs, ctx.lastDelayMs)
+    const raw = Math.min(this._maxMs, this._baseMs * ctx.attempt)
+    return jitter(raw, this._jitter, this._baseMs, this._maxMs, ctx.lastDelayMs)
   }
 }
 
@@ -130,22 +130,22 @@ export interface ExponentialBackoffOptions {
  * capped at `maxMs`, then jittered.
  */
 export class ExponentialBackoff implements BackoffStrategy {
-  private readonly baseMs: number
-  private readonly maxMs: number
-  private readonly multiplier: number
-  private readonly jitter: JitterKind
+  private readonly _baseMs: number
+  private readonly _maxMs: number
+  private readonly _multiplier: number
+  private readonly _jitter: JitterKind
 
   constructor(opts: ExponentialBackoffOptions = {}) {
-    this.baseMs = opts.baseMs ?? 1000
-    this.maxMs = opts.maxMs ?? 30_000
-    this.multiplier = opts.multiplier ?? 2
-    this.jitter = opts.jitter ?? 'full'
+    this._baseMs = opts.baseMs ?? 1000
+    this._maxMs = opts.maxMs ?? 30_000
+    this._multiplier = opts.multiplier ?? 2
+    this._jitter = opts.jitter ?? 'full'
   }
 
   nextDelay(ctx: BackoffContext): number {
     validateAttempt(ctx.attempt, 'ExponentialBackoff')
-    const raw = Math.min(this.maxMs, this.baseMs * this.multiplier ** (ctx.attempt - 1))
-    return jitter(raw, this.jitter, this.baseMs, this.maxMs, ctx.lastDelayMs)
+    const raw = Math.min(this._maxMs, this._baseMs * this._multiplier ** (ctx.attempt - 1))
+    return jitter(raw, this._jitter, this._baseMs, this._maxMs, ctx.lastDelayMs)
   }
 }
 

--- a/strands-ts/src/retry/backoff-strategy.ts
+++ b/strands-ts/src/retry/backoff-strategy.ts
@@ -1,0 +1,171 @@
+/**
+ * Backoff strategies for computing delay between retry attempts.
+ *
+ * A `BackoffStrategy` is pure delay math: given a `BackoffContext`, it returns
+ * how long to wait before the next attempt. Policy concerns — whether to retry,
+ * whether to honor a server-provided `Retry-After` hint, max attempts, total
+ * time budgets — live in the retry orchestration layer, not here.
+ */
+
+/**
+ * Context passed to a {@link BackoffStrategy} for each retry decision.
+ *
+ * Treated as an open, additive-only contract: new optional fields may be added
+ * over time, but existing fields will not be removed or repurposed.
+ */
+export interface BackoffContext {
+  /** 1-based index of the attempt that just failed. Must be \>= 1. */
+  attempt: number
+  /** Total milliseconds elapsed since the first attempt started. */
+  elapsedMs: number
+  /** Previously computed delay, if any. Absent before the first retry. */
+  lastDelayMs?: number
+}
+
+/**
+ * Computes the delay before the next retry attempt.
+ */
+export interface BackoffStrategy {
+  /**
+   * Returns the delay in milliseconds before the next attempt.
+   *
+   * Must be a non-negative finite number. Implementations should treat
+   * `ctx.attempt < 1` as a programmer error.
+   */
+  nextDelay(ctx: BackoffContext): number
+}
+
+/**
+ * Supported jitter modes.
+ *
+ * - `none`: return the raw delay unchanged
+ * - `full`: uniform random in `[0, raw]`
+ * - `equal`: `raw/2 + uniform(0, raw/2)` (half fixed, half random)
+ * - `decorrelated`: `uniform(baseMs, lastDelayMs * 3)`, capped at `maxMs`;
+ *   falls back to `full` on the first retry when `lastDelayMs` is unavailable
+ *
+ * For jitter outside these modes, implement {@link BackoffStrategy} directly.
+ */
+export type JitterKind = 'none' | 'full' | 'equal' | 'decorrelated'
+
+function validateAttempt(attempt: number, className: string): void {
+  if (!Number.isInteger(attempt) || attempt < 1) {
+    throw new Error(`${className}: attempt must be an integer >= 1 (got ${attempt})`)
+  }
+}
+
+/**
+ * Options for {@link ConstantBackoff}.
+ */
+export interface ConstantBackoffOptions {
+  /** Delay in ms returned for every retry. Default 1000. */
+  delayMs?: number
+}
+
+/**
+ * Constant backoff: returns the same delay for every retry.
+ */
+export class ConstantBackoff implements BackoffStrategy {
+  private readonly delayMs: number
+
+  constructor(opts: ConstantBackoffOptions = {}) {
+    this.delayMs = opts.delayMs ?? 1000
+  }
+
+  nextDelay(ctx: BackoffContext): number {
+    validateAttempt(ctx.attempt, 'ConstantBackoff')
+    return this.delayMs
+  }
+}
+
+/**
+ * Options for {@link LinearBackoff}.
+ */
+export interface LinearBackoffOptions {
+  /** Base delay in ms. Delay grows as `baseMs * attempt`. Default 1000. */
+  baseMs?: number
+  /** Upper bound applied before jitter. Default 30_000. */
+  maxMs?: number
+  /** Jitter mode. Default 'full'. */
+  jitter?: JitterKind
+}
+
+/**
+ * Linear backoff: delay grows as `baseMs * attempt`, capped at `maxMs`, then jittered.
+ */
+export class LinearBackoff implements BackoffStrategy {
+  private readonly baseMs: number
+  private readonly maxMs: number
+  private readonly jitter: JitterKind
+
+  constructor(opts: LinearBackoffOptions = {}) {
+    this.baseMs = opts.baseMs ?? 1000
+    this.maxMs = opts.maxMs ?? 30_000
+    this.jitter = opts.jitter ?? 'full'
+  }
+
+  nextDelay(ctx: BackoffContext): number {
+    validateAttempt(ctx.attempt, 'LinearBackoff')
+    const raw = Math.min(this.maxMs, this.baseMs * ctx.attempt)
+    return jitter(raw, this.jitter, this.baseMs, this.maxMs, ctx.lastDelayMs)
+  }
+}
+
+/**
+ * Options for {@link ExponentialBackoff}.
+ */
+export interface ExponentialBackoffOptions {
+  /** Base delay in ms. Delay grows as `baseMs * multiplier^(attempt-1)`. Default 1000. */
+  baseMs?: number
+  /** Upper bound applied before jitter. Default 30_000. */
+  maxMs?: number
+  /** Growth factor per attempt. Default 2. */
+  multiplier?: number
+  /** Jitter mode. Default 'full'. */
+  jitter?: JitterKind
+}
+
+/**
+ * Exponential backoff: delay grows as `baseMs * multiplier^(attempt-1)`,
+ * capped at `maxMs`, then jittered.
+ */
+export class ExponentialBackoff implements BackoffStrategy {
+  private readonly baseMs: number
+  private readonly maxMs: number
+  private readonly multiplier: number
+  private readonly jitter: JitterKind
+
+  constructor(opts: ExponentialBackoffOptions = {}) {
+    this.baseMs = opts.baseMs ?? 1000
+    this.maxMs = opts.maxMs ?? 30_000
+    this.multiplier = opts.multiplier ?? 2
+    this.jitter = opts.jitter ?? 'full'
+  }
+
+  nextDelay(ctx: BackoffContext): number {
+    validateAttempt(ctx.attempt, 'ExponentialBackoff')
+    const raw = Math.min(this.maxMs, this.baseMs * this.multiplier ** (ctx.attempt - 1))
+    return jitter(raw, this.jitter, this.baseMs, this.maxMs, ctx.lastDelayMs)
+  }
+}
+
+function jitter(raw: number, kind: JitterKind, baseMs: number, maxMs: number, lastDelayMs?: number): number {
+  switch (kind) {
+    case 'none':
+      return raw
+    case 'full':
+      return Math.random() * raw
+    case 'equal':
+      return raw / 2 + Math.random() * (raw / 2)
+    case 'decorrelated': {
+      if (lastDelayMs === undefined) {
+        return Math.random() * raw
+      }
+      // Standard decorrelated jitter: uniform(baseMs, min(maxMs, lastDelay * 3)).
+      // The max() guards against the degenerate case where maxMs < baseMs,
+      // which would otherwise produce an inverted range.
+      const upper = Math.max(baseMs, Math.min(maxMs, lastDelayMs * 3))
+      return baseMs + Math.random() * (upper - baseMs)
+    }
+  }
+}

--- a/strands-ts/src/retry/default-model-retry-strategy.ts
+++ b/strands-ts/src/retry/default-model-retry-strategy.ts
@@ -1,11 +1,14 @@
 /**
- * Retry strategy for model invocations.
+ * Default concrete retry strategy for model invocations.
  *
- * Overrides {@link ModelRetryStrategy.retryModel} to retry failed model calls.
+ * Implements {@link ModelRetryStrategy.computeRetryDecision} to retry failed model
+ * calls classified by {@link isRetryable}, bounded by `maxAttempts`, with
+ * delays computed by the configured {@link BackoffStrategy}.
+ *
  * The attempt counter lives on {@link AfterModelCallEvent.attemptCount},
  * maintained by the agent loop. This strategy only keeps per-turn backoff
- * state (first-failure timestamp, last delay), which is cleared on the
- * first attempt of each new turn (detected via `event.attemptCount === 1`).
+ * state (first-failure timestamp, last delay), which is cleared in
+ * {@link onFirstModelAttempt}.
  */
 
 import type { AfterModelCallEvent } from '../hooks/events.js'
@@ -14,6 +17,7 @@ import { logger } from '../logging/logger.js'
 import type { BackoffContext, BackoffStrategy } from './backoff-strategy.js'
 import { ExponentialBackoff } from './backoff-strategy.js'
 import { ModelRetryStrategy } from './model-retry-strategy.js'
+import type { RetryDecision } from './retry-strategy.js'
 
 const DEFAULT_MAX_ATTEMPTS = 6
 const DEFAULT_BACKOFF_BASE_MS = 4_000
@@ -38,17 +42,18 @@ export interface DefaultModelRetryStrategyOptions {
 /**
  * Retries failed model calls classified by the SDK as retryable.
  *
- * Today, only {@link ModelThrottledError} is treated as retryable. The set of
- * retryable errors may grow over time (e.g. transient server errors) without
- * requiring changes to this class's public API.
+ * Today, only {@link ModelThrottledError} is treated as retryable — subclass
+ * and override {@link isRetryable} to expand or narrow that set without
+ * reimplementing the rest of the retry policy.
  *
- * State is per-turn: backoff timing state resets on the first attempt of
- * each new turn. The attempt counter itself is owned by the agent loop and
- * read off {@link AfterModelCallEvent.attemptCount}.
+ * State is per-turn: backoff timing state resets in {@link onFirstModelAttempt},
+ * which the base class calls when `event.attemptCount === 1`. The attempt
+ * counter itself is owned by the agent loop and read off
+ * {@link AfterModelCallEvent.attemptCount}.
  *
  * Hook precedence: {@link AfterModelCallEvent} fires hooks in reverse registration
  * order, so user-registered hooks run before this strategy. If a user hook sets
- * `event.retry = true` first, this strategy returns early and does not stack
+ * `event.retry = true` first, the base class returns early and does not stack
  * additional backoff on top.
  *
  * Sharing: a given instance tracks its own backoff state and must not be shared
@@ -63,7 +68,7 @@ export interface DefaultModelRetryStrategyOptions {
  * ```
  */
 export class DefaultModelRetryStrategy extends ModelRetryStrategy {
-  readonly name = 'strands:model-retry-strategy'
+  readonly name: string = 'strands:default-model-retry-strategy'
 
   private readonly _maxAttempts: number
   private readonly _backoff: BackoffStrategy
@@ -82,40 +87,45 @@ export class DefaultModelRetryStrategy extends ModelRetryStrategy {
       opts.backoff ?? new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })
   }
 
-  override async retryModel(event: AfterModelCallEvent): Promise<void> {
-    // Another hook already requested retry — don't stack a second delay on top.
-    if (event.retry) return
+  /**
+   * Whether `error` should be retried. Override to extend or narrow the
+   * retryable set (e.g. to also retry transient 5xx errors).
+   */
+  public isRetryable(error: Error): boolean {
+    return error instanceof ModelThrottledError
+  }
 
-    // Clear any state left over from a prior turn at the turn boundary.
-    if (event.attemptCount === 1) this._reset()
-
-    if (event.error === undefined) return
-    if (!this._isRetryable(event.error)) return
+  protected override computeRetryDecision(event: AfterModelCallEvent): RetryDecision {
+    const error = event.error
+    if (error === undefined || !this.isRetryable(error)) {
+      return { retry: false }
+    }
 
     if (event.attemptCount >= this._maxAttempts) {
       logger.debug(
         `attempt_count=<${event.attemptCount}> max_attempts=<${this._maxAttempts}> | max retry attempts reached`
       )
-      return
+      return { retry: false }
     }
 
     if (this._firstFailureAt === undefined) {
       this._firstFailureAt = Date.now()
     }
 
-    // Per-error-class backoff selection is a future extension; today every
-    // retryable error uses the single configured backoff.
-    const delayMs = this._backoff.nextDelay(this._buildContext(event.attemptCount))
+    const waitMs = this._backoff.nextDelay(this._buildContext(event.attemptCount))
 
     logger.debug(
-      `retry_delay_ms=<${delayMs}> attempt_count=<${event.attemptCount}> max_attempts=<${this._maxAttempts}> ` +
+      `retry_delay_ms=<${waitMs}> attempt_count=<${event.attemptCount}> max_attempts=<${this._maxAttempts}> ` +
         `| retryable model error, delaying before retry`
     )
 
-    await sleep(delayMs)
+    this._lastDelayMs = waitMs
+    return { retry: true, waitMs }
+  }
 
-    this._lastDelayMs = delayMs
-    event.retry = true
+  protected override onFirstModelAttempt(): void {
+    this._lastDelayMs = undefined
+    this._firstFailureAt = undefined
   }
 
   private _buildContext(attemptCount: number): BackoffContext {
@@ -128,17 +138,4 @@ export class DefaultModelRetryStrategy extends ModelRetryStrategy {
     }
     return ctx
   }
-
-  private _isRetryable(error: Error): boolean {
-    return error instanceof ModelThrottledError
-  }
-
-  private _reset(): void {
-    this._lastDelayMs = undefined
-    this._firstFailureAt = undefined
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
 }

--- a/strands-ts/src/retry/default-model-retry-strategy.ts
+++ b/strands-ts/src/retry/default-model-retry-strategy.ts
@@ -1,0 +1,144 @@
+/**
+ * Retry strategy for model invocations.
+ *
+ * Overrides {@link ModelRetryStrategy.retryModel} to retry failed model calls.
+ * The attempt counter lives on {@link AfterModelCallEvent.attemptCount},
+ * maintained by the agent loop. This strategy only keeps per-turn backoff
+ * state (first-failure timestamp, last delay), which is cleared on the
+ * first attempt of each new turn (detected via `event.attemptCount === 1`).
+ */
+
+import type { AfterModelCallEvent } from '../hooks/events.js'
+import { ModelThrottledError } from '../errors.js'
+import { logger } from '../logging/logger.js'
+import type { BackoffContext, BackoffStrategy } from './backoff-strategy.js'
+import { ExponentialBackoff } from './backoff-strategy.js'
+import { ModelRetryStrategy } from './model-retry-strategy.js'
+
+const DEFAULT_MAX_ATTEMPTS = 6
+const DEFAULT_BACKOFF_BASE_MS = 4_000
+const DEFAULT_BACKOFF_MAX_MS = 240_000
+
+/**
+ * Options for {@link DefaultModelRetryStrategy}.
+ */
+export interface DefaultModelRetryStrategyOptions {
+  /**
+   * Total model attempts before giving up and re-raising the error.
+   * Must be \>= 1. Default {@link DEFAULT_MAX_ATTEMPTS}.
+   */
+  maxAttempts?: number
+  /**
+   * Backoff used to compute the delay between retries.
+   * Default: `new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })`.
+   */
+  backoff?: BackoffStrategy
+}
+
+/**
+ * Retries failed model calls classified by the SDK as retryable.
+ *
+ * Today, only {@link ModelThrottledError} is treated as retryable. The set of
+ * retryable errors may grow over time (e.g. transient server errors) without
+ * requiring changes to this class's public API.
+ *
+ * State is per-turn: backoff timing state resets on the first attempt of
+ * each new turn. The attempt counter itself is owned by the agent loop and
+ * read off {@link AfterModelCallEvent.attemptCount}.
+ *
+ * Hook precedence: {@link AfterModelCallEvent} fires hooks in reverse registration
+ * order, so user-registered hooks run before this strategy. If a user hook sets
+ * `event.retry = true` first, this strategy returns early and does not stack
+ * additional backoff on top.
+ *
+ * Sharing: a given instance tracks its own backoff state and must not be shared
+ * across multiple agents. Create a separate instance per agent.
+ *
+ * @example
+ * ```ts
+ * const agent = new Agent({
+ *   model,
+ *   retryStrategy: new DefaultModelRetryStrategy({ maxAttempts: 4 }),
+ * })
+ * ```
+ */
+export class DefaultModelRetryStrategy extends ModelRetryStrategy {
+  readonly name = 'strands:model-retry-strategy'
+
+  private readonly _maxAttempts: number
+  private readonly _backoff: BackoffStrategy
+
+  private _lastDelayMs: number | undefined
+  private _firstFailureAt: number | undefined
+
+  constructor(opts: DefaultModelRetryStrategyOptions = {}) {
+    super()
+    const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+    if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+      throw new Error(`DefaultModelRetryStrategy: maxAttempts must be an integer >= 1 (got ${maxAttempts})`)
+    }
+    this._maxAttempts = maxAttempts
+    this._backoff =
+      opts.backoff ?? new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })
+  }
+
+  override async retryModel(event: AfterModelCallEvent): Promise<void> {
+    // Another hook already requested retry — don't stack a second delay on top.
+    if (event.retry) return
+
+    // Clear any state left over from a prior turn at the turn boundary.
+    if (event.attemptCount === 1) this._reset()
+
+    if (event.error === undefined) return
+    if (!this._isRetryable(event.error)) return
+
+    if (event.attemptCount >= this._maxAttempts) {
+      logger.debug(
+        `attempt_count=<${event.attemptCount}> max_attempts=<${this._maxAttempts}> | max retry attempts reached`
+      )
+      return
+    }
+
+    if (this._firstFailureAt === undefined) {
+      this._firstFailureAt = Date.now()
+    }
+
+    // Per-error-class backoff selection is a future extension; today every
+    // retryable error uses the single configured backoff.
+    const delayMs = this._backoff.nextDelay(this._buildContext(event.attemptCount))
+
+    logger.debug(
+      `retry_delay_ms=<${delayMs}> attempt_count=<${event.attemptCount}> max_attempts=<${this._maxAttempts}> ` +
+        `| retryable model error, delaying before retry`
+    )
+
+    await sleep(delayMs)
+
+    this._lastDelayMs = delayMs
+    event.retry = true
+  }
+
+  private _buildContext(attemptCount: number): BackoffContext {
+    const ctx: BackoffContext = {
+      attempt: attemptCount,
+      elapsedMs: this._firstFailureAt === undefined ? 0 : Date.now() - this._firstFailureAt,
+    }
+    if (this._lastDelayMs !== undefined) {
+      ctx.lastDelayMs = this._lastDelayMs
+    }
+    return ctx
+  }
+
+  private _isRetryable(error: Error): boolean {
+    return error instanceof ModelThrottledError
+  }
+
+  private _reset(): void {
+    this._lastDelayMs = undefined
+    this._firstFailureAt = undefined
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
+}

--- a/strands-ts/src/retry/default-model-retry-strategy.ts
+++ b/strands-ts/src/retry/default-model-retry-strategy.ts
@@ -91,7 +91,7 @@ export class DefaultModelRetryStrategy extends ModelRetryStrategy {
    * Whether `error` should be retried. Override to extend or narrow the
    * retryable set (e.g. to also retry transient 5xx errors).
    */
-  public isRetryable(error: Error): boolean {
+  protected isRetryable(error: Error): boolean {
     return error instanceof ModelThrottledError
   }
 

--- a/strands-ts/src/retry/index.ts
+++ b/strands-ts/src/retry/index.ts
@@ -14,4 +14,6 @@ export {
   ExponentialBackoff,
 } from './backoff-strategy.js'
 
+export { RetryStrategy } from './retry-strategy.js'
+
 export { ModelRetryStrategy, type ModelRetryStrategyOptions } from './model-retry-strategy.js'

--- a/strands-ts/src/retry/index.ts
+++ b/strands-ts/src/retry/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Retry utilities.
+ */
+
+export {
+  type BackoffContext,
+  type BackoffStrategy,
+  type JitterKind,
+  type ConstantBackoffOptions,
+  type LinearBackoffOptions,
+  type ExponentialBackoffOptions,
+  ConstantBackoff,
+  LinearBackoff,
+  ExponentialBackoff,
+} from './backoff-strategy.js'
+
+export { ModelRetryStrategy, type ModelRetryStrategyOptions } from './model-retry-strategy.js'

--- a/strands-ts/src/retry/index.ts
+++ b/strands-ts/src/retry/index.ts
@@ -18,4 +18,4 @@ export { ModelRetryStrategy } from './model-retry-strategy.js'
 
 export { DefaultModelRetryStrategy, type DefaultModelRetryStrategyOptions } from './default-model-retry-strategy.js'
 
-export type { RetryStrategy } from './retry-strategy.js'
+export type { RetryStrategy, RetryDecision } from './retry-strategy.js'

--- a/strands-ts/src/retry/index.ts
+++ b/strands-ts/src/retry/index.ts
@@ -14,6 +14,8 @@ export {
   ExponentialBackoff,
 } from './backoff-strategy.js'
 
-export { RetryStrategy } from './retry-strategy.js'
+export { ModelRetryStrategy } from './model-retry-strategy.js'
 
-export { ModelRetryStrategy, type ModelRetryStrategyOptions } from './model-retry-strategy.js'
+export { DefaultModelRetryStrategy, type DefaultModelRetryStrategyOptions } from './default-model-retry-strategy.js'
+
+export type { RetryStrategy } from './retry-strategy.js'

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -1,0 +1,168 @@
+/**
+ * Retry strategy for model invocations.
+ *
+ * Registered as a {@link Plugin}; hooks into {@link AfterModelCallEvent} to
+ * retry failed model calls, and {@link AfterInvocationEvent} to reset per-
+ * invocation state.
+ */
+
+import { AfterInvocationEvent, AfterModelCallEvent } from '../hooks/events.js'
+import { ModelThrottledError } from '../errors.js'
+import { logger } from '../logging/logger.js'
+import type { Plugin } from '../plugins/plugin.js'
+import type { LocalAgent } from '../types/agent.js'
+import type { BackoffContext, BackoffStrategy } from './backoff-strategy.js'
+import { ExponentialBackoff } from './backoff-strategy.js'
+
+const DEFAULT_MAX_ATTEMPTS = 6
+const DEFAULT_BACKOFF_BASE_MS = 4_000
+const DEFAULT_BACKOFF_MAX_MS = 240_000
+
+/**
+ * Options for {@link ModelRetryStrategy}.
+ */
+export interface ModelRetryStrategyOptions {
+  /**
+   * Total model attempts before giving up and re-raising the error.
+   * Must be \>= 1. Default {@link DEFAULT_MAX_ATTEMPTS}.
+   */
+  maxAttempts?: number
+  /**
+   * Backoff used to compute the delay between retries.
+   * Default: `new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })`.
+   */
+  backoff?: BackoffStrategy
+}
+
+/**
+ * Retries failed model calls classified by the SDK as retryable.
+ *
+ * Today, only {@link ModelThrottledError} is treated as retryable. The set of
+ * retryable errors may grow over time (e.g. transient server errors) without
+ * requiring changes to this class's public API.
+ *
+ * State is per-invocation: the attempt counter and the last computed delay
+ * reset on {@link AfterInvocationEvent}, and also after any successful model
+ * call within an invocation.
+ *
+ * Hook precedence: {@link AfterModelCallEvent} fires hooks in reverse registration
+ * order, so user-registered hooks run before this strategy. If a user hook sets
+ * `event.retry = true` first, this strategy returns early and does not stack
+ * additional backoff on top.
+ *
+ * Sharing: a given instance tracks its own attempt state and must not be shared
+ * across multiple agents. Create a separate instance per agent.
+ *
+ * @example
+ * ```ts
+ * const agent = new Agent({
+ *   model,
+ *   modelRetryStrategy: new ModelRetryStrategy({ maxAttempts: 4 }),
+ * })
+ * ```
+ */
+export class ModelRetryStrategy implements Plugin {
+  readonly name = 'strands:model-retry-strategy'
+
+  private readonly maxAttempts: number
+  private readonly backoff: BackoffStrategy
+
+  private currentAttempt = 0
+  private lastDelayMs: number | undefined
+  private firstFailureAt: number | undefined
+  private attachedAgent: LocalAgent | undefined
+
+  constructor(opts: ModelRetryStrategyOptions = {}) {
+    const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+    if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+      throw new Error(`ModelRetryStrategy: maxAttempts must be an integer >= 1 (got ${maxAttempts})`)
+    }
+    this.maxAttempts = maxAttempts
+    this.backoff =
+      opts.backoff ?? new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })
+  }
+
+  initAgent(agent: LocalAgent): void {
+    if (this.attachedAgent !== undefined && this.attachedAgent !== agent) {
+      throw new Error(
+        'ModelRetryStrategy: instance is already attached to another agent. ' +
+          'Create a separate ModelRetryStrategy per agent.'
+      )
+    }
+    this.attachedAgent = agent
+    agent.addHook(AfterModelCallEvent, (event) => this.onAfterModelCall(event))
+    agent.addHook(AfterInvocationEvent, () => this.resetState())
+  }
+
+  private async onAfterModelCall(event: AfterModelCallEvent): Promise<void> {
+    // Another hook already requested retry — don't stack a second delay on top.
+    if (event.retry) return
+
+    // Success: reset state for the next model call in this invocation.
+    if (event.error === undefined) {
+      this.resetState()
+      return
+    }
+
+    if (!this.isRetryable(event.error)) return
+
+    // currentAttempt represents the attempt that just failed.
+    this.currentAttempt += 1
+    if (this.currentAttempt >= this.maxAttempts) {
+      logger.debug(
+        `current_attempt=<${this.currentAttempt}> max_attempts=<${this.maxAttempts}> | max retry attempts reached`
+      )
+      return
+    }
+
+    if (this.firstFailureAt === undefined) {
+      this.firstFailureAt = Date.now()
+    }
+
+    const delayMs = this.resolveBackoff(event.error).nextDelay(this.buildContext())
+
+    logger.debug(
+      `retry_delay_ms=<${delayMs}> attempt=<${this.currentAttempt}> max_attempts=<${this.maxAttempts}> ` +
+        `| retryable model error, delaying before retry`
+    )
+
+    await sleep(delayMs)
+
+    this.lastDelayMs = delayMs
+    event.retry = true
+  }
+
+  private buildContext(): BackoffContext {
+    const ctx: BackoffContext = {
+      attempt: this.currentAttempt,
+      elapsedMs: this.firstFailureAt === undefined ? 0 : Date.now() - this.firstFailureAt,
+    }
+    if (this.lastDelayMs !== undefined) {
+      ctx.lastDelayMs = this.lastDelayMs
+    }
+    return ctx
+  }
+
+  /**
+   * Returns the backoff to use for a given error. Today this always returns
+   * the configured strategy; the indirection exists so a future per-error-type
+   * map can be layered in without changing the public API.
+   */
+  private resolveBackoff(_error: Error): BackoffStrategy {
+    return this.backoff
+  }
+
+  private isRetryable(error: Error): boolean {
+    return error instanceof ModelThrottledError
+  }
+
+  private resetState(): void {
+    this.currentAttempt = 0
+    this.lastDelayMs = undefined
+    this.firstFailureAt = undefined
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
+}

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -1,18 +1,18 @@
 /**
  * Retry strategy for model invocations.
  *
- * Registered as a {@link Plugin}; hooks into {@link AfterModelCallEvent} to
- * retry failed model calls, and {@link AfterInvocationEvent} to reset per-
- * invocation state.
+ * Overrides {@link RetryStrategy.retryModel} to retry failed model calls.
+ * Per-invocation state (attempt counters, timers) is cleared via
+ * {@link RetryStrategy.reset}, which the base class calls on
+ * {@link AfterInvocationEvent}.
  */
 
-import { AfterInvocationEvent, AfterModelCallEvent } from '../hooks/events.js'
+import type { AfterModelCallEvent } from '../hooks/events.js'
 import { ModelThrottledError } from '../errors.js'
 import { logger } from '../logging/logger.js'
-import type { Plugin } from '../plugins/plugin.js'
-import type { LocalAgent } from '../types/agent.js'
 import type { BackoffContext, BackoffStrategy } from './backoff-strategy.js'
 import { ExponentialBackoff } from './backoff-strategy.js'
+import { RetryStrategy } from './retry-strategy.js'
 
 const DEFAULT_MAX_ATTEMPTS = 6
 const DEFAULT_BACKOFF_BASE_MS = 4_000
@@ -57,11 +57,11 @@ export interface ModelRetryStrategyOptions {
  * ```ts
  * const agent = new Agent({
  *   model,
- *   modelRetryStrategy: new ModelRetryStrategy({ maxAttempts: 4 }),
+ *   retryStrategy: new ModelRetryStrategy({ maxAttempts: 4 }),
  * })
  * ```
  */
-export class ModelRetryStrategy implements Plugin {
+export class ModelRetryStrategy extends RetryStrategy {
   readonly name = 'strands:model-retry-strategy'
 
   private readonly _maxAttempts: number
@@ -70,9 +70,9 @@ export class ModelRetryStrategy implements Plugin {
   private _currentAttempt = 0
   private _lastDelayMs: number | undefined
   private _firstFailureAt: number | undefined
-  private _attachedAgent: LocalAgent | undefined
 
   constructor(opts: ModelRetryStrategyOptions = {}) {
+    super()
     const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
     if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
       throw new Error(`ModelRetryStrategy: maxAttempts must be an integer >= 1 (got ${maxAttempts})`)
@@ -82,25 +82,13 @@ export class ModelRetryStrategy implements Plugin {
       opts.backoff ?? new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })
   }
 
-  initAgent(agent: LocalAgent): void {
-    if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
-      throw new Error(
-        'ModelRetryStrategy: instance is already attached to another agent. ' +
-          'Create a separate ModelRetryStrategy per agent.'
-      )
-    }
-    this._attachedAgent = agent
-    agent.addHook(AfterModelCallEvent, (event) => this._onAfterModelCall(event))
-    agent.addHook(AfterInvocationEvent, () => this._resetState())
-  }
-
-  private async _onAfterModelCall(event: AfterModelCallEvent): Promise<void> {
+  override async retryModel(event: AfterModelCallEvent): Promise<void> {
     // Another hook already requested retry — don't stack a second delay on top.
     if (event.retry) return
 
     // Success: reset state for the next model call in this invocation.
     if (event.error === undefined) {
-      this._resetState()
+      this.reset()
       return
     }
 
@@ -149,7 +137,7 @@ export class ModelRetryStrategy implements Plugin {
     return error instanceof ModelThrottledError
   }
 
-  private _resetState(): void {
+  protected override reset(): void {
     this._currentAttempt = 0
     this._lastDelayMs = undefined
     this._firstFailureAt = undefined

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -64,102 +64,95 @@ export interface ModelRetryStrategyOptions {
 export class ModelRetryStrategy implements Plugin {
   readonly name = 'strands:model-retry-strategy'
 
-  private readonly maxAttempts: number
-  private readonly backoff: BackoffStrategy
+  private readonly _maxAttempts: number
+  private readonly _backoff: BackoffStrategy
 
-  private currentAttempt = 0
-  private lastDelayMs: number | undefined
-  private firstFailureAt: number | undefined
-  private attachedAgent: LocalAgent | undefined
+  private _currentAttempt = 0
+  private _lastDelayMs: number | undefined
+  private _firstFailureAt: number | undefined
+  private _attachedAgent: LocalAgent | undefined
 
   constructor(opts: ModelRetryStrategyOptions = {}) {
     const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
     if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
       throw new Error(`ModelRetryStrategy: maxAttempts must be an integer >= 1 (got ${maxAttempts})`)
     }
-    this.maxAttempts = maxAttempts
-    this.backoff =
+    this._maxAttempts = maxAttempts
+    this._backoff =
       opts.backoff ?? new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })
   }
 
   initAgent(agent: LocalAgent): void {
-    if (this.attachedAgent !== undefined && this.attachedAgent !== agent) {
+    if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
       throw new Error(
         'ModelRetryStrategy: instance is already attached to another agent. ' +
           'Create a separate ModelRetryStrategy per agent.'
       )
     }
-    this.attachedAgent = agent
-    agent.addHook(AfterModelCallEvent, (event) => this.onAfterModelCall(event))
-    agent.addHook(AfterInvocationEvent, () => this.resetState())
+    this._attachedAgent = agent
+    agent.addHook(AfterModelCallEvent, (event) => this._onAfterModelCall(event))
+    agent.addHook(AfterInvocationEvent, () => this._resetState())
   }
 
-  private async onAfterModelCall(event: AfterModelCallEvent): Promise<void> {
+  private async _onAfterModelCall(event: AfterModelCallEvent): Promise<void> {
     // Another hook already requested retry — don't stack a second delay on top.
     if (event.retry) return
 
     // Success: reset state for the next model call in this invocation.
     if (event.error === undefined) {
-      this.resetState()
+      this._resetState()
       return
     }
 
-    if (!this.isRetryable(event.error)) return
+    if (!this._isRetryable(event.error)) return
 
-    // currentAttempt represents the attempt that just failed.
-    this.currentAttempt += 1
-    if (this.currentAttempt >= this.maxAttempts) {
+    // _currentAttempt represents the attempt that just failed.
+    this._currentAttempt += 1
+    if (this._currentAttempt >= this._maxAttempts) {
       logger.debug(
-        `current_attempt=<${this.currentAttempt}> max_attempts=<${this.maxAttempts}> | max retry attempts reached`
+        `current_attempt=<${this._currentAttempt}> max_attempts=<${this._maxAttempts}> | max retry attempts reached`
       )
       return
     }
 
-    if (this.firstFailureAt === undefined) {
-      this.firstFailureAt = Date.now()
+    if (this._firstFailureAt === undefined) {
+      this._firstFailureAt = Date.now()
     }
 
-    const delayMs = this.resolveBackoff(event.error).nextDelay(this.buildContext())
+    // Per-error-class backoff selection is a future extension; today every
+    // retryable error uses the single configured backoff.
+    const delayMs = this._backoff.nextDelay(this._buildContext())
 
     logger.debug(
-      `retry_delay_ms=<${delayMs}> attempt=<${this.currentAttempt}> max_attempts=<${this.maxAttempts}> ` +
+      `retry_delay_ms=<${delayMs}> attempt=<${this._currentAttempt}> max_attempts=<${this._maxAttempts}> ` +
         `| retryable model error, delaying before retry`
     )
 
     await sleep(delayMs)
 
-    this.lastDelayMs = delayMs
+    this._lastDelayMs = delayMs
     event.retry = true
   }
 
-  private buildContext(): BackoffContext {
+  private _buildContext(): BackoffContext {
     const ctx: BackoffContext = {
-      attempt: this.currentAttempt,
-      elapsedMs: this.firstFailureAt === undefined ? 0 : Date.now() - this.firstFailureAt,
+      attempt: this._currentAttempt,
+      elapsedMs: this._firstFailureAt === undefined ? 0 : Date.now() - this._firstFailureAt,
     }
-    if (this.lastDelayMs !== undefined) {
-      ctx.lastDelayMs = this.lastDelayMs
+    if (this._lastDelayMs !== undefined) {
+      ctx.lastDelayMs = this._lastDelayMs
     }
     return ctx
   }
 
-  /**
-   * Returns the backoff to use for a given error. Today this always returns
-   * the configured strategy; the indirection exists so a future per-error-type
-   * map can be layered in without changing the public API.
-   */
-  private resolveBackoff(_error: Error): BackoffStrategy {
-    return this.backoff
-  }
-
-  private isRetryable(error: Error): boolean {
+  private _isRetryable(error: Error): boolean {
     return error instanceof ModelThrottledError
   }
 
-  private resetState(): void {
-    this.currentAttempt = 0
-    this.lastDelayMs = undefined
-    this.firstFailureAt = undefined
+  private _resetState(): void {
+    this._currentAttempt = 0
+    this._lastDelayMs = undefined
+    this._firstFailureAt = undefined
   }
 }
 

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -1,149 +1,64 @@
 /**
- * Retry strategy for model invocations.
- *
- * Overrides {@link RetryStrategy.retryModel} to retry failed model calls.
- * Per-invocation state (attempt counters, timers) is cleared via
- * {@link RetryStrategy.reset}, which the base class calls on
- * {@link AfterInvocationEvent}.
+ * Abstract base class for retry strategies.
  */
 
-import type { AfterModelCallEvent } from '../hooks/events.js'
-import { ModelThrottledError } from '../errors.js'
-import { logger } from '../logging/logger.js'
-import type { BackoffContext, BackoffStrategy } from './backoff-strategy.js'
-import { ExponentialBackoff } from './backoff-strategy.js'
-import { RetryStrategy } from './retry-strategy.js'
-
-const DEFAULT_MAX_ATTEMPTS = 6
-const DEFAULT_BACKOFF_BASE_MS = 4_000
-const DEFAULT_BACKOFF_MAX_MS = 240_000
+import { AfterModelCallEvent } from '../hooks/events.js'
+import type { Plugin } from '../plugins/plugin.js'
+import type { LocalAgent } from '../types/agent.js'
 
 /**
- * Options for {@link ModelRetryStrategy}.
+ * Abstract base class for retry strategies.
+ *
+ * A {@link ModelRetryStrategy} is a {@link Plugin} that retries failed agent calls.
+ * {@link ModelRetryStrategy.retryModel} is abstract: every subclass must declare
+ * how it handles model failures (even if only as an empty method body).
+ *
+ * Future retry topics (e.g. `retryTool`) will be added as non-abstract
+ * methods with no-op defaults so that introducing a new topic does not
+ * break existing external `ModelRetryStrategy` subclasses.
+ *
+ * State scope: the base class does not define any turn- or invocation-level
+ * reset hook. The retried unit is a single turn (one {@link AfterModelCallEvent}),
+ * so any attempt counters or timers are owned by the subclass and cleared
+ * inside {@link ModelRetryStrategy.retryModel} — typically on the success
+ * branch and the non-retryable-error branch.
+ *
+ * Single-agent attachment: retry strategies typically carry per-turn state
+ * (attempt counters, timers), so sharing one instance across two agents
+ * would let their calls trample each other. The base class enforces this by
+ * remembering the first agent it's attached to and throwing on attempts to
+ * attach to a different one. Stateless strategies are unaffected (the guard
+ * only fires when the caller tries to share an instance across agents,
+ * regardless of whether that instance has state).
  */
-export interface ModelRetryStrategyOptions {
+export abstract class ModelRetryStrategy implements Plugin {
   /**
-   * Total model attempts before giving up and re-raising the error.
-   * Must be \>= 1. Default {@link DEFAULT_MAX_ATTEMPTS}.
+   * A stable string identifier for this retry strategy.
    */
-  maxAttempts?: number
+  abstract readonly name: string
+
+  private _attachedAgent: LocalAgent | undefined
+
   /**
-   * Backoff used to compute the delay between retries.
-   * Default: `new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })`.
+   * Handle a post-model-call event. Set `event.retry = true` (typically after
+   * an `await sleep(delayMs)`) to request that the agent re-invoke the model.
+   * Return without setting `event.retry` to let the error propagate.
+   *
+   * Subclasses that don't retry model calls should implement this as an
+   * empty method — the {@link AfterModelCallEvent} hook is registered by
+   * the base class regardless.
    */
-  backoff?: BackoffStrategy
-}
+  abstract retryModel(event: AfterModelCallEvent): void | Promise<void>
 
-/**
- * Retries failed model calls classified by the SDK as retryable.
- *
- * Today, only {@link ModelThrottledError} is treated as retryable. The set of
- * retryable errors may grow over time (e.g. transient server errors) without
- * requiring changes to this class's public API.
- *
- * State is per-invocation: the attempt counter and the last computed delay
- * reset on {@link AfterInvocationEvent}, and also after any successful model
- * call within an invocation.
- *
- * Hook precedence: {@link AfterModelCallEvent} fires hooks in reverse registration
- * order, so user-registered hooks run before this strategy. If a user hook sets
- * `event.retry = true` first, this strategy returns early and does not stack
- * additional backoff on top.
- *
- * Sharing: a given instance tracks its own attempt state and must not be shared
- * across multiple agents. Create a separate instance per agent.
- *
- * @example
- * ```ts
- * const agent = new Agent({
- *   model,
- *   retryStrategy: new ModelRetryStrategy({ maxAttempts: 4 }),
- * })
- * ```
- */
-export class ModelRetryStrategy extends RetryStrategy {
-  readonly name = 'strands:model-retry-strategy'
-
-  private readonly _maxAttempts: number
-  private readonly _backoff: BackoffStrategy
-
-  private _currentAttempt = 0
-  private _lastDelayMs: number | undefined
-  private _firstFailureAt: number | undefined
-
-  constructor(opts: ModelRetryStrategyOptions = {}) {
-    super()
-    const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
-    if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
-      throw new Error(`ModelRetryStrategy: maxAttempts must be an integer >= 1 (got ${maxAttempts})`)
-    }
-    this._maxAttempts = maxAttempts
-    this._backoff =
-      opts.backoff ?? new ExponentialBackoff({ baseMs: DEFAULT_BACKOFF_BASE_MS, maxMs: DEFAULT_BACKOFF_MAX_MS })
-  }
-
-  override async retryModel(event: AfterModelCallEvent): Promise<void> {
-    // Another hook already requested retry — don't stack a second delay on top.
-    if (event.retry) return
-
-    // Success: reset state for the next model call in this invocation.
-    if (event.error === undefined) {
-      this.reset()
-      return
-    }
-
-    if (!this._isRetryable(event.error)) return
-
-    // _currentAttempt represents the attempt that just failed.
-    this._currentAttempt += 1
-    if (this._currentAttempt >= this._maxAttempts) {
-      logger.debug(
-        `current_attempt=<${this._currentAttempt}> max_attempts=<${this._maxAttempts}> | max retry attempts reached`
+  initAgent(agent: LocalAgent): void {
+    if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
+      throw new Error(
+        `${this.constructor.name}: instance is already attached to another agent. ` +
+          'Create a separate instance per agent.'
       )
-      return
     }
+    this._attachedAgent = agent
 
-    if (this._firstFailureAt === undefined) {
-      this._firstFailureAt = Date.now()
-    }
-
-    // Per-error-class backoff selection is a future extension; today every
-    // retryable error uses the single configured backoff.
-    const delayMs = this._backoff.nextDelay(this._buildContext())
-
-    logger.debug(
-      `retry_delay_ms=<${delayMs}> attempt=<${this._currentAttempt}> max_attempts=<${this._maxAttempts}> ` +
-        `| retryable model error, delaying before retry`
-    )
-
-    await sleep(delayMs)
-
-    this._lastDelayMs = delayMs
-    event.retry = true
+    agent.addHook(AfterModelCallEvent, (event) => this.retryModel(event))
   }
-
-  private _buildContext(): BackoffContext {
-    const ctx: BackoffContext = {
-      attempt: this._currentAttempt,
-      elapsedMs: this._firstFailureAt === undefined ? 0 : Date.now() - this._firstFailureAt,
-    }
-    if (this._lastDelayMs !== undefined) {
-      ctx.lastDelayMs = this._lastDelayMs
-    }
-    return ctx
-  }
-
-  private _isRetryable(error: Error): boolean {
-    return error instanceof ModelThrottledError
-  }
-
-  protected override reset(): void {
-    this._currentAttempt = 0
-    this._lastDelayMs = undefined
-    this._firstFailureAt = undefined
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
 }

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -7,29 +7,25 @@ import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
 
 /**
- * Abstract base class for retry strategies.
+ * Abstract base class for model-retry strategies.
  *
- * A {@link ModelRetryStrategy} is a {@link Plugin} that retries failed agent calls.
- * {@link ModelRetryStrategy.retryModel} is abstract: every subclass must declare
- * how it handles model failures (even if only as an empty method body).
+ * A {@link ModelRetryStrategy} is a {@link Plugin} that retries failed model
+ * calls. {@link ModelRetryStrategy.retryModel} is abstract: every subclass
+ * must declare how it handles model failures (even if only as an empty method
+ * body). The method receives every `AfterModelCallEvent`, success or failure.
  *
- * Future retry topics (e.g. `retryTool`) will be added as non-abstract
- * methods with no-op defaults so that introducing a new topic does not
- * break existing external `ModelRetryStrategy` subclasses.
+ * Other retry kinds (e.g. tool retries) will land as *sibling* abstract
+ * classes, not as additional methods on this one — different retry kinds
+ * have different unit-of-work boundaries and don't share a single reset
+ * contract.
  *
- * State scope: the base class does not define any turn- or invocation-level
- * reset hook. The retried unit is a single turn (one {@link AfterModelCallEvent}),
- * so any attempt counters or timers are owned by the subclass and cleared
- * inside {@link ModelRetryStrategy.retryModel} — typically on the success
- * branch and the non-retryable-error branch.
+ * State scope: the base class does not define any reset hook. Per-turn
+ * state ownership lives in the subclass; {@link DefaultModelRetryStrategy}
+ * uses `event.attemptCount === 1` as its turn boundary.
  *
- * Single-agent attachment: retry strategies typically carry per-turn state
- * (attempt counters, timers), so sharing one instance across two agents
- * would let their calls trample each other. The base class enforces this by
- * remembering the first agent it's attached to and throwing on attempts to
- * attach to a different one. Stateless strategies are unaffected (the guard
- * only fires when the caller tries to share an instance across agents,
- * regardless of whether that instance has state).
+ * Single-agent attachment: instances typically carry per-turn state, so
+ * sharing one instance across agents would let their calls trample each
+ * other. The base class throws on attempts to attach to a different agent.
  */
 export abstract class ModelRetryStrategy implements Plugin {
   /**
@@ -40,9 +36,15 @@ export abstract class ModelRetryStrategy implements Plugin {
   private _attachedAgent: LocalAgent | undefined
 
   /**
-   * Handle a post-model-call event. Set `event.retry = true` (typically after
-   * an `await sleep(delayMs)`) to request that the agent re-invoke the model.
-   * Return without setting `event.retry` to let the error propagate.
+   * Handle a post-model-call event. Fires for **every** {@link AfterModelCallEvent},
+   * including successful completions (where `event.error` is undefined) — this
+   * lets stateful subclasses use the success path as a turn-boundary signal
+   * (e.g. to reset per-turn backoff state). Error events pass through the
+   * same method; implementations typically branch on `event.error`.
+   *
+   * To request a retry, set `event.retry = true` (typically after an
+   * `await sleep(delayMs)`). Returning without setting `event.retry` lets
+   * the error propagate normally.
    *
    * Subclasses that don't retry model calls should implement this as an
    * empty method — the {@link AfterModelCallEvent} hook is registered by

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -1,27 +1,30 @@
 /**
- * Abstract base class for retry strategies.
+ * Abstract base class for model-retry strategies.
  */
 
 import { AfterModelCallEvent } from '../hooks/events.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
+import type { RetryDecision } from './retry-strategy.js'
 
 /**
  * Abstract base class for model-retry strategies.
  *
  * A {@link ModelRetryStrategy} is a {@link Plugin} that retries failed model
- * calls. {@link ModelRetryStrategy.retryModel} is abstract: every subclass
- * must declare how it handles model failures (even if only as an empty method
- * body). The method receives every `AfterModelCallEvent`, success or failure.
+ * calls. Subclasses implement {@link computeRetryDecision} to answer *whether* to retry
+ * and *how long* to wait; the base class orchestrates the rest:
+ *
+ * 1. Short-circuits if another hook already set `event.retry` (no stacked delay).
+ * 2. Short-circuits on success events (`event.error === undefined`).
+ * 3. Calls {@link onFirstModelAttempt} on turn boundaries (`event.attemptCount === 1`),
+ *    letting stateful subclasses clear per-turn state.
+ * 4. Invokes {@link computeRetryDecision}; on `retry: true`, sleeps for `waitMs` then
+ *    sets `event.retry = true`.
  *
  * Other retry kinds (e.g. tool retries) will land as *sibling* abstract
  * classes, not as additional methods on this one — different retry kinds
- * have different unit-of-work boundaries and don't share a single reset
+ * have different unit-of-work boundaries and don't share a single state
  * contract.
- *
- * State scope: the base class does not define any reset hook. Per-turn
- * state ownership lives in the subclass; {@link DefaultModelRetryStrategy}
- * uses `event.attemptCount === 1` as its turn boundary.
  *
  * Single-agent attachment: instances typically carry per-turn state, so
  * sharing one instance across agents would let their calls trample each
@@ -36,21 +39,50 @@ export abstract class ModelRetryStrategy implements Plugin {
   private _attachedAgent: LocalAgent | undefined
 
   /**
-   * Handle a post-model-call event. Fires for **every** {@link AfterModelCallEvent},
-   * including successful completions (where `event.error` is undefined) — this
-   * lets stateful subclasses use the success path as a turn-boundary signal
-   * (e.g. to reset per-turn backoff state). Error events pass through the
-   * same method; implementations typically branch on `event.error`.
+   * Decide whether to retry the failed model call, and how long to wait first.
    *
-   * To request a retry, set `event.retry = true` (typically after an
-   * `await sleep(delayMs)`). Returning without setting `event.retry` lets
-   * the error propagate normally.
+   * Called only for error events that have not already been marked for retry
+   * by another hook. The base class has already filtered out successes and
+   * short-circuited events where `event.retry` is true, so implementations
+   * only need to reason about `event.error`.
    *
-   * Subclasses that don't retry model calls should implement this as an
-   * empty method — the {@link AfterModelCallEvent} hook is registered by
-   * the base class regardless.
+   * Return `{ retry: false }` to let the error propagate. Return
+   * `{ retry: true, waitMs }` to retry after sleeping for `waitMs`
+   * milliseconds.
    */
-  abstract retryModel(event: AfterModelCallEvent): void | Promise<void>
+  protected abstract computeRetryDecision(event: AfterModelCallEvent): RetryDecision | Promise<RetryDecision>
+
+  /**
+   * Called when `event.attemptCount === 1`, i.e. at the start of a fresh
+   * turn. Subclasses with per-turn state override this to clear it; the
+   * default is a no-op.
+   *
+   * The agent loop guarantees `attemptCount === 1` on every new turn, so
+   * this is a reliable turn-boundary signal.
+   */
+  protected onFirstModelAttempt(): void {}
+
+  /**
+   * @internal
+   * Hook callback invoked by the agent on every {@link AfterModelCallEvent}.
+   * Subclasses should override {@link computeRetryDecision} or
+   * {@link onFirstModelAttempt} instead of this method.
+   */
+  async retryModel(event: AfterModelCallEvent): Promise<void> {
+    // Fire the turn-boundary signal before any short-circuit so per-turn state
+    // always clears at the start of a new turn, even if a user hook already
+    // set event.retry on attempt 1.
+    if (event.attemptCount === 1) this.onFirstModelAttempt()
+
+    if (event.retry) return
+    if (event.error === undefined) return
+
+    const decision = await this.computeRetryDecision(event)
+    if (!decision.retry) return
+
+    await sleep(decision.waitMs)
+    event.retry = true
+  }
 
   initAgent(agent: LocalAgent): void {
     if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
@@ -63,4 +95,8 @@ export abstract class ModelRetryStrategy implements Plugin {
 
     agent.addHook(AfterModelCallEvent, (event) => this.retryModel(event))
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
 }

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -84,6 +84,18 @@ export abstract class ModelRetryStrategy implements Plugin {
     event.retry = true
   }
 
+  /**
+   * Initialize the retry strategy with the agent instance.
+   *
+   * Enforces the single-agent attachment guard and registers the
+   * {@link AfterModelCallEvent} hook that drives retry orchestration.
+   *
+   * Subclasses that override this method MUST call `super.initAgent(agent)`
+   * to preserve the attachment guard and hook registration. Additional
+   * hooks may be registered after the `super` call.
+   *
+   * @param agent - The agent to register hooks with
+   */
   initAgent(agent: LocalAgent): void {
     if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
       throw new Error(

--- a/strands-ts/src/retry/retry-strategy.ts
+++ b/strands-ts/src/retry/retry-strategy.ts
@@ -1,0 +1,85 @@
+/**
+ * Abstract base class for retry strategies.
+ */
+
+import { AfterInvocationEvent, AfterModelCallEvent } from '../hooks/events.js'
+import type { Plugin } from '../plugins/plugin.js'
+import type { LocalAgent } from '../types/agent.js'
+
+/**
+ * Abstract base class for retry strategies.
+ *
+ * A {@link RetryStrategy} is a {@link Plugin} that retries failed agent calls.
+ * {@link RetryStrategy.retryModel} is abstract: every subclass must declare
+ * how it handles model failures (even if only as an empty method body).
+ *
+ * Future retry topics (e.g. `retryTool`) will be added as non-abstract
+ * methods with no-op defaults so that introducing a new topic does not
+ * break existing external `RetryStrategy` subclasses.
+ *
+ * State reset: the base class registers `AfterInvocationEvent` and calls
+ * {@link RetryStrategy.reset} so subclasses get a clean-slate hook at every
+ * invocation boundary without re-implementing hook wiring. Subclasses with
+ * state override `reset` (and typically call `super.reset()`).
+ *
+ * Single-agent attachment: retry strategies typically carry per-invocation
+ * state (attempt counters, timers), so sharing one instance across two
+ * agents would let their invocations trample each other. The base class
+ * enforces this by remembering the first agent it's attached to and
+ * throwing on attempts to attach to a different one. Stateless strategies
+ * are unaffected (the guard only fires when the caller tries to share an
+ * instance across agents, regardless of whether that instance has state).
+ *
+ * @example
+ * ```typescript
+ * class MyRetryStrategy extends ModelRetryStrategy {
+ *   private _toolAttempts = 0
+ *   override async retryTool(event: AfterToolCallEvent): Promise<void> {
+ *     // custom tool retry logic
+ *   }
+ *   protected override reset(): void {
+ *     super.reset()
+ *     this._toolAttempts = 0
+ *   }
+ * }
+ * ```
+ */
+export abstract class RetryStrategy implements Plugin {
+  /**
+   * A stable string identifier for this retry strategy.
+   */
+  abstract readonly name: string
+
+  private _attachedAgent: LocalAgent | undefined
+
+  /**
+   * Handle a post-model-call event. Set `event.retry = true` (typically after
+   * an `await sleep(delayMs)`) to request that the agent re-invoke the model.
+   * Return without setting `event.retry` to let the error propagate.
+   *
+   * Subclasses that don't retry model calls should implement this as an
+   * empty method — the {@link AfterModelCallEvent} hook is registered by
+   * the base class regardless.
+   */
+  abstract retryModel(event: AfterModelCallEvent): void | Promise<void>
+
+  /**
+   * Reset any per-invocation state. Called on {@link AfterInvocationEvent}.
+   * Subclasses with attempt counters or timers should override and clear
+   * their state here (typically calling `super.reset()` first).
+   */
+  protected reset(): void {}
+
+  initAgent(agent: LocalAgent): void {
+    if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
+      throw new Error(
+        `${this.constructor.name}: instance is already attached to another agent. ` +
+          'Create a separate instance per agent.'
+      )
+    }
+    this._attachedAgent = agent
+
+    agent.addHook(AfterModelCallEvent, (event) => this.retryModel(event))
+    agent.addHook(AfterInvocationEvent, () => this.reset())
+  }
+}

--- a/strands-ts/src/retry/retry-strategy.ts
+++ b/strands-ts/src/retry/retry-strategy.ts
@@ -1,5 +1,5 @@
 /**
- * Union type for all retry strategies accepted by the agent.
+ * Shared retry primitives.
  */
 
 import { logger } from '../logging/logger.js'
@@ -11,6 +11,18 @@ import type { ModelRetryStrategy } from './model-retry-strategy.js'
 // Today this only admits model retries. Future retry kinds (e.g. tool retries)
 // will be added as additional arms of this union.
 export type RetryStrategy = ModelRetryStrategy
+
+/**
+ * Decision returned by a retry strategy's per-event `compute*RetryDecision` method.
+ *
+ * Discriminated union: `retry: true` carries the wait duration the framework
+ * will sleep for before re-invoking the failed operation. `retry: false`
+ * carries nothing — the error propagates to the caller.
+ *
+ * Shared across retry kinds (model retries today; tool retries and others
+ * later) so all strategies speak the same decision shape.
+ */
+export type RetryDecision = { retry: false } | { retry: true; waitMs: number }
 
 /**
  * Emit a warning for each duplicate-type retry strategy in the list.

--- a/strands-ts/src/retry/retry-strategy.ts
+++ b/strands-ts/src/retry/retry-strategy.ts
@@ -1,85 +1,33 @@
 /**
- * Abstract base class for retry strategies.
+ * Union type for all retry strategies accepted by the agent.
  */
 
-import { AfterInvocationEvent, AfterModelCallEvent } from '../hooks/events.js'
-import type { Plugin } from '../plugins/plugin.js'
-import type { LocalAgent } from '../types/agent.js'
+import { logger } from '../logging/logger.js'
+import type { ModelRetryStrategy } from './model-retry-strategy.js'
 
 /**
- * Abstract base class for retry strategies.
- *
- * A {@link RetryStrategy} is a {@link Plugin} that retries failed agent calls.
- * {@link RetryStrategy.retryModel} is abstract: every subclass must declare
- * how it handles model failures (even if only as an empty method body).
- *
- * Future retry topics (e.g. `retryTool`) will be added as non-abstract
- * methods with no-op defaults so that introducing a new topic does not
- * break existing external `RetryStrategy` subclasses.
- *
- * State reset: the base class registers `AfterInvocationEvent` and calls
- * {@link RetryStrategy.reset} so subclasses get a clean-slate hook at every
- * invocation boundary without re-implementing hook wiring. Subclasses with
- * state override `reset` (and typically call `super.reset()`).
- *
- * Single-agent attachment: retry strategies typically carry per-invocation
- * state (attempt counters, timers), so sharing one instance across two
- * agents would let their invocations trample each other. The base class
- * enforces this by remembering the first agent it's attached to and
- * throwing on attempts to attach to a different one. Stateless strategies
- * are unaffected (the guard only fires when the caller tries to share an
- * instance across agents, regardless of whether that instance has state).
- *
- * @example
- * ```typescript
- * class MyRetryStrategy extends ModelRetryStrategy {
- *   private _toolAttempts = 0
- *   override async retryTool(event: AfterToolCallEvent): Promise<void> {
- *     // custom tool retry logic
- *   }
- *   protected override reset(): void {
- *     super.reset()
- *     this._toolAttempts = 0
- *   }
- * }
- * ```
+ * Any retry strategy accepted by the agent.
  */
-export abstract class RetryStrategy implements Plugin {
-  /**
-   * A stable string identifier for this retry strategy.
-   */
-  abstract readonly name: string
+// Today this only admits model retries. Future retry kinds (e.g. tool retries)
+// will be added as additional arms of this union.
+export type RetryStrategy = ModelRetryStrategy
 
-  private _attachedAgent: LocalAgent | undefined
-
-  /**
-   * Handle a post-model-call event. Set `event.retry = true` (typically after
-   * an `await sleep(delayMs)`) to request that the agent re-invoke the model.
-   * Return without setting `event.retry` to let the error propagate.
-   *
-   * Subclasses that don't retry model calls should implement this as an
-   * empty method — the {@link AfterModelCallEvent} hook is registered by
-   * the base class regardless.
-   */
-  abstract retryModel(event: AfterModelCallEvent): void | Promise<void>
-
-  /**
-   * Reset any per-invocation state. Called on {@link AfterInvocationEvent}.
-   * Subclasses with attempt counters or timers should override and clear
-   * their state here (typically calling `super.reset()` first).
-   */
-  protected reset(): void {}
-
-  initAgent(agent: LocalAgent): void {
-    if (this._attachedAgent !== undefined && this._attachedAgent !== agent) {
-      throw new Error(
-        `${this.constructor.name}: instance is already attached to another agent. ` +
-          'Create a separate instance per agent.'
-      )
+/**
+ * Emit a warning for each duplicate-type retry strategy in the list.
+ *
+ * Two strategies of the same concrete class share the same `plugin.name`
+ * and would otherwise collide in the plugin registry. This is a warning,
+ * not an error — the caller decides how to handle duplicates (e.g. keep
+ * the first, drop the rest).
+ */
+export function warnOnDuplicateRetryStrategyTypes(strategies: readonly RetryStrategy[]): void {
+  const seen = new Set<new (...args: never[]) => RetryStrategy>()
+  for (const strategy of strategies) {
+    const ctor = strategy.constructor as new (...args: never[]) => RetryStrategy
+    if (seen.has(ctor)) {
+      logger.warn(`retry_strategy_type=<${ctor.name}> | multiple instances provided; only the first will be used`)
+    } else {
+      seen.add(ctor)
     }
-    this._attachedAgent = agent
-
-    agent.addHook(AfterModelCallEvent, (event) => this.retryModel(event))
-    agent.addHook(AfterInvocationEvent, () => this.reset())
   }
 }


### PR DESCRIPTION
## Description

Adds automatic retry for failed model calls, default-on. Every provider in this SDK already normalizes rate-limit signals into `ModelThrottledError` (Anthropic 429, OpenAI 429 / `rate_limit_exceeded`, Bedrock `throttlingException`, Vercel 429, Google `RESOURCE_EXHAUSTED` / `UNAVAILABLE`), but the agent loop re-throws and users are left to wire their own `AfterModelCallEvent` hook with their own backoff math. The Python SDK ships retries by default; TS did not. This PR closes that gap.

The work is split into four reusable pieces:

1. **`BackoffStrategy` interface** with `ConstantBackoff`, `LinearBackoff`, and `ExponentialBackoff` implementations — pure delay math, no retry policy. Supports four jitter modes (`none`, `full`, `equal`, `decorrelated`). `BackoffContext` is documented as an additive-only contract so new signals (e.g. `retryAfterMs`) can be added later without breaking existing strategies.

2. **`ModelRetryStrategy`** — an abstract `Plugin` base class, one-per-retry-kind. Owns `AfterModelCallEvent` hook registration and a single-agent attachment guard (instances carry per-turn state, so sharing across agents would let calls trample each other). Declares a single abstract method `retryModel(event)` that subclasses implement. No `reset()` contract — state scope is owned entirely by the subclass.

3. **`DefaultModelRetryStrategy extends ModelRetryStrategy`** — the default concrete strategy. Implements `retryModel` to drive the existing `event.retry` flow in `_invokeModel`, reading the attempt counter off `AfterModelCallEvent.attemptCount` (new — see below). Retries are gated by a private `_isRetryable(err)` check (today: `ModelThrottledError` only) and dispatched through the single configured backoff. Both are the forward-compatible extension points for adding transient-error classification or per-error-class backoff selection without a public API change. Per-turn backoff state (`_firstFailureAt`, `_lastDelayMs`) is cleared on `event.attemptCount === 1`, which the agent loop guarantees on every fresh turn.

4. **`AfterModelCallEvent.attemptCount`** — new readonly 1-indexed field on the event. The first call in a turn is `1`; each subsequent retry increments by one. The agent loop in `_invokeModel` is the single owner of this counter, so every `ModelRetryStrategy` subclass sees a consistent attempt number regardless of how many strategies are registered. Retry strategies can rely on `attemptCount === 1` as a turn-boundary marker.

## Pattern Going Forward

Each new type of retry will get its own abstract base class. The agent instance itself takes on a list of retry strategies. The type retry strategy gets an additional `|` union member for each new type. So, we get additive, combinable, and fully customizable retry strategies.

### Public API

One new field on `AgentConfig`:

```typescript
// Before: throttling failures propagate unless the user registers a retry hook.
const agent = new Agent({ model })

// After: default-on retry with sensible exponential backoff
// (6 attempts, baseMs=4s, maxMs=240s, full jitter).
const agent = new Agent({ model })

// Tune the default strategy
const agent = new Agent({
  model,
  retryStrategy: new DefaultModelRetryStrategy({
    maxAttempts: 4,
    backoff: new ExponentialBackoff({ baseMs: 500, maxMs: 60_000, jitter: 'full' }),
  }),
})

// Opt out entirely — no retry plugin is registered. (`null` signifies no strategy)
const agent = new Agent({ model, retryStrategy: null })
```

The field is typed `retryStrategy?: RetryStrategy | RetryStrategy[] | null`. Today `RetryStrategy` is a type alias for `ModelRetryStrategy` — a union that will grow arms (e.g. `| ToolRetryStrategy`) as new retry kinds are added.

Four-state on purpose:
- **Omitted** installs the default `DefaultModelRetryStrategy`.
- **A single `RetryStrategy` instance** registers that instance.
- **An array** registers all strategies in the given order. Passing two instances of the same concrete class logs a warning via `warnOnDuplicateRetryStrategyTypes` — they would collide on `plugin.name` in the plugin registry.
- **`null` or `[]`** explicitly disables retry. `null` is preferred over sentinel values like `maxAttempts: 1` because it reads as intent, not a workaround.

The array form is intentional: once future retry kinds (tool retries, etc.) land as sibling abstract classes, composing "default model retry + custom tool retry" becomes `retryStrategy: [new DefaultModelRetryStrategy(), new MyToolRetryStrategy()]` rather than requiring one subclass to own both topics.

Retry-strategy registration ordering is not load-bearing for correctness: `DefaultModelRetryStrategy` guards on `event.retry`, so a hook that already set it short-circuits the strategy regardless of registration order.

New exports from the top-level index: `RetryStrategy` (type), `ModelRetryStrategy` (abstract class), `DefaultModelRetryStrategy`, `DefaultModelRetryStrategyOptions`, `BackoffStrategy`, `BackoffContext`, `JitterKind`, `ConstantBackoff`, `ConstantBackoffOptions`, `LinearBackoff`, `LinearBackoffOptions`, `ExponentialBackoff`, `ExponentialBackoffOptions`.

No changes to any provider module. The only change to `_invokeModel` is threading the new `attemptCount` value onto each `AfterModelCallEvent`; the retry dispatch still flows through the existing `event.retry` flag. `AfterModelCallEvent` is a reverse-callback event, so user-registered `AfterModelCallEvent` hooks run **before** this strategy — a user hook that sets `event.retry = true` short-circuits the default strategy and no extra delay is stacked.

### How this scales to future retry topics

When a future topic like tool retries lands, it's a new **sibling abstract class**, not a method added to `ModelRetryStrategy`. Different retry kinds have different units of work and different turn boundaries; collapsing them into one class would force a shared reset contract that doesn't match either kind cleanly.

```ts
// Future sibling abstract class — not part of this PR.
export abstract class ToolRetryStrategy implements Plugin {
  abstract readonly name: string
  abstract retryTool(event: AfterToolCallEvent): void | Promise<void>

  initAgent(agent: LocalAgent): void {
    // ... attachment guard, hook registration for AfterToolCallEvent ...
  }
}

// The union grows an arm; existing subclasses and the config field are unchanged.
export type RetryStrategy = ModelRetryStrategy | ToolRetryStrategy
```

`DefaultModelRetryStrategy` is untouched when this lands.

The two common user stories:

**Extend `DefaultModelRetryStrategy`** — keep the default policy (throttled-error classification, attempt-based gating, per-turn state reset) and tweak one piece:

```ts
class MyModelRetries extends DefaultModelRetryStrategy {
  override readonly name = 'my:model-retries'
  // Override retryModel / _isRetryable / etc. as needed.
}
```

**Fully custom** — subclass `ModelRetryStrategy` directly and own `retryModel` end to end:

```ts
class FullCustomModelRetries extends ModelRetryStrategy {
  readonly name = 'my:full-custom'
  override async retryModel(event: AfterModelCallEvent) {
    // Own attempt-count interpretation, classification, backoff dispatch.
    // Use event.attemptCount === 1 as the turn boundary if you need per-turn state.
  }
}
```

Either subclass inherits the single-agent attachment guard and the `AfterModelCallEvent` hook registration from `ModelRetryStrategy` for free.

### Behavior Change

Agents now retry `ModelThrottledError` by default (6 attempts, exponential backoff with `baseMs=4s`, `maxMs=240s`, full jitter). Callers that relied on immediate propagation of `ModelThrottledError` can restore prior behavior with `retryStrategy: null`.

```typescript
// Before
const agent = new Agent({ model })
// ModelThrottledError propagates immediately on throttling

// After (equivalent behavior)
const agent = new Agent({ model, retryStrategy: null })
```

## Related Issues

Resolves: #472

## Documentation PR

will follow up

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
