### PR TITLE
feat: add steering plugin for vended-plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1719,29 +1719,6 @@
         "componentize-js": "src/cli.js"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2305,7 +2282,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -2837,6 +2813,7 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4769,6 +4746,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -4996,6 +4974,7 @@
       "integrity": "sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -5020,6 +4999,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -5177,6 +5157,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5225,7 +5206,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5647,7 +5627,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -5802,6 +5781,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-is": {
@@ -6007,6 +6000,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6403,7 +6397,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -6435,6 +6428,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6478,7 +6472,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
       "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -7146,7 +7139,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -7357,7 +7349,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7417,8 +7408,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8349,6 +8339,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8394,7 +8385,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -8405,6 +8395,7 @@
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -9211,6 +9202,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -9430,6 +9422,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9510,6 +9503,7 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9811,6 +9805,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -9860,7 +9855,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
@@ -9888,6 +9882,7 @@
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.943.0",
         "@types/json-schema": "^7.0.15",
+        "dedent": "^1.7.2",
         "uuid": "^13.0.0",
         "yaml": "^2.8.3"
       },

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -73,6 +73,10 @@
     "./vended-plugins/skills": {
       "types": "./dist/src/vended-plugins/skills/index.d.ts",
       "default": "./dist/src/vended-plugins/skills/index.js"
+    },
+    "./vended-plugins/steering": {
+      "types": "./dist/src/vended-plugins/steering/index.d.ts",
+      "default": "./dist/src/vended-plugins/steering/index.js"
     }
   },
   "scripts": {
@@ -160,6 +164,7 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.943.0",
     "@types/json-schema": "^7.0.15",
+    "dedent": "^1.7.2",
     "uuid": "^13.0.0",
     "yaml": "^2.8.3"
   },

--- a/strands-ts/src/vended-plugins/steering/actions.ts
+++ b/strands-ts/src/vended-plugins/steering/actions.ts
@@ -1,0 +1,56 @@
+/**
+ * Steering action types for steering evaluation results.
+ *
+ * Defines structured outcomes from steering handlers that determine how agent actions
+ * should be handled. Steering actions enable modular prompting by providing just-in-time
+ * feedback rather than front-loading all instructions in monolithic prompts.
+ *
+ * Action types:
+ * - Proceed: allow execution to continue without intervention
+ * - Guide: provide contextual guidance to redirect the agent
+ * - Interrupt: pause execution for human input
+ */
+
+/**
+ * Allow execution to continue without intervention.
+ * The reason provides context for logging and debugging.
+ */
+export interface Proceed {
+  readonly type: 'proceed'
+  readonly reason: string
+}
+
+/**
+ * Provide contextual guidance to redirect the agent.
+ * The agent receives the reason as contextual feedback to help guide its behavior.
+ */
+export interface Guide {
+  readonly type: 'guide'
+  readonly reason: string
+}
+
+/**
+ * Pause execution for human input via the interrupt system.
+ * The human can approve or deny the operation.
+ */
+export interface Interrupt {
+  readonly type: 'interrupt'
+  readonly reason: string
+}
+
+/**
+ * Steering actions valid for tool steering (steerBeforeTool).
+ *
+ * - Proceed: allow tool execution to continue
+ * - Guide: cancel tool and provide feedback for alternative approaches
+ * - Interrupt: pause for human input before tool execution
+ */
+export type ToolSteeringAction = Proceed | Guide | Interrupt
+
+/**
+ * Steering actions valid for model steering (steerAfterModel).
+ *
+ * - Proceed: accept model response without modification
+ * - Guide: discard model response and retry with guidance
+ */
+export type ModelSteeringAction = Proceed | Guide

--- a/strands-ts/src/vended-plugins/steering/handlers/handler.ts
+++ b/strands-ts/src/vended-plugins/steering/handlers/handler.ts
@@ -1,0 +1,192 @@
+/**
+ * Steering handler base class for providing contextual guidance to agents.
+ *
+ * Provides modular prompting through contextual guidance that appears when relevant,
+ * rather than front-loading all instructions. Handlers integrate with the hook system
+ * to intercept actions and provide just-in-time feedback based on local context.
+ *
+ * Lifecycle:
+ * 1. Context providers register hooks via initAgent
+ * 2. BeforeToolCallEvent triggers steerBeforeTool() for tool steering
+ * 3. AfterModelCallEvent triggers steerAfterModel() for model steering
+ * 4. SteeringAction determines execution flow
+ *
+ * Subclass SteeringHandler and override steerBeforeTool() and/or steerAfterModel().
+ * Both methods have default implementations that return Proceed.
+ */
+
+import { AfterModelCallEvent, BeforeToolCallEvent } from '../../../hooks/events.js'
+import { logger } from '../../../logging/logger.js'
+import type { Plugin } from '../../../plugins/plugin.js'
+import type { LocalAgent } from '../../../types/agent.js'
+import { Message, TextBlock } from '../../../types/messages.js'
+import type { StopReason } from '../../../types/messages.js'
+import type { ModelSteeringAction, ToolSteeringAction } from '../actions.js'
+import type { SteeringContextData, SteeringProvider } from '../providers/provider.js'
+import type { ToolUse } from '../../../tools/types.js'
+
+/**
+ * Base class for steering handlers that provide contextual guidance to agents.
+ *
+ * Steering handlers accept context providers that track agent activity,
+ * and use the accumulated context to make guidance decisions.
+ *
+ * @example
+ * ```typescript
+ * class MySteeringHandler extends SteeringHandler {
+ *   async steerBeforeTool(agent: LocalAgent, toolUse: ToolUse): Promise<ToolSteeringAction> {
+ *     const context = this.getSteeringContext()
+ *     if (toolUse.name === 'dangerous_tool') {
+ *       return { type: 'guide', reason: 'This tool requires extra caution.' }
+ *     }
+ *     return { type: 'proceed', reason: 'Allowing tool execution.' }
+ *   }
+ * }
+ * ```
+ */
+export abstract class SteeringHandler implements Plugin {
+  readonly name: string = 'strands:steering'
+
+  private readonly _contextProviders: SteeringProvider[]
+
+  constructor(contextProviders?: SteeringProvider[]) {
+    this._contextProviders = contextProviders ?? []
+    logger.debug(`handler_class=<${this.constructor.name}> | initialized`)
+  }
+
+  initAgent(agent: LocalAgent): void {
+    // Initialize context providers first so their hooks fire before steering evaluation
+    for (const provider of this._contextProviders) {
+      provider.initAgent(agent)
+    }
+
+    // Register tool steering hook
+    agent.addHook(BeforeToolCallEvent, async (event) => {
+      await this._provideToolSteeringGuidance(event)
+    })
+
+    // Register model steering hook
+    agent.addHook(AfterModelCallEvent, async (event) => {
+      await this._provideModelSteeringGuidance(event)
+    })
+  }
+
+  /**
+   * Collect context from all registered providers.
+   *
+   * @returns Array of context data objects from each provider
+   */
+  protected getSteeringContext(): SteeringContextData[] {
+    return this._contextProviders.map((provider) => provider.context)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hook handlers
+  // ---------------------------------------------------------------------------
+
+  private async _provideToolSteeringGuidance(event: BeforeToolCallEvent): Promise<void> {
+    const toolName = event.toolUse.name
+    logger.debug(`tool_name=<${toolName}> | providing tool steering guidance`)
+
+    let action: ToolSteeringAction
+    try {
+      action = await this.steerBeforeTool(event.agent, event.toolUse)
+    } catch (e) {
+      logger.debug(`tool_name=<${toolName}>, error=<${e}> | tool steering handler guidance failed`)
+      return
+    }
+
+    this._handleToolSteeringAction(action, event, toolName)
+  }
+
+  private _handleToolSteeringAction(action: ToolSteeringAction, event: BeforeToolCallEvent, toolName: string): void {
+    switch (action.type) {
+      case 'proceed':
+        logger.debug(`tool_name=<${toolName}> | tool call proceeding`)
+        break
+      case 'guide':
+        logger.debug(`tool_name=<${toolName}>, reason=<${action.reason}> | tool call guided`)
+        event.cancel = `Tool call cancelled. ${action.reason} You MUST follow this guidance immediately.`
+        break
+      case 'interrupt':
+        logger.debug(`tool_name=<${toolName}>, reason=<${action.reason}> | tool call requires human input`)
+        // Treat interrupt as cancel until the TS SDK interrupt system is wired into BeforeToolCallEvent
+        event.cancel = `Tool call paused for human review. ${action.reason}`
+        break
+      default:
+        throw new Error(`Unknown steering action type for tool call: ${(action as { type: string }).type}`)
+    }
+  }
+
+  private async _provideModelSteeringGuidance(event: AfterModelCallEvent): Promise<void> {
+    logger.debug('providing model steering guidance')
+
+    if (!event.stopData) {
+      logger.debug('no stop data available | skipping model steering')
+      return
+    }
+
+    let action: ModelSteeringAction
+    try {
+      action = await this.steerAfterModel(event.agent, event.stopData.message, event.stopData.stopReason)
+    } catch (e) {
+      logger.debug(`error=<${e}> | model steering handler guidance failed`)
+      return
+    }
+
+    this._handleModelSteeringAction(action, event)
+  }
+
+  private _handleModelSteeringAction(action: ModelSteeringAction, event: AfterModelCallEvent): void {
+    switch (action.type) {
+      case 'proceed':
+        logger.debug('model response proceeding')
+        break
+      case 'guide':
+        logger.debug(`reason=<${action.reason}> | model response guided, retrying`)
+        event.retry = true
+        event.agent.messages.push(
+          new Message({
+            role: 'user',
+            content: [new TextBlock(action.reason)],
+          })
+        )
+        break
+      default:
+        throw new Error(`Unknown steering action type for model response: ${(action as { type: string }).type}`)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Override points
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Provide contextual guidance before tool execution.
+   *
+   * Override this method to implement custom tool steering logic.
+   * Use this.getSteeringContext() to access context from providers.
+   *
+   * @param agent - The agent instance
+   * @param toolUse - The tool use object with name and arguments
+   * @returns ToolSteeringAction indicating how to guide the tool execution
+   */
+  async steerBeforeTool(_agent: LocalAgent, _toolUse: ToolUse): Promise<ToolSteeringAction> {
+    return { type: 'proceed', reason: 'Default implementation: allowing tool execution' }
+  }
+
+  /**
+   * Provide contextual guidance after model response.
+   *
+   * Override this method to implement custom model steering logic.
+   * Use this.getSteeringContext() to access context from providers.
+   *
+   * @param agent - The agent instance
+   * @param message - The model's generated message
+   * @param stopReason - The reason the model stopped generating
+   * @returns ModelSteeringAction indicating how to handle the model response
+   */
+  async steerAfterModel(_agent: LocalAgent, _message: Message, _stopReason: StopReason): Promise<ModelSteeringAction> {
+    return { type: 'proceed', reason: 'Default implementation: accepting model response' }
+  }
+}

--- a/strands-ts/src/vended-plugins/steering/handlers/llm.ts
+++ b/strands-ts/src/vended-plugins/steering/handlers/llm.ts
@@ -1,0 +1,181 @@
+/**
+ * LLM-based steering handler that uses an LLM to provide contextual guidance.
+ */
+
+import dedent from 'dedent'
+import { z } from 'zod'
+import { Agent } from '../../../agent/agent.js'
+import { takeSnapshot, loadSnapshot } from '../../../agent/snapshot.js'
+import type { Model } from '../../../models/model.js'
+import type { SystemPrompt, ContentBlock } from '../../../types/messages.js'
+import { TextBlock, CachePointBlock } from '../../../types/messages.js'
+import type { LocalAgent } from '../../../types/agent.js'
+import type { ToolUse } from '../../../tools/types.js'
+import type { ToolSteeringAction } from '../actions.js'
+import type { SteeringContextData, SteeringProvider } from '../providers/provider.js'
+import { ToolLedgerSteeringProvider } from '../providers/ledgers.js'
+import { SteeringHandler } from './handler.js'
+
+// ---------------------------------------------------------------------------
+// Prompt building
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the evaluation prompt sent to the steering LLM.
+ * Return a string for simple prompts, or ContentBlock[] to use cache points.
+ */
+type PromptBuilder = (context: SteeringContextData[], toolUse?: ToolUse) => string | ContentBlock[]
+
+/**
+ * Default prompt builder. Returns content blocks with a cache point
+ * between static instructions and dynamic context/event data.
+ */
+function defaultPromptBuilder(context: SteeringContextData[], toolUse?: ToolUse): ContentBlock[] {
+  const contextStr = context.length > 0 ? JSON.stringify(context, null, 2) : 'No context available'
+
+  let eventDescription: string
+  if (toolUse) {
+    eventDescription = `Tool: ${toolUse.name}\nArguments: ${JSON.stringify(toolUse.input, null, 2)}`
+  } else {
+    eventDescription = 'General evaluation'
+  }
+
+  const hasLedger = context.some((c) => c.type === 'toolLedger')
+
+  const ledgerExplanation = hasLedger
+    ? dedent`
+
+      The context includes a ledger with tool_calls. Each entry has a "status" field:
+      - "pending": the tool is currently being evaluated by you and has NOT started executing yet
+      - "success": the tool completed successfully in a previous turn
+      - "error": the tool failed or was cancelled in a previous turn
+    `
+    : ''
+
+  const instructions = dedent`
+    You are a steering agent that evaluates actions another agent is attempting.
+    Decide whether the action should proceed, be guided with feedback, or be interrupted for human input.
+
+    Rules:
+    - Base decisions ONLY on the provided context data
+    - Do not use external knowledge about tools or domains
+    - Focus on patterns: repeated failures, inappropriate timing, excessive retries
+    ${ledgerExplanation}
+  `
+
+  return [
+    new TextBlock(instructions),
+    new CachePointBlock({ cacheType: 'default' }),
+    new TextBlock(`Context:\n${contextStr}\n\nEvent:\n${eventDescription}`),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// LLM steering handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the LLMSteeringHandler.
+ */
+export interface LLMSteeringHandlerConfig {
+  /**
+   * Model for steering evaluation.
+   */
+  model: Model
+
+  /**
+   * Optional system prompt for the steering LLM.
+   */
+  systemPrompt?: SystemPrompt
+
+  /**
+   * Custom prompt builder for evaluation prompts.
+   * Defaults to defaultPromptBuilder.
+   */
+  promptBuilder?: PromptBuilder
+
+  /**
+   * Context providers for populating steering context.
+   * Defaults to [new LedgerProvider()] if undefined. Pass an empty array to disable.
+   */
+  providers?: SteeringProvider[]
+}
+
+/**
+ * Steering handler that uses an LLM to provide contextual guidance.
+ *
+ * Uses natural language prompts to evaluate tool calls and provide
+ * contextual steering guidance to help agents navigate complex workflows.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { LLMSteeringHandler } from '@strands-agents/sdk/vended-plugins/steering'
+ * import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
+ *
+ * const handler = new LLMSteeringHandler({
+ *   model: new BedrockModel(),
+ *   systemPrompt: `You ensure emails maintain a cheerful, positive tone.
+ *     Review email content and suggest more cheerful phrasing if needed.`,
+ * })
+ *
+ * const agent = new Agent({
+ *   tools: [sendEmail],
+ *   plugins: [handler],
+ * })
+ * ```
+ */
+export class LLMSteeringHandler extends SteeringHandler {
+  private readonly _promptBuilder: PromptBuilder
+  private readonly _agent: Agent
+
+  constructor(config: LLMSteeringHandlerConfig) {
+    const providers = config.providers === undefined ? [new ToolLedgerSteeringProvider()] : config.providers
+    super(providers)
+
+    this._promptBuilder = config.promptBuilder ?? defaultPromptBuilder
+    this._agent = new Agent({
+      model: config.model,
+      ...(config.systemPrompt !== undefined && { systemPrompt: config.systemPrompt }),
+      structuredOutputSchema: z.object({
+        type: z
+          .enum(['proceed', 'guide', 'interrupt'])
+          .describe(
+            "Steering decision: 'proceed' to continue, 'guide' to provide feedback, 'interrupt' for human input"
+          ),
+        reason: z.string().describe('Clear explanation of the steering decision and any guidance provided'),
+      }),
+      printer: false,
+    })
+  }
+
+  /**
+   * Evaluate a tool call using the steering LLM.
+   *
+   * @param _agent - The agent instance
+   * @param toolUse - The tool use being evaluated
+   * @returns Steering action for the tool call
+   */
+  override async steerBeforeTool(_agent: LocalAgent, toolUse: ToolUse): Promise<ToolSteeringAction> {
+    const context = this.getSteeringContext()
+    const prompt = this._promptBuilder(context, toolUse)
+
+    return this._invoke(prompt)
+  }
+
+  /**
+   * Invoke the steering agent and return the validated decision.
+   *
+   * @param prompt - The evaluation prompt
+   * @returns The validated steering action
+   */
+  private async _invoke(prompt: string | ContentBlock[]): Promise<ToolSteeringAction> {
+    const snapshot = takeSnapshot(this._agent, { include: ['messages', 'state'] })
+    try {
+      const result = await this._agent.invoke(prompt)
+      return result.structuredOutput as ToolSteeringAction
+    } finally {
+      loadSnapshot(this._agent, snapshot)
+    }
+  }
+}

--- a/strands-ts/src/vended-plugins/steering/index.ts
+++ b/strands-ts/src/vended-plugins/steering/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Steering system for Strands agents.
+ *
+ * Provides contextual guidance for agents through modular prompting.
+ * Instead of front-loading all instructions, steering handlers provide
+ * just-in-time feedback based on context data from registered providers.
+ *
+ * Core components:
+ * - SteeringHandler: base class for guidance logic
+ * - SteeringProvider: interface for context data providers
+ * - ToolSteeringAction/ModelSteeringAction: proceed/guide/interrupt decisions
+ *
+ * @example
+ * ```typescript
+ * import { LLMSteeringHandler } from '@strands-agents/sdk/vended-plugins/steering'
+ *
+ * const handler = new LLMSteeringHandler({
+ *   systemPrompt: '...',
+ *   model: new BedrockModel(),
+ * })
+ * const agent = new Agent({ tools: [...], plugins: [handler] })
+ * ```
+ */
+
+// Core
+export type { Guide, Interrupt, ModelSteeringAction, Proceed, ToolSteeringAction } from './actions.js'
+export type { SteeringContextData, SteeringProvider } from './providers/provider.js'
+export { SteeringHandler } from './handlers/handler.js'
+
+// Context providers
+export { ToolLedgerSteeringProvider } from './providers/ledgers.js'
+
+// Handler implementations
+export { LLMSteeringHandler, type LLMSteeringHandlerConfig } from './handlers/llm.js'

--- a/strands-ts/src/vended-plugins/steering/providers/index.ts
+++ b/strands-ts/src/vended-plugins/steering/providers/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Steering context providers.
+ *
+ * Providers track agent activity and supply context data to steering handlers
+ * for evaluation. Each provider registers hooks via initAgent to observe events,
+ * and exposes a context getter that returns a typed snapshot of accumulated data.
+ *
+ * Built-in providers:
+ * - LedgerSteeringProvider: tracks tool call history with timing and status
+ *
+ * Custom providers implement the SteeringProvider interface.
+ */
+
+export type { SteeringContextData, SteeringProvider } from './provider.js'
+export { ToolLedgerSteeringProvider } from './ledgers.js'

--- a/strands-ts/src/vended-plugins/steering/providers/ledgers.ts
+++ b/strands-ts/src/vended-plugins/steering/providers/ledgers.ts
@@ -1,0 +1,113 @@
+/**
+ * Ledger context provider for comprehensive agent activity tracking.
+ *
+ * Tracks tool call history with inputs, outputs, timing, and success/failure status.
+ * This audit trail enables steering handlers to make informed guidance decisions
+ * based on agent behavior patterns and history.
+ */
+
+import { AfterInvocationEvent, AfterToolCallEvent, BeforeToolCallEvent } from '../../../hooks/events.js'
+import type { LocalAgent } from '../../../types/agent.js'
+import type { JSONValue } from '../../../types/json.js'
+import type { SteeringContextData, SteeringProvider } from './provider.js'
+
+/**
+ * A single entry in the tool call ledger.
+ */
+interface LedgerToolCall {
+  /** Tool input arguments. */
+  args: JSONValue
+  /** When the tool finished executing. */
+  endTime?: string
+  /** Error message if the tool failed. */
+  error?: string | null
+  /** Unique tool use identifier. */
+  id: string
+  /** Tool name. */
+  name: string
+  /** Tool execution result. */
+  result?: JSONValue
+  /** When the tool call was initiated. */
+  startTime: string
+  /** Current execution state: pending, success, or error. */
+  status: 'pending' | 'success' | 'error'
+}
+
+/**
+ * Context provider that tracks tool call history.
+ *
+ * Records every tool invocation with inputs, execution time, and success/failure status.
+ * The ledger is available to steering handlers for pattern detection
+ * (e.g., repeated failures, excessive retries).
+ *
+ * When the ledger exceeds maxEntries, the oldest entries are dropped.
+ *
+ * @example
+ * ```typescript
+ * const handler = new LLMSteeringHandler({
+ *   systemPrompt: '...',
+ *   model: new BedrockModel(),
+ *   providers: [new ToolLedgerSteeringProvider()],
+ * })
+ * ```
+ */
+export class ToolLedgerSteeringProvider implements SteeringProvider {
+  readonly name = 'strands:steering:toolLedger'
+  private readonly _maxEntries: number = 100
+  private readonly _toolCalls: LedgerToolCall[] = []
+
+  constructor(options?: { maxEntries?: number }) {
+    if (options?.maxEntries !== undefined) {
+      this._maxEntries = options.maxEntries
+    }
+  }
+
+  initAgent(agent: LocalAgent): void {
+    // Rehydrate from appState if a previous session was restored
+    const saved = agent.appState.get(this.name)
+    if (Array.isArray(saved)) {
+      this._toolCalls.push(...(saved as unknown as LedgerToolCall[]))
+    }
+
+    agent.addHook(BeforeToolCallEvent, (event) => {
+      this._toolCalls.push({
+        startTime: new Date().toISOString(),
+        id: event.toolUse.toolUseId,
+        name: event.toolUse.name,
+        args: event.toolUse.input,
+        status: 'pending',
+      })
+      if (this._toolCalls.length > this._maxEntries) {
+        this._toolCalls.splice(0, this._toolCalls.length - this._maxEntries)
+      }
+    })
+
+    agent.addHook(AfterToolCallEvent, (event) => {
+      const toolUseId = event.toolUse.toolUseId
+      for (let i = this._toolCalls.length - 1; i >= 0; i--) {
+        const call = this._toolCalls[i]
+        if (call?.id === toolUseId) {
+          call.endTime = new Date().toISOString()
+          call.status = event.result.status === 'success' ? 'success' : 'error'
+          call.result = event.result.content.map((block) => block.toJSON()) as JSONValue
+          call.error = event.error ? event.error.message : null
+          break
+        }
+      }
+    })
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      event.agent.appState.set(this.name, this._toolCalls as unknown as JSONValue)
+    })
+  }
+
+  /**
+   * Return the current ledger snapshot.
+   */
+  get context(): SteeringContextData {
+    return {
+      type: 'toolLedger',
+      calls: this._toolCalls as unknown as JSONValue,
+    }
+  }
+}

--- a/strands-ts/src/vended-plugins/steering/providers/provider.ts
+++ b/strands-ts/src/vended-plugins/steering/providers/provider.ts
@@ -1,0 +1,51 @@
+/**
+ * Steering context provider interface.
+ *
+ * Providers track agent activity and supply context data to steering handlers
+ * for evaluation decisions.
+ */
+
+import type { Plugin } from '../../../plugins/plugin.js'
+import type { JSONValue } from '../../../types/json.js'
+
+/**
+ * Context data returned by a SteeringProvider.
+ * The type field identifies which provider produced the data.
+ */
+export interface SteeringContextData {
+  /** Discriminator identifying the context provider. */
+  readonly type: string
+  /** Additional context fields. */
+  [key: string]: JSONValue
+}
+
+/**
+ * A component that provides context data for steering evaluation.
+ *
+ * Providers register hooks via initAgent to observe agent activity,
+ * and expose accumulated data through the context getter.
+ *
+ * @example
+ * ```typescript
+ * class CostTracker implements SteeringProvider {
+ *   readonly name = 'costTracker'
+ *   private _totalTokens = 0
+ *
+ *   initAgent(agent: LocalAgent): void {
+ *     agent.addHook(AfterModelCallEvent, (event) => {
+ *       this._totalTokens += getTokenCount(event)
+ *     })
+ *   }
+ *
+ *   get context(): SteeringContextData {
+ *     return { type: 'costTracker', totalTokens: this._totalTokens }
+ *   }
+ * }
+ * ```
+ */
+export interface SteeringProvider extends Pick<Plugin, 'initAgent' | 'name'> {
+  /**
+   * Return the current context snapshot for steering evaluation.
+   */
+  get context(): SteeringContextData
+}


### PR DESCRIPTION
## Motivation

The Python SDK provides a steering system that enables modular, contextual guidance for agents through just-in-time feedback rather than front-loading all instructions into monolithic system prompts. This PR ports that capability to the TypeScript SDK as a vended plugin, maintaining API parity across SDKs.

Steering handlers intercept tool calls and model responses via the hooks system, evaluate them against accumulated context from registered providers, and return structured decisions (proceed, guide, or interrupt) that shape agent behavior at runtime.

## Public API Changes

New vended plugin importable from `@strands-agents/sdk/vended-plugins/steering`:

```typescript
import { Agent } from "@strands-agents/sdk"
import { LLMSteeringHandler } from "@strands-agents/sdk/vended-plugins/steering"
import { BedrockModel } from "@strands-agents/sdk/models/bedrock"

const handler = new LLMSteeringHandler({
  model: new BedrockModel(),
  systemPrompt: `You ensure emails maintain a cheerful, positive tone.
    Review email content and suggest more cheerful phrasing if needed.`,
})

const agent = new Agent({
  tools: [sendEmail],
  plugins: [handler],
})
```

The plugin exposes:

- `SteeringHandler` base class for custom steering logic (override `steerBeforeTool` and/or `steerAfterModel`)
- `LLMSteeringHandler` concrete implementation that uses a secondary LLM with structured output to evaluate actions
- `SteeringProvider` interface for context data providers that track agent activity
- `ToolLedgerSteeringProvider` built-in provider that maintains a ledger of tool call history
- `ToolSteeringAction` / `ModelSteeringAction` discriminated union types for steering decisions (proceed, guide, interrupt)

Custom steering handlers can be built by extending `SteeringHandler`:

```typescript
import { SteeringHandler } from "@strands-agents/sdk/vended-plugins/steering"

class MyHandler extends SteeringHandler {
  async steerBeforeTool(agent, toolUse) {
    const context = this.getSteeringContext()
    if (toolUse.name === "dangerous_tool") {
      return { type: "guide", reason: "Use the safer alternative instead." }
    }
    return { type: "proceed", reason: "Allowed." }
  }
}
```

## Use Cases

- **Tone/policy enforcement**: An LLM steering handler reviews outgoing emails or messages to ensure they match organizational tone guidelines before the send tool executes
- **Cost/safety guardrails**: A custom handler tracks tool call patterns via the ledger provider and intervenes when it detects excessive retries or repeated failures
- **Human-in-the-loop**: The interrupt action type pauses execution for human approval before sensitive operations