### PR TITLE
feat: add cancellation support to BeforeInvocationEvent and BeforeModelCallEvent

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -13,6 +13,7 @@ import {
   ModelStreamUpdateEvent,
   InitializedEvent,
   HookableEvent,
+  ModelMessageEvent,
 } from '../../hooks/index.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { MockPlugin } from '../../__fixtures__/mock-plugin.js'
@@ -803,6 +804,144 @@ describe('Agent Hooks Integration', () => {
       expect(result.stopReason).toBe('endTurn')
       expect(beforeCount).toBe(2)
       expect(toolCallCount).toBe(1) // Only executed on second attempt
+    })
+  })
+
+  describe('cancel invocation via hooks', () => {
+    it('cancels invocation with default message when cancel is true', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeInvocationEvent, (event: BeforeInvocationEvent) => {
+        event.cancel = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content[0]).toEqual(new TextBlock('invocation denied by hook'))
+
+      const beforeModelCallEvents = mockPlugin.invocations.filter((e) => e instanceof BeforeModelCallEvent)
+      expect(beforeModelCallEvents).toHaveLength(0)
+    })
+
+    it('cancels invocation with custom message when cancel is a string', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeInvocationEvent, (event: BeforeInvocationEvent) => {
+        event.cancel = 'Unauthorized user'
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content[0]).toEqual(new TextBlock('Unauthorized user'))
+    })
+
+    it('does not append user message when invocation is cancelled', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+      agent.addHook(BeforeInvocationEvent, (event: BeforeInvocationEvent) => {
+        event.cancel = true
+      })
+
+      await agent.invoke('Test')
+
+      expect(agent.messages).toHaveLength(1)
+      expect(agent.messages[0]!.role).toBe('assistant')
+    })
+
+    it('emits AfterInvocationEvent when invocation is cancelled', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeInvocationEvent, (event: BeforeInvocationEvent) => {
+        event.cancel = true
+      })
+
+      await agent.invoke('Test')
+
+      const beforeInvocationEvents = mockPlugin.invocations.filter((e) => e instanceof BeforeInvocationEvent)
+      const afterInvocationEvents = mockPlugin.invocations.filter((e) => e instanceof AfterInvocationEvent)
+      expect(beforeInvocationEvents).toHaveLength(1)
+      expect(afterInvocationEvents).toHaveLength(1)
+    })
+  })
+
+  describe('cancel model call via hooks', () => {
+    it('cancels model call with default message when cancel is true', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeModelCallEvent, (event: BeforeModelCallEvent) => {
+        event.cancel = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content[0]).toEqual(new TextBlock('model call denied by hook'))
+    })
+
+    it('cancels model call with custom message when cancel is a string', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeModelCallEvent, (event: BeforeModelCallEvent) => {
+        event.cancel = 'Rate limited'
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content[0]).toEqual(new TextBlock('Rate limited'))
+    })
+
+    it('emits AfterModelCallEvent when model call is cancelled', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeModelCallEvent, (event: BeforeModelCallEvent) => {
+        event.cancel = true
+      })
+
+      await agent.invoke('Test')
+
+      const beforeModelCallEvents = mockPlugin.invocations.filter((e) => e instanceof BeforeModelCallEvent)
+      const afterModelCallEvents = mockPlugin.invocations.filter((e) => e instanceof AfterModelCallEvent)
+      expect(beforeModelCallEvents).toHaveLength(1)
+      expect(afterModelCallEvents).toHaveLength(1)
+    })
+
+    it('does not emit ModelMessageEvent when model call is cancelled', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeModelCallEvent, (event: BeforeModelCallEvent) => {
+        event.cancel = true
+      })
+
+      await agent.invoke('Test')
+
+      const modelMessageEvents = mockPlugin.invocations.filter((e) => e instanceof ModelMessageEvent)
+      expect(modelMessageEvents).toHaveLength(0)
+    })
+
+    it('allows retry after cancel on model call', async () => {
+      let beforeCount = 0
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [mockPlugin] })
+      agent.addHook(BeforeModelCallEvent, (event: BeforeModelCallEvent) => {
+        beforeCount++
+        if (beforeCount === 1) {
+          event.cancel = 'Not yet'
+        }
+      })
+      agent.addHook(AfterModelCallEvent, (event: AfterModelCallEvent) => {
+        if (beforeCount === 1) {
+          event.retry = true
+        }
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(beforeCount).toBe(2)
+      expect(result.lastMessage.content[0]).toEqual(new TextBlock('Hello'))
     })
   })
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -604,8 +604,24 @@ export class Agent implements LocalAgent, InvokableAgent {
     const structuredOutputTool = structuredOutputSchema ? new StructuredOutputTool(structuredOutputSchema) : undefined
     let structuredOutputChoice: ToolChoice | undefined
 
-    // Emit event before the try block
-    yield new BeforeInvocationEvent({ agent: this })
+    const beforeInvocationEvent = new BeforeInvocationEvent({ agent: this })
+    yield beforeInvocationEvent
+
+    if (beforeInvocationEvent.cancel) {
+      const cancelText =
+        typeof beforeInvocationEvent.cancel === 'string'
+          ? beforeInvocationEvent.cancel
+          : 'invocation denied by hook'
+      const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
+      yield this._appendMessage(message)
+      yield new AfterInvocationEvent({ agent: this })
+      return new AgentResult({
+        stopReason: 'endTurn',
+        lastMessage: message,
+        traces: this._tracer.localTraces,
+        metrics: this._meter.metrics,
+      })
+    }
 
     // Normalize input to get the user messages for telemetry
     const inputMessages = this._normalizeInput(args)
@@ -897,7 +913,25 @@ export class Agent implements LocalAgent, InvokableAgent {
       streamOptions.toolChoice = toolChoice
     }
 
-    yield new BeforeModelCallEvent({ agent: this, model: this.model })
+    const beforeModelCallEvent = new BeforeModelCallEvent({ agent: this, model: this.model })
+    yield beforeModelCallEvent
+
+    if (beforeModelCallEvent.cancel) {
+      const cancelText =
+        typeof beforeModelCallEvent.cancel === 'string'
+          ? beforeModelCallEvent.cancel
+          : 'model call denied by hook'
+      const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
+      const stopData: ModelStopData = { message, stopReason: 'endTurn' }
+      const afterModelCallEvent = new AfterModelCallEvent({ agent: this, model: this.model, stopData })
+      yield afterModelCallEvent
+
+      if (afterModelCallEvent.retry) {
+        return yield* this._invokeModel(toolChoice)
+      }
+
+      return { message, stopReason: 'endTurn' }
+    }
 
     // Start model span within loop span context
     const modelId = this.model.modelId

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -52,6 +52,7 @@ describe('BeforeInvocationEvent', () => {
     expect(event).toEqual({
       type: 'beforeInvocationEvent',
       agent: agent,
+      cancel: false,
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -61,6 +62,23 @@ describe('BeforeInvocationEvent', () => {
     const agent = new Agent()
     const event = new BeforeInvocationEvent({ agent })
     expect(event._shouldReverseCallbacks()).toBe(false)
+  })
+
+  it('allows cancel to be set to true', () => {
+    const agent = new Agent()
+    const event = new BeforeInvocationEvent({ agent })
+
+    expect(event.cancel).toBe(false)
+    event.cancel = true
+    expect(event.cancel).toBe(true)
+  })
+
+  it('allows cancel to be set to a string message', () => {
+    const agent = new Agent()
+    const event = new BeforeInvocationEvent({ agent })
+
+    event.cancel = 'unauthorized'
+    expect(event.cancel).toBe('unauthorized')
   })
 })
 
@@ -303,6 +321,7 @@ describe('BeforeModelCallEvent', () => {
       type: 'beforeModelCallEvent',
       agent: agent,
       model: agent.model,
+      cancel: false,
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -312,6 +331,23 @@ describe('BeforeModelCallEvent', () => {
     const agent = new Agent()
     const event = new BeforeModelCallEvent({ agent, model: agent.model })
     expect(event._shouldReverseCallbacks()).toBe(false)
+  })
+
+  it('allows cancel to be set to true', () => {
+    const agent = new Agent()
+    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+
+    expect(event.cancel).toBe(false)
+    event.cancel = true
+    expect(event.cancel).toBe(true)
+  })
+
+  it('allows cancel to be set to a string message', () => {
+    const agent = new Agent()
+    const event = new BeforeModelCallEvent({ agent, model: agent.model })
+
+    event.cancel = 'rate limited'
+    expect(event.cancel).toBe('rate limited')
   })
 })
 

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -108,6 +108,13 @@ export class BeforeInvocationEvent extends HookableEvent {
   readonly type = 'beforeInvocationEvent' as const
   readonly agent: LocalAgent
 
+  /**
+   * Set by hook callbacks to cancel this invocation.
+   * When set to `true`, a default cancel message is used.
+   * When set to a string, that string is used as the assistant response message.
+   */
+  cancel: boolean | string = false
+
   constructor(data: { agent: LocalAgent }) {
     super()
     this.agent = data.agent
@@ -283,6 +290,13 @@ export class BeforeModelCallEvent extends HookableEvent {
   readonly type = 'beforeModelCallEvent' as const
   readonly agent: LocalAgent
   readonly model: Model
+
+  /**
+   * Set by hook callbacks to cancel this model call.
+   * When set to `true`, a default cancel message is used.
+   * When set to a string, that string is used as the assistant response message.
+   */
+  cancel: boolean | string = false
 
   constructor(data: { agent: LocalAgent; model: Model }) {
     super()


### PR DESCRIPTION


## Description

Adds a mutable `cancel: boolean | string` field to `BeforeInvocationEvent` and `BeforeModelCallEvent`, enabling hook callbacks to prevent agent invocations and model calls from proceeding.

Three events already support this pattern: `BeforeToolCallEvent`, `BeforeToolsEvent`, and `BeforeNodeCallEvent`. This PR extends it to the remaining two "Before" lifecycle events.

**Behavior when cancelled:**

Each cancel path produces the response type its caller expects, following the same pattern as existing cancellable events (`BeforeToolCallEvent`, `BeforeToolsEvent`, `BeforeNodeCallEvent`):

- `BeforeInvocationEvent.cancel` — `_stream()` returns an `AgentResult` with `stopReason: 'endTurn'` and the cancel message as the assistant response, matching how the method normally returns. User input is not appended to messages. `AfterInvocationEvent` is still emitted (Before/After pair guarantee). No telemetry spans are created — the invocation is denied before tracing starts.
- `BeforeModelCallEvent.cancel` — `_invokeModel()` returns a synthetic `StreamAggregatedResult` with the cancel message and `stopReason: 'endTurn'`, matching how the method normally returns after model inference. The model is never called. `AfterModelCallEvent` is emitted with `stopData`, and `AfterModelCallEvent.retry` is honored, consistent with the existing error-retry pattern.

**Example traces:**

Normal flow:
```
Agent Span ("my-agent")
  └─ Cycle #1
       └─ Model Span (tokens: 150, latency: 800ms)
```

`BeforeModelCallEvent.cancel` (e.g. Datadog detecting prompt injection):
```
Agent Span ("my-agent")
  └─ Cycle #1
       [no model span — model was never called]
```

`BeforeInvocationEvent.cancel` (e.g. agent-level auth denial):
```
[no spans — invocation denied before tracing starts]
```

**Use cases unblocked:**

- Agent-level authorization (e.g. Galileo Agent Control denying invocations based on budget or user policies)
- Pre-model-call guardrails (e.g. Datadog AI Guard scanning messages for prompt injection before they reach the model)

## Related Issues

#846

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?
- [x] I ran `npm run check`
- 9 new integration tests covering: default/custom cancel messages for both events, user message not appended on invocation cancel, Before/After pair guarantee for both events, no `ModelMessageEvent` on model cancel, and retry-after-cancel on model call
- 4 new unit tests for the `cancel` field on both event classes

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published