### PR TITLE
feat: expose model on local agent

### DIFF
--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -22,6 +22,7 @@ import type {
 } from '../hooks/events.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
 import type { ToolRegistry } from '../registry/tool-registry.js'
+import type { Model } from '../models/model.js'
 import type { z } from 'zod'
 import { AgentMetrics } from '../telemetry/meter.js'
 
@@ -155,6 +156,11 @@ export interface LocalAgent {
    * The tool registry for registering tools with the agent.
    */
   readonly toolRegistry: ToolRegistry
+
+  /**
+   * The model provider used by the agent for inference.
+   */
+  readonly model: Model
 
   /**
    * The system prompt to pass to the model provider.


### PR DESCRIPTION


## Description

Exposes the `model` property on the `LocalAgent` interface so that plugins, hooks, and tools can access the agent's model provider (e.g. for token counting via `model.countTokens()`) without unsafe type casts.

The concrete `Agent` class already has `public model: Model` — this change adds `readonly model: Model` to the `LocalAgent` interface to make it visible through the typed surface that plugins receive. No implementation changes needed.

Brings TypeScript to parity with the Python SDK, where `event.agent.model` is already accessible.

## Related Issues

https://github.com/strands-agents/sdk-typescript/issues/936
https://github.com/strands-agents/sdk-typescript/issues/934

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- Type-checks pass cleanly (`tsc --noEmit` on `src/tsconfig.json`)
- No new tests needed — the `Agent` class already satisfies the interface, this just widens the type surface

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.