### PR TITLE
fix(wasm): fix stale imports and ToolRegistry API in WASM bridge

### DIFF
--- a/strands-ts/src/registry/__tests__/tool-registry.test.ts
+++ b/strands-ts/src/registry/__tests__/tool-registry.test.ts
@@ -147,6 +147,19 @@ describe('ToolRegistry', () => {
     })
   })
 
+  describe('clear', () => {
+    it('should remove all registered tools', () => {
+      registry.add([createMockTool({ name: 'tool-1' }), createMockTool({ name: 'tool-2' })])
+      registry.clear()
+      expect(registry.list()).toStrictEqual([])
+    })
+
+    it('should be a no-op on an empty registry', () => {
+      expect(() => registry.clear()).not.toThrow()
+      expect(registry.list()).toStrictEqual([])
+    })
+  })
+
   describe('constructor', () => {
     it('accepts initial tools', () => {
       const tool = createMockTool()

--- a/strands-ts/src/registry/tool-registry.ts
+++ b/strands-ts/src/registry/tool-registry.ts
@@ -52,6 +52,13 @@ export class ToolRegistry {
   }
 
   /**
+   * Removes all registered tools.
+   */
+  clear(): void {
+    this._tools.clear()
+  }
+
+  /**
    * Returns all registered tools.
    *
    * @returns Array of all registered tools

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -26,11 +26,12 @@ import type {
 
 import { callTool } from 'strands:agent/tool-provider'
 import { log as hostLog } from 'strands:agent/host-log'
-import { Agent, FunctionTool, SessionManager, FileStorage, S3Storage } from '@strands-agents/sdk'
-import { AnthropicModel } from '@strands-agents/sdk/anthropic'
-import { BedrockModel } from '@strands-agents/sdk/bedrock'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
-import { GeminiModel } from '@strands-agents/sdk/gemini'
+import { Agent, FunctionTool, SessionManager, FileStorage } from '@strands-agents/sdk'
+import { S3Storage } from '@strands-agents/sdk/session/s3-storage'
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { GoogleModel } from '@strands-agents/sdk/models/google'
 import type { StopReason, AgentStreamEvent, Model, BaseModelConfig, Plugin, LocalAgent } from '@strands-agents/sdk'
 import {
   ConversationManager,
@@ -69,8 +70,8 @@ function mapUsage(src: any): import('strands:agent/types').Usage | undefined {
     inputTokens: src.inputTokens ?? 0,
     outputTokens: src.outputTokens ?? 0,
     totalTokens: src.totalTokens ?? (src.inputTokens ?? 0) + (src.outputTokens ?? 0),
-    cacheReadInputTokens: src.cacheReadInputTokens ?? undefined,
-    cacheWriteInputTokens: src.cacheWriteInputTokens ?? undefined,
+    cacheReadInputTokens: src.cacheReadInputTokens,
+    cacheWriteInputTokens: src.cacheWriteInputTokens,
   }
 }
 
@@ -80,30 +81,35 @@ function mapMetrics(src: any): import('strands:agent/types').Metrics | undefined
   return { latencyMs: typeof src.latencyMs === 'number' ? src.latencyMs : 0 }
 }
 
+/** Map a TS SDK StopReason string to the WIT reason tag. */
+function mapStopReasonTag(reason: StopReason): StopData['reason'] {
+  switch (reason) {
+    case 'endTurn':
+      return 'end-turn'
+    case 'toolUse':
+      return 'tool-use'
+    case 'maxTokens':
+      return 'max-tokens'
+    case 'contentFiltered':
+      return 'content-filtered'
+    case 'guardrailIntervened':
+      return 'guardrail-intervened'
+    case 'stopSequence':
+      return 'stop-sequence'
+    case 'modelContextWindowExceeded':
+      return 'model-context-window-exceeded'
+    default:
+      return 'error'
+  }
+}
+
 /** Convert a TS SDK StopReason to a WIT StopData with usage/metrics. */
 function mapStopReason(reason: StopReason, agentResult?: any): StopData {
-  const mapped: StopData['reason'] = (() => {
-    switch (reason) {
-      case 'endTurn':
-        return 'end-turn'
-      case 'toolUse':
-        return 'tool-use'
-      case 'maxTokens':
-        return 'max-tokens'
-      case 'contentFiltered':
-        return 'content-filtered'
-      case 'guardrailIntervened':
-        return 'guardrail-intervened'
-      case 'stopSequence':
-        return 'stop-sequence'
-      case 'modelContextWindowExceeded':
-        return 'model-context-window-exceeded'
-      default:
-        return 'error'
-    }
-  })()
-
-  return { reason: mapped, usage: mapUsage(agentResult?.usage), metrics: mapMetrics(agentResult?.metrics) }
+  return {
+    reason: mapStopReasonTag(reason),
+    usage: mapUsage(agentResult?.usage),
+    metrics: mapMetrics(agentResult?.metrics),
+  }
 }
 
 /** Convert a TS SDK AgentStreamEvent to a WIT StreamEvent for the host. */
@@ -200,13 +206,14 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
 
   if (!config) {
     glog('info', 'createModel: defaulting to Bedrock')
-    return new BedrockModel({ ...base })
+    return new BedrockModel(base)
   }
+
+  const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {}
 
   switch (config.tag) {
     case 'anthropic': {
       glog('info', 'createModel: Anthropic', { modelId: config.val.modelId })
-      const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {}
       return new AnthropicModel({
         ...base,
         ...(config.val.modelId ? { modelId: config.val.modelId } : {}),
@@ -216,7 +223,6 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
     }
     case 'bedrock': {
       glog('info', 'createModel: Bedrock', { modelId: config.val.modelId, region: config.val.region })
-      const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {}
       const clientConfig: Record<string, unknown> = extra.clientConfig ?? {}
       if (config.val.accessKeyId && config.val.secretAccessKey) {
         clientConfig.credentials = {
@@ -235,7 +241,6 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
     }
     case 'openai': {
       glog('info', 'createModel: OpenAI', { modelId: config.val.modelId })
-      const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {}
       return new OpenAIModel({
         ...base,
         ...(config.val.modelId ? { modelId: config.val.modelId } : {}),
@@ -245,8 +250,7 @@ function createModel(config?: ModelConfig, params?: ModelParams): Model<BaseMode
     }
     case 'gemini': {
       glog('info', 'createModel: Gemini', { modelId: config.val.modelId })
-      const extra = config.val.additionalConfig ? JSON.parse(config.val.additionalConfig) : {}
-      return new GeminiModel({
+      return new GoogleModel({
         ...base,
         ...(config.val.modelId ? { modelId: config.val.modelId } : {}),
         ...(config.val.apiKey ? { apiKey: config.val.apiKey } : {}),
@@ -310,7 +314,7 @@ function buildSystemPrompt(config: AgentConfig): any {
   if (config.systemPromptBlocks) {
     return JSON.parse(config.systemPromptBlocks)
   }
-  return config.systemPrompt ?? undefined
+  return config.systemPrompt
 }
 
 /** Wrap a model in a Proxy that injects toolChoice into every stream() call. */
@@ -430,9 +434,9 @@ function createConversationManager(config: AgentConfig): ConversationManager | u
       }
       return new SummarizingConversationManager({
         model: summaryModel,
-        summaryRatio: cmConfig.summaryRatio ?? undefined,
-        preserveRecentMessages: cmConfig.preserveRecentMessages ?? undefined,
-        summarizationSystemPrompt: cmConfig.summarizationSystemPrompt ?? undefined,
+        summaryRatio: cmConfig.summaryRatio,
+        preserveRecentMessages: cmConfig.preserveRecentMessages,
+        summarizationSystemPrompt: cmConfig.summarizationSystemPrompt,
       })
     }
     default:
@@ -485,7 +489,7 @@ class AgentImpl {
       const requestTools = createTools(args.tools)
       this.agent.toolRegistry.clear()
       if (requestTools) {
-        this.agent.toolRegistry.addAll(requestTools)
+        this.agent.toolRegistry.add(requestTools)
       }
     }
 
@@ -541,7 +545,6 @@ class ResponseStreamImpl {
   private bridge: LifecycleBridge
   private defaultTools: FunctionTool[] | undefined
   private originalModel: any
-  private eventIndex = 0
 
   constructor(
     agent: Agent,
@@ -563,7 +566,7 @@ class ResponseStreamImpl {
     }
     this.agent.toolRegistry.clear()
     if (this.defaultTools) {
-      this.agent.toolRegistry.addAll(this.defaultTools)
+      this.agent.toolRegistry.add(this.defaultTools)
     }
   }
 
@@ -584,7 +587,6 @@ class ResponseStreamImpl {
         return lifecycle.length > 0 ? lifecycle : undefined
       }
 
-      this.eventIndex++
       const mapped = mapEvent(result.value)
       if (mapped) lifecycle.push(mapped)
       return lifecycle.length > 0 ? lifecycle : []


### PR DESCRIPTION
## Motivation

The WASM bridge (`strands-wasm/entry.ts`) was imported from a separate repo (PR #829) after the Plugin migration (PR #619) and the monorepo restructure (PR #827). It carried pre-monorepo SDK import paths and calls to non-existent `ToolRegistry` methods. The result: the WASM component has never built from this monorepo.

The LifecycleBridge fix was split into #967 and merged separately.

## Public API Changes

Adds `ToolRegistry.clear()` for removing all registered tools:

```typescript
agent.toolRegistry.clear()
```

No other public API changes. The remaining fixes are internal to `strands-wasm/entry.ts`.

## What Changed

Fixed all import paths to match the current SDK exports map (`sdk/models/anthropic` not `sdk/anthropic`, `sdk/session/s3-storage` for `S3Storage`, `GoogleModel` not `GeminiModel`). Added `ToolRegistry.clear()` for bulk tool removal needed by the WASM bridge's per-request tool override flow. Replaced non-existent `toolRegistry.addAll()` with `toolRegistry.add()` which already accepts arrays.

## Known Limitations

`strands-wasm/` has no `tsconfig.json` and no type checking in CI. The stale API references survived because esbuild strips types without validating them. Adding type checking to the WASM bridge would prevent this entire class of bug from recurring.