### PR TITLE
fix: remove internal ProviderTokenCountError from public exports

### DIFF
--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -27,7 +27,6 @@ export {
   JsonValidationError,
   ConcurrentInvocationError,
   ModelThrottledError,
-  ProviderTokenCountError,
   ToolValidationError,
   StructuredOutputError,
 } from './errors.js'


### PR DESCRIPTION
  ## Description
  
  Remove `ProviderTokenCountError` from the public SDK exports. This error is internal control flow within provider `countTokens()` overrides — it's thrown and caught inside the provider implementation
  and never surfaces to users. Exporting it adds unnecessary public API surface.
  
  Addresses post-merge feedback on #886: https://github.com/strands-agents/sdk-typescript/pull/886#discussion_r3154850135
  
  ## Related Issues
  
  #886 
  
  ## Documentation PR
  
  N/A — no public API was documented for this error
  
  ## Type of Change
  
  Bug fix
  
  ## Testing
  
  How have you tested the change?
  
  - [x] I ran `npm run check`
  - Verified no tests or public code reference `ProviderTokenCountError` via import from `index.ts`
  
  ## Checklist
  - [x] I have read the CONTRIBUTING document
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [x] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published
  
  ----
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
