### PR TITLE
fix: add missing root script delegations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ When proposing solutions or reviewing code, we reference these principles to gui
    npm run type-check
    ```
 
-The repo is an npm workspace. The SDK source lives in `strands-ts/`, and the root `package.json` proxies common commands (`test`, `lint`, `format:check`, `type-check`, `build`) into that workspace. For commands that aren't proxied at root (like `test:integ` or `test:watch`), run them from `strands-ts/` directly.
+The repo is an npm workspace. The SDK source lives in `strands-ts/`, and the root `package.json` proxies common commands (`test`, `check`, `lint`, `build`, etc.) into that workspace. For commands that aren't proxied at root (like `test:watch`), run them from `strands-ts/` directly.
 
 ### WASM and Python Development
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build": "npm run build -w strands-ts",
     "test": "npm run test -w strands-ts",
     "test:coverage": "npm run test:coverage -w strands-ts",
+    "test:all": "npm run test:all -w strands-ts",
     "test:all:coverage": "npm run test:all:coverage -w strands-ts",
+    "test:integ": "npm run test:integ -w strands-ts",
     "test:integ:all": "npm run test:integ:all -w strands-ts",
     "test:browser:install": "npm run test:browser:install -w strands-ts",
     "test:package": "npm run test:package -w strands-ts",
@@ -21,6 +23,7 @@
     "format": "npm run format -w strands-ts",
     "format:check": "npm run format:check -w strands-ts",
     "type-check": "npm run type-check -w strands-ts",
+    "check": "npm run check -w strands-ts",
     "check:browser-bundle": "npm run check:browser-bundle -w strands-ts"
   }
 }


### PR DESCRIPTION
## Description

The root `package.json` was missing delegations for several scripts that are documented in CONTRIBUTING.md and the docs site's contribution guide. Contributors cloning the repo and running commands from the root directory would get "missing script" errors for these documented commands.

Adds root-level delegations for:
- `check` — the full quality gate (lint, format, type-check, browser-bundle, test:coverage, test:package)
- `test:all` — unit tests in both Node.js and browser environments
- `test:integ` — node integration tests

All three are referenced in CONTRIBUTING.md and/or the docs site.

Also updates the paragraph in CONTRIBUTING.md that lists which commands are proxied at root, since it previously listed `test:integ` as not proxied.

## Type of Change

Bug fix

## Testing

- [x] I ran `npm run check`
- [x] Verified each new script delegates correctly from the root

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings