### PR TITLE
fix(mcp): fix transport type cast for StreamableHTTPClientTransport

### DIFF
--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -226,7 +226,7 @@ export { configureLogging } from './logging/logger.js'
 export type { Logger } from './logging/types.js'
 
 // MCP Client types and implementations
-export { type McpClientConfig, type TasksConfig, McpClient } from './mcp.js'
+export { type McpClientConfig, type McpTransport, type TasksConfig, McpClient } from './mcp.js'
 export type { ElicitationCallback, ElicitationContext } from './types/elicitation.js'
 
 // Session management

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -8,6 +8,16 @@ import type { ElicitationCallback } from './types/elicitation.js'
 import { McpTool } from './tools/mcp-tool.js'
 import { logger } from './logging/index.js'
 
+/**
+ * Widened transport type that accepts MCP transport implementations without requiring explicit casts.
+ *
+ * Under `exactOptionalPropertyTypes`, `StreamableHTTPClientTransport` is not directly assignable
+ * to `Transport` because its `sessionId` getter returns `string | undefined`, while `Transport`
+ * declares `sessionId?: string` (absent or string, but not explicitly undefined).
+ * This type relaxes that constraint so users can pass any MCP transport without `as Transport`.
+ */
+export type McpTransport = Omit<Transport, 'sessionId'> & { sessionId?: string | undefined }
+
 /** Temporary placeholder for RuntimeConfig */
 export interface RuntimeConfig {
   applicationName?: string
@@ -40,7 +50,7 @@ export interface TasksConfig {
 
 /** Arguments for configuring an MCP Client. */
 export type McpClientConfig = RuntimeConfig & {
-  transport: Transport
+  transport: McpTransport
 
   /** Disable OpenTelemetry MCP instrumentation. */
   disableMcpInstrumentation?: boolean
@@ -80,7 +90,7 @@ export class McpClient {
   constructor(args: McpClientConfig) {
     this._clientName = args.applicationName || 'strands-agents-ts-sdk'
     this._clientVersion = args.applicationVersion || '0.0.1'
-    this._transport = args.transport
+    this._transport = args.transport as Transport
     this._connected = false
     this._tasksConfig = args.tasksConfig
     this._elicitationCallback = args.elicitationCallback

--- a/strands-ts/test/integ/mcp/mcp-tasks.test.node.ts
+++ b/strands-ts/test/integ/mcp/mcp-tasks.test.node.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { McpClient, Agent } from '@strands-agents/sdk'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { startTaskHTTPServer, type TaskHttpServerInfo } from '../__fixtures__/test-mcp-task-server.js'
 import { startHTTPServer, type HttpServerInfo } from '../__fixtures__/test-mcp-server.js'
 import { bedrock } from '../__fixtures__/model-providers.js'
@@ -19,7 +18,7 @@ import type { TasksConfig } from '@strands-agents/sdk'
 function createClient(serverUrl: string, appName: string, tasksConfig?: TasksConfig): McpClient {
   return new McpClient({
     applicationName: appName,
-    transport: new StreamableHTTPClientTransport(new URL(serverUrl)) as Transport,
+    transport: new StreamableHTTPClientTransport(new URL(serverUrl)),
     ...(tasksConfig !== undefined && { tasksConfig }),
   })
 }

--- a/strands-ts/test/integ/mcp/mcp.test.node.ts
+++ b/strands-ts/test/integ/mcp/mcp.test.node.ts
@@ -13,7 +13,6 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { resolve } from 'node:path'
 import { URL } from 'node:url'
 import { startHTTPServer, type HttpServerInfo } from '../__fixtures__/test-mcp-server.js'
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { bedrock } from '../__fixtures__/model-providers.js'
 
 type TransportConfig = {
@@ -56,7 +55,7 @@ describe('MCP Integration Tests', () => {
         if (!httpServerInfo) throw new Error('HTTP server not started')
         return new McpClient({
           applicationName: 'test-mcp-http',
-          transport: new StreamableHTTPClientTransport(new URL(httpServerInfo.url)) as Transport,
+          transport: new StreamableHTTPClientTransport(new URL(httpServerInfo.url)),
         })
       },
     },


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds a McpTransport type that accepts StreamableHTTPClientTransport without requiring an as Transport cast. This fixes a type incompatibility under the repo's exactOptionalPropertyTypes: true setting, where the transport's sessionId getter returning `string | undefined` doesn't satisfy Transport's `sessionId?: string`

## Related Issues

<!-- Link to related issues using #issue-number format -->

Closes #398 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
