### PR TITLE
feat: add optional session token to browser-agent Bedrock settings

### DIFF
--- a/strands-ts/examples/browser-agent/index.html
+++ b/strands-ts/examples/browser-agent/index.html
@@ -295,6 +295,9 @@
 
         <label for="bedrock-secret-key">AWS Secret Access Key</label>
         <input type="password" id="bedrock-secret-key">
+
+        <label for="bedrock-session-token">AWS Session Token (optional)</label>
+        <input type="password" id="bedrock-session-token" placeholder="Optional - for temporary credentials">
       </div>
 
       <div class="button-group">

--- a/strands-ts/examples/browser-agent/src/index.ts
+++ b/strands-ts/examples/browser-agent/src/index.ts
@@ -22,6 +22,7 @@ const anthropicKeyInput = document.getElementById('anthropic-key') as HTMLInputE
 const bedrockRegionInput = document.getElementById('bedrock-region') as HTMLInputElement
 const bedrockAccessKeyInput = document.getElementById('bedrock-access-key') as HTMLInputElement
 const bedrockSecretKeyInput = document.getElementById('bedrock-secret-key') as HTMLInputElement
+const bedrockSessionTokenInput = document.getElementById('bedrock-session-token') as HTMLInputElement
 const openaiFields = document.querySelector('.openai-fields') as HTMLElement
 const anthropicFields = document.querySelector('.anthropic-fields') as HTMLElement
 const bedrockFields = document.querySelector('.bedrock-fields') as HTMLElement
@@ -65,6 +66,9 @@ function getModel(): BedrockModel | AnthropicModel | OpenAIModel {
         credentials: {
           accessKeyId: credentials['bedrock_access_key'],
           secretAccessKey: credentials['bedrock_secret_key'],
+          ...(credentials['bedrock_session_token'] && {
+            sessionToken: credentials['bedrock_session_token'],
+          }),
         },
       },
     })
@@ -119,6 +123,7 @@ Be concise in your text responses.`,
     bedrockRegionInput.value = credentials['bedrock_region'] || 'us-west-2'
     bedrockAccessKeyInput.value = credentials['bedrock_access_key'] || ''
     bedrockSecretKeyInput.value = credentials['bedrock_secret_key'] || ''
+    bedrockSessionTokenInput.value = credentials['bedrock_session_token'] || ''
     toggleProviderFields(currentProvider)
     settingsModal.classList.add('show')
   })
@@ -138,6 +143,7 @@ Be concise in your text responses.`,
       credentials['bedrock_region'] = bedrockRegionInput.value
       credentials['bedrock_access_key'] = bedrockAccessKeyInput.value
       credentials['bedrock_secret_key'] = bedrockSecretKeyInput.value
+      credentials['bedrock_session_token'] = bedrockSessionTokenInput.value
     }
 
     settingsModal.classList.remove('show')


### PR DESCRIPTION
## Description

The browser-agent example only accepts an AWS Access Key ID and Secret Access Key for Bedrock credentials. This means users with temporary credentials (SSO, assumed roles, federated identity) cannot use the example without creating a dedicated IAM user with long-term keys.

This adds an optional Session Token field to the Bedrock settings in the browser-agent example. Users with long-term IAM keys leave it blank and everything works as before. Users with temporary credentials can now paste their session token alongside the access key and secret key.

## Related Issues

None

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

Verified the session token is conditionally spread into the Bedrock credentials config only when a value is provided, so existing behavior is unchanged.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.