### PR TITLE
feat: concurrent tool execution strategy by default

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.cancel.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.cancel.test.ts
@@ -181,7 +181,7 @@ describe('Agent Cancellation', () => {
         ])
         .addTurn({ type: 'textBlock', text: 'Should not reach' })
 
-      agent = new Agent({ model, tools: [tool1, tool2], printer: false })
+      agent = new Agent({ model, tools: [tool1, tool2], toolExecutor: 'sequential', printer: false })
       const result = await agent.invoke('Go')
 
       expect(result.stopReason).toBe('cancelled')

--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -140,13 +140,13 @@ function twoToolTurn(): MockMessageModel {
 }
 
 describe('Agent concurrent tool execution', () => {
-  it('runs multiple tools in parallel', async () => {
+  it('runs tools concurrently by default', async () => {
     const toolA = new GatedTool('toolA')
     const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
       tools: [toolA, toolB],
-      toolExecutor: 'concurrent',
+      // no toolExecutor — relies on the concurrent default
       printer: false,
     })
 
@@ -163,13 +163,13 @@ describe('Agent concurrent tool execution', () => {
     expect(toolB.observations.completed).toBe(true)
   })
 
-  it('runs tools sequentially under default executor', async () => {
+  it('runs tools sequentially when toolExecutor is sequential', async () => {
     const toolA = new GatedTool('toolA')
     const toolB = new GatedTool('toolB')
     const agent = new Agent({
       model: twoToolTurn(),
       tools: [toolA, toolB],
-      // default (sequential)
+      toolExecutor: 'sequential',
       printer: false,
     })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -86,10 +86,10 @@ export type ToolList = (Tool | McpClient | Agent | ToolList)[]
 /**
  * Strategy for executing tool calls that the model emits in a single assistant turn.
  *
- * - `'sequential'` (default) — runs tool calls one at a time
- * - `'concurrent'` — runs all tool calls from a single turn in parallel. Per-tool event
+ * - `'concurrent'` (default) — runs all tool calls from a single turn in parallel. Per-tool event
  *   order (`BeforeToolCallEvent` → `ToolStreamUpdateEvent*` → `AfterToolCallEvent` →
  *   `ToolResultEvent`) is preserved, while cross-tool events may interleave.
+ * - `'sequential'` — runs tool calls one at a time
  *
  * Cancellation works identically in both modes: {@link Agent.cancel} flips
  * {@link Agent.cancelSignal} and tools must observe it cooperatively to stop early.
@@ -187,7 +187,7 @@ export type AgentConfig = {
   id?: string
   /**
    * Strategy for executing tool calls from a single assistant turn.
-   * Defaults to `'sequential'`. See {@link ToolExecutorStrategy} for details.
+   * Defaults to `'concurrent'`. See {@link ToolExecutorStrategy} for details.
    */
   toolExecutor?: ToolExecutorStrategy
 }
@@ -340,8 +340,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     // Initialize meter for local metrics accumulation
     this._meter = new Meter()
 
-    // Default to sequential tool execution
-    this._toolExecutor = config?.toolExecutor ?? 'sequential'
+    this._toolExecutor = config?.toolExecutor ?? 'concurrent'
 
     this._initialized = false
   }


### PR DESCRIPTION
## Description

Concurrent tool execution strategy by default

## Related Issues

no issue

## Documentation PR

no PR

## Type of Change

Breaking change

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
