### PR TITLE
fix(bedrock): handle 'citation' delta key from Converse API

### DIFF
--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -913,6 +913,76 @@ describe('BedrockModel', () => {
       expect(events).toContainEqual({ stopReason: 'endTurn', type: 'modelMessageStopEvent' })
     })
 
+    it('handles citation delta key as alias for citationsContent', async () => {
+      // Bedrock Converse API sends "citation" key in stream deltas,
+      // not "citationsContent". Both must be handled. See #910.
+      const bedrockCitationsData = {
+        citations: [
+          {
+            location: { documentChar: { documentIndex: 0, start: 0, end: 20 } },
+            sourceContent: [{ text: 'source' }],
+            source: 'doc-0',
+            title: 'Citation Key Test',
+          },
+        ],
+        content: [{ text: 'cited text' }],
+      }
+
+      const mockSend = vi.fn(async () => {
+        if (stream) {
+          return {
+            stream: (async function* (): AsyncGenerator<unknown> {
+              yield { messageStart: { role: 'assistant' } }
+              yield { contentBlockStart: {} }
+              yield {
+                contentBlockDelta: {
+                  delta: { citation: bedrockCitationsData },
+                },
+              }
+              yield { contentBlockStop: {} }
+              yield { messageStop: { stopReason: 'end_turn' } }
+              yield {
+                metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, metrics: { latencyMs: 100 } },
+              }
+            })(),
+          }
+        } else {
+          return {
+            output: {
+              message: {
+                role: 'assistant',
+                content: [{ citation: bedrockCitationsData }],
+              },
+            },
+            stopReason: 'end_turn',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            metrics: { latencyMs: 100 },
+          }
+        }
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+
+      const provider = new BedrockModel({ stream })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Cite this.')] })]
+      const events = await collectIterator(provider.stream(messages))
+
+      expect(events).toContainEqual({
+        type: 'modelContentBlockDeltaEvent',
+        delta: {
+          type: 'citationsDelta',
+          citations: [
+            {
+              location: { type: 'documentChar', documentIndex: 0, start: 0, end: 20 },
+              sourceContent: [{ text: 'source' }],
+              source: 'doc-0',
+              title: 'Citation Key Test',
+            },
+          ],
+          content: [{ text: 'cited text' }],
+        },
+      })
+    })
+
     describe('error handling', async () => {
       it.each([
         {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -1160,6 +1160,19 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         events.push({ type: 'modelContentBlockDeltaEvent', delta })
         events.push({ type: 'modelContentBlockStopEvent' })
       },
+      citation: (block: BedrockCitationsContentBlock): void => {
+        if (!block) return
+        events.push({ type: 'modelContentBlockStartEvent' })
+
+        const mapped = this._mapBedrockCitationsData(block)
+        const delta: CitationsDelta = {
+          type: 'citationsDelta',
+          citations: mapped.citations,
+          content: mapped.content,
+        }
+        events.push({ type: 'modelContentBlockDeltaEvent', delta })
+        events.push({ type: 'modelContentBlockStopEvent' })
+      },
     }
 
     const content = ensureDefined(message.content, 'message.content')
@@ -1291,6 +1304,16 @@ export class BedrockModel extends Model<BedrockModelConfig> {
             }
           },
           citationsContent: (block: BedrockCitationsContentBlock): void => {
+            if (!block) return
+            const mapped = this._mapBedrockCitationsData(block)
+            const delta: CitationsDelta = {
+              type: 'citationsDelta',
+              citations: mapped.citations,
+              content: mapped.content,
+            }
+            events.push({ type: 'modelContentBlockDeltaEvent', delta })
+          },
+          citation: (block: BedrockCitationsContentBlock): void => {
             if (!block) return
             const mapped = this._mapBedrockCitationsData(block)
             const delta: CitationsDelta = {


### PR DESCRIPTION
## Problem

Bedrock's Converse API sends citation data using the key `citation` in both stream deltas (`contentBlockDelta`) and content blocks, but the SDK only has a handler for `citationsContent`. This causes citations to be silently dropped with:

```
delta_key=<citation> | skipping unsupported delta key
```

## Solution

Add `citation` as a handler in both:
1. **Streaming path** (`deltaHandlers` in `contentBlockDelta` case) 
2. **Non-streaming path** (`blockHandlers` in `_mapStreamedBedrockEventToSDKEvent`)

Both handlers delegate to the same `_mapBedrockCitationsData` logic and emit `citationsDelta` events.

## Testing

- Added test case `handles citation delta key as alias for citationsContent` covering both streaming and non-streaming paths
- All 272 existing tests pass
- Verified end-to-end with Bedrock Knowledge Base retrieval (citations now render correctly)

Fixes #910