### PR TITLE
feat: auto-populate contextWindowLimit from model ID lookup tables

### DIFF
--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -136,6 +136,30 @@ describe('AnthropicModel', () => {
         expect.stringContaining('using default modelId')
       )
     })
+
+    it('auto-populates contextWindowLimit from model ID lookup', () => {
+      const provider = new AnthropicModel({ apiKey: 'sk-test', modelId: 'claude-sonnet-4-20250514' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+    })
+
+    it('auto-populates contextWindowLimit for default model ID', () => {
+      const provider = new AnthropicModel({ apiKey: 'sk-test' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+    })
+
+    it('does not override explicit contextWindowLimit', () => {
+      const provider = new AnthropicModel({
+        apiKey: 'sk-test',
+        modelId: 'claude-sonnet-4-20250514',
+        contextWindowLimit: 100_000,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(100_000)
+    })
+
+    it('leaves contextWindowLimit undefined for unknown model IDs', () => {
+      const provider = new AnthropicModel({ apiKey: 'sk-test', modelId: 'unknown-model' })
+      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+    })
   })
 
   describe('updateConfig', () => {

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -139,12 +139,20 @@ describe('AnthropicModel', () => {
 
     it('auto-populates contextWindowLimit from model ID lookup', () => {
       const provider = new AnthropicModel({ apiKey: 'sk-test', modelId: 'claude-sonnet-4-20250514' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'claude-sonnet-4-20250514',
+        maxTokens: 64_000,
+        contextWindowLimit: 1_000_000,
+      })
     })
 
     it('auto-populates contextWindowLimit for default model ID', () => {
       const provider = new AnthropicModel({ apiKey: 'sk-test' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'claude-sonnet-4-6',
+        maxTokens: 64_000,
+        contextWindowLimit: 1_000_000,
+      })
     })
 
     it('does not override explicit contextWindowLimit', () => {
@@ -153,12 +161,19 @@ describe('AnthropicModel', () => {
         modelId: 'claude-sonnet-4-20250514',
         contextWindowLimit: 100_000,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(100_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'claude-sonnet-4-20250514',
+        maxTokens: 64_000,
+        contextWindowLimit: 100_000,
+      })
     })
 
     it('leaves contextWindowLimit undefined for unknown model IDs', () => {
       const provider = new AnthropicModel({ apiKey: 'sk-test', modelId: 'unknown-model' })
-      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'unknown-model',
+        maxTokens: 64_000,
+      })
     })
   })
 
@@ -170,6 +185,22 @@ describe('AnthropicModel', () => {
         temperature: 0.8,
         maxTokens: 8192,
       })
+    })
+
+    it('re-resolves contextWindowLimit when modelId changes and it was auto-resolved', () => {
+      const provider = new AnthropicModel({ apiKey: 'sk-test' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000) // claude-sonnet-4-6 default
+
+      provider.updateConfig({ modelId: 'claude-sonnet-4-20250514' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000) // claude-sonnet-4-20250514 value
+    })
+
+    it('preserves explicit contextWindowLimit when modelId changes', () => {
+      const provider = new AnthropicModel({ apiKey: 'sk-test', contextWindowLimit: 50_000 })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+
+      provider.updateConfig({ modelId: 'claude-sonnet-4-20250514' })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000) // preserved
     })
   })
 

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -208,6 +208,7 @@ describe('BedrockModel', () => {
       const provider = new BedrockModel({ modelId: customModelId })
       expect(provider.getConfig()).toStrictEqual({
         modelId: customModelId,
+        contextWindowLimit: 200_000,
       })
     })
 
@@ -292,6 +293,7 @@ describe('BedrockModel', () => {
       expect(config).toStrictEqual({
         modelId: 'global.anthropic.claude-sonnet-4-6',
         temperature: 0.5,
+        contextWindowLimit: 1_000_000,
       })
     })
 
@@ -305,6 +307,34 @@ describe('BedrockModel', () => {
         contextWindowLimit: 200_000,
       })
     })
+
+    it('auto-populates contextWindowLimit from model ID lookup', () => {
+      const provider = new BedrockModel({ modelId: 'anthropic.claude-sonnet-4-20250514-v1:0' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+    })
+
+    it('auto-populates contextWindowLimit for cross-region model IDs', () => {
+      const provider = new BedrockModel({ modelId: 'us.anthropic.claude-sonnet-4-6' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+    })
+
+    it('auto-populates contextWindowLimit for default model ID', () => {
+      const provider = new BedrockModel()
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+    })
+
+    it('does not override explicit contextWindowLimit', () => {
+      const provider = new BedrockModel({
+        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        contextWindowLimit: 100_000,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(100_000)
+    })
+
+    it('leaves contextWindowLimit undefined for unknown model IDs', () => {
+      const provider = new BedrockModel({ modelId: 'unknown.model-v1:0' })
+      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+    })
   })
 
   describe('updateConfig', () => {
@@ -315,6 +345,7 @@ describe('BedrockModel', () => {
         modelId: 'global.anthropic.claude-sonnet-4-6',
         temperature: 0.8,
         maxTokens: 2048,
+        contextWindowLimit: 1_000_000,
       })
     })
 

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -310,17 +310,26 @@ describe('BedrockModel', () => {
 
     it('auto-populates contextWindowLimit from model ID lookup', () => {
       const provider = new BedrockModel({ modelId: 'anthropic.claude-sonnet-4-20250514-v1:0' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        contextWindowLimit: 1_000_000,
+      })
     })
 
     it('auto-populates contextWindowLimit for cross-region model IDs', () => {
       const provider = new BedrockModel({ modelId: 'us.anthropic.claude-sonnet-4-6' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'us.anthropic.claude-sonnet-4-6',
+        contextWindowLimit: 1_000_000,
+      })
     })
 
     it('auto-populates contextWindowLimit for default model ID', () => {
       const provider = new BedrockModel()
-      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'global.anthropic.claude-sonnet-4-6',
+        contextWindowLimit: 1_000_000,
+      })
     })
 
     it('does not override explicit contextWindowLimit', () => {
@@ -328,12 +337,17 @@ describe('BedrockModel', () => {
         modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
         contextWindowLimit: 100_000,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(100_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        contextWindowLimit: 100_000,
+      })
     })
 
     it('leaves contextWindowLimit undefined for unknown model IDs', () => {
       const provider = new BedrockModel({ modelId: 'unknown.model-v1:0' })
-      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'unknown.model-v1:0',
+      })
     })
   })
 
@@ -362,6 +376,30 @@ describe('BedrockModel', () => {
         temperature: 0.8,
         maxTokens: 1024,
       })
+    })
+
+    it('re-resolves contextWindowLimit when modelId changes and it was auto-resolved', () => {
+      const provider = new BedrockModel({ region: 'us-west-2' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+
+      provider.updateConfig({ modelId: 'anthropic.claude-haiku-4-5-20251001-v1:0' })
+      expect(provider.getConfig().contextWindowLimit).toBe(200_000)
+    })
+
+    it('clears contextWindowLimit when modelId changes to unknown model', () => {
+      const provider = new BedrockModel({ region: 'us-west-2' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_000_000)
+
+      provider.updateConfig({ modelId: 'my-custom-finetuned-model' })
+      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+    })
+
+    it('preserves explicit contextWindowLimit when modelId changes', () => {
+      const provider = new BedrockModel({ region: 'us-west-2', contextWindowLimit: 50_000 })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+
+      provider.updateConfig({ modelId: 'anthropic.claude-haiku-4-5-20251001-v1:0' })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
     })
   })
 

--- a/strands-ts/src/models/__tests__/defaults.test.ts
+++ b/strands-ts/src/models/__tests__/defaults.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { getContextWindowLimit, getModelMetadata, MODEL_METADATA } from '../defaults.js'
+
+describe('getContextWindowLimit', () => {
+  it('returns the context window limit for known model IDs across all providers', () => {
+    // Anthropic direct API
+    expect(getContextWindowLimit('claude-sonnet-4-6')).toBe(1_000_000)
+    expect(getContextWindowLimit('claude-opus-4-6')).toBe(1_000_000)
+    expect(getContextWindowLimit('claude-opus-4-5')).toBe(200_000)
+    expect(getContextWindowLimit('claude-haiku-4-5')).toBe(200_000)
+    // Bedrock Anthropic
+    expect(getContextWindowLimit('anthropic.claude-sonnet-4-6')).toBe(1_000_000)
+    // Bedrock Amazon Nova
+    expect(getContextWindowLimit('amazon.nova-pro-v1:0')).toBe(300_000)
+    expect(getContextWindowLimit('amazon.nova-micro-v1:0')).toBe(128_000)
+    // OpenAI
+    expect(getContextWindowLimit('gpt-5.4')).toBe(1_050_000)
+    expect(getContextWindowLimit('gpt-4o')).toBe(128_000)
+    expect(getContextWindowLimit('o3')).toBe(200_000)
+    expect(getContextWindowLimit('o4-mini')).toBe(200_000)
+    // Gemini
+    expect(getContextWindowLimit('gemini-2.5-flash')).toBe(1_048_576)
+    expect(getContextWindowLimit('gemini-2.5-pro')).toBe(1_048_576)
+  })
+
+  it('strips Bedrock cross-region prefix before lookup', () => {
+    expect(getContextWindowLimit('us.anthropic.claude-sonnet-4-6')).toBe(1_000_000)
+  })
+
+  it('does not strip unknown prefixes', () => {
+    expect(getContextWindowLimit('custom.gpt-5.4')).toBeUndefined()
+  })
+
+  it('returns undefined for unknown model IDs', () => {
+    expect(getContextWindowLimit('unknown-model-xyz')).toBeUndefined()
+    expect(getContextWindowLimit('us.unknown.model-v1:0')).toBeUndefined()
+  })
+})
+
+describe('getModelMetadata', () => {
+  it('returns the metadata entry for a known model', () => {
+    expect(getModelMetadata('gpt-5.4')).toStrictEqual({ contextWindowLimit: 1_050_000 })
+  })
+
+  it('returns undefined for an unknown model', () => {
+    expect(getModelMetadata('unknown-model')).toBeUndefined()
+  })
+
+  it('strips cross-region prefix', () => {
+    expect(getModelMetadata('global.anthropic.claude-sonnet-4-6')).toStrictEqual({ contextWindowLimit: 1_000_000 })
+  })
+})
+
+describe('MODEL_METADATA', () => {
+  it('contains entries for all default model IDs with positive contextWindowLimit values', () => {
+    expect(MODEL_METADATA['claude-sonnet-4-6']).toBeDefined()
+    expect(MODEL_METADATA['gpt-5.4']).toBeDefined()
+    expect(MODEL_METADATA['gemini-2.5-flash']).toBeDefined()
+
+    for (const [key, entry] of Object.entries(MODEL_METADATA)) {
+      expect(entry.contextWindowLimit, `${key} should have a positive contextWindowLimit`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/strands-ts/src/models/__tests__/defaults.test.ts
+++ b/strands-ts/src/models/__tests__/defaults.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getContextWindowLimit, getModelMetadata, MODEL_METADATA } from '../defaults.js'
+import { getContextWindowLimit } from '../defaults.js'
 
 describe('getContextWindowLimit', () => {
   it('returns the context window limit for known model IDs across all providers', () => {
@@ -25,6 +25,7 @@ describe('getContextWindowLimit', () => {
 
   it('strips Bedrock cross-region prefix before lookup', () => {
     expect(getContextWindowLimit('us.anthropic.claude-sonnet-4-6')).toBe(1_000_000)
+    expect(getContextWindowLimit('global.anthropic.claude-sonnet-4-6')).toBe(1_000_000)
   })
 
   it('does not strip unknown prefixes', () => {
@@ -34,31 +35,5 @@ describe('getContextWindowLimit', () => {
   it('returns undefined for unknown model IDs', () => {
     expect(getContextWindowLimit('unknown-model-xyz')).toBeUndefined()
     expect(getContextWindowLimit('us.unknown.model-v1:0')).toBeUndefined()
-  })
-})
-
-describe('getModelMetadata', () => {
-  it('returns the metadata entry for a known model', () => {
-    expect(getModelMetadata('gpt-5.4')).toStrictEqual({ contextWindowLimit: 1_050_000 })
-  })
-
-  it('returns undefined for an unknown model', () => {
-    expect(getModelMetadata('unknown-model')).toBeUndefined()
-  })
-
-  it('strips cross-region prefix', () => {
-    expect(getModelMetadata('global.anthropic.claude-sonnet-4-6')).toStrictEqual({ contextWindowLimit: 1_000_000 })
-  })
-})
-
-describe('MODEL_METADATA', () => {
-  it('contains entries for all default model IDs with positive contextWindowLimit values', () => {
-    expect(MODEL_METADATA['claude-sonnet-4-6']).toBeDefined()
-    expect(MODEL_METADATA['gpt-5.4']).toBeDefined()
-    expect(MODEL_METADATA['gemini-2.5-flash']).toBeDefined()
-
-    for (const [key, entry] of Object.entries(MODEL_METADATA)) {
-      expect(entry.contextWindowLimit, `${key} should have a positive contextWindowLimit`).toBeGreaterThan(0)
-    }
   })
 })

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -142,6 +142,30 @@ describe('GoogleModel', () => {
         contextWindowLimit: 1_048_576,
       })
     })
+
+    it('re-resolves contextWindowLimit when modelId changes and it was auto-resolved', () => {
+      const provider = new GoogleModel({ apiKey: 'test-key' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+
+      provider.updateConfig({ modelId: 'gemini-2.0-flash' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+    })
+
+    it('clears contextWindowLimit when modelId changes to unknown model', () => {
+      const provider = new GoogleModel({ apiKey: 'test-key' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+
+      provider.updateConfig({ modelId: 'my-custom-finetuned-model' })
+      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+    })
+
+    it('preserves explicit contextWindowLimit when modelId changes', () => {
+      const provider = new GoogleModel({ apiKey: 'test-key', contextWindowLimit: 50_000 })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+
+      provider.updateConfig({ modelId: 'gemini-2.0-flash' })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+    })
   })
 
   describe('getConfig', () => {
@@ -172,12 +196,17 @@ describe('GoogleModel', () => {
 
     it('auto-populates contextWindowLimit from model ID lookup', () => {
       const provider = new GoogleModel({ apiKey: 'test-key', modelId: 'gemini-2.5-pro' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'gemini-2.5-pro',
+        contextWindowLimit: 1_048_576,
+      })
     })
 
     it('auto-populates contextWindowLimit for default model ID', () => {
       const provider = new GoogleModel({ apiKey: 'test-key' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+      expect(provider.getConfig()).toStrictEqual({
+        contextWindowLimit: 1_048_576,
+      })
     })
 
     it('does not override explicit contextWindowLimit', () => {
@@ -186,12 +215,17 @@ describe('GoogleModel', () => {
         modelId: 'gemini-2.5-flash',
         contextWindowLimit: 500_000,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(500_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'gemini-2.5-flash',
+        contextWindowLimit: 500_000,
+      })
     })
 
     it('leaves contextWindowLimit undefined for unknown model IDs', () => {
       const provider = new GoogleModel({ apiKey: 'test-key', modelId: 'unknown-model' })
-      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'unknown-model',
+      })
     })
   })
 

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -139,6 +139,7 @@ describe('GoogleModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'gemini-2.5-flash',
         params: { temperature: 0.5 },
+        contextWindowLimit: 1_048_576,
       })
     })
   })
@@ -153,6 +154,7 @@ describe('GoogleModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'gemini-2.5-flash',
         params: { maxOutputTokens: 1024, temperature: 0.7 },
+        contextWindowLimit: 1_048_576,
       })
     })
 
@@ -166,6 +168,30 @@ describe('GoogleModel', () => {
         modelId: 'gemini-2.5-flash',
         contextWindowLimit: 1_048_576,
       })
+    })
+
+    it('auto-populates contextWindowLimit from model ID lookup', () => {
+      const provider = new GoogleModel({ apiKey: 'test-key', modelId: 'gemini-2.5-pro' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+    })
+
+    it('auto-populates contextWindowLimit for default model ID', () => {
+      const provider = new GoogleModel({ apiKey: 'test-key' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_048_576)
+    })
+
+    it('does not override explicit contextWindowLimit', () => {
+      const provider = new GoogleModel({
+        apiKey: 'test-key',
+        modelId: 'gemini-2.5-flash',
+        contextWindowLimit: 500_000,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(500_000)
+    })
+
+    it('leaves contextWindowLimit undefined for unknown model IDs', () => {
+      const provider = new GoogleModel({ apiKey: 'test-key', modelId: 'unknown-model' })
+      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
     })
   })
 

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -8,7 +8,12 @@ import type { ImageBlock, DocumentBlock } from '../types/media.js'
 import { encodeBase64 } from '../types/media.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
-import { MODEL_DEFAULTS, defaultMaxTokensWarningMessage, defaultModelWarningMessage } from './defaults.js'
+import {
+  MODEL_DEFAULTS,
+  defaultMaxTokensWarningMessage,
+  defaultModelWarningMessage,
+  getContextWindowLimit,
+} from './defaults.js'
 
 const CONTEXT_WINDOW_OVERFLOW_ERRORS = ['prompt is too long', 'max_tokens exceeded', 'input too long']
 const TEXT_FILE_FORMATS = ['txt', 'md', 'markdown', 'csv', 'json', 'xml', 'html', 'yml', 'yaml', 'js', 'ts', 'py']
@@ -51,6 +56,11 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
 
     if (modelConfig.maxTokens === undefined) {
       warnOnce(logger, defaultMaxTokensWarningMessage(MODEL_DEFAULTS.anthropic.maxTokens))
+    }
+
+    if (this._config.contextWindowLimit === undefined) {
+      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.anthropic.modelId)
+      if (contextWindowLimit !== undefined) this._config.contextWindowLimit = contextWindowLimit
     }
 
     if (client) {

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -1,5 +1,11 @@
 import Anthropic, { type ClientOptions } from '@anthropic-ai/sdk'
-import { Model, type BaseModelConfig, type CountTokensOptions, type StreamOptions } from '../models/model.js'
+import {
+  Model,
+  type BaseModelConfig,
+  type CountTokensOptions,
+  type StreamOptions,
+  resolveConfigMetadata,
+} from '../models/model.js'
 import type { Message, ContentBlock } from '../types/messages.js'
 import type { ModelStreamEvent } from '../models/streaming.js'
 import { createEmptyUsage } from '../models/streaming.js'
@@ -8,12 +14,7 @@ import type { ImageBlock, DocumentBlock } from '../types/media.js'
 import { encodeBase64 } from '../types/media.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
-import {
-  MODEL_DEFAULTS,
-  defaultMaxTokensWarningMessage,
-  defaultModelWarningMessage,
-  getContextWindowLimit,
-} from './defaults.js'
+import { MODEL_DEFAULTS, defaultMaxTokensWarningMessage, defaultModelWarningMessage } from './defaults.js'
 
 const CONTEXT_WINDOW_OVERFLOW_ERRORS = ['prompt is too long', 'max_tokens exceeded', 'input too long']
 const TEXT_FILE_FORMATS = ['txt', 'md', 'markdown', 'csv', 'json', 'xml', 'html', 'yml', 'yaml', 'js', 'ts', 'py']
@@ -58,11 +59,6 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       warnOnce(logger, defaultMaxTokensWarningMessage(MODEL_DEFAULTS.anthropic.maxTokens))
     }
 
-    if (this._config.contextWindowLimit === undefined) {
-      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.anthropic.modelId)
-      if (contextWindowLimit !== undefined) this._config.contextWindowLimit = contextWindowLimit
-    }
-
     if (client) {
       this._client = client
     } else {
@@ -91,7 +87,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
   }
 
   getConfig(): AnthropicModelConfig {
-    return this._config
+    return resolveConfigMetadata(this._config, this._config.modelId ?? MODEL_DEFAULTS.anthropic.modelId)
   }
 
   /**

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -59,7 +59,7 @@ import { ensureDefined } from '../types/validation.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
 import { NOOP_TOOL_SPEC } from '../tools/noop-tool.js'
-import { MODEL_DEFAULTS, defaultModelWarningMessage } from './defaults.js'
+import { MODEL_DEFAULTS, defaultModelWarningMessage, getContextWindowLimit } from './defaults.js'
 
 const DEFAULT_BEDROCK_REGION_SUPPORTS_FIP = false
 
@@ -368,6 +368,11 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
     if (modelConfig.modelId === undefined) {
       warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.bedrock.modelId))
+    }
+
+    if (this._config.contextWindowLimit === undefined) {
+      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.bedrock.modelId)
+      if (contextWindowLimit !== undefined) this._config.contextWindowLimit = contextWindowLimit
     }
 
     // Build user agent string (extend if provided, otherwise use SDK identifier)

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -48,6 +48,7 @@ import {
   type CountTokensOptions,
   Model,
   type StreamOptions,
+  resolveConfigMetadata,
 } from '../models/model.js'
 import type { ContentBlock, Message, StopReason, ToolUseBlock } from '../types/messages.js'
 import type { ImageSource, VideoSource, DocumentSource } from '../types/media.js'
@@ -59,7 +60,7 @@ import { ensureDefined } from '../types/validation.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
 import { NOOP_TOOL_SPEC } from '../tools/noop-tool.js'
-import { MODEL_DEFAULTS, defaultModelWarningMessage, getContextWindowLimit } from './defaults.js'
+import { MODEL_DEFAULTS, defaultModelWarningMessage } from './defaults.js'
 
 const DEFAULT_BEDROCK_REGION_SUPPORTS_FIP = false
 
@@ -370,11 +371,6 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.bedrock.modelId))
     }
 
-    if (this._config.contextWindowLimit === undefined) {
-      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.bedrock.modelId)
-      if (contextWindowLimit !== undefined) this._config.contextWindowLimit = contextWindowLimit
-    }
-
     // Build user agent string (extend if provided, otherwise use SDK identifier)
     const customUserAgent = clientConfig?.customUserAgent
       ? `${clientConfig.customUserAgent} strands-agents-ts-sdk`
@@ -468,7 +464,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
    * ```
    */
   getConfig(): BedrockModelConfig {
-    return this._config
+    return resolveConfigMetadata(this._config, this._config.modelId ?? MODEL_DEFAULTS.bedrock.modelId)
   }
 
   /**

--- a/strands-ts/src/models/defaults.ts
+++ b/strands-ts/src/models/defaults.ts
@@ -41,3 +41,152 @@ export function defaultModelWarningMessage(defaultModelId: string): string {
 export function defaultMaxTokensWarningMessage(defaultMaxTokens: number): string {
   return `max_tokens=<${defaultMaxTokens}> | using default maxTokens, which is subject to change | set maxTokens explicitly to pin the value`
 }
+
+/**
+ * Metadata for known model IDs.
+ *
+ * Values sourced from provider documentation and
+ * https://github.com/BerriAI/litellm/blob/litellm_internal_staging/model_prices_and_context_window.json
+ *
+ * For Bedrock models with cross-region prefixes (e.g. `us.`, `eu.`, `global.`),
+ * {@link getModelMetadata} strips the prefix before lookup so only the base model ID is needed here.
+ */
+export interface ModelMetadataEntry {
+  /**
+   * Maximum context window size in tokens (input + output combined).
+   */
+  contextWindowLimit: number
+}
+
+export const MODEL_METADATA: Record<string, ModelMetadataEntry> = {
+  // Anthropic (direct API)
+  'claude-sonnet-4-6': { contextWindowLimit: 1_000_000 },
+  'claude-sonnet-4-20250514': { contextWindowLimit: 1_000_000 },
+  'claude-sonnet-4-5': { contextWindowLimit: 200_000 },
+  'claude-sonnet-4-5-20250929': { contextWindowLimit: 200_000 },
+  'claude-opus-4-6': { contextWindowLimit: 1_000_000 },
+  'claude-opus-4-6-20260205': { contextWindowLimit: 1_000_000 },
+  'claude-opus-4-7': { contextWindowLimit: 1_000_000 },
+  'claude-opus-4-7-20260416': { contextWindowLimit: 1_000_000 },
+  'claude-opus-4-5': { contextWindowLimit: 200_000 },
+  'claude-opus-4-5-20251101': { contextWindowLimit: 200_000 },
+  'claude-opus-4-20250514': { contextWindowLimit: 200_000 },
+  'claude-opus-4-1': { contextWindowLimit: 200_000 },
+  'claude-opus-4-1-20250805': { contextWindowLimit: 200_000 },
+  'claude-haiku-4-5': { contextWindowLimit: 200_000 },
+  'claude-haiku-4-5-20251001': { contextWindowLimit: 200_000 },
+  'claude-3-7-sonnet-20250219': { contextWindowLimit: 200_000 },
+  'claude-3-5-sonnet-20241022': { contextWindowLimit: 200_000 },
+  'claude-3-5-sonnet-20240620': { contextWindowLimit: 200_000 },
+  'claude-3-5-haiku-20241022': { contextWindowLimit: 200_000 },
+  'claude-3-opus-20240229': { contextWindowLimit: 200_000 },
+  'claude-3-haiku-20240307': { contextWindowLimit: 200_000 },
+
+  // Bedrock Anthropic (base model IDs — cross-region prefixes stripped by getModelMetadata)
+  'anthropic.claude-sonnet-4-6': { contextWindowLimit: 1_000_000 },
+  'anthropic.claude-sonnet-4-20250514-v1:0': { contextWindowLimit: 1_000_000 },
+  'anthropic.claude-sonnet-4-5-20250929-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-opus-4-6-v1': { contextWindowLimit: 1_000_000 },
+  'anthropic.claude-opus-4-7': { contextWindowLimit: 1_000_000 },
+  'anthropic.claude-opus-4-5-20251101-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-opus-4-20250514-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-opus-4-1-20250805-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-haiku-4-5-20251001-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-haiku-4-5@20251001': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-7-sonnet-20250219-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-7-sonnet-20240620-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-5-sonnet-20241022-v2:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-5-sonnet-20240620-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-5-haiku-20241022-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-opus-20240229-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-haiku-20240307-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-3-sonnet-20240229-v1:0': { contextWindowLimit: 200_000 },
+  'anthropic.claude-mythos-preview': { contextWindowLimit: 1_000_000 },
+
+  // Bedrock Amazon Nova
+  'amazon.nova-pro-v1:0': { contextWindowLimit: 300_000 },
+  'amazon.nova-lite-v1:0': { contextWindowLimit: 300_000 },
+  'amazon.nova-micro-v1:0': { contextWindowLimit: 128_000 },
+  'amazon.nova-premier-v1:0': { contextWindowLimit: 1_000_000 },
+  'amazon.nova-2-lite-v1:0': { contextWindowLimit: 1_000_000 },
+  'amazon.nova-2-pro-preview-20251202-v1:0': { contextWindowLimit: 1_000_000 },
+
+  // OpenAI
+  'gpt-5.5': { contextWindowLimit: 1_050_000 },
+  'gpt-5.5-pro': { contextWindowLimit: 1_050_000 },
+  'gpt-5.4': { contextWindowLimit: 1_050_000 },
+  'gpt-5.4-pro': { contextWindowLimit: 1_050_000 },
+  'gpt-5.4-mini': { contextWindowLimit: 272_000 },
+  'gpt-5.4-nano': { contextWindowLimit: 272_000 },
+  'gpt-5.2': { contextWindowLimit: 272_000 },
+  'gpt-5.2-pro': { contextWindowLimit: 272_000 },
+  'gpt-5.1': { contextWindowLimit: 272_000 },
+  'gpt-5': { contextWindowLimit: 272_000 },
+  'gpt-5-mini': { contextWindowLimit: 272_000 },
+  'gpt-5-nano': { contextWindowLimit: 272_000 },
+  'gpt-5-pro': { contextWindowLimit: 128_000 },
+  'gpt-4.1': { contextWindowLimit: 1_047_576 },
+  'gpt-4.1-mini': { contextWindowLimit: 1_047_576 },
+  'gpt-4.1-nano': { contextWindowLimit: 1_047_576 },
+  'gpt-4o': { contextWindowLimit: 128_000 },
+  'gpt-4o-mini': { contextWindowLimit: 128_000 },
+  'gpt-4-turbo': { contextWindowLimit: 128_000 },
+  o3: { contextWindowLimit: 200_000 },
+  'o3-mini': { contextWindowLimit: 200_000 },
+  'o3-pro': { contextWindowLimit: 200_000 },
+  'o4-mini': { contextWindowLimit: 200_000 },
+  o1: { contextWindowLimit: 200_000 },
+
+  // Google Gemini
+  'gemini-2.5-flash': { contextWindowLimit: 1_048_576 },
+  'gemini-2.5-flash-lite': { contextWindowLimit: 1_048_576 },
+  'gemini-2.5-pro': { contextWindowLimit: 1_048_576 },
+  'gemini-2.0-flash': { contextWindowLimit: 1_048_576 },
+  'gemini-2.0-flash-lite': { contextWindowLimit: 1_048_576 },
+  'gemini-3-pro-preview': { contextWindowLimit: 1_048_576 },
+  'gemini-3-flash-preview': { contextWindowLimit: 1_048_576 },
+  'gemini-3.1-pro-preview': { contextWindowLimit: 1_048_576 },
+  'gemini-3.1-flash-lite-preview': { contextWindowLimit: 1_048_576 },
+}
+
+/**
+ * Known Bedrock cross-region routing prefixes.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+ */
+const BEDROCK_REGION_PREFIXES = new Set(['us', 'eu', 'ap', 'global', 'apac', 'au', 'jp', 'us-gov'])
+
+/**
+ * Looks up metadata for a model ID.
+ *
+ * For Bedrock cross-region model IDs (e.g. `us.anthropic.claude-sonnet-4-6`),
+ * the region prefix is stripped before lookup.
+ *
+ * @param modelId - The model ID to look up
+ * @returns The metadata entry, or undefined if not found
+ */
+export function getModelMetadata(modelId: string): ModelMetadataEntry | undefined {
+  const direct = MODEL_METADATA[modelId]
+  if (direct !== undefined) return direct
+
+  // Strip known Bedrock cross-region prefixes
+  const dotIndex = modelId.indexOf('.')
+  if (dotIndex !== -1) {
+    const prefix = modelId.substring(0, dotIndex)
+    if (BEDROCK_REGION_PREFIXES.has(prefix)) {
+      return MODEL_METADATA[modelId.substring(dotIndex + 1)]
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Looks up the context window limit for a model ID.
+ *
+ * @param modelId - The model ID to look up
+ * @returns The context window limit in tokens, or undefined if not found
+ */
+export function getContextWindowLimit(modelId: string): number | undefined {
+  return getModelMetadata(modelId)?.contextWindowLimit
+}

--- a/strands-ts/src/models/defaults.ts
+++ b/strands-ts/src/models/defaults.ts
@@ -43,110 +43,108 @@ export function defaultMaxTokensWarningMessage(defaultMaxTokens: number): string
 }
 
 /**
- * Metadata for known model IDs.
+ * Context window limits (in tokens) for known model IDs.
+ *
+ * Best-effort lookup table — unknown models return `undefined` and callers
+ * fall back gracefully (e.g. proactive compression is disabled).
+ * Entries can be pruned when a model is no longer available from the provider.
+ * Users can always override with an explicit `contextWindowLimit` in their model config.
  *
  * Values sourced from provider documentation and
  * https://github.com/BerriAI/litellm/blob/litellm_internal_staging/model_prices_and_context_window.json
  *
  * For Bedrock models with cross-region prefixes (e.g. `us.`, `eu.`, `global.`),
- * {@link getModelMetadata} strips the prefix before lookup so only the base model ID is needed here.
+ * {@link getContextWindowLimit} strips the prefix before lookup so only the base model ID is needed here.
  */
-export interface ModelMetadataEntry {
-  /**
-   * Maximum context window size in tokens (input + output combined).
-   */
-  contextWindowLimit: number
-}
-
-export const MODEL_METADATA: Record<string, ModelMetadataEntry> = {
+const CONTEXT_WINDOW_LIMITS: Record<string, number> = {
   // Anthropic (direct API)
-  'claude-sonnet-4-6': { contextWindowLimit: 1_000_000 },
-  'claude-sonnet-4-20250514': { contextWindowLimit: 1_000_000 },
-  'claude-sonnet-4-5': { contextWindowLimit: 200_000 },
-  'claude-sonnet-4-5-20250929': { contextWindowLimit: 200_000 },
-  'claude-opus-4-6': { contextWindowLimit: 1_000_000 },
-  'claude-opus-4-6-20260205': { contextWindowLimit: 1_000_000 },
-  'claude-opus-4-7': { contextWindowLimit: 1_000_000 },
-  'claude-opus-4-7-20260416': { contextWindowLimit: 1_000_000 },
-  'claude-opus-4-5': { contextWindowLimit: 200_000 },
-  'claude-opus-4-5-20251101': { contextWindowLimit: 200_000 },
-  'claude-opus-4-20250514': { contextWindowLimit: 200_000 },
-  'claude-opus-4-1': { contextWindowLimit: 200_000 },
-  'claude-opus-4-1-20250805': { contextWindowLimit: 200_000 },
-  'claude-haiku-4-5': { contextWindowLimit: 200_000 },
-  'claude-haiku-4-5-20251001': { contextWindowLimit: 200_000 },
-  'claude-3-7-sonnet-20250219': { contextWindowLimit: 200_000 },
-  'claude-3-5-sonnet-20241022': { contextWindowLimit: 200_000 },
-  'claude-3-5-sonnet-20240620': { contextWindowLimit: 200_000 },
-  'claude-3-5-haiku-20241022': { contextWindowLimit: 200_000 },
-  'claude-3-opus-20240229': { contextWindowLimit: 200_000 },
-  'claude-3-haiku-20240307': { contextWindowLimit: 200_000 },
+  'claude-sonnet-4-6': 1_000_000,
+  'claude-sonnet-4-20250514': 1_000_000,
+  'claude-sonnet-4-5': 200_000,
+  'claude-sonnet-4-5-20250929': 200_000,
+  'claude-opus-4-6': 1_000_000,
+  'claude-opus-4-6-20260205': 1_000_000,
+  'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-7-20260416': 1_000_000,
+  'claude-opus-4-5': 200_000,
+  'claude-opus-4-5-20251101': 200_000,
+  'claude-opus-4-20250514': 200_000,
+  'claude-opus-4-1': 200_000,
+  'claude-opus-4-1-20250805': 200_000,
+  'claude-haiku-4-5': 200_000,
+  'claude-haiku-4-5-20251001': 200_000,
+  'claude-3-7-sonnet-20250219': 200_000,
+  'claude-3-5-sonnet-20241022': 200_000,
+  'claude-3-5-sonnet-20240620': 200_000,
+  'claude-3-5-haiku-20241022': 200_000,
+  'claude-3-opus-20240229': 200_000,
+  'claude-3-haiku-20240307': 200_000,
 
-  // Bedrock Anthropic (base model IDs — cross-region prefixes stripped by getModelMetadata)
-  'anthropic.claude-sonnet-4-6': { contextWindowLimit: 1_000_000 },
-  'anthropic.claude-sonnet-4-20250514-v1:0': { contextWindowLimit: 1_000_000 },
-  'anthropic.claude-sonnet-4-5-20250929-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-opus-4-6-v1': { contextWindowLimit: 1_000_000 },
-  'anthropic.claude-opus-4-7': { contextWindowLimit: 1_000_000 },
-  'anthropic.claude-opus-4-5-20251101-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-opus-4-20250514-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-opus-4-1-20250805-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-haiku-4-5-20251001-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-haiku-4-5@20251001': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-7-sonnet-20250219-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-7-sonnet-20240620-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-5-sonnet-20241022-v2:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-5-sonnet-20240620-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-5-haiku-20241022-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-opus-20240229-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-haiku-20240307-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-3-sonnet-20240229-v1:0': { contextWindowLimit: 200_000 },
-  'anthropic.claude-mythos-preview': { contextWindowLimit: 1_000_000 },
+  // Bedrock Anthropic (base model IDs — cross-region prefixes stripped by getContextWindowLimit)
+  'anthropic.claude-sonnet-4-6': 1_000_000,
+  'anthropic.claude-sonnet-4-20250514-v1:0': 1_000_000,
+  'anthropic.claude-sonnet-4-5-20250929-v1:0': 200_000,
+  'anthropic.claude-opus-4-6-v1': 1_000_000,
+  'anthropic.claude-opus-4-7': 1_000_000,
+  'anthropic.claude-opus-4-5-20251101-v1:0': 200_000,
+  'anthropic.claude-opus-4-20250514-v1:0': 200_000,
+  'anthropic.claude-opus-4-1-20250805-v1:0': 200_000,
+  'anthropic.claude-haiku-4-5-20251001-v1:0': 200_000,
+  'anthropic.claude-haiku-4-5@20251001': 200_000,
+  'anthropic.claude-3-7-sonnet-20250219-v1:0': 200_000,
+  'anthropic.claude-3-7-sonnet-20240620-v1:0': 200_000,
+  'anthropic.claude-3-5-sonnet-20241022-v2:0': 200_000,
+  'anthropic.claude-3-5-sonnet-20240620-v1:0': 200_000,
+  'anthropic.claude-3-5-haiku-20241022-v1:0': 200_000,
+  'anthropic.claude-3-opus-20240229-v1:0': 200_000,
+  'anthropic.claude-3-haiku-20240307-v1:0': 200_000,
+  'anthropic.claude-3-sonnet-20240229-v1:0': 200_000,
+  'anthropic.claude-mythos-preview': 1_000_000,
 
   // Bedrock Amazon Nova
-  'amazon.nova-pro-v1:0': { contextWindowLimit: 300_000 },
-  'amazon.nova-lite-v1:0': { contextWindowLimit: 300_000 },
-  'amazon.nova-micro-v1:0': { contextWindowLimit: 128_000 },
-  'amazon.nova-premier-v1:0': { contextWindowLimit: 1_000_000 },
-  'amazon.nova-2-lite-v1:0': { contextWindowLimit: 1_000_000 },
-  'amazon.nova-2-pro-preview-20251202-v1:0': { contextWindowLimit: 1_000_000 },
+  'amazon.nova-pro-v1:0': 300_000,
+  'amazon.nova-lite-v1:0': 300_000,
+  'amazon.nova-micro-v1:0': 128_000,
+  'amazon.nova-premier-v1:0': 1_000_000,
+  'amazon.nova-2-lite-v1:0': 1_000_000,
+  'amazon.nova-2-pro-preview-20251202-v1:0': 1_000_000,
 
   // OpenAI
-  'gpt-5.5': { contextWindowLimit: 1_050_000 },
-  'gpt-5.5-pro': { contextWindowLimit: 1_050_000 },
-  'gpt-5.4': { contextWindowLimit: 1_050_000 },
-  'gpt-5.4-pro': { contextWindowLimit: 1_050_000 },
-  'gpt-5.4-mini': { contextWindowLimit: 272_000 },
-  'gpt-5.4-nano': { contextWindowLimit: 272_000 },
-  'gpt-5.2': { contextWindowLimit: 272_000 },
-  'gpt-5.2-pro': { contextWindowLimit: 272_000 },
-  'gpt-5.1': { contextWindowLimit: 272_000 },
-  'gpt-5': { contextWindowLimit: 272_000 },
-  'gpt-5-mini': { contextWindowLimit: 272_000 },
-  'gpt-5-nano': { contextWindowLimit: 272_000 },
-  'gpt-5-pro': { contextWindowLimit: 128_000 },
-  'gpt-4.1': { contextWindowLimit: 1_047_576 },
-  'gpt-4.1-mini': { contextWindowLimit: 1_047_576 },
-  'gpt-4.1-nano': { contextWindowLimit: 1_047_576 },
-  'gpt-4o': { contextWindowLimit: 128_000 },
-  'gpt-4o-mini': { contextWindowLimit: 128_000 },
-  'gpt-4-turbo': { contextWindowLimit: 128_000 },
-  o3: { contextWindowLimit: 200_000 },
-  'o3-mini': { contextWindowLimit: 200_000 },
-  'o3-pro': { contextWindowLimit: 200_000 },
-  'o4-mini': { contextWindowLimit: 200_000 },
-  o1: { contextWindowLimit: 200_000 },
+  'gpt-5.5': 1_050_000,
+  'gpt-5.5-pro': 1_050_000,
+  'gpt-5.4': 1_050_000,
+  'gpt-5.4-pro': 1_050_000,
+  'gpt-5.4-mini': 272_000,
+  'gpt-5.4-nano': 272_000,
+  'gpt-5.2': 272_000,
+  'gpt-5.2-pro': 272_000,
+  'gpt-5.1': 272_000,
+  'gpt-5': 272_000,
+  'gpt-5-mini': 272_000,
+  'gpt-5-nano': 272_000,
+  'gpt-5-pro': 128_000,
+  'gpt-4.1': 1_047_576,
+  'gpt-4.1-mini': 1_047_576,
+  'gpt-4.1-nano': 1_047_576,
+  'gpt-4o': 128_000,
+  'gpt-4o-mini': 128_000,
+  'gpt-4-turbo': 128_000,
+  o3: 200_000,
+  'o3-mini': 200_000,
+  'o3-pro': 200_000,
+  'o4-mini': 200_000,
+  o1: 200_000,
 
   // Google Gemini
-  'gemini-2.5-flash': { contextWindowLimit: 1_048_576 },
-  'gemini-2.5-flash-lite': { contextWindowLimit: 1_048_576 },
-  'gemini-2.5-pro': { contextWindowLimit: 1_048_576 },
-  'gemini-2.0-flash': { contextWindowLimit: 1_048_576 },
-  'gemini-2.0-flash-lite': { contextWindowLimit: 1_048_576 },
-  'gemini-3-pro-preview': { contextWindowLimit: 1_048_576 },
-  'gemini-3-flash-preview': { contextWindowLimit: 1_048_576 },
-  'gemini-3.1-pro-preview': { contextWindowLimit: 1_048_576 },
-  'gemini-3.1-flash-lite-preview': { contextWindowLimit: 1_048_576 },
+  'gemini-2.5-flash': 1_048_576,
+  'gemini-2.5-flash-lite': 1_048_576,
+  'gemini-2.5-pro': 1_048_576,
+  'gemini-2.0-flash': 1_048_576,
+  'gemini-2.0-flash-lite': 1_048_576,
+  'gemini-3-pro-preview': 1_048_576,
+  'gemini-3-flash-preview': 1_048_576,
+  'gemini-3.1-pro-preview': 1_048_576,
+  'gemini-3.1-flash-lite-preview': 1_048_576,
 }
 
 /**
@@ -157,16 +155,16 @@ export const MODEL_METADATA: Record<string, ModelMetadataEntry> = {
 const BEDROCK_REGION_PREFIXES = new Set(['us', 'eu', 'ap', 'global', 'apac', 'au', 'jp', 'us-gov'])
 
 /**
- * Looks up metadata for a model ID.
+ * Looks up the context window limit for a model ID.
  *
  * For Bedrock cross-region model IDs (e.g. `us.anthropic.claude-sonnet-4-6`),
  * the region prefix is stripped before lookup.
  *
  * @param modelId - The model ID to look up
- * @returns The metadata entry, or undefined if not found
+ * @returns The context window limit in tokens, or undefined if not found
  */
-export function getModelMetadata(modelId: string): ModelMetadataEntry | undefined {
-  const direct = MODEL_METADATA[modelId]
+export function getContextWindowLimit(modelId: string): number | undefined {
+  const direct = CONTEXT_WINDOW_LIMITS[modelId]
   if (direct !== undefined) return direct
 
   // Strip known Bedrock cross-region prefixes
@@ -174,19 +172,9 @@ export function getModelMetadata(modelId: string): ModelMetadataEntry | undefine
   if (dotIndex !== -1) {
     const prefix = modelId.substring(0, dotIndex)
     if (BEDROCK_REGION_PREFIXES.has(prefix)) {
-      return MODEL_METADATA[modelId.substring(dotIndex + 1)]
+      return CONTEXT_WINDOW_LIMITS[modelId.substring(dotIndex + 1)]
     }
   }
 
   return undefined
-}
-
-/**
- * Looks up the context window limit for a model ID.
- *
- * @param modelId - The model ID to look up
- * @returns The context window limit in tokens, or undefined if not found
- */
-export function getContextWindowLimit(modelId: string): number | undefined {
-  return getModelMetadata(modelId)?.contextWindowLimit
 }

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -22,7 +22,7 @@ import type { GoogleModelConfig, GoogleModelOptions, GoogleStreamState } from '.
 export type { GoogleModelConfig, GoogleModelOptions }
 import { classifyGoogleError } from './errors.js'
 import { formatMessages, mapChunkToEvents } from './adapters.js'
-import { MODEL_DEFAULTS, defaultModelWarningMessage } from '../defaults.js'
+import { MODEL_DEFAULTS, defaultModelWarningMessage, getContextWindowLimit } from '../defaults.js'
 import { warnOnce } from '../../logging/warn-once.js'
 import { logger } from '../../logging/logger.js'
 
@@ -94,6 +94,11 @@ export class GoogleModel extends Model<GoogleModelConfig> {
 
     if (modelConfig.modelId === undefined) {
       warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.gemini.modelId))
+    }
+
+    if (this._config.contextWindowLimit === undefined) {
+      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.gemini.modelId)
+      if (contextWindowLimit !== undefined) this._config.contextWindowLimit = contextWindowLimit
     }
 
     if (client) {

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -13,7 +13,7 @@ import {
   type GenerateContentConfig,
   type GenerateContentParameters,
 } from '@google/genai'
-import { Model } from '../model.js'
+import { Model, resolveConfigMetadata } from '../model.js'
 import type { CountTokensOptions, StreamOptions } from '../model.js'
 import type { Message } from '../../types/messages.js'
 import type { ModelStreamEvent } from '../streaming.js'
@@ -22,7 +22,7 @@ import type { GoogleModelConfig, GoogleModelOptions, GoogleStreamState } from '.
 export type { GoogleModelConfig, GoogleModelOptions }
 import { classifyGoogleError } from './errors.js'
 import { formatMessages, mapChunkToEvents } from './adapters.js'
-import { MODEL_DEFAULTS, defaultModelWarningMessage, getContextWindowLimit } from '../defaults.js'
+import { MODEL_DEFAULTS, defaultModelWarningMessage } from '../defaults.js'
 import { warnOnce } from '../../logging/warn-once.js'
 import { logger } from '../../logging/logger.js'
 
@@ -96,11 +96,6 @@ export class GoogleModel extends Model<GoogleModelConfig> {
       warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.gemini.modelId))
     }
 
-    if (this._config.contextWindowLimit === undefined) {
-      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.gemini.modelId)
-      if (contextWindowLimit !== undefined) this._config.contextWindowLimit = contextWindowLimit
-    }
-
     if (client) {
       this._client = client
     } else {
@@ -149,7 +144,7 @@ export class GoogleModel extends Model<GoogleModelConfig> {
    * ```
    */
   getConfig(): GoogleModelConfig {
-    return this._config
+    return resolveConfigMetadata(this._config, this._config.modelId ?? MODEL_DEFAULTS.gemini.modelId)
   }
 
   /**

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -26,6 +26,23 @@ import {
 import { MaxTokensError, ModelError, normalizeError } from '../errors.js'
 import type { Redaction } from '../hooks/events.js'
 import { logger } from '../logging/logger.js'
+import { getContextWindowLimit } from './defaults.js'
+
+/**
+ * Resolves model metadata fields on a config object from built-in lookup tables
+ * when not explicitly set. Explicit values pass through unchanged.
+ *
+ * @internal
+ * @param config - The stored model config
+ * @param modelId - The model ID to look up
+ * @returns A new config with resolved metadata, or the original config if nothing to resolve
+ */
+export function resolveConfigMetadata<T extends BaseModelConfig>(config: T, modelId: string): T {
+  if (config.contextWindowLimit !== undefined) return config
+  const limit = getContextWindowLimit(modelId)
+  if (limit === undefined) return config
+  return { ...config, contextWindowLimit: limit }
+}
 
 class CitationAccumulator {
   citations: Citation[] = []
@@ -98,6 +115,11 @@ export interface BaseModelConfig {
    * Maximum context window size in tokens for the model.
    *
    * This value represents the total token capacity shared between input and output.
+   * When not provided, it is automatically resolved from a built-in lookup table
+   * based on the configured model ID. An explicit value always takes precedence.
+   *
+   * When `modelId` is changed via `updateConfig()`, this value is automatically
+   * re-resolved if it was initially auto-populated. Explicitly set values are preserved.
    */
   contextWindowLimit?: number
 }

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -298,12 +298,17 @@ describe('OpenAIModel', () => {
 
     it('auto-populates contextWindowLimit from model ID lookup', () => {
       const provider = new OpenAIModel({ api: 'chat', modelId: 'gpt-4o', apiKey: 'sk-test' })
-      expect(provider.getConfig().contextWindowLimit).toBe(128_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'gpt-4o',
+        contextWindowLimit: 128_000,
+      })
     })
 
     it('auto-populates contextWindowLimit for default model ID', () => {
       const provider = new OpenAIModel({ api: 'chat', apiKey: 'sk-test' })
-      expect(provider.getConfig().contextWindowLimit).toBe(1_050_000)
+      expect(provider.getConfig()).toStrictEqual({
+        contextWindowLimit: 1_050_000,
+      })
     })
 
     it('does not override explicit contextWindowLimit', () => {
@@ -313,12 +318,17 @@ describe('OpenAIModel', () => {
         apiKey: 'sk-test',
         contextWindowLimit: 50_000,
       })
-      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'gpt-4o',
+        contextWindowLimit: 50_000,
+      })
     })
 
     it('leaves contextWindowLimit undefined for unknown model IDs', () => {
       const provider = new OpenAIModel({ api: 'chat', modelId: 'unknown-model', apiKey: 'sk-test' })
-      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
+      expect(provider.getConfig()).toStrictEqual({
+        modelId: 'unknown-model',
+      })
     })
   })
 

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -229,6 +229,7 @@ describe('OpenAIModel', () => {
         modelId: 'gpt-5.4',
         temperature: 0.8,
         maxTokens: 2048,
+        contextWindowLimit: 1_050_000,
       })
     })
 
@@ -247,6 +248,22 @@ describe('OpenAIModel', () => {
         maxTokens: 1024,
       })
     })
+
+    it('re-resolves contextWindowLimit when modelId changes and it was auto-resolved', () => {
+      const provider = new OpenAIModel({ api: 'chat', apiKey: 'sk-test' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_050_000) // gpt-5.4 default
+
+      provider.updateConfig({ modelId: 'gpt-4o' })
+      expect(provider.getConfig().contextWindowLimit).toBe(128_000) // gpt-4o value
+    })
+
+    it('preserves explicit contextWindowLimit when modelId changes', () => {
+      const provider = new OpenAIModel({ api: 'chat', apiKey: 'sk-test', contextWindowLimit: 50_000 })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+
+      provider.updateConfig({ modelId: 'gpt-4o' })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000) // preserved
+    })
   })
 
   describe('getConfig', () => {
@@ -262,6 +279,7 @@ describe('OpenAIModel', () => {
         modelId: 'gpt-5.4',
         maxTokens: 1024,
         temperature: 0.7,
+        contextWindowLimit: 1_050_000,
       })
     })
 
@@ -276,6 +294,31 @@ describe('OpenAIModel', () => {
         modelId: 'gpt-4o',
         contextWindowLimit: 128_000,
       })
+    })
+
+    it('auto-populates contextWindowLimit from model ID lookup', () => {
+      const provider = new OpenAIModel({ api: 'chat', modelId: 'gpt-4o', apiKey: 'sk-test' })
+      expect(provider.getConfig().contextWindowLimit).toBe(128_000)
+    })
+
+    it('auto-populates contextWindowLimit for default model ID', () => {
+      const provider = new OpenAIModel({ api: 'chat', apiKey: 'sk-test' })
+      expect(provider.getConfig().contextWindowLimit).toBe(1_050_000)
+    })
+
+    it('does not override explicit contextWindowLimit', () => {
+      const provider = new OpenAIModel({
+        api: 'chat',
+        modelId: 'gpt-4o',
+        apiKey: 'sk-test',
+        contextWindowLimit: 50_000,
+      })
+      expect(provider.getConfig().contextWindowLimit).toBe(50_000)
+    })
+
+    it('leaves contextWindowLimit undefined for unknown model IDs', () => {
+      const provider = new OpenAIModel({ api: 'chat', modelId: 'unknown-model', apiKey: 'sk-test' })
+      expect(provider.getConfig().contextWindowLimit).toBeUndefined()
     })
   })
 

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -17,7 +17,7 @@ import type { ModelStreamEvent } from '../streaming.js'
 import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import { logger } from '../../logging/logger.js'
 import { warnOnce } from '../../logging/warn-once.js'
-import { MODEL_DEFAULTS, defaultModelWarningMessage } from '../defaults.js'
+import { MODEL_DEFAULTS, defaultModelWarningMessage, getContextWindowLimit } from '../defaults.js'
 import { classifyOpenAIError } from './errors.js'
 import { formatChatRequest, mapChatChunkToEvents, warnManagedParams as warnChatManagedParams } from './chat-adapter.js'
 import {
@@ -68,6 +68,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
   private readonly _api: OpenAIApi
   private _config: OpenAIModelConfig
   private _client: OpenAI
+  private _autoResolvedContextWindow = false
 
   constructor(options: OpenAIModelOptions) {
     super()
@@ -84,6 +85,14 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
 
     if (modelConfig.modelId === undefined) {
       warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.openai.modelId))
+    }
+
+    if (this._config.contextWindowLimit === undefined) {
+      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.openai.modelId)
+      if (contextWindowLimit !== undefined) {
+        this._config.contextWindowLimit = contextWindowLimit
+        this._autoResolvedContextWindow = true
+      }
     }
 
     if (api === 'responses') {
@@ -152,7 +161,16 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
       warnChatManagedParams(rest.params)
     }
 
+    const modelIdChanged = rest.modelId && rest.modelId !== this._config.modelId
     this._config = { ...this._config, ...rest }
+    
+    // Re-resolve contextWindowLimit if it was auto-resolved initially and modelId changed
+    if (this._autoResolvedContextWindow && modelIdChanged && !rest.contextWindowLimit) {
+      const contextWindowLimit = getContextWindowLimit(this._config.modelId!)
+      if (contextWindowLimit !== undefined) {
+        this._config.contextWindowLimit = contextWindowLimit
+      }
+    }
   }
 
   getConfig(): OpenAIModelConfig {

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -10,14 +10,14 @@
 
 import OpenAI from 'openai'
 import type { ResponseStreamEvent } from 'openai/resources/responses/responses'
-import { Model } from '../model.js'
+import { Model, resolveConfigMetadata } from '../model.js'
 import type { StreamOptions } from '../model.js'
 import type { Message } from '../../types/messages.js'
 import type { ModelStreamEvent } from '../streaming.js'
 import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import { logger } from '../../logging/logger.js'
 import { warnOnce } from '../../logging/warn-once.js'
-import { MODEL_DEFAULTS, defaultModelWarningMessage, getContextWindowLimit } from '../defaults.js'
+import { MODEL_DEFAULTS, defaultModelWarningMessage } from '../defaults.js'
 import { classifyOpenAIError } from './errors.js'
 import { formatChatRequest, mapChatChunkToEvents, warnManagedParams as warnChatManagedParams } from './chat-adapter.js'
 import {
@@ -68,7 +68,6 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
   private readonly _api: OpenAIApi
   private _config: OpenAIModelConfig
   private _client: OpenAI
-  private _autoResolvedContextWindow = false
 
   constructor(options: OpenAIModelOptions) {
     super()
@@ -85,14 +84,6 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
 
     if (modelConfig.modelId === undefined) {
       warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.openai.modelId))
-    }
-
-    if (this._config.contextWindowLimit === undefined) {
-      const contextWindowLimit = getContextWindowLimit(this._config.modelId ?? MODEL_DEFAULTS.openai.modelId)
-      if (contextWindowLimit !== undefined) {
-        this._config.contextWindowLimit = contextWindowLimit
-        this._autoResolvedContextWindow = true
-      }
     }
 
     if (api === 'responses') {
@@ -161,20 +152,11 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
       warnChatManagedParams(rest.params)
     }
 
-    const modelIdChanged = rest.modelId && rest.modelId !== this._config.modelId
     this._config = { ...this._config, ...rest }
-    
-    // Re-resolve contextWindowLimit if it was auto-resolved initially and modelId changed
-    if (this._autoResolvedContextWindow && modelIdChanged && !rest.contextWindowLimit) {
-      const contextWindowLimit = getContextWindowLimit(this._config.modelId!)
-      if (contextWindowLimit !== undefined) {
-        this._config.contextWindowLimit = contextWindowLimit
-      }
-    }
   }
 
   getConfig(): OpenAIModelConfig {
-    return this._config
+    return resolveConfigMetadata(this._config, this._config.modelId ?? MODEL_DEFAULTS.openai.modelId)
   }
 
   async *stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent> {


### PR DESCRIPTION
## Description

`contextWindowLimit` is now auto-populated from a built-in lookup table when not explicitly provided in the model config. This removes the need for users to manually look up and hard-code context window sizes for every model they instantiate.

A new `MODEL_METADATA` table in `defaults.ts` maps model IDs to their known metadata (currently `contextWindowLimit`, structured as `Record<string, ModelMetadataEntry>` to support adding fields like `maxTokens` in a follow-up). Each provider constructor resolves the limit after setting the model ID. Explicit `contextWindowLimit` always takes precedence. Unknown model IDs leave it `undefined`.

For Bedrock cross-region model IDs (e.g. `us.anthropic.claude-sonnet-4-6`), the region prefix is stripped before lookup.

```typescript
// Before: users had to supply contextWindowLimit manually
const model = new BedrockModel({
  modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
  contextWindowLimit: 1_000_000,
})

// After: resolved automatically from the model ID
const model = new BedrockModel({
  modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
})

model.getConfig().contextWindowLimit // 1_000_000
```
Values sourced from https://github.com/BerriAI/litellm/blob/litellm_internal_staging/model_prices_and_context_window.json


## Related Issues

Resolves: #851
Follow-up to #848 (added contextWindowLimit to BaseModelConfig)

## Documentation PR

NA

## Type of Change

New feature

## Testing

- [x] I ran npm run check

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published