### PR TITLE
fix: include README and LICENSE files in published npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,4 @@ CLAUDE.md
 
 # Files copied into strands-ts/ during prepack (originals live at repo root)
 strands-ts/README.md
-strands-ts/LICENSE.APACHE
-strands-ts/LICENSE.MIT
+strands-ts/LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ CLAUDE.md
 
 # dev
 .vitest*
+
+# Files copied into strands-ts/ during prepack (originals live at repo root)
+strands-ts/README.md
+strands-ts/LICENSE.APACHE
+strands-ts/LICENSE.MIT

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -7,7 +7,10 @@
   "types": "dist/src/index.d.ts",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE.APACHE",
+    "LICENSE.MIT"
   ],
   "exports": {
     ".": {
@@ -77,7 +80,8 @@
   },
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
-    "prepack": "npm run build",
+    "prepack": "npm run build && cp ../README.md ../LICENSE.APACHE ../LICENSE.MIT .",
+    "postpack": "rm -f README.md LICENSE.APACHE LICENSE.MIT",
     "check": "npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
     "check:browser-bundle": "esbuild src/index.ts --bundle --platform=browser --format=esm --packages=external --outfile=/dev/null",
     "clean": "rm -rf node_modules dist",
@@ -109,7 +113,7 @@
     "strands"
   ],
   "author": "Strands Agents",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0 OR MIT",
   "devDependencies": {
     "@a2a-js/sdk": "^0.3.10",
     "@ai-sdk/amazon-bedrock": "^4.0.77",

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -9,8 +9,7 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE.APACHE",
-    "LICENSE.MIT"
+    "LICENSE"
   ],
   "exports": {
     ".": {
@@ -80,8 +79,8 @@
   },
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
-    "prepack": "npm run build && cp ../README.md ../LICENSE.APACHE ../LICENSE.MIT .",
-    "postpack": "rm -f README.md LICENSE.APACHE LICENSE.MIT",
+    "prepack": "npm run build && cp ../README.md . && cp ../LICENSE.APACHE LICENSE",
+    "postpack": "rm -f README.md LICENSE",
     "check": "npm run lint && npm run format && npm run type-check && npm run check:browser-bundle && npm run test:coverage && npm run test:package",
     "check:browser-bundle": "esbuild src/index.ts --bundle --platform=browser --format=esm --packages=external --outfile=/dev/null",
     "clean": "rm -rf node_modules dist",
@@ -113,7 +112,7 @@
     "strands"
   ],
   "author": "Strands Agents",
-  "license": "Apache-2.0 OR MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@a2a-js/sdk": "^0.3.10",
     "@ai-sdk/amazon-bedrock": "^4.0.77",


### PR DESCRIPTION
## Motivation

The monorepo restructure moved the SDK into `strands-ts/`, but `README.md` and the `LICENSE` file remained at the repo root. Since npm's `files` field only supports paths relative to the package directory, these files were excluded from the published tarball. This causes the [npm registry page](https://www.npmjs.com/package/@strands-agents/sdk) to show no README or license information.

Prior to the restructure (e.g. `1.0.0-rc.4`), the tarball included both `README.md` and `LICENSE` at the package root and they displayed correctly.

## Public API Changes

No public API changes.

## Changes

Adds `prepack`/`postpack` lifecycle scripts to `strands-ts/package.json` that copy `README.md` and `LICENSE.APACHE` (as `LICENSE`) from the repo root into the package directory during packing, then clean them up afterward. The `files` array now includes these files so they end up in the tarball.

Only `LICENSE.APACHE` is included in the npm package. The `LICENSE.MIT` file in the repo root was added for the `strands-py` and `strands-wasm` packages and does not apply to the `@strands-agents/sdk` npm package, which remains Apache-2.0.

Verified with `npm pack --dry-run` that the tarball matches the structure of `1.0.0-rc.4`:

```
npm notice 10.1kB LICENSE
npm notice 11.1kB README.md
npm notice 8.0kB  package.json
npm notice ...    dist/...
```

## Testing

- [x] `npm pack --dry-run` confirms README and LICENSE files are included in the tarball
- [x] `npm run check` passes (pre-commit hooks ran build, tests, lint, format, type-check)