### PR TITLE
feat: make tool result mutable

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -832,12 +832,14 @@ describe('Agent Hooks Integration', () => {
       const toolResultMessage = agent.messages.find(
         (m) => m.role === 'user' && m.content.some((b) => b.type === 'toolResultBlock')
       )
-      expect(toolResultMessage).toBeDefined()
-      const toolResultBlock = toolResultMessage!.content.find(
-        (b): b is ToolResultBlock => b.type === 'toolResultBlock'
+      const toolResultBlock = toolResultMessage!.content.find((b): b is ToolResultBlock => b.type === 'toolResultBlock')
+      expect(toolResultBlock).toStrictEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('replaced result')],
+        })
       )
-      expect(toolResultBlock).toBeDefined()
-      expect(toolResultBlock!.content).toEqual([new TextBlock('replaced result')])
     })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -804,5 +804,40 @@ describe('Agent Hooks Integration', () => {
       expect(beforeCount).toBe(2)
       expect(toolCallCount).toBe(1) // Only executed on second attempt
     })
+
+    it('allows hooks to replace result on AfterToolCallEvent', async () => {
+      const tool = createMockTool('myTool', () => {
+        return new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('original result')],
+        })
+      })
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolCallEvent, (event: AfterToolCallEvent) => {
+        event.result = new ToolResultBlock({
+          toolUseId: event.result.toolUseId,
+          status: 'success',
+          content: [new TextBlock('replaced result')],
+        })
+      })
+
+      await agent.invoke('Test')
+
+      const toolResultMessage = agent.messages.find(
+        (m) => m.role === 'user' && m.content.some((b) => b.type === 'toolResultBlock')
+      )
+      expect(toolResultMessage).toBeDefined()
+      const toolResultBlock = toolResultMessage!.content.find(
+        (b): b is ToolResultBlock => b.type === 'toolResultBlock'
+      )
+      expect(toolResultBlock).toBeDefined()
+      expect(toolResultBlock!.content).toEqual([new TextBlock('replaced result')])
+    })
   })
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1133,7 +1133,7 @@ export class Agent implements LocalAgent, InvokableAgent {
         if (afterToolCallEvent.retry) {
           continue
         }
-        return toolResult
+        return afterToolCallEvent.result
       }
 
       // Start tool span within loop span context
@@ -1226,7 +1226,7 @@ export class Agent implements LocalAgent, InvokableAgent {
         continue
       }
 
-      return toolResult
+      return afterToolCallEvent.result
     }
   }
 

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -220,8 +220,6 @@ describe('AfterToolCallEvent', () => {
     event.toolUse = toolUse
     // @ts-expect-error verifying that property is readonly
     event.tool = tool
-    // @ts-expect-error verifying that property is readonly
-    event.result = result
   })
 
   it('creates instance with error property when tool execution fails', () => {

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -222,6 +222,21 @@ describe('AfterToolCallEvent', () => {
     event.tool = tool
   })
 
+  it('allows result to be replaced', () => {
+    const agent = new Agent()
+    const toolUse = { name: 'test', toolUseId: 'id', input: {} }
+    const result = new ToolResultBlock({ toolUseId: 'id', status: 'success', content: [new TextBlock('original')] })
+    const event = new AfterToolCallEvent({ agent, toolUse, tool: undefined, result })
+
+    const replacedResult = new ToolResultBlock({
+      toolUseId: 'id',
+      status: 'success',
+      content: [new TextBlock('replaced')],
+    })
+    event.result = replacedResult
+    expect(event.result).toBe(replacedResult)
+  })
+
   it('creates instance with error property when tool execution fails', () => {
     const agent = new Agent()
     const toolUse = { name: 'test', toolUseId: 'id', input: {} }

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -230,7 +230,9 @@ export class AfterToolCallEvent extends HookableEvent {
     input: JSONValue
   }
   readonly tool: Tool | undefined
-  readonly result: ToolResultBlock
+
+  result: ToolResultBlock
+
   readonly error?: Error
 
   /**

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -231,6 +231,10 @@ export class AfterToolCallEvent extends HookableEvent {
   }
   readonly tool: Tool | undefined
 
+  /**
+   * The tool result. Can be replaced by hook callbacks to transform the result
+   * before it enters the conversation history.
+   */
   result: ToolResultBlock
 
   readonly error?: Error


### PR DESCRIPTION
## Description

Makes `AfterToolCallEvent.result` mutable so hook callbacks can replace tool results before they enter the conversation history.

Previously, `result` was `readonly` and the agent loop returned its local `toolResult` variable, ignoring any modifications hooks made to the event. This change removes `readonly` from the property and updates `executeTool()` to return `afterToolCallEvent.result`, so plugins can intercept and transform tool results.

This is a non-breaking change — existing code that reads `event.result` is unaffected. The only difference is that assigning to `event.result` now compiles and takes effect. This follows the same pattern as the existing mutable `retry` field on the same event.

Motivated by the `ContextOffloader` plugin port (sdk-python#2162), which needs to replace oversized tool results with truncated previews. This also enables the `Transform` intervention action in Interventions (https://github.com/strands-agents/sdk-typescript/pull/883).

## Related Issues

sdk-python#2162

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?
- [ ] I ran `npm run check`
- New unit test verifies that replacing `event.result` in an `AfterToolCallEvent` hook causes the modified result to appear in the agent's conversation history
- All existing tests pass (26 hook tests, 37 events tests)

## Checklist
- [X] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.