### PR TITLE
fix: align context overflow detection patterns(#894)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2704,7 +2706,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2719,7 +2723,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -7506,21 +7512,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -360,11 +360,7 @@ describe('AnthropicModel', () => {
 
     it.each([
       'PROMPT IS TOO LONG: request exceeds context window',
-      'max_tokens exceeded',
-      'input too long',
       'input is too long',
-      'input length and `max_tokens` exceed context limit',
-      'input length and max_tokens exceed context limit',
       'input length exceeds context window',
       'input and output tokens exceed your context limit',
     ])('maps context overflow error "%s" to ContextWindowOverflowError', async (message) => {

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -358,10 +358,18 @@ describe('AnthropicModel', () => {
       await expect(collectIterator(provider.stream(messages))).rejects.toThrow('API Error')
     })
 
-    it('maps overload error to ContextWindowOverflowError', async () => {
+    it.each([
+      'PROMPT IS TOO LONG: request exceeds context window',
+      'max_tokens exceeded',
+      'input too long',
+      'input is too long',
+      'input length and max_tokens exceed context limit',
+      'input length exceeds context window',
+      'input and output tokens exceed your context limit',
+    ])('maps context overflow error "%s" to ContextWindowOverflowError', async (message) => {
       const mockClient = createMockClient(async function* () {
         yield { type: 'ping' } // Satisfy linter require-yield
-        throw new Error('prompt is too long')
+        throw new Error(message)
       })
       const provider = new AnthropicModel({ client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -360,6 +360,8 @@ describe('AnthropicModel', () => {
 
     it.each([
       'PROMPT IS TOO LONG: request exceeds context window',
+      'max_tokens exceeded',
+      'input too long',
       'input is too long',
       'input length exceeds context window',
       'input and output tokens exceed your context limit',

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -363,6 +363,7 @@ describe('AnthropicModel', () => {
       'max_tokens exceeded',
       'input too long',
       'input is too long',
+      'input length and `max_tokens` exceed context limit',
       'input length and max_tokens exceed context limit',
       'input length exceeds context window',
       'input and output tokens exceed your context limit',

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -18,11 +18,7 @@ import { MODEL_DEFAULTS, defaultMaxTokensWarningMessage, defaultModelWarningMess
 
 const CONTEXT_WINDOW_OVERFLOW_ERRORS = [
   'prompt is too long',
-  'max_tokens exceeded',
-  'input too long',
   'input is too long',
-  'input length and `max_tokens` exceed context limit',
-  'input length and max_tokens exceed context limit',
   'input length exceeds context window',
   'input and output tokens exceed your context limit',
 ]

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -16,7 +16,16 @@ import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
 import { MODEL_DEFAULTS, defaultMaxTokensWarningMessage, defaultModelWarningMessage } from './defaults.js'
 
-const CONTEXT_WINDOW_OVERFLOW_ERRORS = ['prompt is too long', 'max_tokens exceeded', 'input too long']
+const CONTEXT_WINDOW_OVERFLOW_ERRORS = [
+  'prompt is too long',
+  'max_tokens exceeded',
+  'input too long',
+  'input is too long',
+  'input length and `max_tokens` exceed context limit',
+  'input length and max_tokens exceed context limit',
+  'input length exceeds context window',
+  'input and output tokens exceed your context limit',
+]
 const TEXT_FILE_FORMATS = ['txt', 'md', 'markdown', 'csv', 'json', 'xml', 'html', 'yml', 'yaml', 'js', 'ts', 'py']
 
 export interface AnthropicModelConfig extends BaseModelConfig {
@@ -256,7 +265,8 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     } catch (unknownError) {
       const error = normalizeError(unknownError)
 
-      if (CONTEXT_WINDOW_OVERFLOW_ERRORS.some((msg) => error.message.includes(msg))) {
+      const lowerMessage = error.message.toLowerCase()
+      if (CONTEXT_WINDOW_OVERFLOW_ERRORS.some((msg) => lowerMessage.includes(msg))) {
         throw new ContextWindowOverflowError(error.message)
       }
 

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -18,6 +18,8 @@ import { MODEL_DEFAULTS, defaultMaxTokensWarningMessage, defaultModelWarningMess
 
 const CONTEXT_WINDOW_OVERFLOW_ERRORS = [
   'prompt is too long',
+  'max_tokens exceeded',
+  'input too long',
   'input is too long',
   'input length exceeds context window',
   'input and output tokens exceed your context limit',

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -1643,12 +1643,18 @@ describe('OpenAIModel', () => {
       }).rejects.toThrow(ContextWindowOverflowError)
     })
 
-    it('throws ContextWindowOverflowError for error with message pattern', async () => {
+    it.each([
+      'maximum context length exceeded',
+      'Input is too long for requested model',
+      'input length and `max_tokens` exceed context limit',
+      'input length and max_tokens exceed context limit',
+      'too many total text bytes',
+    ])('throws ContextWindowOverflowError for error message pattern "%s"', async (message) => {
       const mockClient = {
         chat: {
           completions: {
             create: vi.fn(async () => {
-              throw new Error('maximum context length exceeded')
+              throw new Error(message)
             }),
           },
         },

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -1644,10 +1644,8 @@ describe('OpenAIModel', () => {
     })
 
     it.each([
-      'maximum context length exceeded',
       'Input is too long for requested model',
       'input length and `max_tokens` exceed context limit',
-      'input length and max_tokens exceed context limit',
       'too many total text bytes',
     ])('throws ContextWindowOverflowError for error message pattern "%s"', async (message) => {
       const mockClient = {

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -1644,6 +1644,10 @@ describe('OpenAIModel', () => {
     })
 
     it.each([
+      'maximum context length exceeded',
+      'context_length_exceeded',
+      'too many tokens',
+      'context length',
       'Input is too long for requested model',
       'input length and `max_tokens` exceed context limit',
       'too many total text bytes',

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -719,6 +719,20 @@ describe("OpenAIModel (api: 'responses')", () => {
       ).rejects.toBeInstanceOf(ContextWindowOverflowError)
     })
 
+    it('wraps context overflow message patterns as ContextWindowOverflowError', async () => {
+      const client: any = {
+        responses: {
+          create: vi.fn(async () => {
+            throw new Error('too many total text bytes')
+          }),
+        },
+      }
+      const model = new OpenAIModel({ api: 'responses', client })
+      await expect(
+        collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      ).rejects.toBeInstanceOf(ContextWindowOverflowError)
+    })
+
     it('rethrows unknown errors untouched', async () => {
       const client: any = {
         responses: {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -722,7 +722,6 @@ describe("OpenAIModel (api: 'responses')", () => {
     it.each([
       'Input is too long for requested model',
       'input length and `max_tokens` exceed context limit',
-      'input length and max_tokens exceed context limit',
       'too many total text bytes',
     ])('wraps context overflow message pattern "%s" as ContextWindowOverflowError', async (message) => {
       const client: any = {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -719,11 +719,16 @@ describe("OpenAIModel (api: 'responses')", () => {
       ).rejects.toBeInstanceOf(ContextWindowOverflowError)
     })
 
-    it('wraps context overflow message patterns as ContextWindowOverflowError', async () => {
+    it.each([
+      'Input is too long for requested model',
+      'input length and `max_tokens` exceed context limit',
+      'input length and max_tokens exceed context limit',
+      'too many total text bytes',
+    ])('wraps context overflow message pattern "%s" as ContextWindowOverflowError', async (message) => {
       const client: any = {
         responses: {
           create: vi.fn(async () => {
-            throw new Error('too many total text bytes')
+            throw new Error(message)
           }),
         },
       }

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -720,6 +720,10 @@ describe("OpenAIModel (api: 'responses')", () => {
     })
 
     it.each([
+      'maximum context length exceeded',
+      'context_length_exceeded',
+      'too many tokens',
+      'context length',
       'Input is too long for requested model',
       'input length and `max_tokens` exceed context limit',
       'too many total text bytes',

--- a/strands-ts/src/models/openai/errors.ts
+++ b/strands-ts/src/models/openai/errors.ts
@@ -14,6 +14,10 @@ const CONTEXT_WINDOW_OVERFLOW_PATTERNS = [
   'context_length_exceeded',
   'too many tokens',
   'context length',
+  'input is too long for requested model',
+  'input length and `max_tokens` exceed context limit',
+  'input length and max_tokens exceed context limit',
+  'too many total text bytes',
 ]
 
 /**
@@ -32,16 +36,13 @@ export type OpenAIErrorKind = 'contextOverflow' | 'throttling'
  */
 export function classifyOpenAIError(err: Error & { status?: number; code?: string }): OpenAIErrorKind | undefined {
   const message = err.message?.toLowerCase() ?? ''
+  const code = err.code?.toLowerCase() ?? ''
 
-  if (
-    err.status === 429 ||
-    err.code === 'rate_limit_exceeded' ||
-    RATE_LIMIT_PATTERNS.some((p) => message.includes(p))
-  ) {
+  if (err.status === 429 || code === 'rate_limit_exceeded' || RATE_LIMIT_PATTERNS.some((p) => message.includes(p))) {
     return 'throttling'
   }
 
-  if (err.code === 'context_length_exceeded' || CONTEXT_WINDOW_OVERFLOW_PATTERNS.some((p) => message.includes(p))) {
+  if (code === 'context_length_exceeded' || CONTEXT_WINDOW_OVERFLOW_PATTERNS.some((p) => message.includes(p))) {
     return 'contextOverflow'
   }
 

--- a/strands-ts/src/models/openai/errors.ts
+++ b/strands-ts/src/models/openai/errors.ts
@@ -10,13 +10,8 @@
  * @see https://platform.openai.com/docs/guides/error-codes
  */
 const CONTEXT_WINDOW_OVERFLOW_PATTERNS = [
-  'maximum context length',
-  'context_length_exceeded',
-  'too many tokens',
-  'context length',
-  'input is too long for requested model',
+  'Input is too long for requested model',
   'input length and `max_tokens` exceed context limit',
-  'input length and max_tokens exceed context limit',
   'too many total text bytes',
 ]
 
@@ -42,7 +37,10 @@ export function classifyOpenAIError(err: Error & { status?: number; code?: strin
     return 'throttling'
   }
 
-  if (code === 'context_length_exceeded' || CONTEXT_WINDOW_OVERFLOW_PATTERNS.some((p) => message.includes(p))) {
+  if (
+    code === 'context_length_exceeded' ||
+    CONTEXT_WINDOW_OVERFLOW_PATTERNS.some((pattern) => message.includes(pattern.toLowerCase()))
+  ) {
     return 'contextOverflow'
   }
 

--- a/strands-ts/src/models/openai/errors.ts
+++ b/strands-ts/src/models/openai/errors.ts
@@ -10,6 +10,10 @@
  * @see https://platform.openai.com/docs/guides/error-codes
  */
 const CONTEXT_WINDOW_OVERFLOW_PATTERNS = [
+  'maximum context length',
+  'context_length_exceeded',
+  'too many tokens',
+  'context length',
   'Input is too long for requested model',
   'input length and `max_tokens` exceed context limit',
   'too many total text bytes',


### PR DESCRIPTION
## Description

- Ran `npm audit fix` in this PR to pass CI for protobufjs vulnerabilities:
  - codegen: GHSA-xq3m-2v4x-88gg
  - protobufjs: GHSA-h755-8qp9-cq85

Aligns context window overflow detection between the TypeScript SDK and the Python SDK for Anthropic and OpenAI providers.

For Anthropic, this adds the missing overflow message patterns from the cross-SDK scan and makes message matching case-insensitive.

For OpenAI, this expands the shared overflow classifier with the Python SDK's known overflow patterns while preserving structured `code === "context_length_exceeded"` handling.

**Updated files:**
- `strands-ts/src/models/anthropic.ts`
- `strands-ts/src/models/openai/errors.ts`
- `strands-ts/src/models/__tests__/anthropic.test.ts`
- `strands-ts/src/models/openai/__tests__/chat.test.ts`
- `strands-ts/src/models/openai/__tests__/responses.test.ts`

## Related Issues

Fixes #894

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [ ] I ran `npm run check`
- [x] I ran focused provider tests:
```powershell
  npm run test -w strands-ts -- src/models/__tests__/anthropic.test.ts src/models/openai/__tests__/chat.test.ts src/models/openai/__tests__/responses.test.ts
```
- [x] I ran lint:
```powershell
  npm run lint -w strands-ts
```
- [x] I ran formatting check on changed files:
```powershell
  npx prettier --check strands-ts/src/models/anthropic.ts strands-ts/src/models/openai/errors.ts strands-ts/src/models/__tests__/anthropic.test.ts strands-ts/src/models/openai/__tests__/chat.test.ts strands-ts/src/models/openai/__tests__/responses.test.ts
```
- [x] I ran:
```powershell
  git diff --check
```

> **Note:** `npm run check` / full build is currently blocked locally by unrelated existing telemetry/OpenTelemetry type errors in `strands-ts/src/telemetry`.

## Checklist

- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.