### PR TITLE
fix: change token counting fallback log from warn to debug

### DIFF
--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -110,7 +110,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       logger.debug(`total_tokens=<${response.input_tokens}> | native token count`)
       return response.input_tokens
     } catch (error) {
-      logger.warn(`error=<${error}> | native token counting failed, falling back to estimation`)
+      logger.debug(`error=<${error}> | native token counting failed, falling back to estimation`)
       return super.countTokens(messages, options)
     }
   }

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -498,7 +498,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       logger.debug(`total_tokens=<${response.inputTokens}> | native token count`)
       return response.inputTokens
     } catch (error) {
-      logger.warn(`error=<${error}> | native token counting failed, falling back to estimation`)
+      logger.debug(`error=<${error}> | native token counting failed, falling back to estimation`)
       return super.countTokens(messages, options)
     }
   }

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -189,7 +189,7 @@ export class GoogleModel extends Model<GoogleModelConfig> {
       logger.debug(`total_tokens=<${totalTokens}> | native token count`)
       return totalTokens
     } catch (error) {
-      logger.warn(`error=<${error}> | native token counting failed, falling back to estimation`)
+      logger.debug(`error=<${error}> | native token counting failed, falling back to estimation`)
       return super.countTokens(messages, options)
     }
   }


### PR DESCRIPTION
## Description

Change the native token counting fallback log from `warning` to `debug` in all model providers. When a provider's native `count_tokens` API fails (e.g., missing credentials, API unavailable), the SDK falls back to heuristic estimation. This is expected behavior, not an actionable warning. Demoting it to debug reduces log noise.

## Related Issues

#886 

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
