### PR TITLE
feat: add proactive context compression to conversation managers

### DIFF
--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -3,6 +3,7 @@ import {
   ConversationManager,
   type ConversationManagerReduceOptions,
   type ConversationManagerThresholdOptions,
+  type ProactiveCompressionConfig,
 } from '../conversation-manager.js'
 import { NullConversationManager } from '../null-conversation-manager.js'
 import { Agent } from '../../agent/agent.js'
@@ -12,7 +13,6 @@ import { ContextWindowOverflowError } from '../../errors.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import type { BaseModelConfig } from '../../models/model.js'
-import type { ConversationManagerConfig } from '../conversation-manager.js'
 import { warnOnce } from '../../logging/warn-once.js'
 
 vi.mock('../../logging/warn-once.js', () => ({
@@ -24,8 +24,8 @@ class TestConversationManager extends ConversationManager {
   reduceCallCount = 0
   shouldReduce = true
 
-  constructor(config?: ConversationManagerConfig) {
-    super(config)
+  constructor(compressProactively?: boolean | ProactiveCompressionConfig) {
+    super(compressProactively)
   }
 
   reduce({ agent }: ConversationManagerReduceOptions): boolean {
@@ -40,6 +40,10 @@ class ThresholdTestManager extends ConversationManager {
   readonly name = 'test:threshold-manager'
   reduceOnThresholdCallCount = 0
   shouldReduceOnThreshold = true
+
+  constructor(compressProactively?: boolean | ProactiveCompressionConfig) {
+    super(compressProactively)
+  }
 
   reduce(): boolean {
     return false
@@ -133,11 +137,11 @@ describe('ConversationManager', () => {
     })
   })
 
-  describe('compressionThreshold', () => {
+  describe('compressProactively', () => {
     const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
 
-    it('registers a BeforeModelCallEvent hook when compressionThreshold is set', () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+    it('registers a BeforeModelCallEvent hook when compressProactively is true', () => {
+      const manager = new ThresholdTestManager(true)
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -146,7 +150,16 @@ describe('ConversationManager', () => {
       expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
     })
 
-    it('does not register BeforeModelCallEvent hook when compressionThreshold is not set', () => {
+    it('registers a BeforeModelCallEvent hook when compressProactively is a config object', () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.8 })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      expect(mockAgent.trackedHooks).toHaveLength(2)
+      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
+    })
+
+    it('does not register BeforeModelCallEvent hook when compressProactively is not set', () => {
       const manager = new TestConversationManager()
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
@@ -155,8 +168,38 @@ describe('ConversationManager', () => {
       expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
     })
 
-    it('calls reduceOnThreshold when projected tokens exceed compressionThreshold', async () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+    it('uses default threshold of 0.7 when compressProactively is true', async () => {
+      const manager = new ThresholdTestManager(true)
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
+      ]
+      const mockAgent = createMockAgent({ messages })
+      manager.initAgent(mockAgent)
+
+      // 650/1000 = 0.65 < 0.7 — should NOT trigger
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 650,
+      })
+      await invokeTrackedHook(mockAgent, event)
+      expect(manager.reduceOnThresholdCallCount).toBe(0)
+
+      // 800/1000 = 0.8 >= 0.7 — should trigger
+      const event2 = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+      await invokeTrackedHook(mockAgent, event2)
+      expect(manager.reduceOnThresholdCallCount).toBe(1)
+    })
+
+    it('calls reduceOnThreshold when projected tokens exceed custom threshold', async () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.5 })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -168,15 +211,14 @@ describe('ConversationManager', () => {
         agent: mockAgent,
         model: mockModel,
         invocationState: {},
-        projectedInputTokens: 800, // 800/1000 = 0.8 >= 0.7
+        projectedInputTokens: 600, // 600/1000 = 0.6 >= 0.5
       })
       await invokeTrackedHook(mockAgent, event)
 
       expect(manager.reduceOnThresholdCallCount).toBe(1)
-      expect(mockAgent.messages).toHaveLength(1)
     })
 
-    it('does not call reduceOnThreshold when below compressionThreshold', async () => {
+    it('does not call reduceOnThreshold when below threshold', async () => {
       const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
@@ -193,7 +235,7 @@ describe('ConversationManager', () => {
     })
 
     it('does not call reduceOnThreshold when projectedInputTokens is undefined', async () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const manager = new ThresholdTestManager(true)
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -208,7 +250,7 @@ describe('ConversationManager', () => {
     })
 
     it('warns and skips when contextWindowLimit is undefined', async () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const manager = new ThresholdTestManager(true)
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -232,7 +274,7 @@ describe('ConversationManager', () => {
       const { logger } = await import('../../logging/logger.js')
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
 
-      const manager = new TestConversationManager({ compressionThreshold: 0.7 })
+      const manager = new TestConversationManager(true)
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -1,21 +1,53 @@
-import { describe, it, expect } from 'vitest'
-import { ConversationManager, type ConversationManagerReduceOptions } from '../conversation-manager.js'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  ConversationManager,
+  type ConversationManagerReduceOptions,
+  type ConversationManagerThresholdOptions,
+} from '../conversation-manager.js'
 import { NullConversationManager } from '../null-conversation-manager.js'
 import { Agent } from '../../agent/agent.js'
 import { Message, TextBlock } from '../../index.js'
-import { AfterModelCallEvent } from '../../hooks/events.js'
+import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { ContextWindowOverflowError } from '../../errors.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import type { BaseModelConfig } from '../../models/model.js'
+import type { ConversationManagerConfig } from '../conversation-manager.js'
+import { warnOnce } from '../../logging/warn-once.js'
+
+vi.mock('../../logging/warn-once.js', () => ({
+  warnOnce: vi.fn(),
+}))
 
 class TestConversationManager extends ConversationManager {
   readonly name = 'test:conversation-manager'
   reduceCallCount = 0
   shouldReduce = true
 
+  constructor(config?: ConversationManagerConfig) {
+    super(config)
+  }
+
   reduce({ agent }: ConversationManagerReduceOptions): boolean {
     this.reduceCallCount++
     if (!this.shouldReduce) return false
+    agent.messages.splice(0, 1)
+    return true
+  }
+}
+
+class ThresholdTestManager extends ConversationManager {
+  readonly name = 'test:threshold-manager'
+  reduceOnThresholdCallCount = 0
+  shouldReduceOnThreshold = true
+
+  reduce(): boolean {
+    return false
+  }
+
+  reduceOnThreshold({ agent }: ConversationManagerThresholdOptions): boolean {
+    this.reduceOnThresholdCallCount++
+    if (!this.shouldReduceOnThreshold) return false
     agent.messages.splice(0, 1)
     return true
   }
@@ -98,6 +130,135 @@ describe('ConversationManager', () => {
       expect(receivedArgs).toHaveLength(1)
       expect(receivedArgs[0]!.error).toBe(error)
       expect(receivedArgs[0]!.agent).toBe(mockAgent)
+    })
+  })
+
+  describe('compressionThreshold', () => {
+    const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+
+    it('registers a BeforeModelCallEvent hook when compressionThreshold is set', () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      expect(mockAgent.trackedHooks).toHaveLength(2)
+      expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
+      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
+    })
+
+    it('does not register BeforeModelCallEvent hook when compressionThreshold is not set', () => {
+      const manager = new TestConversationManager()
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      expect(mockAgent.trackedHooks).toHaveLength(1)
+      expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
+    })
+
+    it('calls reduceOnThreshold when projected tokens exceed compressionThreshold', async () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
+      ]
+      const mockAgent = createMockAgent({ messages })
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 800, // 800/1000 = 0.8 >= 0.7
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(manager.reduceOnThresholdCallCount).toBe(1)
+      expect(mockAgent.messages).toHaveLength(1)
+    })
+
+    it('does not call reduceOnThreshold when below compressionThreshold', async () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 500, // 500/1000 = 0.5 < 0.7
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(manager.reduceOnThresholdCallCount).toBe(0)
+    })
+
+    it('does not call reduceOnThreshold when projectedInputTokens is undefined', async () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(manager.reduceOnThresholdCallCount).toBe(0)
+    })
+
+    it('warns and skips when contextWindowLimit is undefined', async () => {
+      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      const modelWithoutLimit = { getConfig: () => ({}) as BaseModelConfig } as any
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: modelWithoutLimit,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(manager.reduceOnThresholdCallCount).toBe(0)
+      expect(warnOnce).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('contextWindowLimit is not set on the model, proactive compression is disabled')
+      )
+    })
+
+    it('warns when subclass does not implement reduceOnThreshold', async () => {
+      const { logger } = await import('../../logging/logger.js')
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+      const manager = new TestConversationManager({ compressionThreshold: 0.7 })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      expect(mockAgent.trackedHooks).toHaveLength(1)
+      expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('reduceOnThreshold is not implemented'))
+      warnSpy.mockRestore()
+    })
+
+    it('throws on compressionThreshold <= 0', () => {
+      expect(() => new ThresholdTestManager({ compressionThreshold: 0 })).toThrow(
+        'must be between 0 (exclusive) and 1 (inclusive)'
+      )
+      expect(() => new ThresholdTestManager({ compressionThreshold: -1 })).toThrow(
+        'must be between 0 (exclusive) and 1 (inclusive)'
+      )
+    })
+
+    it('throws on compressionThreshold > 1', () => {
+      expect(() => new ThresholdTestManager({ compressionThreshold: 1.5 })).toThrow(
+        'must be between 0 (exclusive) and 1 (inclusive)'
+      )
+    })
+
+    it('accepts compressionThreshold of exactly 1', () => {
+      expect(() => new ThresholdTestManager({ compressionThreshold: 1 })).not.toThrow()
     })
   })
 })

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -135,10 +135,10 @@ describe('ConversationManager', () => {
     })
   })
 
-  describe('compressProactively', () => {
+  describe('proactiveCompression', () => {
     const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
 
-    it('always registers a BeforeModelCallEvent hook regardless of compressProactively setting', () => {
+    it('always registers a BeforeModelCallEvent hook regardless of proactiveCompression setting', () => {
       const manager = new TestConversationManager()
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
@@ -149,7 +149,7 @@ describe('ConversationManager', () => {
       expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
     })
 
-    it('BeforeModelCallEvent handler is a no-op when compressProactively is not set', async () => {
+    it('BeforeModelCallEvent handler is a no-op when proactiveCompression is not set', async () => {
       const manager = new ThresholdTestManager()
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
@@ -165,8 +165,8 @@ describe('ConversationManager', () => {
       expect(manager.reduceCallCount).toBe(0)
     })
 
-    it('uses default threshold of 0.7 when compressProactively is true', async () => {
-      const manager = new ThresholdTestManager({ compressProactively: true })
+    it('uses default threshold of 0.7 when proactiveCompression is true', async () => {
+      const manager = new ThresholdTestManager({ proactiveCompression: true })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -206,7 +206,7 @@ describe('ConversationManager', () => {
         }
       }
 
-      const manager = new CapturingManager({ compressProactively: { compressionThreshold: 0.5 } })
+      const manager = new CapturingManager({ proactiveCompression: { compressionThreshold: 0.5 } })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -229,7 +229,7 @@ describe('ConversationManager', () => {
     })
 
     it('does not call reduce when below threshold', async () => {
-      const manager = new ThresholdTestManager({ compressProactively: { compressionThreshold: 0.7 } })
+      const manager = new ThresholdTestManager({ proactiveCompression: { compressionThreshold: 0.7 } })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -245,7 +245,7 @@ describe('ConversationManager', () => {
     })
 
     it('does not call reduce when projectedInputTokens is undefined', async () => {
-      const manager = new ThresholdTestManager({ compressProactively: true })
+      const manager = new ThresholdTestManager({ proactiveCompression: true })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -260,7 +260,7 @@ describe('ConversationManager', () => {
     })
 
     it('uses 200k default when contextWindowLimit is undefined and logs warning', async () => {
-      const manager = new ThresholdTestManager({ compressProactively: { compressionThreshold: 0.7 } })
+      const manager = new ThresholdTestManager({ proactiveCompression: { compressionThreshold: 0.7 } })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -286,7 +286,7 @@ describe('ConversationManager', () => {
     })
 
     it('does not trigger with 200k default when below threshold', async () => {
-      const manager = new ThresholdTestManager({ compressProactively: { compressionThreshold: 0.7 } })
+      const manager = new ThresholdTestManager({ proactiveCompression: { compressionThreshold: 0.7 } })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -314,7 +314,7 @@ describe('ConversationManager', () => {
         }
       }
 
-      const manager = new ThrowingManager({ compressProactively: true })
+      const manager = new ThrowingManager({ proactiveCompression: true })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -330,22 +330,22 @@ describe('ConversationManager', () => {
     })
 
     it('throws on compressionThreshold <= 0', () => {
-      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: 0 } })).toThrow(
+      expect(() => new ThresholdTestManager({ proactiveCompression: { compressionThreshold: 0 } })).toThrow(
         'must be between 0 (exclusive) and 1 (inclusive)'
       )
-      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: -1 } })).toThrow(
+      expect(() => new ThresholdTestManager({ proactiveCompression: { compressionThreshold: -1 } })).toThrow(
         'must be between 0 (exclusive) and 1 (inclusive)'
       )
     })
 
     it('throws on compressionThreshold > 1', () => {
-      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: 1.5 } })).toThrow(
+      expect(() => new ThresholdTestManager({ proactiveCompression: { compressionThreshold: 1.5 } })).toThrow(
         'must be between 0 (exclusive) and 1 (inclusive)'
       )
     })
 
     it('accepts compressionThreshold of exactly 1', () => {
-      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: 1 } })).not.toThrow()
+      expect(() => new ThresholdTestManager({ proactiveCompression: { compressionThreshold: 1 } })).not.toThrow()
     })
   })
 })

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   ConversationManager,
   type ConversationManagerReduceOptions,
-  type ConversationManagerThresholdOptions,
+  type ConversationManagerOptions,
   type ProactiveCompressionConfig,
 } from '../conversation-manager.js'
 import { NullConversationManager } from '../null-conversation-manager.js'
@@ -24,8 +24,8 @@ class TestConversationManager extends ConversationManager {
   reduceCallCount = 0
   shouldReduce = true
 
-  constructor(compressProactively?: boolean | ProactiveCompressionConfig) {
-    super(compressProactively)
+  constructor(options?: ConversationManagerOptions) {
+    super(options)
   }
 
   reduce({ agent }: ConversationManagerReduceOptions): boolean {
@@ -38,20 +38,16 @@ class TestConversationManager extends ConversationManager {
 
 class ThresholdTestManager extends ConversationManager {
   readonly name = 'test:threshold-manager'
-  reduceOnThresholdCallCount = 0
-  shouldReduceOnThreshold = true
+  reduceCallCount = 0
+  shouldReduce = true
 
-  constructor(compressProactively?: boolean | ProactiveCompressionConfig) {
-    super(compressProactively)
+  constructor(options?: ConversationManagerOptions) {
+    super(options)
   }
 
-  reduce(): boolean {
-    return false
-  }
-
-  reduceOnThreshold({ agent }: ConversationManagerThresholdOptions): boolean {
-    this.reduceOnThresholdCallCount++
-    if (!this.shouldReduceOnThreshold) return false
+  reduce({ agent }: ConversationManagerReduceOptions): boolean {
+    this.reduceCallCount++
+    if (!this.shouldReduce) return false
     agent.messages.splice(0, 1)
     return true
   }
@@ -59,13 +55,15 @@ class ThresholdTestManager extends ConversationManager {
 
 describe('ConversationManager', () => {
   describe('initAgent', () => {
-    it('registers an AfterModelCallEvent hook', () => {
+    it('registers both AfterModelCallEvent and BeforeModelCallEvent hooks', () => {
       const manager = new TestConversationManager()
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
-      expect(mockAgent.trackedHooks).toHaveLength(1)
+      // Always registers both hooks now
+      expect(mockAgent.trackedHooks).toHaveLength(2)
       expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
+      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
     })
 
     it('calls reduce and sets retry=true on ContextWindowOverflowError when reduce returns true', async () => {
@@ -140,36 +138,35 @@ describe('ConversationManager', () => {
   describe('compressProactively', () => {
     const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
 
-    it('registers a BeforeModelCallEvent hook when compressProactively is true', () => {
-      const manager = new ThresholdTestManager(true)
-      const mockAgent = createMockAgent()
-      manager.initAgent(mockAgent)
-
-      expect(mockAgent.trackedHooks).toHaveLength(2)
-      expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
-      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
-    })
-
-    it('registers a BeforeModelCallEvent hook when compressProactively is a config object', () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.8 })
-      const mockAgent = createMockAgent()
-      manager.initAgent(mockAgent)
-
-      expect(mockAgent.trackedHooks).toHaveLength(2)
-      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
-    })
-
-    it('does not register BeforeModelCallEvent hook when compressProactively is not set', () => {
+    it('always registers a BeforeModelCallEvent hook regardless of compressProactively setting', () => {
       const manager = new TestConversationManager()
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
-      expect(mockAgent.trackedHooks).toHaveLength(1)
+      // Both hooks always registered
+      expect(mockAgent.trackedHooks).toHaveLength(2)
       expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
+      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
+    })
+
+    it('BeforeModelCallEvent handler is a no-op when compressProactively is not set', async () => {
+      const manager = new ThresholdTestManager()
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 900, // Would exceed any threshold
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(manager.reduceCallCount).toBe(0)
     })
 
     it('uses default threshold of 0.7 when compressProactively is true', async () => {
-      const manager = new ThresholdTestManager(true)
+      const manager = new ThresholdTestManager({ compressProactively: true })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -185,7 +182,7 @@ describe('ConversationManager', () => {
         projectedInputTokens: 650,
       })
       await invokeTrackedHook(mockAgent, event)
-      expect(manager.reduceOnThresholdCallCount).toBe(0)
+      expect(manager.reduceCallCount).toBe(0)
 
       // 800/1000 = 0.8 >= 0.7 — should trigger
       const event2 = new BeforeModelCallEvent({
@@ -195,11 +192,21 @@ describe('ConversationManager', () => {
         projectedInputTokens: 800,
       })
       await invokeTrackedHook(mockAgent, event2)
-      expect(manager.reduceOnThresholdCallCount).toBe(1)
+      expect(manager.reduceCallCount).toBe(1)
     })
 
-    it('calls reduceOnThreshold when projected tokens exceed custom threshold', async () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.5 })
+    it('calls reduce without error when projected tokens exceed custom threshold', async () => {
+      const receivedArgs: ConversationManagerReduceOptions[] = []
+      class CapturingManager extends ConversationManager {
+        readonly name = 'test:capturing-threshold'
+        reduce(args: ConversationManagerReduceOptions): boolean {
+          receivedArgs.push(args)
+          args.agent.messages.splice(0, 1)
+          return true
+        }
+      }
+
+      const manager = new CapturingManager({ compressProactively: { compressionThreshold: 0.5 } })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -215,11 +222,14 @@ describe('ConversationManager', () => {
       })
       await invokeTrackedHook(mockAgent, event)
 
-      expect(manager.reduceOnThresholdCallCount).toBe(1)
+      expect(receivedArgs).toHaveLength(1)
+      expect(receivedArgs[0]!.error).toBeUndefined()
+      expect(receivedArgs[0]!.model).toBe(mockModel)
+      expect(receivedArgs[0]!.agent).toBe(mockAgent)
     })
 
-    it('does not call reduceOnThreshold when below threshold', async () => {
-      const manager = new ThresholdTestManager({ compressionThreshold: 0.7 })
+    it('does not call reduce when below threshold', async () => {
+      const manager = new ThresholdTestManager({ compressProactively: { compressionThreshold: 0.7 } })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -231,11 +241,11 @@ describe('ConversationManager', () => {
       })
       await invokeTrackedHook(mockAgent, event)
 
-      expect(manager.reduceOnThresholdCallCount).toBe(0)
+      expect(manager.reduceCallCount).toBe(0)
     })
 
-    it('does not call reduceOnThreshold when projectedInputTokens is undefined', async () => {
-      const manager = new ThresholdTestManager(true)
+    it('does not call reduce when projectedInputTokens is undefined', async () => {
+      const manager = new ThresholdTestManager({ compressProactively: true })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
@@ -246,61 +256,96 @@ describe('ConversationManager', () => {
       })
       await invokeTrackedHook(mockAgent, event)
 
-      expect(manager.reduceOnThresholdCallCount).toBe(0)
+      expect(manager.reduceCallCount).toBe(0)
     })
 
-    it('warns and skips when contextWindowLimit is undefined', async () => {
-      const manager = new ThresholdTestManager(true)
-      const mockAgent = createMockAgent()
+    it('uses 200k default when contextWindowLimit is undefined and logs warning', async () => {
+      const manager = new ThresholdTestManager({ compressProactively: { compressionThreshold: 0.7 } })
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
+      ]
+      const mockAgent = createMockAgent({ messages })
       manager.initAgent(mockAgent)
 
       const modelWithoutLimit = { getConfig: () => ({}) as BaseModelConfig } as any
+      // 150000/200000 = 0.75 >= 0.7 — should trigger with the 200k default
       const event = new BeforeModelCallEvent({
         agent: mockAgent,
         model: modelWithoutLimit,
         invocationState: {},
-        projectedInputTokens: 800,
+        projectedInputTokens: 150000,
       })
       await invokeTrackedHook(mockAgent, event)
 
-      expect(manager.reduceOnThresholdCallCount).toBe(0)
+      expect(manager.reduceCallCount).toBe(1)
       expect(warnOnce).toHaveBeenCalledWith(
         expect.anything(),
-        expect.stringContaining('contextWindowLimit is not set on the model, proactive compression is disabled')
+        expect.stringContaining('contextWindowLimit is not set on the model, using default of 200000')
       )
     })
 
-    it('warns when subclass does not implement reduceOnThreshold', async () => {
-      const { logger } = await import('../../logging/logger.js')
-      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
-
-      const manager = new TestConversationManager(true)
+    it('does not trigger with 200k default when below threshold', async () => {
+      const manager = new ThresholdTestManager({ compressProactively: { compressionThreshold: 0.7 } })
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
-      expect(mockAgent.trackedHooks).toHaveLength(1)
-      expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('reduceOnThreshold is not implemented'))
-      warnSpy.mockRestore()
+      const modelWithoutLimit = { getConfig: () => ({}) as BaseModelConfig } as any
+      // 100000/200000 = 0.5 < 0.7 — should NOT trigger
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: modelWithoutLimit,
+        invocationState: {},
+        projectedInputTokens: 100000,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(manager.reduceCallCount).toBe(0)
+    })
+
+    it('swallows errors from proactive reduce and continues', async () => {
+      class ThrowingManager extends ConversationManager {
+        readonly name = 'test:throwing'
+        reduce({ error }: ConversationManagerReduceOptions): boolean {
+          if (!error) {
+            throw new Error('proactive compression exploded')
+          }
+          return false
+        }
+      }
+
+      const manager = new ThrowingManager({ compressProactively: true })
+      const mockAgent = createMockAgent()
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+
+      // Should not throw — error is swallowed
+      await expect(invokeTrackedHook(mockAgent, event)).resolves.toBeUndefined()
     })
 
     it('throws on compressionThreshold <= 0', () => {
-      expect(() => new ThresholdTestManager({ compressionThreshold: 0 })).toThrow(
+      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: 0 } })).toThrow(
         'must be between 0 (exclusive) and 1 (inclusive)'
       )
-      expect(() => new ThresholdTestManager({ compressionThreshold: -1 })).toThrow(
+      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: -1 } })).toThrow(
         'must be between 0 (exclusive) and 1 (inclusive)'
       )
     })
 
     it('throws on compressionThreshold > 1', () => {
-      expect(() => new ThresholdTestManager({ compressionThreshold: 1.5 })).toThrow(
+      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: 1.5 } })).toThrow(
         'must be between 0 (exclusive) and 1 (inclusive)'
       )
     })
 
     it('accepts compressionThreshold of exactly 1', () => {
-      expect(() => new ThresholdTestManager({ compressionThreshold: 1 })).not.toThrow()
+      expect(() => new ThresholdTestManager({ compressProactively: { compressionThreshold: 1 } })).not.toThrow()
     })
   })
 })

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -3,7 +3,6 @@ import {
   ConversationManager,
   type ConversationManagerReduceOptions,
   type ConversationManagerOptions,
-  type ProactiveCompressionConfig,
 } from '../conversation-manager.js'
 import { NullConversationManager } from '../null-conversation-manager.js'
 import { Agent } from '../../agent/agent.js'

--- a/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/null-conversation-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { NullConversationManager } from '../null-conversation-manager.js'
 import { Message, TextBlock } from '../../index.js'
-import { AfterModelCallEvent } from '../../hooks/events.js'
+import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { ContextWindowOverflowError } from '../../errors.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 
@@ -39,14 +39,15 @@ describe('NullConversationManager', () => {
       expect(event.retry).toBeUndefined()
     })
 
-    it('registers only the overflow recovery hook', () => {
+    it('registers both the overflow recovery and proactive compression hooks', () => {
       const manager = new NullConversationManager()
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
-      // Base class registers exactly one hook (AfterModelCallEvent for overflow recovery)
-      expect(mockAgent.trackedHooks).toHaveLength(1)
+      // Base class always registers both hooks
+      expect(mockAgent.trackedHooks).toHaveLength(2)
       expect(mockAgent.trackedHooks[0]!.eventType).toBe(AfterModelCallEvent)
+      expect(mockAgent.trackedHooks[1]!.eventType).toBe(BeforeModelCallEvent)
     })
   })
 

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -765,7 +765,10 @@ describe('SlidingWindowConversationManager', () => {
 
   describe('reduceOnThreshold', () => {
     it('trims oldest messages when compressionThreshold is exceeded', async () => {
-      const manager = new SlidingWindowConversationManager({ windowSize: 4, compressionThreshold: 0.7 })
+      const manager = new SlidingWindowConversationManager({
+        windowSize: 4,
+        compressProactively: { compressionThreshold: 0.7 },
+      })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
@@ -790,7 +793,10 @@ describe('SlidingWindowConversationManager', () => {
     })
 
     it('does not trim when below compressionThreshold', async () => {
-      const manager = new SlidingWindowConversationManager({ windowSize: 4, compressionThreshold: 0.7 })
+      const manager = new SlidingWindowConversationManager({
+        windowSize: 4,
+        compressProactively: { compressionThreshold: 0.7 },
+      })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -8,9 +8,10 @@ import {
   ToolResultBlock,
   type Model,
 } from '../../index.js'
-import { AfterInvocationEvent, AfterModelCallEvent } from '../../hooks/events.js'
+import { AfterInvocationEvent, AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import type { Agent } from '../../agent/agent.js'
+import type { BaseModelConfig } from '../../models/model.js'
 
 async function triggerSlidingWindow(manager: SlidingWindowConversationManager, agent: Agent): Promise<void> {
   const pluginAgent = createMockAgent()
@@ -759,6 +760,54 @@ describe('SlidingWindowConversationManager', () => {
         const result = (manager as any)._truncateToolResults(messages, 0)
         expect(result).toBe(false)
       })
+    })
+  })
+
+  describe('reduceOnThreshold', () => {
+    it('trims oldest messages when compressionThreshold is exceeded', async () => {
+      const manager = new SlidingWindowConversationManager({ windowSize: 4, compressionThreshold: 0.7 })
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
+        new Message({ role: 'user', content: [new TextBlock('Message 2')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 2')] }),
+        new Message({ role: 'user', content: [new TextBlock('Message 3')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 3')] }),
+      ]
+      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockAgent = createMockAgent({ messages })
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(mockAgent.messages.length).toBe(4)
+    })
+
+    it('does not trim when below compressionThreshold', async () => {
+      const manager = new SlidingWindowConversationManager({ windowSize: 4, compressionThreshold: 0.7 })
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
+      ]
+      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockAgent = createMockAgent({ messages })
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 500,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(mockAgent.messages).toHaveLength(2)
     })
   })
 })

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -767,7 +767,7 @@ describe('SlidingWindowConversationManager', () => {
     it('trims oldest messages when compressionThreshold is exceeded', async () => {
       const manager = new SlidingWindowConversationManager({
         windowSize: 4,
-        compressProactively: { compressionThreshold: 0.7 },
+        proactiveCompression: { compressionThreshold: 0.7 },
       })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
@@ -795,7 +795,7 @@ describe('SlidingWindowConversationManager', () => {
     it('does not trim when below compressionThreshold', async () => {
       const manager = new SlidingWindowConversationManager({
         windowSize: 4,
-        compressProactively: { compressionThreshold: 0.7 },
+        proactiveCompression: { compressionThreshold: 0.7 },
       })
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { SummarizingConversationManager } from '../summarizing-conversation-manager.js'
 import { ContextWindowOverflowError, Message, TextBlock, ToolUseBlock, ToolResultBlock } from '../../index.js'
-import { AfterModelCallEvent } from '../../hooks/events.js'
+import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
-import type { Model } from '../../models/model.js'
+import type { Model, BaseModelConfig } from '../../models/model.js'
 
 function textMsg(role: 'user' | 'assistant', text: string): Message {
   return new Message({ role, content: [new TextBlock(text)] })
@@ -315,6 +315,94 @@ describe('SummarizingConversationManager', () => {
 
       expect(event.retry).toBe(true)
       expect(agent.messages).toHaveLength(11)
+    })
+  })
+
+  describe('reduceOnThreshold', () => {
+    it('summarizes oldest messages when compressionThreshold is exceeded', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary of conversation' })
+
+      const manager = new SummarizingConversationManager({
+        model: model as unknown as Model,
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        compressionThreshold: 0.7,
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({ messages })
+      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      // 20 * 0.5 = 10 summarized → 1 summary + 10 remaining = 11
+      expect(mockAgent.messages).toHaveLength(11)
+      expect(mockAgent.messages[0]!.role).toBe('user')
+      expect(mockAgent.messages[0]!.content[0]!).toEqual({
+        type: 'textBlock',
+        text: 'Summary of conversation',
+      })
+    })
+
+    it('does not summarize when below compressionThreshold', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+
+      const manager = new SummarizingConversationManager({
+        model: model as unknown as Model,
+        compressionThreshold: 0.7,
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({ messages })
+      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 500,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(mockAgent.messages).toHaveLength(20)
+    })
+
+    it('returns false and does not throw when summarization fails', async () => {
+      const model = new MockMessageModel()
+      model.addTurn(new Error('model failed'))
+
+      const manager = new SummarizingConversationManager({
+        model: model as unknown as Model,
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        compressionThreshold: 0.7,
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({ messages })
+      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: mockModel,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+
+      // Should not throw — reduceOnThreshold is best-effort
+      await invokeTrackedHook(mockAgent, event)
+      expect(mockAgent.messages).toHaveLength(20)
     })
   })
 })

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -327,7 +327,7 @@ describe('SummarizingConversationManager', () => {
         model: model as unknown as Model,
         summaryRatio: 0.5,
         preserveRecentMessages: 2,
-        compressionThreshold: 0.7,
+        compressProactively: { compressionThreshold: 0.7 },
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
@@ -358,7 +358,7 @@ describe('SummarizingConversationManager', () => {
 
       const manager = new SummarizingConversationManager({
         model: model as unknown as Model,
-        compressionThreshold: 0.7,
+        compressProactively: { compressionThreshold: 0.7 },
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
@@ -385,7 +385,7 @@ describe('SummarizingConversationManager', () => {
         model: model as unknown as Model,
         summaryRatio: 0.5,
         preserveRecentMessages: 2,
-        compressionThreshold: 0.7,
+        compressProactively: { compressionThreshold: 0.7 },
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -327,7 +327,7 @@ describe('SummarizingConversationManager', () => {
         model: model as unknown as Model,
         summaryRatio: 0.5,
         preserveRecentMessages: 2,
-        compressProactively: { compressionThreshold: 0.7 },
+        proactiveCompression: { compressionThreshold: 0.7 },
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
@@ -358,7 +358,7 @@ describe('SummarizingConversationManager', () => {
 
       const manager = new SummarizingConversationManager({
         model: model as unknown as Model,
-        compressProactively: { compressionThreshold: 0.7 },
+        proactiveCompression: { compressionThreshold: 0.7 },
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
@@ -385,7 +385,7 @@ describe('SummarizingConversationManager', () => {
         model: model as unknown as Model,
         summaryRatio: 0.5,
         preserveRecentMessages: 2,
-        compressProactively: { compressionThreshold: 0.7 },
+        proactiveCompression: { compressionThreshold: 0.7 },
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })

--- a/strands-ts/src/conversation-manager/conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/conversation-manager.ts
@@ -13,6 +13,9 @@ import type { Model } from '../models/model.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
 
+/** Default compression threshold ratio. */
+const DEFAULT_COMPRESSION_THRESHOLD = 0.7
+
 /**
  * Options passed to {@link ConversationManager.reduce}.
  */
@@ -47,15 +50,15 @@ export type ConversationManagerThresholdOptions = {
 }
 
 /**
- * Configuration for the conversation manager base class.
+ * Configuration for proactive compression when passed as an object.
  */
-export type ConversationManagerConfig = {
+export type ProactiveCompressionConfig = {
   /**
    * Ratio of context window usage that triggers proactive compression.
-   * Value between 0 and 1 (e.g. 0.7 means compress when 70% of the context window is used).
-   * When not set, proactive compression is disabled and only reactive overflow recovery is used.
+   * Value between 0 (exclusive) and 1 (inclusive).
+   * Defaults to 0.7 (compress when 70% of the context window is used).
    */
-  compressionThreshold?: number
+  compressionThreshold: number
 }
 
 /**
@@ -68,9 +71,9 @@ export type ConversationManagerConfig = {
  * the agent loop uncaught. This makes `reduce` a critical operation — implementations
  * must be able to make meaningful progress when called with `error` set.
  *
- * Optionally, a manager can enable proactive compression by setting `compressionThreshold`
- * in the config. When set, the base class registers a `BeforeModelCallEvent` hook that
- * checks projected input tokens against the model's context window limit and calls
+ * Subclasses can enable proactive compression by passing their `compressProactively`
+ * option to the base constructor. When set, the base class registers a `BeforeModelCallEvent`
+ * hook that checks projected input tokens against the model's context window limit and calls
  * {@link ConversationManager.reduceOnThreshold} when the threshold is exceeded.
  *
  * @example
@@ -94,16 +97,22 @@ export abstract class ConversationManager implements Plugin {
 
   protected readonly _compressionThreshold: number | undefined
 
-  constructor(config?: ConversationManagerConfig) {
-    if (
-      config?.compressionThreshold !== undefined &&
-      (config.compressionThreshold <= 0 || config.compressionThreshold > 1)
-    ) {
-      throw new Error(
-        `compressionThreshold must be between 0 (exclusive) and 1 (inclusive), got ${config.compressionThreshold}`
-      )
+  /**
+   * @param compressProactively - Enable proactive compression. `true` uses the default
+   *   threshold, a config object specifies a custom threshold, `undefined`/`false` disables.
+   */
+  constructor(compressProactively?: boolean | ProactiveCompressionConfig) {
+    const threshold =
+      compressProactively === true
+        ? DEFAULT_COMPRESSION_THRESHOLD
+        : compressProactively
+          ? compressProactively.compressionThreshold
+          : undefined
+
+    if (threshold !== undefined && (threshold <= 0 || threshold > 1)) {
+      throw new Error(`compressionThreshold must be between 0 (exclusive) and 1 (inclusive), got ${threshold}`)
     }
-    this._compressionThreshold = config?.compressionThreshold
+    this._compressionThreshold = threshold
   }
 
   /**
@@ -127,7 +136,7 @@ export abstract class ConversationManager implements Plugin {
   /**
    * Proactively reduce the conversation history before a model call.
    *
-   * Called when projected input tokens exceed the configured compressionThreshold
+   * Called when projected input tokens exceed the configured compression threshold
    * of the model's context window limit. Subclasses implement this to reduce
    * context before the model call, avoiding overflow errors.
    *
@@ -144,7 +153,7 @@ export abstract class ConversationManager implements Plugin {
    * calls {@link ConversationManager.reduce} and retries the model call if reduction succeeded.
    * If `reduce` returns `false`, the error propagates out of the agent loop uncaught.
    *
-   * When `compressionThreshold` is configured and the subclass implements `reduceOnThreshold`,
+   * When a compression threshold is configured and the subclass implements `reduceOnThreshold`,
    * also registers a `BeforeModelCallEvent` hook for proactive compression.
    *
    * Subclasses that override `initAgent` MUST call `super.initAgent(agent)` to
@@ -163,7 +172,7 @@ export abstract class ConversationManager implements Plugin {
 
     if (this._compressionThreshold !== undefined && !this.reduceOnThreshold) {
       logger.warn(
-        `conversation_manager=<${this.name}> | compressionThreshold is configured but reduceOnThreshold is not implemented, proactive compression is disabled`
+        `conversation_manager=<${this.name}> | compressProactively is enabled but reduceOnThreshold is not implemented, proactive compression is disabled`
       )
     }
 

--- a/strands-ts/src/conversation-manager/conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/conversation-manager.ts
@@ -44,12 +44,6 @@ export type ConversationManagerThresholdOptions = {
    * The agent instance. Mutate `agent.messages` in place to reduce history.
    */
   agent: LocalAgent
-
-  /**
-   * The model instance for the upcoming call. Used by conversation
-   * managers that perform model-based reduction (e.g. summarization).
-   */
-  model: Model
 }
 
 /**
@@ -106,7 +100,7 @@ export abstract class ConversationManager implements Plugin {
       (config.compressionThreshold <= 0 || config.compressionThreshold > 1)
     ) {
       throw new Error(
-        `compression_threshold=<${config.compressionThreshold}> | must be between 0 (exclusive) and 1 (inclusive)`
+        `compressionThreshold must be between 0 (exclusive) and 1 (inclusive), got ${config.compressionThreshold}`
       )
     }
     this._compressionThreshold = config?.compressionThreshold
@@ -193,7 +187,7 @@ export abstract class ConversationManager implements Plugin {
           logger.debug(
             `projected_tokens=<${event.projectedInputTokens}>, limit=<${contextWindowLimit}>, ratio=<${ratio.toFixed(2)}>, compression_threshold=<${this._compressionThreshold}> | compression threshold exceeded, reducing context`
           )
-          await this.reduceOnThreshold!({ agent: event.agent, model: event.model })
+          await this.reduceOnThreshold!({ agent: event.agent })
         }
       })
     }

--- a/strands-ts/src/conversation-manager/conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/conversation-manager.ts
@@ -7,9 +7,11 @@
 
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
-import { AfterModelCallEvent } from '../hooks/events.js'
+import { AfterModelCallEvent, BeforeModelCallEvent } from '../hooks/events.js'
 import { ContextWindowOverflowError } from '../errors.js'
 import type { Model } from '../models/model.js'
+import { logger } from '../logging/logger.js'
+import { warnOnce } from '../logging/warn-once.js'
 
 /**
  * Options passed to {@link ConversationManager.reduce}.
@@ -35,6 +37,34 @@ export type ConversationManagerReduceOptions = {
 }
 
 /**
+ * Options passed to {@link ConversationManager.reduceOnThreshold}.
+ */
+export type ConversationManagerThresholdOptions = {
+  /**
+   * The agent instance. Mutate `agent.messages` in place to reduce history.
+   */
+  agent: LocalAgent
+
+  /**
+   * The model instance for the upcoming call. Used by conversation
+   * managers that perform model-based reduction (e.g. summarization).
+   */
+  model: Model
+}
+
+/**
+ * Configuration for the conversation manager base class.
+ */
+export type ConversationManagerConfig = {
+  /**
+   * Ratio of context window usage that triggers proactive compression.
+   * Value between 0 and 1 (e.g. 0.7 means compress when 70% of the context window is used).
+   * When not set, proactive compression is disabled and only reactive overflow recovery is used.
+   */
+  compressionThreshold?: number
+}
+
+/**
  * Abstract base class for conversation history management strategies.
  *
  * The primary responsibility of a ConversationManager is overflow recovery: when the
@@ -44,9 +74,10 @@ export type ConversationManagerReduceOptions = {
  * the agent loop uncaught. This makes `reduce` a critical operation — implementations
  * must be able to make meaningful progress when called with `error` set.
  *
- * Optionally, a manager can also do proactive management (e.g. trimming after every
- * invocation to stay within a window) by overriding `initAgent`, calling
- * `super.initAgent(agent)` to preserve overflow recovery, then registering additional hooks.
+ * Optionally, a manager can enable proactive compression by setting `compressionThreshold`
+ * in the config. When set, the base class registers a `BeforeModelCallEvent` hook that
+ * checks projected input tokens against the model's context window limit and calls
+ * {@link ConversationManager.reduceOnThreshold} when the threshold is exceeded.
  *
  * @example
  * ```typescript
@@ -67,6 +98,20 @@ export abstract class ConversationManager implements Plugin {
    */
   abstract readonly name: string
 
+  protected readonly _compressionThreshold: number | undefined
+
+  constructor(config?: ConversationManagerConfig) {
+    if (
+      config?.compressionThreshold !== undefined &&
+      (config.compressionThreshold <= 0 || config.compressionThreshold > 1)
+    ) {
+      throw new Error(
+        `compression_threshold=<${config.compressionThreshold}> | must be between 0 (exclusive) and 1 (inclusive)`
+      )
+    }
+    this._compressionThreshold = config?.compressionThreshold
+  }
+
   /**
    * Reduce the conversation history.
    *
@@ -86,14 +131,30 @@ export abstract class ConversationManager implements Plugin {
   abstract reduce(options: ConversationManagerReduceOptions): boolean | Promise<boolean>
 
   /**
+   * Proactively reduce the conversation history before a model call.
+   *
+   * Called when projected input tokens exceed the configured compressionThreshold
+   * of the model's context window limit. Subclasses implement this to reduce
+   * context before the model call, avoiding overflow errors.
+   *
+   * @param options - The reduction options
+   * @returns `true` if the history was reduced, `false` otherwise.
+   *   May return a `Promise` for implementations that need async I/O.
+   */
+  reduceOnThreshold?(options: ConversationManagerThresholdOptions): boolean | Promise<boolean>
+
+  /**
    * Initialize the conversation manager with the agent instance.
    *
    * Registers overflow recovery: when a {@link ContextWindowOverflowError} occurs,
    * calls {@link ConversationManager.reduce} and retries the model call if reduction succeeded.
    * If `reduce` returns `false`, the error propagates out of the agent loop uncaught.
    *
-   * Subclasses that need proactive management MUST call `super.initAgent(agent)` to
-   * preserve this overflow recovery behavior.
+   * When `compressionThreshold` is configured and the subclass implements `reduceOnThreshold`,
+   * also registers a `BeforeModelCallEvent` hook for proactive compression.
+   *
+   * Subclasses that override `initAgent` MUST call `super.initAgent(agent)` to
+   * preserve overflow recovery and proactive compression behavior.
    *
    * @param agent - The agent to register hooks with
    */
@@ -105,5 +166,36 @@ export abstract class ConversationManager implements Plugin {
         }
       }
     })
+
+    if (this._compressionThreshold !== undefined && !this.reduceOnThreshold) {
+      logger.warn(
+        `conversation_manager=<${this.name}> | compressionThreshold is configured but reduceOnThreshold is not implemented, proactive compression is disabled`
+      )
+    }
+
+    if (this._compressionThreshold !== undefined && this.reduceOnThreshold) {
+      agent.addHook(BeforeModelCallEvent, async (event) => {
+        const contextWindowLimit = event.model.getConfig().contextWindowLimit
+        if (contextWindowLimit === undefined) {
+          warnOnce(
+            logger,
+            `conversation_manager=<${this.name}> | contextWindowLimit is not set on the model, proactive compression is disabled | set contextWindowLimit in your model config`
+          )
+          return
+        }
+
+        if (event.projectedInputTokens === undefined) {
+          return
+        }
+
+        const ratio = event.projectedInputTokens / contextWindowLimit
+        if (ratio >= this._compressionThreshold!) {
+          logger.debug(
+            `projected_tokens=<${event.projectedInputTokens}>, limit=<${contextWindowLimit}>, ratio=<${ratio.toFixed(2)}>, compression_threshold=<${this._compressionThreshold}> | compression threshold exceeded, reducing context`
+          )
+          await this.reduceOnThreshold!({ agent: event.agent, model: event.model })
+        }
+      })
+    }
   }
 }

--- a/strands-ts/src/conversation-manager/conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/conversation-manager.ts
@@ -16,8 +16,17 @@ import { warnOnce } from '../logging/warn-once.js'
 /** Default compression threshold ratio. */
 const DEFAULT_COMPRESSION_THRESHOLD = 0.7
 
+/** Default context window limit fallback when the model doesn't report one. */
+const DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
+
 /**
  * Options passed to {@link ConversationManager.reduce}.
+ *
+ * When `error` is set, this is a reactive overflow recovery call — the implementation
+ * MUST remove enough history for the next model call to succeed.
+ *
+ * When `error` is undefined, this is a proactive compression call — best-effort reduction
+ * to avoid hitting the context window limit.
  */
 export type ConversationManagerReduceOptions = {
   /**
@@ -26,27 +35,22 @@ export type ConversationManagerReduceOptions = {
   agent: LocalAgent
 
   /**
-   * The model instance that triggered the overflow. Used by conversation
-   * managers that perform model-based reduction (e.g. summarization).
+   * The model instance. Used by conversation managers that perform model-based
+   * reduction (e.g. summarization).
    */
   model: Model
 
   /**
-   * The {@link ContextWindowOverflowError} that triggered this call.
-   * `reduce` MUST remove enough history for the next model call to succeed,
+   * The {@link ContextWindowOverflowError} that triggered this call, or `undefined`
+   * for proactive compression calls.
+   *
+   * When set, `reduce` MUST remove enough history for the next model call to succeed,
    * or this error will propagate out of the agent loop uncaught.
+   *
+   * When undefined, `reduce` is best-effort — errors are swallowed and the model call
+   * proceeds regardless.
    */
-  error: ContextWindowOverflowError
-}
-
-/**
- * Options passed to {@link ConversationManager.reduceOnThreshold}.
- */
-export type ConversationManagerThresholdOptions = {
-  /**
-   * The agent instance. Mutate `agent.messages` in place to reduce history.
-   */
-  agent: LocalAgent
+  error?: ContextWindowOverflowError
 }
 
 /**
@@ -62,19 +66,33 @@ export type ProactiveCompressionConfig = {
 }
 
 /**
+ * Configuration options for the ConversationManager base class.
+ */
+export type ConversationManagerOptions = {
+  /**
+   * Enable proactive context compression before the model call.
+   *
+   * - `true`: compress when 70% of the context window is used (default threshold).
+   * - `{ compressionThreshold: number }`: compress at the specified ratio (0, 1].
+   * - `false` or omitted: disabled, only reactive overflow recovery is used.
+   */
+  compressProactively?: boolean | ProactiveCompressionConfig
+}
+
+/**
  * Abstract base class for conversation history management strategies.
  *
  * The primary responsibility of a ConversationManager is overflow recovery: when the
  * model returns a {@link ContextWindowOverflowError}, {@link ConversationManager.reduce}
- * is called and MUST reduce the history enough for the next model call to succeed.
- * If `reduce` returns `false` (no reduction performed), the error propagates out of
- * the agent loop uncaught. This makes `reduce` a critical operation — implementations
- * must be able to make meaningful progress when called with `error` set.
+ * is called with `error` set and MUST reduce the history enough for the next model call
+ * to succeed. If `reduce` returns `false` (no reduction performed), the error propagates
+ * out of the agent loop uncaught. This makes `reduce` a critical operation —
+ * implementations must be able to make meaningful progress when called with `error` set.
  *
- * Subclasses can enable proactive compression by passing their `compressProactively`
- * option to the base constructor. When set, the base class registers a `BeforeModelCallEvent`
- * hook that checks projected input tokens against the model's context window limit and calls
- * {@link ConversationManager.reduceOnThreshold} when the threshold is exceeded.
+ * Subclasses can enable proactive compression by passing `compressProactively` in the
+ * options object to the base constructor. When enabled, the base class registers a
+ * `BeforeModelCallEvent` hook that checks projected input tokens against the model's
+ * context window limit and calls `reduce` (without `error`) when the threshold is exceeded.
  *
  * @example
  * ```typescript
@@ -98,10 +116,10 @@ export abstract class ConversationManager implements Plugin {
   protected readonly _compressionThreshold: number | undefined
 
   /**
-   * @param compressProactively - Enable proactive compression. `true` uses the default
-   *   threshold, a config object specifies a custom threshold, `undefined`/`false` disables.
+   * @param options - Configuration options for the conversation manager.
    */
-  constructor(compressProactively?: boolean | ProactiveCompressionConfig) {
+  constructor(options?: ConversationManagerOptions) {
+    const compressProactively = options?.compressProactively
     const threshold =
       compressProactively === true
         ? DEFAULT_COMPRESSION_THRESHOLD
@@ -118,11 +136,12 @@ export abstract class ConversationManager implements Plugin {
   /**
    * Reduce the conversation history.
    *
-   * Called automatically when a {@link ContextWindowOverflowError} occurs (with `error` set).
-   *
-   * This is a critical call: the implementation MUST remove enough history for the next model call to succeed.
-   * Returning `false` means no reduction was possible, and the {@link ContextWindowOverflowError} will
-   * propagate out of the agent loop.
+   * Called in two scenarios:
+   * 1. **Reactive** (error set): A {@link ContextWindowOverflowError} occurred. The implementation
+   *    MUST remove enough history for the next model call to succeed. Returning `false` means no
+   *    reduction was possible, and the error will propagate out of the agent loop.
+   * 2. **Proactive** (error undefined): The compression threshold was exceeded. This is best-effort —
+   *    returning `false` or throwing is acceptable; the model call proceeds regardless.
    *
    * Implementations should mutate `agent.messages` in place and return `true` if any reduction
    * was performed, `false` otherwise.
@@ -134,27 +153,14 @@ export abstract class ConversationManager implements Plugin {
   abstract reduce(options: ConversationManagerReduceOptions): boolean | Promise<boolean>
 
   /**
-   * Proactively reduce the conversation history before a model call.
-   *
-   * Called when projected input tokens exceed the configured compression threshold
-   * of the model's context window limit. Subclasses implement this to reduce
-   * context before the model call, avoiding overflow errors.
-   *
-   * @param options - The reduction options
-   * @returns `true` if the history was reduced, `false` otherwise.
-   *   May return a `Promise` for implementations that need async I/O.
-   */
-  reduceOnThreshold?(options: ConversationManagerThresholdOptions): boolean | Promise<boolean>
-
-  /**
    * Initialize the conversation manager with the agent instance.
    *
-   * Registers overflow recovery: when a {@link ContextWindowOverflowError} occurs,
-   * calls {@link ConversationManager.reduce} and retries the model call if reduction succeeded.
-   * If `reduce` returns `false`, the error propagates out of the agent loop uncaught.
-   *
-   * When a compression threshold is configured and the subclass implements `reduceOnThreshold`,
-   * also registers a `BeforeModelCallEvent` hook for proactive compression.
+   * Registers two hooks:
+   * 1. `AfterModelCallEvent`: Overflow recovery — when a {@link ContextWindowOverflowError} occurs,
+   *    calls {@link ConversationManager.reduce} with `error` set and retries if reduction succeeded.
+   * 2. `BeforeModelCallEvent`: Proactive compression — when projected input tokens exceed the
+   *    configured compression threshold, calls {@link ConversationManager.reduce} without `error`.
+   *    The hook is always registered but only acts when proactive compression is enabled.
    *
    * Subclasses that override `initAgent` MUST call `super.initAgent(agent)` to
    * preserve overflow recovery and proactive compression behavior.
@@ -162,6 +168,7 @@ export abstract class ConversationManager implements Plugin {
    * @param agent - The agent to register hooks with
    */
   initAgent(agent: LocalAgent): void {
+    // Reactive overflow recovery
     agent.addHook(AfterModelCallEvent, async (event) => {
       if (event.error instanceof ContextWindowOverflowError) {
         if (await this.reduce({ agent: event.agent, model: event.model, error: event.error })) {
@@ -170,35 +177,37 @@ export abstract class ConversationManager implements Plugin {
       }
     })
 
-    if (this._compressionThreshold !== undefined && !this.reduceOnThreshold) {
-      logger.warn(
-        `conversation_manager=<${this.name}> | compressProactively is enabled but reduceOnThreshold is not implemented, proactive compression is disabled`
-      )
-    }
+    // Proactive compression — always subscribe, check threshold in the handler
+    agent.addHook(BeforeModelCallEvent, async (event) => {
+      if (this._compressionThreshold === undefined) {
+        return
+      }
 
-    if (this._compressionThreshold !== undefined && this.reduceOnThreshold) {
-      agent.addHook(BeforeModelCallEvent, async (event) => {
-        const contextWindowLimit = event.model.getConfig().contextWindowLimit
-        if (contextWindowLimit === undefined) {
-          warnOnce(
-            logger,
-            `conversation_manager=<${this.name}> | contextWindowLimit is not set on the model, proactive compression is disabled | set contextWindowLimit in your model config`
-          )
-          return
-        }
+      let contextWindowLimit = event.model.getConfig().contextWindowLimit
+      if (contextWindowLimit === undefined) {
+        contextWindowLimit = DEFAULT_CONTEXT_WINDOW_LIMIT
+        warnOnce(
+          logger,
+          `conversation_manager=<${this.name}> | contextWindowLimit is not set on the model, using default of ${DEFAULT_CONTEXT_WINDOW_LIMIT} | set contextWindowLimit in your model config for accurate proactive compression`
+        )
+      }
 
-        if (event.projectedInputTokens === undefined) {
-          return
-        }
+      if (event.projectedInputTokens === undefined) {
+        return
+      }
 
-        const ratio = event.projectedInputTokens / contextWindowLimit
-        if (ratio >= this._compressionThreshold!) {
-          logger.debug(
-            `projected_tokens=<${event.projectedInputTokens}>, limit=<${contextWindowLimit}>, ratio=<${ratio.toFixed(2)}>, compression_threshold=<${this._compressionThreshold}> | compression threshold exceeded, reducing context`
-          )
-          await this.reduceOnThreshold!({ agent: event.agent })
+      const ratio = event.projectedInputTokens / contextWindowLimit
+      if (ratio >= this._compressionThreshold) {
+        logger.debug(
+          `projected_tokens=<${event.projectedInputTokens}>, limit=<${contextWindowLimit}>, ratio=<${ratio.toFixed(2)}>, compression_threshold=<${this._compressionThreshold}> | compression threshold exceeded, reducing context`
+        )
+        // Proactive compression is best-effort: swallow errors so the model call can still proceed.
+        try {
+          await this.reduce({ agent: event.agent, model: event.model })
+        } catch (e) {
+          logger.warn(`conversation_manager=<${this.name}> | proactive compression failed, continuing | error=<${e}>`)
         }
-      })
-    }
+      }
+    })
   }
 }

--- a/strands-ts/src/conversation-manager/conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/conversation-manager.ts
@@ -76,7 +76,7 @@ export type ConversationManagerOptions = {
    * - `{ compressionThreshold: number }`: compress at the specified ratio (0, 1].
    * - `false` or omitted: disabled, only reactive overflow recovery is used.
    */
-  compressProactively?: boolean | ProactiveCompressionConfig
+  proactiveCompression?: boolean | ProactiveCompressionConfig
 }
 
 /**
@@ -89,7 +89,7 @@ export type ConversationManagerOptions = {
  * out of the agent loop uncaught. This makes `reduce` a critical operation —
  * implementations must be able to make meaningful progress when called with `error` set.
  *
- * Subclasses can enable proactive compression by passing `compressProactively` in the
+ * Subclasses can enable proactive compression by passing `proactiveCompression` in the
  * options object to the base constructor. When enabled, the base class registers a
  * `BeforeModelCallEvent` hook that checks projected input tokens against the model's
  * context window limit and calls `reduce` (without `error`) when the threshold is exceeded.
@@ -119,12 +119,12 @@ export abstract class ConversationManager implements Plugin {
    * @param options - Configuration options for the conversation manager.
    */
   constructor(options?: ConversationManagerOptions) {
-    const compressProactively = options?.compressProactively
+    const proactiveCompression = options?.proactiveCompression
     const threshold =
-      compressProactively === true
+      proactiveCompression === true
         ? DEFAULT_COMPRESSION_THRESHOLD
-        : compressProactively
-          ? compressProactively.compressionThreshold
+        : proactiveCompression
+          ? proactiveCompression.compressionThreshold
           : undefined
 
     if (threshold !== undefined && (threshold <= 0 || threshold > 1)) {

--- a/strands-ts/src/conversation-manager/index.ts
+++ b/strands-ts/src/conversation-manager/index.ts
@@ -4,7 +4,12 @@
  * This module exports conversation manager implementations.
  */
 
-export { ConversationManager, type ConversationManagerReduceOptions as ReduceOptions } from './conversation-manager.js'
+export {
+  ConversationManager,
+  type ConversationManagerConfig,
+  type ConversationManagerReduceOptions as ReduceOptions,
+  type ConversationManagerThresholdOptions,
+} from './conversation-manager.js'
 export { NullConversationManager } from './null-conversation-manager.js'
 export {
   SlidingWindowConversationManager,

--- a/strands-ts/src/conversation-manager/index.ts
+++ b/strands-ts/src/conversation-manager/index.ts
@@ -6,7 +6,7 @@
 
 export {
   ConversationManager,
-  type ConversationManagerConfig,
+  type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions as ReduceOptions,
   type ConversationManagerThresholdOptions,
 } from './conversation-manager.js'

--- a/strands-ts/src/conversation-manager/index.ts
+++ b/strands-ts/src/conversation-manager/index.ts
@@ -8,7 +8,7 @@ export {
   ConversationManager,
   type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions as ReduceOptions,
-  type ConversationManagerThresholdOptions,
+  type ConversationManagerOptions,
 } from './conversation-manager.js'
 export { NullConversationManager } from './null-conversation-manager.js'
 export {

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -8,13 +8,18 @@
 import { Message, TextBlock, ToolResultBlock } from '../types/messages.js'
 import type { LocalAgent } from '../types/agent.js'
 import { AfterInvocationEvent } from '../hooks/events.js'
-import { ConversationManager, type ConversationManagerReduceOptions } from './conversation-manager.js'
+import {
+  ConversationManager,
+  type ConversationManagerConfig,
+  type ConversationManagerReduceOptions,
+  type ConversationManagerThresholdOptions,
+} from './conversation-manager.js'
 import { logger } from '../logging/logger.js'
 
 /**
  * Configuration for the sliding window conversation manager.
  */
-export type SlidingWindowConversationManagerConfig = {
+export type SlidingWindowConversationManagerConfig = ConversationManagerConfig & {
   /**
    * Maximum number of messages to keep in the conversation history.
    * Defaults to 40 messages.
@@ -55,7 +60,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
    * @param config - Configuration options for the sliding window manager.
    */
   constructor(config?: SlidingWindowConversationManagerConfig) {
-    super()
+    super(config)
     this._windowSize = config?.windowSize ?? 40
     this._shouldTruncateResults = config?.shouldTruncateResults ?? true
   }
@@ -87,6 +92,16 @@ export class SlidingWindowConversationManager extends ConversationManager {
    */
   reduce({ agent, error }: ConversationManagerReduceOptions): boolean {
     return this._reduceContext(agent.messages, error)
+  }
+
+  /**
+   * Proactively reduce context by trimming oldest messages.
+   *
+   * @param options - The threshold reduction options
+   * @returns `true` if the history was reduced, `false` otherwise
+   */
+  reduceOnThreshold({ agent }: ConversationManagerThresholdOptions): boolean {
+    return this._reduceContext(agent.messages, undefined)
   }
 
   /**

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -10,7 +10,7 @@ import type { LocalAgent } from '../types/agent.js'
 import { AfterInvocationEvent } from '../hooks/events.js'
 import {
   ConversationManager,
-  type ConversationManagerConfig,
+  type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
   type ConversationManagerThresholdOptions,
 } from './conversation-manager.js'
@@ -19,7 +19,7 @@ import { logger } from '../logging/logger.js'
 /**
  * Configuration for the sliding window conversation manager.
  */
-export type SlidingWindowConversationManagerConfig = ConversationManagerConfig & {
+export type SlidingWindowConversationManagerConfig = {
   /**
    * Maximum number of messages to keep in the conversation history.
    * Defaults to 40 messages.
@@ -31,6 +31,15 @@ export type SlidingWindowConversationManagerConfig = ConversationManagerConfig &
    * Defaults to true.
    */
   shouldTruncateResults?: boolean
+
+  /**
+   * Enable proactive context compression before the model call.
+   *
+   * - `true`: compress when 70% of the context window is used (default threshold).
+   * - `{ compressionThreshold: number }`: compress at the specified ratio (0, 1].
+   * - `false` or omitted: disabled, only reactive overflow recovery is used.
+   */
+  compressProactively?: boolean | ProactiveCompressionConfig
 }
 
 /**
@@ -60,7 +69,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
    * @param config - Configuration options for the sliding window manager.
    */
   constructor(config?: SlidingWindowConversationManagerConfig) {
-    super(config)
+    super(config?.compressProactively)
     this._windowSize = config?.windowSize ?? 40
     this._shouldTruncateResults = config?.shouldTruncateResults ?? true
   }

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -12,7 +12,6 @@ import {
   ConversationManager,
   type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
-  type ConversationManagerThresholdOptions,
 } from './conversation-manager.js'
 import { logger } from '../logging/logger.js'
 
@@ -53,6 +52,7 @@ export type SlidingWindowConversationManagerConfig = {
  * Registers hooks for:
  * - AfterInvocationEvent: Applies sliding window management after each invocation
  * - AfterModelCallEvent: Reduces context on overflow errors and requests retry (via super)
+ * - BeforeModelCallEvent: Proactive compression when threshold is exceeded (via super)
  */
 export class SlidingWindowConversationManager extends ConversationManager {
   private readonly _windowSize: number
@@ -69,7 +69,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
    * @param config - Configuration options for the sliding window manager.
    */
   constructor(config?: SlidingWindowConversationManagerConfig) {
-    super(config?.compressProactively)
+    super(config?.compressProactively !== undefined ? { compressProactively: config.compressProactively } : undefined)
     this._windowSize = config?.windowSize ?? 40
     this._shouldTruncateResults = config?.shouldTruncateResults ?? true
   }
@@ -80,6 +80,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
    * Registers:
    * - AfterInvocationEvent callback to apply sliding window management
    * - AfterModelCallEvent callback to handle context overflow and request retry (via super)
+   * - BeforeModelCallEvent callback for proactive compression (via super)
    *
    * @param agent - The agent to register hooks with
    */
@@ -92,25 +93,19 @@ export class SlidingWindowConversationManager extends ConversationManager {
   }
 
   /**
-   * Reduce the conversation history in response to a context overflow.
+   * Reduce the conversation history.
    *
-   * Attempts to truncate large tool results first before falling back to message trimming.
+   * When `error` is set (reactive overflow recovery), attempts to truncate large tool results
+   * first before falling back to message trimming.
+   *
+   * When `error` is undefined (proactive compression), only trims messages without attempting
+   * tool result truncation.
    *
    * @param options - The reduction options
    * @returns `true` if the history was reduced, `false` otherwise
    */
   reduce({ agent, error }: ConversationManagerReduceOptions): boolean {
     return this._reduceContext(agent.messages, error)
-  }
-
-  /**
-   * Proactively reduce context by trimming oldest messages.
-   *
-   * @param options - The threshold reduction options
-   * @returns `true` if the history was reduced, `false` otherwise
-   */
-  reduceOnThreshold({ agent }: ConversationManagerThresholdOptions): boolean {
-    return this._reduceContext(agent.messages, undefined)
   }
 
   /**

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -38,7 +38,7 @@ export type SlidingWindowConversationManagerConfig = {
    * - `{ compressionThreshold: number }`: compress at the specified ratio (0, 1].
    * - `false` or omitted: disabled, only reactive overflow recovery is used.
    */
-  compressProactively?: boolean | ProactiveCompressionConfig
+  proactiveCompression?: boolean | ProactiveCompressionConfig
 }
 
 /**
@@ -69,7 +69,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
    * @param config - Configuration options for the sliding window manager.
    */
   constructor(config?: SlidingWindowConversationManagerConfig) {
-    super(config?.compressProactively !== undefined ? { compressProactively: config.compressProactively } : undefined)
+    super(config)
     this._windowSize = config?.windowSize ?? 40
     this._shouldTruncateResults = config?.shouldTruncateResults ?? true
   }

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -7,7 +7,13 @@
  */
 
 import { Message, TextBlock } from '../types/messages.js'
-import { ConversationManager, type ConversationManagerReduceOptions } from './conversation-manager.js'
+import type { LocalAgent } from '../types/agent.js'
+import {
+  ConversationManager,
+  type ConversationManagerConfig,
+  type ConversationManagerReduceOptions,
+  type ConversationManagerThresholdOptions,
+} from './conversation-manager.js'
 import { logger } from '../logging/logger.js'
 import type { Model } from '../models/model.js'
 
@@ -43,7 +49,7 @@ Example format:
 /**
  * Configuration for the summarization conversation manager.
  */
-export type SummarizingConversationManagerConfig = {
+export type SummarizingConversationManagerConfig = ConversationManagerConfig & {
   /**
    * Model to use for generating summaries. When provided, overrides the model
    * attached to the agent. Useful when you want to use a different model than
@@ -86,7 +92,7 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _summarizationSystemPrompt: string
 
   constructor(config?: SummarizingConversationManagerConfig) {
-    super()
+    super(config)
     this._model = config?.model
     // clamped [0.1, 0.8]
     this._summaryRatio = Math.max(0.1, Math.min(0.8, config?.summaryRatio ?? 0.3))
@@ -101,8 +107,40 @@ export class SummarizingConversationManager extends ConversationManager {
    * @returns `true` if the history was reduced, `false` otherwise
    */
   async reduce({ agent, model, error }: ConversationManagerReduceOptions): Promise<boolean> {
-    const resolvedModel = this._model ?? model
+    try {
+      return await this._summarizeOldest(agent, this._model ?? model)
+    } catch (summarizationError) {
+      logger.error(`error=<${summarizationError}> | summarization failed`)
+      const wrapped = summarizationError instanceof Error ? summarizationError : new Error(String(summarizationError))
+      wrapped.cause = error
+      throw wrapped
+    }
+  }
 
+  /**
+   * Proactively reduce context by summarizing oldest messages.
+   *
+   * @param options - The threshold reduction options
+   * @returns `true` if the history was reduced, `false` otherwise
+   */
+  async reduceOnThreshold({ agent, model }: ConversationManagerThresholdOptions): Promise<boolean> {
+    // Best-effort: swallow errors so the model call can still proceed
+    try {
+      return await this._summarizeOldest(agent, this._model ?? model)
+    } catch (summarizationError) {
+      logger.error(`error=<${summarizationError}> | proactive summarization failed`)
+      return false
+    }
+  }
+
+  /**
+   * Summarize the oldest messages and replace them with a summary.
+   *
+   * @param agent - The agent instance
+   * @param model - The model to use for summarization
+   * @returns `true` if the history was reduced, `false` otherwise
+   */
+  private async _summarizeOldest(agent: LocalAgent, model: Model): Promise<boolean> {
     const messages = agent.messages
 
     // Calculate how many messages to summarize
@@ -121,22 +159,15 @@ export class SummarizingConversationManager extends ConversationManager {
     // Adjust split point to avoid breaking tool use/result pairs
     messagesToSummarizeCount = this._adjustSplitPointForToolPairs(messages, messagesToSummarizeCount)
 
-    try {
-      const messagesToSummarize = messages.slice(0, messagesToSummarizeCount)
+    const messagesToSummarize = messages.slice(0, messagesToSummarizeCount)
 
-      // Generate summary via model call
-      const summaryMessage = await this._generateSummary(messagesToSummarize, resolvedModel)
+    // Generate summary via model call
+    const summaryMessage = await this._generateSummary(messagesToSummarize, model)
 
-      // Replace summarized messages with the summary
-      messages.splice(0, messagesToSummarizeCount, summaryMessage)
+    // Replace summarized messages with the summary
+    messages.splice(0, messagesToSummarizeCount, summaryMessage)
 
-      return true
-    } catch (summarizationError) {
-      logger.error(`error=<${summarizationError}> | summarization failed`)
-      const wrapped = summarizationError instanceof Error ? summarizationError : new Error(String(summarizationError))
-      wrapped.cause = error
-      throw wrapped
-    }
+    return true
   }
 
   /**

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -10,7 +10,7 @@ import { Message, TextBlock } from '../types/messages.js'
 import type { LocalAgent } from '../types/agent.js'
 import {
   ConversationManager,
-  type ConversationManagerConfig,
+  type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
   type ConversationManagerThresholdOptions,
 } from './conversation-manager.js'
@@ -49,7 +49,7 @@ Example format:
 /**
  * Configuration for the summarization conversation manager.
  */
-export type SummarizingConversationManagerConfig = ConversationManagerConfig & {
+export type SummarizingConversationManagerConfig = {
   /**
    * Model to use for generating summaries. When provided, overrides the model
    * attached to the agent. Useful when you want to use a different model than
@@ -74,6 +74,15 @@ export type SummarizingConversationManagerConfig = ConversationManagerConfig & {
    * prompt that produces structured bullet-point summaries.
    */
   summarizationSystemPrompt?: string
+
+  /**
+   * Enable proactive context compression before the model call.
+   *
+   * - `true`: compress when 70% of the context window is used (default threshold).
+   * - `{ compressionThreshold: number }`: compress at the specified ratio (0, 1].
+   * - `false` or omitted: disabled, only reactive overflow recovery is used.
+   */
+  compressProactively?: boolean | ProactiveCompressionConfig
 }
 
 /**
@@ -92,7 +101,7 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _summarizationSystemPrompt: string
 
   constructor(config?: SummarizingConversationManagerConfig) {
-    super(config)
+    super(config?.compressProactively)
     this._model = config?.model
     // clamped [0.1, 0.8]
     this._summaryRatio = Math.max(0.1, Math.min(0.8, config?.summaryRatio ?? 0.3))

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -123,10 +123,10 @@ export class SummarizingConversationManager extends ConversationManager {
    * @param options - The threshold reduction options
    * @returns `true` if the history was reduced, `false` otherwise
    */
-  async reduceOnThreshold({ agent, model }: ConversationManagerThresholdOptions): Promise<boolean> {
+  async reduceOnThreshold({ agent }: ConversationManagerThresholdOptions): Promise<boolean> {
     // Best-effort: swallow errors so the model call can still proceed
     try {
-      return await this._summarizeOldest(agent, this._model ?? model)
+      return await this._summarizeOldest(agent, this._model ?? agent.model)
     } catch (summarizationError) {
       logger.error(`error=<${summarizationError}> | proactive summarization failed`)
       return false

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -81,7 +81,7 @@ export type SummarizingConversationManagerConfig = {
    * - `{ compressionThreshold: number }`: compress at the specified ratio (0, 1].
    * - `false` or omitted: disabled, only reactive overflow recovery is used.
    */
-  compressProactively?: boolean | ProactiveCompressionConfig
+  proactiveCompression?: boolean | ProactiveCompressionConfig
 }
 
 /**
@@ -100,7 +100,7 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _summarizationSystemPrompt: string
 
   constructor(config?: SummarizingConversationManagerConfig) {
-    super(config?.compressProactively !== undefined ? { compressProactively: config.compressProactively } : undefined)
+    super(config)
     this._model = config?.model
     // clamped [0.1, 0.8]
     this._summaryRatio = Math.max(0.1, Math.min(0.8, config?.summaryRatio ?? 0.3))

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -12,7 +12,6 @@ import {
   ConversationManager,
   type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
-  type ConversationManagerThresholdOptions,
 } from './conversation-manager.js'
 import { logger } from '../logging/logger.js'
 import type { Model } from '../models/model.js'
@@ -101,7 +100,7 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _summarizationSystemPrompt: string
 
   constructor(config?: SummarizingConversationManagerConfig) {
-    super(config?.compressProactively)
+    super(config?.compressProactively !== undefined ? { compressProactively: config.compressProactively } : undefined)
     this._model = config?.model
     // clamped [0.1, 0.8]
     this._summaryRatio = Math.max(0.1, Math.min(0.8, config?.summaryRatio ?? 0.3))
@@ -112,6 +111,12 @@ export class SummarizingConversationManager extends ConversationManager {
   /**
    * Reduce the conversation history by summarizing older messages.
    *
+   * When `error` is set (reactive overflow recovery), summarization failure is rethrown
+   * with the original error as cause — the agent loop must not proceed with an overflow.
+   *
+   * When `error` is undefined (proactive compression), summarization failure is logged
+   * and returns `false` — the model call proceeds regardless.
+   *
    * @param options - The reduction options
    * @returns `true` if the history was reduced, `false` otherwise
    */
@@ -119,25 +124,15 @@ export class SummarizingConversationManager extends ConversationManager {
     try {
       return await this._summarizeOldest(agent, this._model ?? model)
     } catch (summarizationError) {
-      logger.error(`error=<${summarizationError}> | summarization failed`)
-      const wrapped = summarizationError instanceof Error ? summarizationError : new Error(String(summarizationError))
-      wrapped.cause = error
-      throw wrapped
-    }
-  }
-
-  /**
-   * Proactively reduce context by summarizing oldest messages.
-   *
-   * @param options - The threshold reduction options
-   * @returns `true` if the history was reduced, `false` otherwise
-   */
-  async reduceOnThreshold({ agent }: ConversationManagerThresholdOptions): Promise<boolean> {
-    // Best-effort: swallow errors so the model call can still proceed
-    try {
-      return await this._summarizeOldest(agent, this._model ?? agent.model)
-    } catch (summarizationError) {
-      logger.error(`error=<${summarizationError}> | proactive summarization failed`)
+      if (error) {
+        // Reactive: rethrow so the ContextWindowOverflowError propagates
+        logger.error(`error=<${summarizationError}> | summarization failed`)
+        const wrapped = summarizationError instanceof Error ? summarizationError : new Error(String(summarizationError))
+        wrapped.cause = error
+        throw wrapped
+      }
+      // Proactive: best-effort, swallow errors so the model call can still proceed.
+      logger.warn(`error=<${summarizationError}> | proactive summarization failed, continuing`)
       return false
     }
   }

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -14,6 +14,7 @@ import {
   type ConversationManagerReduceOptions,
 } from './conversation-manager.js'
 import { logger } from '../logging/logger.js'
+import { normalizeError } from '../errors.js'
 import type { Model } from '../models/model.js'
 
 const DEFAULT_SUMMARIZATION_PROMPT = `You are a conversation summarizer. Provide a concise summary of the conversation \
@@ -127,7 +128,7 @@ export class SummarizingConversationManager extends ConversationManager {
       if (error) {
         // Reactive: rethrow so the ContextWindowOverflowError propagates
         logger.error(`error=<${summarizationError}> | summarization failed`)
-        const wrapped = summarizationError instanceof Error ? summarizationError : new Error(String(summarizationError))
+        const wrapped = normalizeError(summarizationError)
         wrapped.cause = error
         throw wrapped
       }

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -223,7 +223,7 @@ export {
   ConversationManager,
   type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
-  type ConversationManagerThresholdOptions,
+  type ConversationManagerOptions,
 } from './conversation-manager/conversation-manager.js'
 export { NullConversationManager } from './conversation-manager/null-conversation-manager.js'
 export {

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -221,7 +221,7 @@ export type { Plugin } from './plugins/index.js'
 // Conversation Manager
 export {
   ConversationManager,
-  type ConversationManagerConfig,
+  type ProactiveCompressionConfig,
   type ConversationManagerReduceOptions,
   type ConversationManagerThresholdOptions,
 } from './conversation-manager/conversation-manager.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -221,7 +221,9 @@ export type { Plugin } from './plugins/index.js'
 // Conversation Manager
 export {
   ConversationManager,
+  type ConversationManagerConfig,
   type ConversationManagerReduceOptions,
+  type ConversationManagerThresholdOptions,
 } from './conversation-manager/conversation-manager.js'
 export { NullConversationManager } from './conversation-manager/null-conversation-manager.js'
 export {


### PR DESCRIPTION
## Description

Conversation managers today are entirely reactive. They only reduce context after the model rejects a request with a `ContextWindowOverflowError`. This wastes a round-trip and causes output token starvation as input tokens approach the limit. This PR implements the proactive compression design from [0008-proactive-context-compression](https://github.com/strands-agents/docs/blob/main/designs/0008-proactive-context-compression.md), building on the `projectedInputTokens` from #890.

The `ConversationManager` base class now accepts an optional `compressionThresold` config. When set, it registers a `BeforeModelCallEvent` hook that checks `projectedInputTokens / contextWindowLimit` and calls `reduceOnThreshold()` on the subclass before the model call.
  
  ```typescript
  // Before: only reactive overflow recovery
  new SlidingWindowConversationManager({ windowSize: 50 })
  new SummarizingConversationManager()
  
  // After: proactive compression at 70% context usage
  new SlidingWindowConversationManager({ windowSize: 50, compressProactively: true })
  new SummarizingConversationManager({ compressProactively: { compressionThreshold: 0.8 } })
```  

## Related Issues

strands-agents/sdk-python#555

## Documentation PR

Will follow 

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
