### PR TITLE
fix(wasm): migrate LifecycleBridge from deleted HookProvider to Plugin

### DIFF
--- a/strands-py/tests_integ/hooks/test_lifecycle_bridge.py
+++ b/strands-py/tests_integ/hooks/test_lifecycle_bridge.py
@@ -1,0 +1,63 @@
+import pytest
+
+from strands import Agent
+from strands.hooks import (
+    AfterInvocationEvent,
+    AfterModelCallEvent,
+    AgentInitializedEvent,
+    BeforeInvocationEvent,
+    BeforeModelCallEvent,
+    HookProvider,
+    MessageAddedEvent,
+)
+
+
+@pytest.fixture
+def callback_names():
+    return []
+
+
+@pytest.fixture
+def hook_provider(callback_names):
+    class LifecycleBridgeHook(HookProvider):
+        def register_hooks(self, registry):
+            registry.add_callback(
+                AgentInitializedEvent,
+                lambda _: callback_names.append("agent_initialized"),
+            )
+            registry.add_callback(
+                BeforeInvocationEvent,
+                lambda _: callback_names.append("before_invocation"),
+            )
+            registry.add_callback(
+                AfterInvocationEvent,
+                lambda _: callback_names.append("after_invocation"),
+            )
+            registry.add_callback(
+                BeforeModelCallEvent,
+                lambda _: callback_names.append("before_model_call"),
+            )
+            registry.add_callback(
+                AfterModelCallEvent, lambda _: callback_names.append("after_model_call")
+            )
+            registry.add_callback(
+                MessageAddedEvent, lambda _: callback_names.append("message_added")
+            )
+
+    return LifecycleBridgeHook()
+
+
+@pytest.fixture
+def agent(hook_provider):
+    return Agent(hooks=[hook_provider])
+
+
+def test_lifecycle_bridge_delivers_events(agent, callback_names):
+    agent("Say hello in one word")
+
+    assert "agent_initialized" in callback_names
+    assert "before_invocation" in callback_names
+    assert "before_model_call" in callback_names
+    assert "after_model_call" in callback_names
+    assert "after_invocation" in callback_names
+    assert callback_names.count("message_added") >= 2

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -20,6 +20,8 @@ import { MockPlugin } from '../../__fixtures__/mock-plugin.js'
 import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
+import type { Plugin } from '../../plugins/plugin.js'
+import type { LocalAgent } from '../../types/agent.js'
 
 describe('Agent Hooks Integration', () => {
   let mockPlugin: MockPlugin
@@ -1007,6 +1009,66 @@ describe('Agent Hooks Integration', () => {
       expect(result.stopReason).toBe('endTurn')
       expect(beforeCount).toBe(2)
       expect(result.lastMessage.content[0]).toEqual(new TextBlock('Hello'))
+    })
+  })
+
+  describe('queue-based lifecycle plugin (WASM bridge pattern)', () => {
+    function createLifecycleBridgePlugin(queue: string[]): Plugin {
+      return {
+        name: 'strands:lifecycle-bridge',
+        initAgent(agent: LocalAgent): void {
+          agent.addHook(InitializedEvent, () => {
+            queue.push('initialized')
+          })
+          agent.addHook(BeforeInvocationEvent, () => {
+            queue.push('before-invocation')
+          })
+          agent.addHook(AfterInvocationEvent, () => {
+            queue.push('after-invocation')
+          })
+          agent.addHook(BeforeModelCallEvent, () => {
+            queue.push('before-model-call')
+          })
+          agent.addHook(AfterModelCallEvent, () => {
+            queue.push('after-model-call')
+          })
+          agent.addHook(MessageAddedEvent, () => {
+            queue.push('message-added')
+          })
+          agent.addHook(BeforeToolCallEvent, () => {
+            queue.push('before-tool-call')
+          })
+          agent.addHook(AfterToolCallEvent, () => {
+            queue.push('after-tool-call')
+          })
+        },
+      }
+    }
+
+    it('receives lifecycle events when registered via plugins config', async () => {
+      const queue: string[] = []
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, plugins: [createLifecycleBridgePlugin(queue)] })
+      await agent.invoke('Hi')
+
+      expect(queue).toStrictEqual([
+        'initialized',
+        'before-invocation',
+        'message-added',
+        'before-model-call',
+        'after-model-call',
+        'message-added',
+        'after-invocation',
+      ])
+    })
+
+    it('receives no events when passed via non-existent hooks config field', async () => {
+      const queue: string[] = []
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model, hooks: [createLifecycleBridgePlugin(queue)] } as any)
+      await agent.invoke('Hi')
+
+      expect(queue).toHaveLength(0)
     })
   })
 })

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -308,7 +308,7 @@ function createToolChoiceProxy(baseModel: any, toolChoice: any): any {
   });
 }
 
-import type { HookProvider, HookRegistry } from '@strands-agents/sdk';
+import type { Plugin, LocalAgent } from '@strands-agents/sdk';
 import {
   AfterInvocationEvent,
   AfterModelCallEvent,
@@ -321,7 +321,8 @@ import {
 } from '@strands-agents/sdk';
 
 /** Bridges TS SDK lifecycle hooks to WIT StreamEvent lifecycle variants for the host. */
-class LifecycleBridge implements HookProvider {
+class LifecycleBridge implements Plugin {
+  readonly name = 'strands:lifecycle-bridge';
   queue: StreamEvent[] = [];
 
   private push(eventType: string, toolUse?: unknown, toolResult?: unknown): void {
@@ -335,20 +336,20 @@ class LifecycleBridge implements HookProvider {
     } as any);
   }
 
-  registerCallbacks(registry: HookRegistry): void {
-    registry.addCallback(InitializedEvent, () => this.push('initialized'));
-    registry.addCallback(BeforeInvocationEvent, () => this.push('before-invocation'));
-    registry.addCallback(AfterInvocationEvent, () => this.push('after-invocation'));
-    registry.addCallback(BeforeModelCallEvent, () => this.push('before-model-call'));
-    registry.addCallback(AfterModelCallEvent, () => this.push('after-model-call'));
-    registry.addCallback(MessageAddedEvent, () => this.push('message-added'));
+  initAgent(agent: LocalAgent): void {
+    agent.addHook(InitializedEvent, () => this.push('initialized'));
+    agent.addHook(BeforeInvocationEvent, () => this.push('before-invocation'));
+    agent.addHook(AfterInvocationEvent, () => this.push('after-invocation'));
+    agent.addHook(BeforeModelCallEvent, () => this.push('before-model-call'));
+    agent.addHook(AfterModelCallEvent, () => this.push('after-model-call'));
+    agent.addHook(MessageAddedEvent, () => this.push('message-added'));
 
-    registry.addCallback(BeforeToolCallEvent, (event: InstanceType<typeof BeforeToolCallEvent>) => {
+    agent.addHook(BeforeToolCallEvent, (event) => {
       this.push('before-tool-call', event.toolUse);
     });
 
-    registry.addCallback(AfterToolCallEvent, (event: InstanceType<typeof AfterToolCallEvent>) => {
-      this.push('after-tool-call', event.toolUse, event.result as unknown);
+    agent.addHook(AfterToolCallEvent, (event) => {
+      this.push('after-tool-call', event.toolUse, event.result);
     });
   }
 
@@ -453,14 +454,14 @@ class AgentImpl {
     this.sessionManager = createSessionManager(config);
     const conversationManager = createConversationManager(config);
 
-    const hooks: any[] = [this.lifecycleBridge];
-    if (this.sessionManager) hooks.push(this.sessionManager);
+    const plugins: Plugin[] = [this.lifecycleBridge];
 
     this.agent = new Agent({
       model,
       systemPrompt: buildSystemPrompt(config),
       tools: this.defaultTools,
-      hooks,
+      plugins,
+      sessionManager: this.sessionManager,
       conversationManager,
       printer: false,
     });


### PR DESCRIPTION
## Motivation

The WASM bridge's `LifecycleBridge` class was imported from a separate repository (PR strands-agents/sdk-typescript#829) that used the pre-v0.7.0 hook API. PR strands-agents/sdk-typescript#619 had already replaced `HookProvider` with `Plugin` and renamed the `hooks` config field to `plugins` 40 days earlier. The stale references came with the import, and because the WASM build pipeline uses esbuild (which strips types without validation) and has no `tsconfig.json`, neither mismatch surfaced at build time.

The result: lifecycle events (`initialized`, `before-model-call`, `after-tool-call`, etc.) silently never reach the Python host. The agent works — model calls, tool execution, streaming all function normally — but the host has zero observability into the agent loop. Any Python `HookProvider` registered for lifecycle events receives no callbacks.

Resolves: strands-agents/sdk-python#2435

## Public API Changes

No public API changes. This is an internal fix to the WASM bridge layer (`strands-wasm/entry.ts`). The Python SDK's `Agent(hooks=[...])` API is unchanged — hooks that were silently broken now work.

## Testing

Regression tests added at two layers:

**TypeScript unit tests** (`strands-ts/src/agent/__tests__/agent.hook.test.ts`): A queue-based lifecycle plugin (matching the LifecycleBridge pattern) verifies events flow when registered via `plugins:`, and proves the old `hooks:` field is silently ignored.

**Python integration test** (`strands-py/tests_integ/hooks/test_lifecycle_bridge.py`): Asserts lifecycle events (`agent_initialized`, `before_invocation`, `before_model_call`, `after_model_call`, `message_added`, `after_invocation`) arrive at a Python `HookProvider` through the full WASM boundary. Verified RED/GREEN: fails with the broken WASM (0 events), passes with the fix (7 events).

- [x] I ran `npm run check`