### PR TITLE
feat: estimate input tokens before model calls

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -43,7 +43,9 @@ describe('Agent Hooks Integration', () => {
       expect(lifecyclePlugin.invocations[2]).toEqual(
         new MessageAddedEvent({ agent, message: new Message({ role: 'user', content: [new TextBlock('Hi')] }) })
       )
-      expect(lifecyclePlugin.invocations[3]).toEqual(new BeforeModelCallEvent({ agent, model: agent.model }))
+      expect(lifecyclePlugin.invocations[3]).toEqual(
+        new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: expect.any(Number) as number })
+      )
       expect(lifecyclePlugin.invocations[4]).toEqual(
         new AfterModelCallEvent({
           agent,
@@ -80,7 +82,9 @@ describe('Agent Hooks Integration', () => {
           message: new Message({ role: 'user', content: [new TextBlock('Hi')] }),
         })
       )
-      expect(lifecyclePlugin.invocations[3]).toEqual(new BeforeModelCallEvent({ agent, model: agent.model }))
+      expect(lifecyclePlugin.invocations[3]).toEqual(
+        new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: expect.any(Number) as number })
+      )
       expect(lifecyclePlugin.invocations[4]).toEqual(
         new AfterModelCallEvent({
           agent,

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -24,6 +24,7 @@ import {
   AfterToolCallEvent,
   AfterToolsEvent,
   BeforeInvocationEvent,
+  BeforeModelCallEvent,
   BeforeToolsEvent,
 } from '../../hooks/events.js'
 import { BedrockModel } from '../../models/bedrock.js'
@@ -1592,5 +1593,127 @@ describe('Agent._redactLastMessage', () => {
 
     expect(() => agent['_redactLastMessage'](redactMessage)).not.toThrow()
     expect(agent['messages']).toHaveLength(0)
+  })
+})
+
+describe('_estimateInputTokens', () => {
+  function captureProjectedTokens(agent: Agent): Promise<number | undefined> {
+    return new Promise((resolve) => {
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        resolve(event.projectedInputTokens)
+      })
+    })
+  }
+
+  it('uses full estimation on cold start (no prior usage metadata)', async () => {
+    const model = new MockMessageModel()
+    model.addTurn({ type: 'textBlock', text: 'Hello' })
+    const countTokensSpy = vi.spyOn(model, 'countTokens')
+    countTokensSpy.mockResolvedValue(42)
+
+    const agent = new Agent({ model, printer: false })
+    const tokenPromise = captureProjectedTokens(agent)
+    await agent.invoke('Hi')
+
+    expect(await tokenPromise).toBe(42)
+    expect(countTokensSpy).toHaveBeenCalledWith(expect.any(Array), expect.any(Object))
+  })
+
+  it('uses known baseline when no new messages after last assistant', async () => {
+    const model = new MockMessageModel()
+    model.addTurn({ type: 'textBlock', text: 'Hello' })
+
+    const agent = new Agent({
+      model,
+      printer: false,
+      messages: [
+        new Message({ role: 'user', content: [new TextBlock('Hi')] }),
+        new Message({
+          role: 'assistant',
+          content: [new TextBlock('Hello')],
+          metadata: { usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 } },
+        }),
+      ],
+    })
+
+    // Invoke with no args — no new user message appended, so the last assistant
+    // message is still the final message and newMessages.length === 0
+    const tokenPromise = captureProjectedTokens(agent)
+    await agent.invoke([])
+
+    // baseline = inputTokens(100) + outputTokens(20) = 120
+    expect(await tokenPromise).toBe(120)
+  })
+
+  it('returns undefined projectedInputTokens when estimation fails', async () => {
+    const model = new MockMessageModel()
+    model.addTurn({ type: 'textBlock', text: 'Hello' })
+    vi.spyOn(model, 'countTokens').mockRejectedValue(new Error('API unavailable'))
+
+    const agent = new Agent({ model, printer: false })
+    const tokenPromise = captureProjectedTokens(agent)
+    await agent.invoke('Hi')
+
+    expect(await tokenPromise).toBeUndefined()
+  })
+
+  it('estimates delta for new messages after last assistant', async () => {
+    const model = new MockMessageModel()
+    model
+      .addTurn([{ type: 'toolUseBlock', name: 'test', toolUseId: 'id-1', input: {} }], {
+        usage: { inputTokens: 100, outputTokens: 30, totalTokens: 130 },
+      })
+      .addTurn({ type: 'textBlock', text: 'Done' })
+    const countTokensSpy = vi.spyOn(model, 'countTokens')
+    countTokensSpy.mockResolvedValue(50)
+
+    const tool = createMockTool(
+      'test',
+      () =>
+        new ToolResultBlock({
+          toolUseId: 'id-1',
+          status: 'success' as const,
+          content: [new TextBlock('result')],
+        })
+    )
+    const agent = new Agent({ model, tools: [tool], printer: false })
+
+    // Capture the second BeforeModelCallEvent (after tool execution)
+    let callCount = 0
+    const tokenPromise = new Promise<number | undefined>((resolve) => {
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        callCount++
+        if (callCount === 2) resolve(event.projectedInputTokens)
+      })
+    })
+
+    await agent.invoke('Use the tool')
+
+    // baseline (100+30) + estimated delta (50) = 180
+    expect(await tokenPromise).toBe(180)
+    expect(countTokensSpy).toHaveBeenCalled()
+  })
+
+  it('uses baseline from prior invocation on second invoke', async () => {
+    const model = new MockMessageModel()
+    model
+      .addTurn(
+        { type: 'textBlock', text: 'First response' },
+        { usage: { inputTokens: 200, outputTokens: 50, totalTokens: 250 } }
+      )
+      .addTurn({ type: 'textBlock', text: 'Second response' })
+    const countTokensSpy = vi.spyOn(model, 'countTokens')
+    countTokensSpy.mockResolvedValue(15)
+
+    const agent = new Agent({ model, printer: false })
+    await agent.invoke('First question')
+
+    // Second invocation — the user message "Second question" is appended after
+    // the assistant message with usage metadata, so it hits the baseline + delta path
+    const tokenPromise = captureProjectedTokens(agent)
+    await agent.invoke('Second question')
+
+    // baseline (200+50) + estimated delta for new user message (15) = 265
+    expect(await tokenPromise).toBe(265)
   })
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -609,9 +609,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     if (beforeInvocationEvent.cancel) {
       const cancelText =
-        typeof beforeInvocationEvent.cancel === 'string'
-          ? beforeInvocationEvent.cancel
-          : 'invocation denied by hook'
+        typeof beforeInvocationEvent.cancel === 'string' ? beforeInvocationEvent.cancel : 'invocation denied by hook'
       const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
       yield this._appendMessage(message)
       yield new AfterInvocationEvent({ agent: this })
@@ -913,14 +911,24 @@ export class Agent implements LocalAgent, InvokableAgent {
       streamOptions.toolChoice = toolChoice
     }
 
-    const beforeModelCallEvent = new BeforeModelCallEvent({ agent: this, model: this.model })
+    // Estimate input tokens for the upcoming model call (non-fatal if estimation fails)
+    let projectedInputTokens: number | undefined
+    try {
+      projectedInputTokens = await this._estimateInputTokens(streamOptions)
+    } catch (e) {
+      logger.debug(`error=<${e}> | token estimation failed, proceeding without estimate`)
+    }
+
+    const beforeModelCallEvent = new BeforeModelCallEvent({
+      agent: this,
+      model: this.model,
+      ...(projectedInputTokens !== undefined && { projectedInputTokens }),
+    })
     yield beforeModelCallEvent
 
     if (beforeModelCallEvent.cancel) {
       const cancelText =
-        typeof beforeModelCallEvent.cancel === 'string'
-          ? beforeModelCallEvent.cancel
-          : 'model call denied by hook'
+        typeof beforeModelCallEvent.cancel === 'string' ? beforeModelCallEvent.cancel : 'model call denied by hook'
       const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
       const stopData: ModelStopData = { message, stopReason: 'endTurn' }
       const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, stopData })
@@ -1313,6 +1321,48 @@ export class Agent implements LocalAgent, InvokableAgent {
         )
       }
     }
+  }
+
+  /**
+   * Estimate the input token count for the next model call.
+   *
+   * Uses the token counting strategy: reads inputTokens + outputTokens
+   * from the last assistant message's metadata as a known baseline, then estimates
+   * only new messages added after it. Falls back to full estimation when no metadata
+   * is available (cold start or first call).
+   *
+   * @param streamOptions - The stream options containing system prompt and tool specs
+   * @returns Estimated input token count
+   */
+  private async _estimateInputTokens(streamOptions: StreamOptions): Promise<number> {
+    // Find the last assistant message with usage metadata
+    let lastAssistantIdx = -1
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      if (this.messages[i]!.role === 'assistant' && this.messages[i]!.metadata?.usage) {
+        lastAssistantIdx = i
+        break
+      }
+    }
+
+    let estimate: number
+    if (lastAssistantIdx >= 0) {
+      const usage = this.messages[lastAssistantIdx]!.metadata!.usage!
+      const knownBaseline = usage.inputTokens + usage.outputTokens
+      const newMessages = this.messages.slice(lastAssistantIdx + 1)
+      if (newMessages.length === 0) {
+        estimate = knownBaseline
+      } else {
+        // System prompt and tool spec tokens are already included in the baseline from the prior model call
+        estimate = knownBaseline + (await this.model.countTokens(newMessages))
+      }
+    } else {
+      estimate = await this.model.countTokens(this.messages, {
+        ...(streamOptions.systemPrompt !== undefined && { systemPrompt: streamOptions.systemPrompt }),
+        ...(streamOptions.toolSpecs !== undefined && { toolSpecs: streamOptions.toolSpecs }),
+      })
+    }
+
+    return estimate
   }
 
   /**

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -340,6 +340,31 @@ describe('BeforeModelCallEvent', () => {
     event.agent = new Agent()
   })
 
+  it('includes projectedInputTokens when provided', () => {
+    const agent = new Agent()
+    const event = new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: 500 })
+
+    expect(event).toEqual({
+      type: 'beforeModelCallEvent',
+      agent,
+      model: agent.model,
+      cancel: false,
+      projectedInputTokens: 500,
+    })
+    expect(event.toJSON()).toStrictEqual({
+      type: 'beforeModelCallEvent',
+      projectedInputTokens: 500,
+    })
+  })
+
+  it('excludes projectedInputTokens from toJSON when not provided', () => {
+    const agent = new Agent()
+    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+
+    expect(event.projectedInputTokens).toBeUndefined()
+    expect(event.toJSON()).toStrictEqual({ type: 'beforeModelCallEvent' })
+  })
+
   it('returns false for _shouldReverseCallbacks', () => {
     const agent = new Agent()
     const event = new BeforeModelCallEvent({ agent, model: agent.model })
@@ -1002,7 +1027,10 @@ describe('toJSON serialization completeness', () => {
       { name: 'InitializedEvent', event: new InitializedEvent({ agent }) },
       { name: 'BeforeInvocationEvent', event: new BeforeInvocationEvent({ agent }) },
       { name: 'AfterInvocationEvent', event: new AfterInvocationEvent({ agent }) },
-      { name: 'BeforeModelCallEvent', event: new BeforeModelCallEvent({ agent, model: agent.model }) },
+      {
+        name: 'BeforeModelCallEvent',
+        event: new BeforeModelCallEvent({ agent, model: agent.model, projectedInputTokens: 100 }),
+      },
       {
         name: 'AfterModelCallEvent',
         event: Object.assign(new AfterModelCallEvent({ agent, model: agent.model, stopData, error }), { retry: true }),

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -304,18 +304,32 @@ export class BeforeModelCallEvent extends HookableEvent {
    */
   cancel: boolean | string = false
 
-  constructor(data: { agent: LocalAgent; model: Model }) {
+  /**
+   * Projected input token count for the upcoming model call.
+   * Computed by the agent loop from message metadata and token estimation.
+   * Available for hooks and plugins (e.g. conversation managers) to make
+   * proactive decisions about context management.
+   */
+  readonly projectedInputTokens?: number
+
+  constructor(data: { agent: LocalAgent; model: Model; projectedInputTokens?: number }) {
     super()
     this.agent = data.agent
     this.model = data.model
+    if (data.projectedInputTokens !== undefined) {
+      this.projectedInputTokens = data.projectedInputTokens
+    }
   }
 
   /**
    * Serializes for wire transport, excluding the agent reference.
    * Called automatically by JSON.stringify().
    */
-  toJSON(): Pick<BeforeModelCallEvent, 'type'> {
-    return { type: this.type }
+  toJSON(): Pick<BeforeModelCallEvent, 'type' | 'projectedInputTokens'> {
+    return {
+      type: this.type,
+      ...(this.projectedInputTokens !== undefined && { projectedInputTokens: this.projectedInputTokens }),
+    }
   }
 }
 

--- a/strands-ts/src/telemetry/__tests__/meter.test.ts
+++ b/strands-ts/src/telemetry/__tests__/meter.test.ts
@@ -333,6 +333,34 @@ describe('Meter', () => {
     })
   })
 
+  describe('projectedContextSize', () => {
+    it('is undefined when no invocations have occurred', () => {
+      expect(meter.metrics.projectedContextSize).toBeUndefined()
+    })
+
+    it('returns inputTokens + outputTokens after a model call', () => {
+      meter.updateCycle({
+        type: 'modelMetadataEvent',
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      })
+
+      expect(meter.metrics.projectedContextSize).toBe(150)
+    })
+
+    it('updates across multiple cycles', () => {
+      meter.updateCycle({
+        type: 'modelMetadataEvent',
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      })
+      meter.updateCycle({
+        type: 'modelMetadataEvent',
+        usage: { inputTokens: 200, outputTokens: 80, totalTokens: 280 },
+      })
+
+      expect(meter.metrics.projectedContextSize).toBe(280)
+    })
+  })
+
   describe('updateCycle', () => {
     it('accumulates usage and latency from metadata', () => {
       meter.updateCycle({

--- a/strands-ts/src/telemetry/meter.ts
+++ b/strands-ts/src/telemetry/meter.ts
@@ -112,6 +112,12 @@ export interface AgentMetricsData {
    * Represents the current context window utilization.
    */
   latestContextSize?: number
+
+  /**
+   * Projected context size for the next model call (inputTokens + outputTokens from the last call).
+   * Represents the baseline token count the next invocation will start with.
+   */
+  projectedContextSize?: number
 }
 
 /**
@@ -184,6 +190,13 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
    */
   readonly latestContextSize: number | undefined
 
+  /**
+   * Projected context size for the next model call (inputTokens + outputTokens from the last call).
+   * Represents the baseline token count the next invocation will start with.
+   * Returns `undefined` when no invocations have occurred.
+   */
+  readonly projectedContextSize: number | undefined
+
   constructor(data?: Partial<AgentMetricsData>) {
     this.cycleCount = data?.cycleCount ?? 0
     this.accumulatedUsage = data?.accumulatedUsage ?? createEmptyUsage()
@@ -191,6 +204,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
     this.agentInvocations = data?.agentInvocations ?? []
     this.toolMetrics = data?.toolMetrics ?? {}
     this.latestContextSize = data?.latestContextSize
+    this.projectedContextSize = data?.projectedContextSize
   }
 
   /**
@@ -251,6 +265,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
       agentInvocations: this.agentInvocations,
       toolMetrics: this.toolMetrics,
       ...(this.latestContextSize !== undefined && { latestContextSize: this.latestContextSize }),
+      ...(this.projectedContextSize !== undefined && { projectedContextSize: this.projectedContextSize }),
     }
   }
 }
@@ -296,6 +311,11 @@ export class Meter {
    * The most recent input token count from the last model invocation.
    */
   private _latestContextSize: number | undefined
+
+  /**
+   * Projected context size for the next model call (inputTokens + outputTokens).
+   */
+  private _projectedContextSize: number | undefined
 
   // OTEL instruments (no-op when no MeterProvider is registered)
   private readonly _otelMeter: OtelMeter
@@ -459,6 +479,7 @@ export class Meter {
       agentInvocations: this._agentInvocations,
       toolMetrics: this._toolMetrics,
       ...(this._latestContextSize !== undefined && { latestContextSize: this._latestContextSize }),
+      ...(this._projectedContextSize !== undefined && { projectedContextSize: this._projectedContextSize }),
     })
   }
 
@@ -496,6 +517,7 @@ export class Meter {
   private _updateUsage(usage: Usage): void {
     accumulateUsage(this._accumulatedUsage, usage)
     this._latestContextSize = usage.inputTokens
+    this._projectedContextSize = usage.inputTokens + usage.outputTokens
 
     this._otelInputTokens.add(usage.inputTokens)
     this._otelOutputTokens.add(usage.outputTokens)

--- a/strands-ts/src/types/__tests__/agent.test.ts
+++ b/strands-ts/src/types/__tests__/agent.test.ts
@@ -244,6 +244,40 @@ describe('AgentResult', () => {
     })
   })
 
+  describe('projectedContextSize', () => {
+    it('returns projectedContextSize from metrics', () => {
+      const message = new Message({
+        role: 'assistant',
+        content: [new TextBlock('Hello')],
+      })
+
+      const metrics = new AgentMetrics({ projectedContextSize: 750 })
+
+      const result = new AgentResult({
+        stopReason: 'endTurn',
+        lastMessage: message,
+        metrics,
+      })
+
+      expect(result.projectedContextSize).toBe(750)
+    })
+
+    it('returns undefined when metrics has no projectedContextSize', () => {
+      const message = new Message({
+        role: 'assistant',
+        content: [new TextBlock('Hello')],
+      })
+
+      const result = new AgentResult({
+        stopReason: 'endTurn',
+        lastMessage: message,
+        metrics: new AgentMetrics(),
+      })
+
+      expect(result.projectedContextSize).toBeUndefined()
+    })
+  })
+
   describe('toJSON', () => {
     it('excludes traces and metrics from serialization', () => {
       const message = new Message({

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -270,6 +270,15 @@ export class AgentResult {
   }
 
   /**
+   * Projected context size for the next model call (inputTokens + outputTokens from the last call).
+   * Convenience accessor that delegates to `metrics.projectedContextSize`.
+   * Returns `undefined` when no metrics or invocations are available.
+   */
+  get projectedContextSize(): number | undefined {
+    return this.metrics?.projectedContextSize
+  }
+
+  /**
    * Custom JSON serialization that excludes traces and metrics by default.
    * This prevents accidentally sending large trace/metric data over the wire
    * when serializing AgentResult for API responses.


### PR DESCRIPTION
## Description                                                                                                                                                                                            
                                                                                                                                                                                                      
Adds input token estimation to the agent loop, making it available on `BeforeModelCallEvent` before every model call. This is the foundation for proactive context compression (design 0008).                                                                                                                                                                                            
                                                                                                                                                                                                      
The estimation uses the token counting strategy from the design doc: it reads `inputTokens + outputTokens` from the last assistant message's metadata as a known baseline, then estimates only new messages added since (typically tool results) via `model.countTokens()`. On cold start (no metadata available), it falls back to estimating all messages. Estimation is non-fatal — if it fails, the agent proceeds without it.                                                                                                                                                                                      
                                                                                                                                                                                                      
`BeforeModelCallEvent` now carries an optional `projectedInputTokens` field:                                                                                                                              
                                                                                                                                                                                                      
```typescript                                                                                                                                                                                             
agent.addHook(BeforeModelCallEvent, (event) => {
     console.log(event.projectedInputTokens) // e.g. 14200
})
```                                                                                                                                                                                              

No breaking changes. All new fields are optional.                                                                                                                                                         

## Related Issues                                                                                                                                                                                            
                                                                                                                                                                                                      
https://github.com/strands-agents/sdk-python/issues/555                                                                                                                                                                                               
                                                                                                                                                                                                      
## Documentation PR                                                                                                                                                                                          
                                                                                                                                                                                                      
Will do one big docs update when proactive compression is out                                                                                             
                                                                                                                                                                                                      
### Type of Change                                                                                                                                                                                            
                                                                                                                                                                                                      
New feature                                                                                                                                                                                               
                                                                                                                                                                                                      
## Testing                                                                                                                                                                                                   
                                                                                                                                                                                                      
How have you tested the change?                                                                                                                                                                           
                                                                                                                                                                                                      
- [x] I ran npm run check                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                      
## Checklist                                                                                                                                                                                                 
                                                                                                                                                                                                      
- [x] I have read the CONTRIBUTING document                                                                                                                                                               
- [x] I have added any necessary tests that prove my fix is effective or my feature works                                                                                                                 
- [ ] I have updated the documentation accordingly                                                                                                                                                        
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed                                                                                          
- [x] My changes generate no new warnings                                                                                                                                                                 
- [x] Any dependent changes have been merged and published                                                                                                                                                
                                                                                                                                                                                                      
--------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.                                                            
                                                                                                                                                   