### PR TITLE
refactor: address concurrent tools follow ups

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -450,45 +450,6 @@ describe('Agent concurrent tool execution', () => {
     expect(blocks.map((b) => b.toolUseId)).toEqual(['a', 'b'])
   })
 
-  it('AfterToolsEvent.message contains completed results when consumer breaks mid-stream', async () => {
-    const toolA = new GatedTool('toolA')
-    const toolB = new GatedTool('toolB') // never released
-    const agent = new Agent({
-      model: twoToolTurn(),
-      tools: [toolA, toolB],
-      toolExecutor: 'concurrent',
-      printer: false,
-    })
-
-    agent.addHook(BeforeToolCallEvent, (e) => {
-      if (e.toolUse.name === 'toolA') toolA.release()
-    })
-
-    let afterToolsMessage: Message | undefined
-    agent.addHook(AfterToolsEvent, (e) => {
-      afterToolsMessage = e.message
-    })
-
-    let toolResultsSeen = 0
-    for await (const event of agent.stream('Go')) {
-      if (event.type === 'toolResultEvent') {
-        toolResultsSeen++
-        if (toolResultsSeen === 1) {
-          // Cancel so toolB (still parked on its gate) observes cancelSignal
-          // and exits cooperatively — otherwise gen.return() stays blocked on
-          // a suspended await.
-          agent.cancel()
-          break
-        }
-      }
-    }
-
-    expect(afterToolsMessage).toBeDefined()
-    const blocks = afterToolsMessage!.content.filter((b): b is ToolResultBlock => b.type === 'toolResultBlock')
-    expect(blocks.length).toBeGreaterThanOrEqual(1)
-    expect(blocks.some((b) => b.toolUseId === 'a')).toBe(true)
-  })
-
   it('pre-launch agent.cancel() during BeforeToolsEvent produces "Tool execution cancelled" (concurrent)', async () => {
     const toolA = new GatedTool('toolA')
     const toolB = new GatedTool('toolB')
@@ -560,5 +521,74 @@ describe('Agent concurrent tool execution', () => {
     expect(blocks.map((b) => b.toolUseId)).toEqual(['a', 'b'])
     expect(blocks.find((b) => b.toolUseId === 'a')!.status).toBe('success')
     expect(blocks.find((b) => b.toolUseId === 'b')!.status).toBe('error')
+  })
+
+  it('surfaces mid-tool ToolStreamUpdateEvents through agent.stream in concurrent mode', async () => {
+    const toolA = new GatedStreamingTool('toolA')
+    const toolB = new GatedStreamingTool('toolB')
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools: [toolA, toolB],
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    const streamEvents: { tool: string; step: number }[] = []
+    const invocation = (async () => {
+      for await (const event of agent.stream('Go')) {
+        if (event.type === 'toolStreamUpdateEvent') {
+          const data = event.event.data as { tool: string; step: number }
+          streamEvents.push(data)
+        }
+      }
+    })()
+
+    await toolA.emit({ tool: 'toolA', step: 0 })
+    await toolB.emit({ tool: 'toolB', step: 0 })
+    await toolA.emit({ tool: 'toolA', step: 1 })
+    await toolB.emit({ tool: 'toolB', step: 1 })
+    await toolA.complete()
+    await toolB.complete()
+    await invocation
+
+    // All four mid-tool events should have been surfaced through agent.stream.
+    expect(streamEvents).toHaveLength(4)
+    expect(streamEvents.filter((e) => e.tool === 'toolA').map((e) => e.step)).toEqual([0, 1])
+    expect(streamEvents.filter((e) => e.tool === 'toolB').map((e) => e.step)).toEqual([0, 1])
+  })
+
+  it('BeforeToolCallEvent.cancel cancels the individual tool without affecting siblings (concurrent)', async () => {
+    const toolA = new GatedTool('toolA')
+    const toolB = new GatedTool('toolB')
+    const agent = new Agent({
+      model: twoToolTurn(),
+      tools: [toolA, toolB],
+      toolExecutor: 'concurrent',
+      printer: false,
+    })
+
+    agent.addHook(BeforeToolCallEvent, (e) => {
+      if (e.toolUse.name === 'toolA') e.cancel = 'A cancelled by hook'
+    })
+
+    let afterMessage: Message | undefined
+    agent.addHook(AfterToolsEvent, (e) => {
+      afterMessage = e.message
+    })
+
+    const invocation = agent.invoke('Go')
+    await toolB.started
+    // toolA never runs because its BeforeToolCallEvent.cancel short-circuits.
+    expect(toolA.observations.started).toBe(false)
+    toolB.release()
+    await invocation
+
+    const blocks = afterMessage!.content as ToolResultBlock[]
+    expect(blocks).toHaveLength(2)
+    const a = blocks.find((b) => b.toolUseId === 'a')!
+    const b = blocks.find((b) => b.toolUseId === 'b')!
+    expect(a.status).toBe('error')
+    expect((a.content[0] as TextBlock).text).toBe('A cancelled by hook')
+    expect(b.status).toBe('success')
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -449,17 +449,27 @@ describe('Agent tracer integration', () => {
         ])
         .addTurn({ type: 'textBlock', text: 'Done' })
 
-      // Tools sleep briefly so the concurrent executor has time to launch both
-      // before either resolves. The assertions below check call order, not
-      // wall-clock timing.
-      const sleep = (ms: number) => new Promise<void>((r) => globalThis.setTimeout(r, ms))
+      // Both tools wait for the other to signal "I started" before resolving,
+      // so neither can complete until the concurrent executor has launched
+      // both. This replaces wall-clock sleeps with cooperative signaling so
+      // the test is deterministic rather than timing-dependent.
+      let resolveStart1!: () => void
+      let resolveStart2!: () => void
+      const started1 = new Promise<void>((r) => (resolveStart1 = r))
+      const started2 = new Promise<void>((r) => (resolveStart2 = r))
       // eslint-disable-next-line require-yield
-      async function* sleepThenReturn(toolUseId: string, text: string) {
-        await sleep(20)
+      async function* awaitPeerThenReturn(
+        toolUseId: string,
+        text: string,
+        signalStarted: () => void,
+        peerStarted: Promise<void>
+      ) {
+        signalStarted()
+        await peerStarted
         return new ToolResultBlock({ toolUseId, status: 'success', content: [new TextBlock(text)] })
       }
-      const tool1 = createMockTool('tool1', () => sleepThenReturn('id-1', 'R1'))
-      const tool2 = createMockTool('tool2', () => sleepThenReturn('id-2', 'R2'))
+      const tool1 = createMockTool('tool1', () => awaitPeerThenReturn('id-1', 'R1', resolveStart1, started2))
+      const tool2 = createMockTool('tool2', () => awaitPeerThenReturn('id-2', 'R2', resolveStart2, started1))
 
       const agent = new Agent({ model, tools: [tool1, tool2], toolExecutor: 'concurrent' })
       const tracer = getLatestTracer()

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -96,6 +96,16 @@ export type ToolList = (Tool | McpClient | Agent | ToolList)[]
 export type ToolExecutorStrategy = 'sequential' | 'concurrent'
 
 /**
+ * Mutable holder for the tool-result message produced by a tool executor.
+ *
+ * `executeTools` centrally emits `AfterToolsEvent` from its `finally` block;
+ * each executor writes the latest message into `ref.message` so the event
+ * still carries partial results even when the consumer breaks the stream
+ * mid-execution via `.return()` and the executor never returns normally.
+ */
+type ToolResultMessageRef = { message: Message }
+
+/**
  * Configuration object for creating a new Agent.
  */
 export type AgentConfig = {
@@ -1082,10 +1092,10 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Emits `BeforeToolsEvent`, handles the pre-launch cancel paths, then
-   * delegates per-tool execution to the configured {@link ToolExecutorStrategy}.
-   * Always pairs `BeforeToolsEvent` with a terminal `AfterToolsEvent`, even on
-   * the invariant-violation throw path.
+   * Emits `BeforeToolsEvent` and the terminal `AfterToolsEvent` around the
+   * per-tool execution delegated to the configured
+   * {@link ToolExecutorStrategy}. Handles pre-launch cancel paths centrally
+   * so per-executor methods only concern themselves with the happy path.
    *
    * @param assistantMessage - The assistant message containing tool use blocks
    * @param toolRegistry - Registry containing available tools
@@ -1095,92 +1105,95 @@ export class Agent implements LocalAgent, InvokableAgent {
     assistantMessage: Message,
     toolRegistry: ToolRegistry
   ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
-    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
-    yield beforeToolsEvent
-
     const toolUseBlocks = assistantMessage.content.filter(
       (block): block is ToolUseBlock => block.type === 'toolUseBlock'
     )
     if (toolUseBlocks.length === 0) {
-      // Preserve BeforeToolsEvent/AfterToolsEvent bracket symmetry even on
-      // this invariant-violation branch.
-      yield new AfterToolsEvent({ agent: this, message: new Message({ role: 'user', content: [] }) })
       throw new Error('Model indicated toolUse but no tool use blocks found in message')
     }
 
-    // Pre-launch cancel paths are strategy-independent.
-    if (beforeToolsEvent.cancel) {
-      const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
-      return yield* this._yieldCancelledToolResults(toolUseBlocks, message)
-    }
-    if (this.isCancelled) {
-      return yield* this._yieldCancelledToolResults(toolUseBlocks, 'Tool execution cancelled')
+    const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage })
+    yield beforeToolsEvent
+
+    // `ref` is populated by the selected executor (or the cancel path) before
+    // any yield it might be interrupted at, so the outer finally can always
+    // emit an `AfterToolsEvent` carrying the latest partial result — even when
+    // the consumer breaks the stream via `.return()`.
+    const ref: ToolResultMessageRef = { message: new Message({ role: 'user', content: [] }) }
+    try {
+      if (beforeToolsEvent.cancel) {
+        const message = typeof beforeToolsEvent.cancel === 'string' ? beforeToolsEvent.cancel : 'Tool cancelled by hook'
+        yield* this._yieldCancelledToolResults(toolUseBlocks, message, ref)
+      } else if (this.isCancelled) {
+        yield* this._yieldCancelledToolResults(toolUseBlocks, 'Tool execution cancelled', ref)
+      } else {
+        switch (this._toolExecutor) {
+          case 'sequential':
+            yield* this._executeToolsSequential(toolUseBlocks, toolRegistry, ref)
+            break
+          case 'concurrent':
+            yield* this._executeToolsConcurrent(toolUseBlocks, toolRegistry, ref)
+            break
+          default: {
+            const _exhaustive: never = this._toolExecutor
+            throw new Error(`Unknown toolExecutor: ${_exhaustive as string}`)
+          }
+        }
+      }
+    } finally {
+      yield new AfterToolsEvent({ agent: this, message: ref.message })
     }
 
-    switch (this._toolExecutor) {
-      case 'sequential':
-        return yield* this._executeToolsSequential(toolUseBlocks, toolRegistry)
-      case 'concurrent':
-        return yield* this._executeToolsConcurrent(toolUseBlocks, toolRegistry)
-      default: {
-        const _exhaustive: never = this._toolExecutor
-        throw new Error(`Unknown toolExecutor: ${_exhaustive as string}`)
-      }
-    }
+    return ref.message
   }
 
   /**
-   * Emits a `ToolResultEvent` for every block plus an `AfterToolsEvent`, and
-   * returns the resulting tool-result message. Used by the pre-launch cancel
-   * paths shared across executors.
+   * Emits a `ToolResultEvent` for every block and writes the resulting
+   * tool-result message to `ref`. Used by the pre-launch cancel paths shared
+   * across executors.
    */
   private async *_yieldCancelledToolResults(
     toolUseBlocks: ToolUseBlock[],
-    message: string
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+    message: string,
+    ref: ToolResultMessageRef
+  ): AsyncGenerator<AgentStreamEvent, void, undefined> {
     const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
+    ref.message = new Message({ role: 'user', content: cancelBlocks })
     for (const result of cancelBlocks) {
       yield new ToolResultEvent({ agent: this, result })
     }
-    const toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
-    yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
-    return toolResultMessage
   }
 
   /**
    * Executes tools one at a time, honoring `agent.cancelSignal` between
-   * iterations to short-circuit not-yet-started tools.
+   * iterations to short-circuit not-yet-started tools. Writes the assembled
+   * tool-result message to `ref` as blocks accumulate, so a consumer break
+   * still leaves the partial results visible to the outer `AfterToolsEvent`.
    */
   private async *_executeToolsSequential(
     toolUseBlocks: ToolUseBlock[],
-    toolRegistry: ToolRegistry
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+    toolRegistry: ToolRegistry,
+    ref: ToolResultMessageRef
+  ): AsyncGenerator<AgentStreamEvent, void, undefined> {
     const toolResultBlocks: ToolResultBlock[] = []
-    let toolResultMessage: Message
+    ref.message = new Message({ role: 'user', content: toolResultBlocks })
 
-    try {
-      for (const toolUseBlock of toolUseBlocks) {
-        if (this.isCancelled) {
-          const cancelBlock = new ToolResultBlock({
-            toolUseId: toolUseBlock.toolUseId,
-            status: 'error',
-            content: [new TextBlock('Tool execution cancelled')],
-          })
-          toolResultBlocks.push(cancelBlock)
-          yield new ToolResultEvent({ agent: this, result: cancelBlock })
-          continue
-        }
-
-        const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
-        toolResultBlocks.push(toolResultBlock)
-        yield new ToolResultEvent({ agent: this, result: toolResultBlock })
+    for (const toolUseBlock of toolUseBlocks) {
+      if (this.isCancelled) {
+        const cancelBlock = new ToolResultBlock({
+          toolUseId: toolUseBlock.toolUseId,
+          status: 'error',
+          content: [new TextBlock('Tool execution cancelled')],
+        })
+        toolResultBlocks.push(cancelBlock)
+        yield new ToolResultEvent({ agent: this, result: cancelBlock })
+        continue
       }
-    } finally {
-      toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
-    }
 
-    return toolResultMessage
+      const toolResultBlock = yield* this.executeTool(toolUseBlock, toolRegistry)
+      toolResultBlocks.push(toolResultBlock)
+      yield new ToolResultEvent({ agent: this, result: toolResultBlock })
+    }
   }
 
   /**
@@ -1210,10 +1223,9 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_executeToolsConcurrent(
     toolUseBlocks: ToolUseBlock[],
-    toolRegistry: ToolRegistry
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
-    let toolResultMessage: Message
-
+    toolRegistry: ToolRegistry,
+    ref: ToolResultMessageRef
+  ): AsyncGenerator<AgentStreamEvent, void, undefined> {
     // Wrap each in-flight `.next()` so the raced promise always resolves to a
     // tagged Step. That prevents one generator rejection from rejecting the
     // whole race and lets us convert per-tool failures into ToolResultBlocks
@@ -1274,27 +1286,17 @@ export class Agent implements LocalAgent, InvokableAgent {
       // Build the result message from whatever completed, in source order.
       // Missing entries get a fallback error block so the message always
       // accounts for every toolUseBlock the model emitted.
-      const toolResultBlocks: ToolResultBlock[] = []
-      for (const block of toolUseBlocks) {
-        const result = resultsByToolUseId.get(block.toolUseId)
-        if (result) {
-          toolResultBlocks.push(result)
-        } else {
-          toolResultBlocks.push(
-            new ToolResultBlock({
-              toolUseId: block.toolUseId,
-              status: 'error',
-              content: [new TextBlock('Tool execution interrupted')],
-            })
-          )
-        }
-      }
-
-      toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage })
+      const toolResultBlocks: ToolResultBlock[] = toolUseBlocks.map(
+        (block) =>
+          resultsByToolUseId.get(block.toolUseId) ??
+          new ToolResultBlock({
+            toolUseId: block.toolUseId,
+            status: 'error',
+            content: [new TextBlock('Tool execution interrupted')],
+          })
+      )
+      ref.message = new Message({ role: 'user', content: toolResultBlocks })
     }
-
-    return toolResultMessage
   }
 
   /**


### PR DESCRIPTION
## Description

Follow-up to #854 addressing review comments left open at merge time.

### Centralize `BeforeToolsEvent` / `AfterToolsEvent` emission

Before, each tool executor (`_executeToolsSequential`, `_executeToolsConcurrent`) and the pre-launch cancel path each emitted their own `AfterToolsEvent`, and `BeforeToolsEvent` was emitted even when the model returned zero tool-use blocks. The invariant-violation branch (model claimed `toolUse` stop reason but produced no tool use blocks) had to paper over this by emitting a synthetic empty `AfterToolsEvent` before throwing, just to keep the bracket contract intact.

`executeTools` now filters tool use blocks first — the invariant error throws cleanly with no events emitted — and wraps the per-executor delegation in a single `try/finally` that emits both the `BeforeToolsEvent` and the terminal `AfterToolsEvent` centrally. Executors write their assembled `Message` into a shared `ToolResultMessageRef` so the `finally` always has the latest partial result, including when the consumer breaks out of the stream via `.return()` mid-execution.

### Test robustness

- The tracer overlap test for concurrent mode used `sleep(20)` to give the executor time to launch both tools before either resolved. Replaced with cooperative signaling: each tool waits on a promise that its peer resolves at entry, so the overlap is guaranteed by construction rather than by wall-clock race.
- Added a concurrent-mode test asserting mid-tool `ToolStreamUpdateEvent`s are surfaced through `agent.stream()`.
- Added a concurrent-mode test for per-tool `BeforeToolCallEvent.cancel` — one tool's hook cancel does not disturb its siblings.
- Removed a duplicate consumer-break test; the surviving test strictly subsumes what the deleted one asserted.

## Related Issues

Follow-up to #854.

## Documentation PR

No documentation changes.

## Type of Change

Other (refactor + test quality)

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
