### PR TITLE
feat(context): add result offload plugin

### DIFF
--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -75,6 +75,10 @@
     "./vended-plugins/skills": {
       "types": "./dist/src/vended-plugins/skills/index.d.ts",
       "default": "./dist/src/vended-plugins/skills/index.js"
+    },
+    "./vended-plugins/context-offloader": {
+      "types": "./dist/src/vended-plugins/context-offloader/index.d.ts",
+      "default": "./dist/src/vended-plugins/context-offloader/index.js"
     }
   },
   "scripts": {

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ContextOffloader } from '../plugin.js'
+import { InMemoryStorage } from '../storage.js'
+import { AfterToolCallEvent } from '../../../hooks/events.js'
+import { TextBlock, JsonBlock, ToolResultBlock } from '../../../types/messages.js'
+import { ImageBlock, DocumentBlock } from '../../../types/media.js'
+import { createMockAgent, invokeTrackedHook } from '../../../__fixtures__/agent-helpers.js'
+import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
+
+const mockModel = new MockMessageModel()
+
+function makeMockAgent() {
+  return createMockAgent({ extra: { model: mockModel } as never })
+}
+
+function makeEvent(
+  content: InstanceType<typeof TextBlock | typeof JsonBlock | typeof ImageBlock | typeof DocumentBlock>[],
+  overrides?: { status?: 'success' | 'error'; toolName?: string }
+) {
+  const agent = makeMockAgent()
+  const result = new ToolResultBlock({
+    toolUseId: 'tool-123',
+    status: overrides?.status ?? 'success',
+    content,
+  })
+  return new AfterToolCallEvent({
+    agent,
+    toolUse: { name: overrides?.toolName ?? 'some_tool', toolUseId: 'tool-123', input: {} },
+    tool: undefined,
+    result,
+    invocationState: {},
+  })
+}
+
+describe('ContextOffloader', () => {
+  describe('constructor validation', () => {
+    it('throws if maxResultTokens is not positive', () => {
+      expect(() => new ContextOffloader({ storage: new InMemoryStorage(), maxResultTokens: 0 })).toThrow(
+        'maxResultTokens must be positive'
+      )
+    })
+
+    it('throws if previewTokens is negative', () => {
+      expect(() => new ContextOffloader({ storage: new InMemoryStorage(), previewTokens: -1 })).toThrow(
+        'previewTokens must be non-negative'
+      )
+    })
+
+    it('throws if previewTokens >= maxResultTokens', () => {
+      expect(
+        () => new ContextOffloader({ storage: new InMemoryStorage(), maxResultTokens: 100, previewTokens: 100 })
+      ).toThrow('previewTokens must be less than maxResultTokens')
+    })
+  })
+
+  describe('plugin interface', () => {
+    it('has correct name', () => {
+      const plugin = new ContextOffloader({ storage: new InMemoryStorage() })
+      expect(plugin.name).toBe('strands:context-offloader')
+    })
+
+    it('registers AfterToolCallEvent hook', () => {
+      const plugin = new ContextOffloader({ storage: new InMemoryStorage() })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+      expect(agent.trackedHooks).toHaveLength(1)
+      expect(agent.trackedHooks[0]!.eventType).toBe(AfterToolCallEvent)
+    })
+
+    it('returns retrieval tool by default', () => {
+      const plugin = new ContextOffloader({ storage: new InMemoryStorage() })
+      const tools = plugin.getTools()
+      expect(tools).toHaveLength(1)
+      expect(tools[0]!.name).toBe('retrieve_offloaded_content')
+    })
+
+    it('returns empty tools when includeRetrievalTool is false', () => {
+      const plugin = new ContextOffloader({ storage: new InMemoryStorage(), includeRetrievalTool: false })
+      expect(plugin.getTools()).toHaveLength(0)
+    })
+  })
+
+  describe('hook behavior', () => {
+    it('does not offload results below threshold', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 2500 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('short text')])
+      await invokeTrackedHook(agent, event)
+
+      expect(event.result.content).toHaveLength(1)
+      expect(event.result.content[0]).toBeInstanceOf(TextBlock)
+      expect((event.result.content[0] as TextBlock).text).toBe('short text')
+    })
+
+    it('does not offload error results', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))], { status: 'error' })
+      await invokeTrackedHook(agent, event)
+
+      expect((event.result.content[0] as TextBlock).text).toBe('x'.repeat(1000))
+    })
+
+    it('does not offload retrieval tool results', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5, includeRetrievalTool: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))], { toolName: 'retrieve_offloaded_content' })
+      await invokeTrackedHook(agent, event)
+
+      expect((event.result.content[0] as TextBlock).text).toBe('x'.repeat(1000))
+    })
+
+    it('offloads large text results', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 100, previewTokens: 10 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const largeText = 'a'.repeat(2000)
+      const event = makeEvent([new TextBlock(largeText)])
+      await invokeTrackedHook(agent, event)
+
+      expect(event.result.content).toHaveLength(1)
+      const preview = (event.result.content[0] as TextBlock).text
+      expect(preview).toContain('[Offloaded:')
+      expect(preview).toContain('Tool result was offloaded')
+      expect(preview).toContain('[Stored references:]')
+      expect(preview).not.toContain(largeText)
+    })
+
+    it('offloads large JSON results', async () => {
+      const storage = new InMemoryStorage()
+      // JSON uses chars/2 heuristic, so 1000 chars of JSON ≈ 500 tokens
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const largeJson = { data: 'x'.repeat(1000) }
+      const event = makeEvent([new JsonBlock({ json: largeJson })])
+      await invokeTrackedHook(agent, event)
+
+      const preview = (event.result.content[0] as TextBlock).text
+      expect(preview).toContain('[Offloaded:')
+      expect(preview).toContain('json,')
+    })
+
+    it('offloads image blocks with placeholder', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const imgBytes = new Uint8Array(10000)
+      const event = makeEvent([
+        new TextBlock('x'.repeat(1000)),
+        new ImageBlock({ format: 'png', source: { bytes: imgBytes } }),
+      ])
+      await invokeTrackedHook(agent, event)
+
+      const imageBlock = event.result.content.find((b) => b instanceof TextBlock && b.text.includes('[image:'))
+      expect(imageBlock).toBeDefined()
+      expect((imageBlock as TextBlock).text).toContain('[image: png,')
+      expect((imageBlock as TextBlock).text).toContain('ref:')
+    })
+
+    it('offloads document blocks with placeholder', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const docBytes = new Uint8Array(10000)
+      const event = makeEvent([
+        new TextBlock('x'.repeat(1000)),
+        new DocumentBlock({ format: 'pdf', name: 'report.pdf', source: { bytes: docBytes } }),
+      ])
+      await invokeTrackedHook(agent, event)
+
+      const docBlock = event.result.content.find((b) => b instanceof TextBlock && b.text.includes('[document:'))
+      expect(docBlock).toBeDefined()
+      expect((docBlock as TextBlock).text).toContain('[document: pdf, report.pdf,')
+      expect((docBlock as TextBlock).text).toContain('ref:')
+    })
+
+    it('preserves original result on storage failure', async () => {
+      const failingStorage: InMemoryStorage = new InMemoryStorage()
+      vi.spyOn(failingStorage, 'store').mockImplementation(() => {
+        throw new Error('storage down')
+      })
+
+      const plugin = new ContextOffloader({ storage: failingStorage, maxResultTokens: 10, previewTokens: 5 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))])
+      const originalResult = event.result
+      await invokeTrackedHook(agent, event)
+
+      expect(event.result).toBe(originalResult)
+    })
+
+    it('includes retrieval tool guidance when enabled', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+        includeRetrievalTool: true,
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))])
+      await invokeTrackedHook(agent, event)
+
+      const preview = (event.result.content[0] as TextBlock).text
+      expect(preview).toContain('retrieve_offloaded_content')
+    })
+
+    it('respects custom previewTokens', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 2 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('a'.repeat(1000))])
+      await invokeTrackedHook(agent, event)
+
+      const preview = (event.result.content[0] as TextBlock).text
+      const previewSection = preview.split('[Stored references:]')[0]
+      // previewTokens=2 → 2*4=8 chars of 'a' in preview
+      expect(previewSection).toContain('a'.repeat(8))
+      expect(previewSection).not.toContain('a'.repeat(100))
+    })
+
+    it('stores and retrieves content round-trip', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+        includeRetrievalTool: true,
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('hello world '.repeat(100))])
+      await invokeTrackedHook(agent, event)
+
+      const preview = (event.result.content[0] as TextBlock).text
+      const refMatch = preview.match(/mem_\d+_tool-123_0/)
+      expect(refMatch).not.toBeNull()
+
+      const retrieved = storage.retrieve(refMatch![0])
+      expect(new TextDecoder().decode(retrieved.content)).toBe('hello world '.repeat(100))
+    })
+  })
+
+  describe('retrieval tool', () => {
+    it('retrieves text content as string', async () => {
+      const storage = new InMemoryStorage()
+      const ref = storage.store('k1', new TextEncoder().encode('hello'), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const tools = plugin.getTools()
+      const retrievalTool = tools[0]!
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      expect(result).toBe('hello')
+    })
+
+    it('retrieves JSON content as parsed object', async () => {
+      const storage = new InMemoryStorage()
+      const ref = storage.store('k1', new TextEncoder().encode('{"foo":"bar"}'), 'application/json')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const tools = plugin.getTools()
+      const retrievalTool = tools[0]!
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      expect(result).toEqual({ foo: 'bar' })
+    })
+
+    it('retrieves image content as ImageBlock', async () => {
+      const storage = new InMemoryStorage()
+      const imgBytes = new Uint8Array([137, 80, 78, 71])
+      const ref = storage.store('k1', imgBytes, 'image/png')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const tools = plugin.getTools()
+      const retrievalTool = tools[0]!
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      expect(result).toBeInstanceOf(ImageBlock)
+      expect((result as ImageBlock).format).toBe('png')
+    })
+
+    it('retrieves document content as DocumentBlock', async () => {
+      const storage = new InMemoryStorage()
+      const docBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46])
+      const ref = storage.store('k1', docBytes, 'application/pdf')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const tools = plugin.getTools()
+      const retrievalTool = tools[0]!
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      expect(result).toBeInstanceOf(DocumentBlock)
+      expect((result as DocumentBlock).format).toBe('pdf')
+    })
+
+    it('returns error string for missing reference', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const tools = plugin.getTools()
+      const retrievalTool = tools[0]!
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({
+        reference: 'nonexistent',
+      })
+      expect(result).toContain('Error: reference not found')
+    })
+  })
+})

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -260,7 +260,7 @@ describe('ContextOffloader', () => {
       const refMatch = preview.match(/mem_\d+_tool-123_0/)
       expect(refMatch).not.toBeNull()
 
-      const retrieved = storage.retrieve(refMatch![0])
+      const retrieved = await storage.retrieve(refMatch![0])
       expect(new TextDecoder().decode(retrieved.content)).toBe('hello world '.repeat(100))
     })
   })
@@ -268,7 +268,7 @@ describe('ContextOffloader', () => {
   describe('retrieval tool', () => {
     it('retrieves text content as string', async () => {
       const storage = new InMemoryStorage()
-      const ref = storage.store('k1', new TextEncoder().encode('hello'), 'text/plain')
+      const ref = await storage.store('k1', new TextEncoder().encode('hello'), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
@@ -279,7 +279,7 @@ describe('ContextOffloader', () => {
 
     it('retrieves JSON content as parsed object', async () => {
       const storage = new InMemoryStorage()
-      const ref = storage.store('k1', new TextEncoder().encode('{"foo":"bar"}'), 'application/json')
+      const ref = await storage.store('k1', new TextEncoder().encode('{"foo":"bar"}'), 'application/json')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
@@ -291,7 +291,7 @@ describe('ContextOffloader', () => {
     it('retrieves image content as ImageBlock', async () => {
       const storage = new InMemoryStorage()
       const imgBytes = new Uint8Array([137, 80, 78, 71])
-      const ref = storage.store('k1', imgBytes, 'image/png')
+      const ref = await storage.store('k1', imgBytes, 'image/png')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
@@ -304,7 +304,7 @@ describe('ContextOffloader', () => {
     it('retrieves document content as DocumentBlock', async () => {
       const storage = new InMemoryStorage()
       const docBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46])
-      const ref = storage.store('k1', docBytes, 'application/pdf')
+      const ref = await storage.store('k1', docBytes, 'application/pdf')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -109,7 +109,12 @@ describe('ContextOffloader', () => {
 
     it('does not offload retrieval tool results', async () => {
       const storage = new InMemoryStorage()
-      const plugin = new ContextOffloader({ storage, maxResultTokens: 10, previewTokens: 5, includeRetrievalTool: true })
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+        includeRetrievalTool: true,
+      })
       const agent = createMockAgent()
       plugin.initAgent(agent)
 
@@ -273,7 +278,9 @@ describe('ContextOffloader', () => {
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
       const retrievalTool = tools[0]!
-      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({
+        reference: ref,
+      })
       expect(result).toBe('hello')
     })
 
@@ -284,7 +291,9 @@ describe('ContextOffloader', () => {
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
       const retrievalTool = tools[0]!
-      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({
+        reference: ref,
+      })
       expect(result).toEqual({ foo: 'bar' })
     })
 
@@ -296,7 +305,9 @@ describe('ContextOffloader', () => {
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
       const retrievalTool = tools[0]!
-      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({
+        reference: ref,
+      })
       expect(result).toBeInstanceOf(ImageBlock)
       expect((result as ImageBlock).format).toBe('png')
     })
@@ -309,7 +320,9 @@ describe('ContextOffloader', () => {
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
       const tools = plugin.getTools()
       const retrievalTool = tools[0]!
-      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({ reference: ref })
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({
+        reference: ref,
+      })
       expect(result).toBeInstanceOf(DocumentBlock)
       expect((result as DocumentBlock).format).toBe('pdf')
     })

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -3,7 +3,7 @@ import { ContextOffloader } from '../plugin.js'
 import { InMemoryStorage } from '../storage.js'
 import { AfterToolCallEvent } from '../../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock } from '../../../types/messages.js'
-import { ImageBlock, DocumentBlock } from '../../../types/media.js'
+import { ImageBlock, VideoBlock, DocumentBlock } from '../../../types/media.js'
 import { createMockAgent, invokeTrackedHook } from '../../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
 
@@ -14,7 +14,9 @@ function makeMockAgent() {
 }
 
 function makeEvent(
-  content: InstanceType<typeof TextBlock | typeof JsonBlock | typeof ImageBlock | typeof DocumentBlock>[],
+  content: InstanceType<
+    typeof TextBlock | typeof JsonBlock | typeof ImageBlock | typeof VideoBlock | typeof DocumentBlock
+  >[],
   overrides?: { status?: 'success' | 'error'; toolName?: string }
 ) {
   const agent = makeMockAgent()
@@ -310,6 +312,21 @@ describe('ContextOffloader', () => {
       })
       expect(result).toBeInstanceOf(ImageBlock)
       expect((result as ImageBlock).format).toBe('png')
+    })
+
+    it('retrieves video content as VideoBlock', async () => {
+      const storage = new InMemoryStorage()
+      const vidBytes = new Uint8Array([0x00, 0x00, 0x00, 0x1c])
+      const ref = await storage.store('k1', vidBytes, 'video/mp4')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const tools = plugin.getTools()
+      const retrievalTool = tools[0]!
+      const result = await (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke({
+        reference: ref,
+      })
+      expect(result).toBeInstanceOf(VideoBlock)
+      expect((result as VideoBlock).format).toBe('mp4')
     })
 
     it('retrieves document content as DocumentBlock', async () => {

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.node.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.node.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { FileStorage } from '../storage.js'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+describe('FileStorage', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'context-offloader-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('stores and retrieves text content', async () => {
+    const storage = new FileStorage(tmpDir)
+    const content = new TextEncoder().encode('hello world')
+    const ref = await storage.store('key1', content, 'text/plain')
+
+    const result = await storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('hello world')
+    expect(result.contentType).toBe('text/plain')
+  })
+
+  it('stores and retrieves binary content', async () => {
+    const storage = new FileStorage(tmpDir)
+    const content = new Uint8Array([1, 2, 3, 4, 5])
+    const ref = await storage.store('key1', content, 'image/png')
+
+    const result = await storage.retrieve(ref)
+    expect(result.content).toEqual(content)
+    expect(result.contentType).toBe('image/png')
+  })
+
+  it('returns file path as reference preserving configured directory', async () => {
+    const storage = new FileStorage(tmpDir)
+    const content = new TextEncoder().encode('test')
+    const ref = await storage.store('k1', content, 'text/plain')
+
+    expect(ref.startsWith(tmpDir)).toBe(true)
+    expect(ref).toMatch(/\.txt$/)
+  })
+
+  it('uses correct file extensions', async () => {
+    const storage = new FileStorage(tmpDir)
+    const content = new TextEncoder().encode('test')
+
+    const txtRef = await storage.store('k1', content, 'text/plain')
+    expect(txtRef).toMatch(/\.txt$/)
+
+    const jsonRef = await storage.store('k2', content, 'application/json')
+    expect(jsonRef).toMatch(/\.json$/)
+
+    const pngRef = await storage.store('k3', content, 'image/png')
+    expect(pngRef).toMatch(/\.png$/)
+  })
+
+  it('throws on missing reference', async () => {
+    const storage = new FileStorage(tmpDir)
+    await expect(storage.retrieve(path.join(tmpDir, 'nonexistent.txt'))).rejects.toThrow('Reference not found')
+  })
+
+  it('sanitizes keys for safe filenames', async () => {
+    const storage = new FileStorage(tmpDir)
+    const content = new TextEncoder().encode('test')
+    const ref = await storage.store('../../../etc/passwd', content, 'text/plain')
+    expect(ref).not.toContain('..')
+  })
+
+  it('prevents path traversal on retrieve', async () => {
+    const storage = new FileStorage(tmpDir)
+    await expect(storage.retrieve('../../etc/passwd')).rejects.toThrow('Reference not found')
+  })
+
+  it('creates artifact directory if it does not exist', async () => {
+    const nestedDir = path.join(tmpDir, 'nested', 'dir')
+    const storage = new FileStorage(nestedDir)
+    const content = new TextEncoder().encode('test')
+    await storage.store('key1', content, 'text/plain')
+
+    const stat = await fs.stat(nestedDir)
+    expect(stat.isDirectory()).toBe(true)
+  })
+
+  it('persists metadata across instances', async () => {
+    const storage1 = new FileStorage(tmpDir)
+    const content = new TextEncoder().encode('test')
+    const ref = await storage1.store('key1', content, 'application/json')
+
+    const storage2 = new FileStorage(tmpDir)
+    const result = await storage2.retrieve(ref)
+    expect(result.contentType).toBe('application/json')
+  })
+})

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { InMemoryStorage, S3Storage } from '../storage.js'
+
+describe('InMemoryStorage', () => {
+  it('stores and retrieves text content', () => {
+    const storage = new InMemoryStorage()
+    const content = new TextEncoder().encode('hello world')
+    const ref = storage.store('key1', content, 'text/plain')
+
+    const result = storage.retrieve(ref)
+    expect(new TextDecoder().decode(result.content)).toBe('hello world')
+    expect(result.contentType).toBe('text/plain')
+  })
+
+  it('stores and retrieves binary content', () => {
+    const storage = new InMemoryStorage()
+    const content = new Uint8Array([1, 2, 3, 4, 5])
+    const ref = storage.store('key1', content, 'image/png')
+
+    const result = storage.retrieve(ref)
+    expect(result.content).toEqual(content)
+    expect(result.contentType).toBe('image/png')
+  })
+
+  it('generates unique references', () => {
+    const storage = new InMemoryStorage()
+    const content = new TextEncoder().encode('test')
+    const ref1 = storage.store('key1', content)
+    const ref2 = storage.store('key2', content)
+    expect(ref1).not.toBe(ref2)
+  })
+
+  it('uses mem_ prefix in references', () => {
+    const storage = new InMemoryStorage()
+    const ref = storage.store('mykey', new TextEncoder().encode('test'))
+    expect(ref).toMatch(/^mem_\d+_mykey$/)
+  })
+
+  it('throws on missing reference', () => {
+    const storage = new InMemoryStorage()
+    expect(() => storage.retrieve('nonexistent')).toThrow('Reference not found: nonexistent')
+  })
+
+  it('clears all stored content', () => {
+    const storage = new InMemoryStorage()
+    const ref = storage.store('key1', new TextEncoder().encode('test'))
+    storage.clear()
+    expect(() => storage.retrieve(ref)).toThrow('Reference not found')
+  })
+
+  it('defaults content type to text/plain', () => {
+    const storage = new InMemoryStorage()
+    const ref = storage.store('key1', new TextEncoder().encode('test'))
+    expect(storage.retrieve(ref).contentType).toBe('text/plain')
+  })
+})
+
+describe('S3Storage', () => {
+  let mockSend: ReturnType<typeof vi.fn>
+  let mockS3Client: { send: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    mockSend = vi.fn()
+    mockS3Client = { send: mockSend }
+  })
+
+  describe('store', () => {
+    it('returns s3:// URI as reference', async () => {
+      mockSend.mockResolvedValue({})
+      const storage = new S3Storage('my-bucket', { s3Client: mockS3Client as never })
+
+      const ref = await storage.store('key1', new TextEncoder().encode('test'), 'text/plain')
+
+      expect(ref).toMatch(/^s3:\/\/my-bucket\//)
+      expect(ref).toContain('key1')
+    })
+
+    it('includes prefix in s3 key', async () => {
+      mockSend.mockResolvedValue({})
+      const storage = new S3Storage('my-bucket', { prefix: 'artifacts', s3Client: mockS3Client as never })
+
+      const ref = await storage.store('key1', new TextEncoder().encode('test'))
+
+      expect(ref).toMatch(/^s3:\/\/my-bucket\/artifacts\//)
+    })
+
+    it('normalizes trailing slashes on prefix', async () => {
+      mockSend.mockResolvedValue({})
+      const storage = new S3Storage('b', { prefix: 'p///', s3Client: mockS3Client as never })
+
+      const ref = await storage.store('k', new TextEncoder().encode('x'))
+
+      expect(ref).toMatch(/^s3:\/\/b\/p\//)
+      // Check no double slashes in the path portion (after s3://)
+      const pathPortion = ref.replace('s3://', '')
+      expect(pathPortion).not.toContain('//')
+    })
+
+    it('sends correct PutObject params', async () => {
+      mockSend.mockResolvedValue({})
+      const storage = new S3Storage('my-bucket', { s3Client: mockS3Client as never })
+      const content = new TextEncoder().encode('hello')
+
+      await storage.store('key1', content, 'application/json')
+
+      expect(mockSend).toHaveBeenCalledOnce()
+      const command = mockSend.mock.calls[0]![0]
+      expect(command.input.Bucket).toBe('my-bucket')
+      expect(command.input.Body).toBe(content)
+      expect(command.input.ContentType).toBe('application/json')
+    })
+
+    it('sanitizes keys', async () => {
+      mockSend.mockResolvedValue({})
+      const storage = new S3Storage('b', { s3Client: mockS3Client as never })
+
+      const ref = await storage.store('../../etc/passwd', new TextEncoder().encode('x'))
+
+      expect(ref).not.toContain('..')
+      expect(ref).not.toContain('etc/passwd')
+    })
+  })
+
+  describe('retrieve', () => {
+    it('retrieves content by s3:// URI', async () => {
+      mockSend
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({
+          Body: { transformToByteArray: () => Promise.resolve(new Uint8Array([1, 2, 3])) },
+          ContentType: 'image/png',
+        })
+
+      const storage = new S3Storage('my-bucket', { s3Client: mockS3Client as never })
+      const ref = await storage.store('key1', new Uint8Array([1, 2, 3]), 'image/png')
+      const result = await storage.retrieve(ref)
+
+      expect(result.content).toEqual(new Uint8Array([1, 2, 3]))
+      expect(result.contentType).toBe('image/png')
+    })
+
+    it('retrieves content by raw key', async () => {
+      mockSend.mockResolvedValue({
+        Body: { transformToByteArray: () => Promise.resolve(new TextEncoder().encode('hello')) },
+        ContentType: 'text/plain',
+      })
+
+      const storage = new S3Storage('b', { s3Client: mockS3Client as never })
+      const result = await storage.retrieve('some/raw/key')
+
+      expect(new TextDecoder().decode(result.content)).toBe('hello')
+      const command = mockSend.mock.calls[0]![0]
+      expect(command.input.Key).toBe('some/raw/key')
+    })
+
+    it('throws on bucket mismatch', async () => {
+      const storage = new S3Storage('my-bucket', { s3Client: mockS3Client as never })
+
+      await expect(storage.retrieve('s3://wrong-bucket/key')).rejects.toThrow('bucket mismatch')
+    })
+
+    it('throws on NoSuchKey error', async () => {
+      const noSuchKey = new Error('not found')
+      noSuchKey.name = 'NoSuchKey'
+      mockSend.mockRejectedValue(noSuchKey)
+
+      const storage = new S3Storage('b', { s3Client: mockS3Client as never })
+
+      await expect(storage.retrieve('missing-key')).rejects.toThrow('Reference not found')
+    })
+
+    it('defaults contentType to application/octet-stream when missing', async () => {
+      mockSend.mockResolvedValue({
+        Body: { transformToByteArray: () => Promise.resolve(new Uint8Array([0])) },
+      })
+
+      const storage = new S3Storage('b', { s3Client: mockS3Client as never })
+      const result = await storage.retrieve('key')
+
+      expect(result.contentType).toBe('application/octet-stream')
+    })
+
+    it('rethrows non-NoSuchKey errors', async () => {
+      const networkError = new Error('network timeout')
+      mockSend.mockRejectedValue(networkError)
+
+      const storage = new S3Storage('b', { s3Client: mockS3Client as never })
+
+      await expect(storage.retrieve('key')).rejects.toThrow('network timeout')
+    })
+  })
+})

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -124,12 +124,10 @@ describe('S3Storage', () => {
 
   describe('retrieve', () => {
     it('retrieves content by s3:// URI', async () => {
-      mockSend
-        .mockResolvedValueOnce({})
-        .mockResolvedValueOnce({
-          Body: { transformToByteArray: () => Promise.resolve(new Uint8Array([1, 2, 3])) },
-          ContentType: 'image/png',
-        })
+      mockSend.mockResolvedValueOnce({}).mockResolvedValueOnce({
+        Body: { transformToByteArray: () => Promise.resolve(new Uint8Array([1, 2, 3])) },
+        ContentType: 'image/png',
+      })
 
       const storage = new S3Storage('my-bucket', { s3Client: mockS3Client as never })
       const ref = await storage.store('key1', new Uint8Array([1, 2, 3]), 'image/png')

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/storage.test.ts
@@ -2,56 +2,57 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { InMemoryStorage, S3Storage } from '../storage.js'
 
 describe('InMemoryStorage', () => {
-  it('stores and retrieves text content', () => {
+  it('stores and retrieves text content', async () => {
     const storage = new InMemoryStorage()
     const content = new TextEncoder().encode('hello world')
-    const ref = storage.store('key1', content, 'text/plain')
+    const ref = await storage.store('key1', content, 'text/plain')
 
-    const result = storage.retrieve(ref)
+    const result = await storage.retrieve(ref)
     expect(new TextDecoder().decode(result.content)).toBe('hello world')
     expect(result.contentType).toBe('text/plain')
   })
 
-  it('stores and retrieves binary content', () => {
+  it('stores and retrieves binary content', async () => {
     const storage = new InMemoryStorage()
     const content = new Uint8Array([1, 2, 3, 4, 5])
-    const ref = storage.store('key1', content, 'image/png')
+    const ref = await storage.store('key1', content, 'image/png')
 
-    const result = storage.retrieve(ref)
+    const result = await storage.retrieve(ref)
     expect(result.content).toEqual(content)
     expect(result.contentType).toBe('image/png')
   })
 
-  it('generates unique references', () => {
+  it('generates unique references', async () => {
     const storage = new InMemoryStorage()
     const content = new TextEncoder().encode('test')
-    const ref1 = storage.store('key1', content)
-    const ref2 = storage.store('key2', content)
+    const ref1 = await storage.store('key1', content)
+    const ref2 = await storage.store('key2', content)
     expect(ref1).not.toBe(ref2)
   })
 
-  it('uses mem_ prefix in references', () => {
+  it('uses mem_ prefix in references', async () => {
     const storage = new InMemoryStorage()
-    const ref = storage.store('mykey', new TextEncoder().encode('test'))
+    const ref = await storage.store('mykey', new TextEncoder().encode('test'))
     expect(ref).toMatch(/^mem_\d+_mykey$/)
   })
 
-  it('throws on missing reference', () => {
+  it('throws on missing reference', async () => {
     const storage = new InMemoryStorage()
-    expect(() => storage.retrieve('nonexistent')).toThrow('Reference not found: nonexistent')
+    await expect(storage.retrieve('nonexistent')).rejects.toThrow('Reference not found: nonexistent')
   })
 
-  it('clears all stored content', () => {
+  it('clears all stored content', async () => {
     const storage = new InMemoryStorage()
-    const ref = storage.store('key1', new TextEncoder().encode('test'))
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
     storage.clear()
-    expect(() => storage.retrieve(ref)).toThrow('Reference not found')
+    await expect(storage.retrieve(ref)).rejects.toThrow('Reference not found')
   })
 
-  it('defaults content type to text/plain', () => {
+  it('defaults content type to text/plain', async () => {
     const storage = new InMemoryStorage()
-    const ref = storage.store('key1', new TextEncoder().encode('test'))
-    expect(storage.retrieve(ref).contentType).toBe('text/plain')
+    const ref = await storage.store('key1', new TextEncoder().encode('test'))
+    const result = await storage.retrieve(ref)
+    expect(result.contentType).toBe('text/plain')
   })
 })
 

--- a/strands-ts/src/vended-plugins/context-offloader/index.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/index.ts
@@ -1,0 +1,4 @@
+export { ContextOffloader } from './plugin.js'
+export type { ContextOffloaderConfig } from './plugin.js'
+export type { Storage } from './storage.js'
+export { InMemoryStorage, FileStorage, S3Storage } from './storage.js'

--- a/strands-ts/src/vended-plugins/context-offloader/index.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/index.ts
@@ -1,3 +1,22 @@
+/**
+ * Context offloading plugin for Strands Agents.
+ *
+ * This module provides the ContextOffloader plugin and Storage backends for
+ * automatically offloading oversized tool results to external storage, replacing
+ * them with truncated previews and actionable storage references.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+ *
+ * const agent = new Agent({
+ *   model,
+ *   plugins: [new ContextOffloader({ storage: new InMemoryStorage() })],
+ * })
+ * ```
+ */
+
 export { ContextOffloader } from './plugin.js'
 export type { ContextOffloaderConfig } from './plugin.js'
 export type { Storage } from './storage.js'

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -1,0 +1,296 @@
+import type { Plugin } from '../../plugins/plugin.js'
+import type { Tool } from '../../tools/tool.js'
+import type { LocalAgent } from '../../types/agent.js'
+import type { Model } from '../../models/model.js'
+import { AfterToolCallEvent } from '../../hooks/events.js'
+import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
+import type { ToolResultContent } from '../../types/messages.js'
+import { ImageBlock, VideoBlock, DocumentBlock } from '../../types/media.js'
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import { logger } from '../../logging/logger.js'
+import type { Storage } from './storage.js'
+
+const CHARS_PER_TOKEN = 4
+const DEFAULT_MAX_RESULT_TOKENS = 2_500
+const DEFAULT_PREVIEW_TOKENS = 1_000
+const RETRIEVAL_TOOL_NAME = 'retrieve_offloaded_content'
+
+function slicePreview(text: string, previewTokens: number): string {
+  const maxChars = previewTokens * CHARS_PER_TOKEN
+  if (text.length <= maxChars) return text
+  return text.slice(0, maxChars)
+}
+
+function getBytes(block: ToolResultContent): Uint8Array | undefined {
+  if (block instanceof ImageBlock && block.source.type === 'imageSourceBytes') {
+    return block.source.bytes
+  }
+  if (block instanceof VideoBlock && block.source.type === 'videoSourceBytes') {
+    return block.source.bytes
+  }
+  if (block instanceof DocumentBlock) {
+    if (block.source.type === 'documentSourceBytes') return block.source.bytes
+    if (block.source.type === 'documentSourceText') return new TextEncoder().encode(block.source.text)
+  }
+  return undefined
+}
+
+export interface ContextOffloaderConfig {
+  storage: Storage
+  maxResultTokens?: number
+  previewTokens?: number
+  includeRetrievalTool?: boolean
+}
+
+export class ContextOffloader implements Plugin {
+  readonly name = 'strands:context-offloader'
+
+  private readonly _storage: Storage
+  private readonly _maxResultTokens: number
+  private readonly _previewTokens: number
+  private readonly _includeRetrievalTool: boolean
+  private _retrievalTool: Tool | undefined
+
+  constructor(config: ContextOffloaderConfig) {
+    const maxResultTokens = config.maxResultTokens ?? DEFAULT_MAX_RESULT_TOKENS
+    const previewTokens = config.previewTokens ?? DEFAULT_PREVIEW_TOKENS
+
+    if (maxResultTokens <= 0) throw new Error('maxResultTokens must be positive')
+    if (previewTokens < 0) throw new Error('previewTokens must be non-negative')
+    if (previewTokens >= maxResultTokens) throw new Error('previewTokens must be less than maxResultTokens')
+
+    this._storage = config.storage
+    this._maxResultTokens = maxResultTokens
+    this._previewTokens = previewTokens
+    this._includeRetrievalTool = config.includeRetrievalTool ?? true
+  }
+
+  initAgent(agent: LocalAgent): void {
+    agent.addHook(AfterToolCallEvent, (event) => this._handleToolResult(event))
+  }
+
+  getTools(): Tool[] {
+    if (!this._includeRetrievalTool) return []
+    if (!this._retrievalTool) {
+      this._retrievalTool = this._createRetrievalTool()
+    }
+    return [this._retrievalTool]
+  }
+
+  private _createRetrievalTool(): Tool {
+    const storage = this._storage
+    return tool({
+      name: RETRIEVAL_TOOL_NAME,
+      description:
+        'Retrieve offloaded content by reference. Use this tool when you see a placeholder with a reference (ref: ...) and need the full content. Only use this as a fallback if the data cannot be accessed using your existing tools.',
+      inputSchema: z.object({
+        reference: z.string().describe('The reference string from the offload placeholder.'),
+      }),
+      callback: async (input) => {
+        let result: { content: Uint8Array; contentType: string }
+        try {
+          result = await storage.retrieve(input.reference)
+        } catch {
+          return `Error: reference not found: ${input.reference}`
+        }
+
+        if (result.contentType.startsWith('text/')) {
+          return new TextDecoder().decode(result.content)
+        }
+
+        if (result.contentType === 'application/json') {
+          try {
+            return JSON.parse(new TextDecoder().decode(result.content))
+          } catch {
+            return new TextDecoder().decode(result.content)
+          }
+        }
+
+        if (result.contentType.startsWith('image/')) {
+          const imgFormat = result.contentType.split('/').pop()!
+          return new ImageBlock({
+            format: imgFormat as import('../../types/media.js').ImageFormat,
+            source: { bytes: result.content },
+          })
+        }
+
+        if (result.contentType.startsWith('application/')) {
+          const docFormat = result.contentType.split('/').pop()!
+          return new DocumentBlock({
+            format: docFormat as import('../../types/media.js').DocumentFormat,
+            name: input.reference,
+            source: { bytes: result.content },
+          })
+        }
+
+        return new TextDecoder('utf-8', { fatal: false }).decode(result.content)
+      },
+    })
+  }
+
+  private async _handleToolResult(event: AfterToolCallEvent): Promise<void> {
+    if (event.result.status === 'error') return
+
+    if (this._includeRetrievalTool && event.toolUse.name === RETRIEVAL_TOOL_NAME) return
+
+    const content = event.result.content
+    const toolUseId = event.result.toolUseId
+
+    const toolResultMessage = new Message({ role: 'user', content: [event.result] })
+    // Cast: LocalAgent doesn't expose model yet. Tracked in https://github.com/strands-agents/sdk-typescript/pull/938
+    // Falls back to 0 (no offloading) if model is unavailable — only affects non-Agent LocalAgent implementations.
+    const model = (event.agent as unknown as { model?: Model }).model
+    const tokenCount = model ? await model.countTokens([toolResultMessage]) : 0
+
+    if (tokenCount <= this._maxResultTokens) return
+
+    const textPreviewParts: string[] = []
+    for (const block of content) {
+      if (block instanceof TextBlock && block.text) {
+        textPreviewParts.push(block.text)
+      } else if (block instanceof JsonBlock) {
+        textPreviewParts.push(JSON.stringify(block.json, null, 2))
+      }
+    }
+    const fullText = textPreviewParts.join('\n')
+
+    const references: Array<{ ref: string; contentType: string; description: string }> = []
+    try {
+      for (let i = 0; i < content.length; i++) {
+        const block = content[i]
+        const key = `${toolUseId}_${i}`
+
+        if (block instanceof TextBlock && block.text) {
+          const ref = await this._storage.store(key, new TextEncoder().encode(block.text), 'text/plain')
+          references.push({
+            ref,
+            contentType: 'text/plain',
+            description: `text, ${block.text.length.toLocaleString()} chars`,
+          })
+        } else if (block instanceof JsonBlock) {
+          const jsonStr = JSON.stringify(block.json, null, 2)
+          const jsonBytes = new TextEncoder().encode(jsonStr)
+          const ref = await this._storage.store(key, jsonBytes, 'application/json')
+          references.push({
+            ref,
+            contentType: 'application/json',
+            description: `json, ${jsonBytes.length.toLocaleString()} bytes`,
+          })
+        } else if (block instanceof ImageBlock) {
+          const imgBytes = getBytes(block)
+          if (imgBytes) {
+            const ref = await this._storage.store(key, imgBytes, `image/${block.format}`)
+            references.push({
+              ref,
+              contentType: `image/${block.format}`,
+              description: `image/${block.format}, ${imgBytes.length.toLocaleString()} bytes`,
+            })
+          } else {
+            references.push({
+              ref: '',
+              contentType: `image/${block.format}`,
+              description: `image/${block.format}, 0 bytes`,
+            })
+          }
+        } else if (block instanceof VideoBlock) {
+          const vidBytes = getBytes(block)
+          if (vidBytes) {
+            const ref = await this._storage.store(key, vidBytes, `video/${block.format}`)
+            references.push({
+              ref,
+              contentType: `video/${block.format}`,
+              description: `video/${block.format}, ${vidBytes.length.toLocaleString()} bytes`,
+            })
+          } else {
+            references.push({
+              ref: '',
+              contentType: `video/${block.format}`,
+              description: `video/${block.format}, 0 bytes`,
+            })
+          }
+        } else if (block instanceof DocumentBlock) {
+          const docBytes = getBytes(block)
+          if (docBytes) {
+            const ref = await this._storage.store(key, docBytes, `application/${block.format}`)
+            references.push({
+              ref,
+              contentType: `application/${block.format}`,
+              description: `${block.name}, ${docBytes.length.toLocaleString()} bytes`,
+            })
+          } else {
+            references.push({
+              ref: '',
+              contentType: `application/${block.format}`,
+              description: `${block.name}, 0 bytes`,
+            })
+          }
+        } else {
+          references.push({ ref: '', contentType: 'unknown', description: 'unknown block type' })
+        }
+      }
+    } catch (err) {
+      logger.warn(`tool_use_id=<${toolUseId}> | failed to offload tool result, keeping original`, err)
+      return
+    }
+
+    logger.debug(
+      `tool_use_id=<${toolUseId}>, blocks=<${references.length}>, tokens=<${tokenCount}> | tool result offloaded`
+    )
+
+    const preview = fullText ? slicePreview(fullText, this._previewTokens) : ''
+    const refLines = references
+      .filter((r) => r.ref)
+      .map((r) => `  ${r.ref} (${r.description})`)
+      .join('\n')
+
+    let guidance =
+      'Tool result was offloaded to external storage due to size.\n' +
+      'Use the preview below to answer if possible.\n' +
+      'Use your available tools to selectively access the data you need.'
+    if (this._includeRetrievalTool) {
+      guidance += '\nYou can also use retrieve_offloaded_content with a reference to get the full content.'
+    }
+
+    const previewText =
+      `[Offloaded: ${content.length} blocks, ~${tokenCount.toLocaleString()} tokens]\n` +
+      `${guidance}\n\n` +
+      `${preview}\n\n` +
+      `[Stored references:]\n${refLines}`
+
+    const newContent: ToolResultContent[] = [new TextBlock(previewText)]
+
+    for (let i = 0; i < content.length; i++) {
+      const block = content[i]
+      const ref = references[i]?.ref ?? ''
+
+      if (block instanceof TextBlock || block instanceof JsonBlock) {
+        continue
+      } else if (block instanceof ImageBlock) {
+        const imgBytes = getBytes(block)
+        let placeholder = `[image: ${block.format}, ${imgBytes ? imgBytes.length : 0} bytes`
+        if (ref) placeholder += ` | ref: ${ref}`
+        placeholder += ']'
+        newContent.push(new TextBlock(placeholder))
+      } else if (block instanceof VideoBlock) {
+        const vidBytes = getBytes(block)
+        let placeholder = `[video: ${block.format}, ${vidBytes ? vidBytes.length : 0} bytes`
+        if (ref) placeholder += ` | ref: ${ref}`
+        placeholder += ']'
+        newContent.push(new TextBlock(placeholder))
+      } else if (block instanceof DocumentBlock) {
+        const docBytes = getBytes(block)
+        let placeholder = `[document: ${block.format}, ${block.name}, ${docBytes ? docBytes.length : 0} bytes`
+        if (ref) placeholder += ` | ref: ${ref}`
+        placeholder += ']'
+        newContent.push(new TextBlock(placeholder))
+      }
+    }
+
+    event.result = new ToolResultBlock({
+      toolUseId: event.result.toolUseId,
+      status: event.result.status,
+      content: newContent,
+    })
+  }
+}

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -6,6 +6,7 @@ import { AfterToolCallEvent } from '../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
 import type { ToolResultContent } from '../../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock } from '../../types/media.js'
+import type { ImageFormat, VideoFormat, DocumentFormat } from '../../types/media.js'
 import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
 import { logger } from '../../logging/logger.js'
@@ -55,21 +56,21 @@ function decodeStoredContent(content: Uint8Array, contentType: string, reference
   if (contentType.startsWith('image/')) {
     const format = contentType.split('/').pop()!
     return new ImageBlock({
-      format: format as import('../../types/media.js').ImageFormat,
+      format: format as ImageFormat,
       source: { bytes: content },
     }) as unknown as JSONValue
   }
   if (contentType.startsWith('video/')) {
     const format = contentType.split('/').pop()!
     return new VideoBlock({
-      format: format as import('../../types/media.js').VideoFormat,
+      format: format as VideoFormat,
       source: { bytes: content },
     }) as unknown as JSONValue
   }
   if (contentType.startsWith('application/')) {
     const format = contentType.split('/').pop()!
     return new DocumentBlock({
-      format: format as import('../../types/media.js').DocumentFormat,
+      format: format as DocumentFormat,
       name: reference,
       source: { bytes: content },
     }) as unknown as JSONValue
@@ -190,7 +191,7 @@ export class ContextOffloader implements Plugin {
       }
       return { ref: '', contentType, description: `${label}, 0 bytes` }
     }
-    logger.warn(`Unsupported content block type encountered during offloading, skipping`)
+    logger.warn('unsupported content block type encountered during offloading, skipping')
     return { ref: '', contentType: 'unknown', description: 'unknown block type' }
   }
 

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -129,115 +129,78 @@ export class ContextOffloader implements Plugin {
     })
   }
 
-  private async _handleToolResult(event: AfterToolCallEvent): Promise<void> {
-    if (event.result.status === 'error') return
-
-    if (this._includeRetrievalTool && event.toolUse.name === RETRIEVAL_TOOL_NAME) return
-
-    const content = event.result.content
-    const toolUseId = event.result.toolUseId
-
+  private async _estimateTokens(event: AfterToolCallEvent): Promise<number> {
     const toolResultMessage = new Message({ role: 'user', content: [event.result] })
     // Cast: LocalAgent doesn't expose model yet. Tracked in https://github.com/strands-agents/sdk-typescript/pull/938
     // Falls back to 0 (no offloading) if model is unavailable — only affects non-Agent LocalAgent implementations.
     const model = (event.agent as unknown as { model?: Model }).model
-    const tokenCount = model ? await model.countTokens([toolResultMessage]) : 0
+    return model ? model.countTokens([toolResultMessage]) : 0
+  }
 
-    if (tokenCount <= this._maxResultTokens) return
-
-    const textPreviewParts: string[] = []
-    for (const block of content) {
-      if (block instanceof TextBlock && block.text) {
-        textPreviewParts.push(block.text)
-      } else if (block instanceof JsonBlock) {
-        textPreviewParts.push(JSON.stringify(block.json, null, 2))
-      }
+  private async _storeBlock(
+    block: ToolResultContent,
+    key: string
+  ): Promise<{ ref: string; contentType: string; description: string }> {
+    if (block instanceof TextBlock && block.text) {
+      const ref = await this._storage.store(key, new TextEncoder().encode(block.text), 'text/plain')
+      return { ref, contentType: 'text/plain', description: `text, ${block.text.length.toLocaleString()} chars` }
     }
-    const fullText = textPreviewParts.join('\n')
-
-    const references: Array<{ ref: string; contentType: string; description: string }> = []
-    try {
-      for (let i = 0; i < content.length; i++) {
-        const block = content[i]
-        const key = `${toolUseId}_${i}`
-
-        if (block instanceof TextBlock && block.text) {
-          const ref = await this._storage.store(key, new TextEncoder().encode(block.text), 'text/plain')
-          references.push({
-            ref,
-            contentType: 'text/plain',
-            description: `text, ${block.text.length.toLocaleString()} chars`,
-          })
-        } else if (block instanceof JsonBlock) {
-          const jsonStr = JSON.stringify(block.json, null, 2)
-          const jsonBytes = new TextEncoder().encode(jsonStr)
-          const ref = await this._storage.store(key, jsonBytes, 'application/json')
-          references.push({
-            ref,
-            contentType: 'application/json',
-            description: `json, ${jsonBytes.length.toLocaleString()} bytes`,
-          })
-        } else if (block instanceof ImageBlock) {
-          const imgBytes = getBytes(block)
-          if (imgBytes) {
-            const ref = await this._storage.store(key, imgBytes, `image/${block.format}`)
-            references.push({
-              ref,
-              contentType: `image/${block.format}`,
-              description: `image/${block.format}, ${imgBytes.length.toLocaleString()} bytes`,
-            })
-          } else {
-            references.push({
-              ref: '',
-              contentType: `image/${block.format}`,
-              description: `image/${block.format}, 0 bytes`,
-            })
-          }
-        } else if (block instanceof VideoBlock) {
-          const vidBytes = getBytes(block)
-          if (vidBytes) {
-            const ref = await this._storage.store(key, vidBytes, `video/${block.format}`)
-            references.push({
-              ref,
-              contentType: `video/${block.format}`,
-              description: `video/${block.format}, ${vidBytes.length.toLocaleString()} bytes`,
-            })
-          } else {
-            references.push({
-              ref: '',
-              contentType: `video/${block.format}`,
-              description: `video/${block.format}, 0 bytes`,
-            })
-          }
-        } else if (block instanceof DocumentBlock) {
-          const docBytes = getBytes(block)
-          if (docBytes) {
-            const ref = await this._storage.store(key, docBytes, `application/${block.format}`)
-            references.push({
-              ref,
-              contentType: `application/${block.format}`,
-              description: `${block.name}, ${docBytes.length.toLocaleString()} bytes`,
-            })
-          } else {
-            references.push({
-              ref: '',
-              contentType: `application/${block.format}`,
-              description: `${block.name}, 0 bytes`,
-            })
-          }
-        } else {
-          references.push({ ref: '', contentType: 'unknown', description: 'unknown block type' })
-        }
-      }
-    } catch (err) {
-      logger.warn(`tool_use_id=<${toolUseId}> | failed to offload tool result, keeping original`, err)
-      return
+    if (block instanceof JsonBlock) {
+      const jsonStr = JSON.stringify(block.json, null, 2)
+      const jsonBytes = new TextEncoder().encode(jsonStr)
+      const ref = await this._storage.store(key, jsonBytes, 'application/json')
+      return { ref, contentType: 'application/json', description: `json, ${jsonBytes.length.toLocaleString()} bytes` }
     }
+    if (block instanceof ImageBlock) {
+      return this._storeMediaBlock(block, key, `image/${block.format}`, `image/${block.format}`)
+    }
+    if (block instanceof VideoBlock) {
+      return this._storeMediaBlock(block, key, `video/${block.format}`, `video/${block.format}`)
+    }
+    if (block instanceof DocumentBlock) {
+      return this._storeMediaBlock(block, key, `application/${block.format}`, block.name)
+    }
+    return { ref: '', contentType: 'unknown', description: 'unknown block type' }
+  }
 
-    logger.debug(
-      `tool_use_id=<${toolUseId}>, blocks=<${references.length}>, tokens=<${tokenCount}> | tool result offloaded`
-    )
+  private async _storeMediaBlock(
+    block: ToolResultContent,
+    key: string,
+    contentType: string,
+    label: string
+  ): Promise<{ ref: string; contentType: string; description: string }> {
+    const bytes = getBytes(block)
+    if (bytes) {
+      const ref = await this._storage.store(key, bytes, contentType)
+      return { ref, contentType, description: `${label}, ${bytes.length.toLocaleString()} bytes` }
+    }
+    return { ref: '', contentType, description: `${label}, 0 bytes` }
+  }
 
+  private _buildMediaPlaceholder(block: ToolResultContent, ref: string): string | undefined {
+    let label: string | undefined
+    if (block instanceof ImageBlock) {
+      label = `image: ${block.format}`
+    } else if (block instanceof VideoBlock) {
+      label = `video: ${block.format}`
+    } else if (block instanceof DocumentBlock) {
+      label = `document: ${block.format}, ${block.name}`
+    }
+    if (!label) return undefined
+
+    const bytes = getBytes(block)
+    let placeholder = `[${label}, ${bytes ? bytes.length : 0} bytes`
+    if (ref) placeholder += ` | ref: ${ref}`
+    placeholder += ']'
+    return placeholder
+  }
+
+  private _buildPreviewText(
+    content: ToolResultContent[],
+    references: Array<{ ref: string; description: string }>,
+    tokenCount: number,
+    fullText: string
+  ): string {
     const preview = fullText ? slicePreview(fullText, this._previewTokens) : ''
     const refLines = references
       .filter((r) => r.ref)
@@ -252,37 +215,59 @@ export class ContextOffloader implements Plugin {
       guidance += '\nYou can also use retrieve_offloaded_content with a reference to get the full content.'
     }
 
-    const previewText =
+    return (
       `[Offloaded: ${content.length} blocks, ~${tokenCount.toLocaleString()} tokens]\n` +
       `${guidance}\n\n` +
       `${preview}\n\n` +
       `[Stored references:]\n${refLines}`
+    )
+  }
 
+  private async _handleToolResult(event: AfterToolCallEvent): Promise<void> {
+    if (event.result.status === 'error') return
+
+    // Skip results from the retrieval tool to prevent circular offloading
+    if (this._includeRetrievalTool && event.toolUse.name === RETRIEVAL_TOOL_NAME) return
+
+    const content = event.result.content
+    const toolUseId = event.result.toolUseId
+    const tokenCount = await this._estimateTokens(event)
+
+    if (tokenCount <= this._maxResultTokens) return
+
+    // Extract text preview from text/JSON blocks
+    const textPreviewParts: string[] = []
+    for (const block of content) {
+      if (block instanceof TextBlock && block.text) {
+        textPreviewParts.push(block.text)
+      } else if (block instanceof JsonBlock) {
+        textPreviewParts.push(JSON.stringify(block.json, null, 2))
+      }
+    }
+    const fullText = textPreviewParts.join('\n')
+
+    // Store each content block to the storage backend
+    let references: Array<{ ref: string; contentType: string; description: string }>
+    try {
+      references = await Promise.all(
+        content.map((block, i) => this._storeBlock(block, `${toolUseId}_${i}`))
+      )
+    } catch (err) {
+      logger.warn(`tool_use_id=<${toolUseId}> | failed to offload tool result, keeping original`, err)
+      return
+    }
+
+    logger.debug(
+      `tool_use_id=<${toolUseId}>, blocks=<${references.length}>, tokens=<${tokenCount}> | tool result offloaded`
+    )
+
+    // Build replacement content: preview text + media placeholders
+    const previewText = this._buildPreviewText(content, references, tokenCount, fullText)
     const newContent: ToolResultContent[] = [new TextBlock(previewText)]
 
     for (let i = 0; i < content.length; i++) {
-      const block = content[i]
-      const ref = references[i]?.ref ?? ''
-
-      if (block instanceof TextBlock || block instanceof JsonBlock) {
-        continue
-      } else if (block instanceof ImageBlock) {
-        const imgBytes = getBytes(block)
-        let placeholder = `[image: ${block.format}, ${imgBytes ? imgBytes.length : 0} bytes`
-        if (ref) placeholder += ` | ref: ${ref}`
-        placeholder += ']'
-        newContent.push(new TextBlock(placeholder))
-      } else if (block instanceof VideoBlock) {
-        const vidBytes = getBytes(block)
-        let placeholder = `[video: ${block.format}, ${vidBytes ? vidBytes.length : 0} bytes`
-        if (ref) placeholder += ` | ref: ${ref}`
-        placeholder += ']'
-        newContent.push(new TextBlock(placeholder))
-      } else if (block instanceof DocumentBlock) {
-        const docBytes = getBytes(block)
-        let placeholder = `[document: ${block.format}, ${block.name}, ${docBytes ? docBytes.length : 0} bytes`
-        if (ref) placeholder += ` | ref: ${ref}`
-        placeholder += ']'
+      const placeholder = this._buildMediaPlaceholder(content[i]!, references[i]?.ref ?? '')
+      if (placeholder) {
         newContent.push(new TextBlock(placeholder))
       }
     }

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -6,9 +6,11 @@ import { AfterToolCallEvent } from '../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
 import type { ToolResultContent } from '../../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock } from '../../types/media.js'
+import type { ImageFormat, DocumentFormat } from '../../types/media.js'
 import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
 import { logger } from '../../logging/logger.js'
+import type { JSONValue } from '../../types/json.js'
 import type { Storage } from './storage.js'
 
 const CHARS_PER_TOKEN = 4
@@ -34,6 +36,38 @@ function getBytes(block: ToolResultContent): Uint8Array | undefined {
     if (block.source.type === 'documentSourceText') return new TextEncoder().encode(block.source.text)
   }
   return undefined
+}
+
+function decodeStoredContent(
+  content: Uint8Array,
+  contentType: string,
+  reference: string
+): JSONValue | ImageBlock | DocumentBlock {
+  if (contentType.startsWith('text/')) {
+    return new TextDecoder().decode(content)
+  }
+  if (contentType === 'application/json') {
+    const text = new TextDecoder().decode(content)
+    try {
+      return JSON.parse(text) as JSONValue
+    } catch {
+      return text
+    }
+  }
+  if (contentType.startsWith('image/')) {
+    return new ImageBlock({
+      format: contentType.split('/').pop()! as ImageFormat,
+      source: { bytes: content },
+    })
+  }
+  if (contentType.startsWith('application/')) {
+    return new DocumentBlock({
+      format: contentType.split('/').pop()! as DocumentFormat,
+      name: reference,
+      source: { bytes: content },
+    })
+  }
+  return new TextDecoder('utf-8', { fatal: false }).decode(content)
 }
 
 export interface ContextOffloaderConfig {
@@ -88,53 +122,14 @@ export class ContextOffloader implements Plugin {
         reference: z.string().describe('The reference string from the offload placeholder.'),
       }),
       callback: async (input) => {
-        let result: { content: Uint8Array; contentType: string }
         try {
-          result = await storage.retrieve(input.reference)
+          const result = await storage.retrieve(input.reference)
+          return decodeStoredContent(result.content, result.contentType, input.reference) as JSONValue
         } catch {
           return `Error: reference not found: ${input.reference}`
         }
-
-        if (result.contentType.startsWith('text/')) {
-          return new TextDecoder().decode(result.content)
-        }
-
-        if (result.contentType === 'application/json') {
-          try {
-            return JSON.parse(new TextDecoder().decode(result.content))
-          } catch {
-            return new TextDecoder().decode(result.content)
-          }
-        }
-
-        if (result.contentType.startsWith('image/')) {
-          const imgFormat = result.contentType.split('/').pop()!
-          return new ImageBlock({
-            format: imgFormat as import('../../types/media.js').ImageFormat,
-            source: { bytes: result.content },
-          })
-        }
-
-        if (result.contentType.startsWith('application/')) {
-          const docFormat = result.contentType.split('/').pop()!
-          return new DocumentBlock({
-            format: docFormat as import('../../types/media.js').DocumentFormat,
-            name: input.reference,
-            source: { bytes: result.content },
-          })
-        }
-
-        return new TextDecoder('utf-8', { fatal: false }).decode(result.content)
       },
     })
-  }
-
-  private async _estimateTokens(event: AfterToolCallEvent): Promise<number> {
-    const toolResultMessage = new Message({ role: 'user', content: [event.result] })
-    // Cast: LocalAgent doesn't expose model yet. Tracked in https://github.com/strands-agents/sdk-typescript/pull/938
-    // Falls back to 0 (no offloading) if model is unavailable — only affects non-Agent LocalAgent implementations.
-    const model = (event.agent as unknown as { model?: Model }).model
-    return model ? model.countTokens([toolResultMessage]) : 0
   }
 
   private async _storeBlock(
@@ -151,48 +146,22 @@ export class ContextOffloader implements Plugin {
       const ref = await this._storage.store(key, jsonBytes, 'application/json')
       return { ref, contentType: 'application/json', description: `json, ${jsonBytes.length.toLocaleString()} bytes` }
     }
-    if (block instanceof ImageBlock) {
-      return this._storeMediaBlock(block, key, `image/${block.format}`, `image/${block.format}`)
-    }
-    if (block instanceof VideoBlock) {
-      return this._storeMediaBlock(block, key, `video/${block.format}`, `video/${block.format}`)
-    }
-    if (block instanceof DocumentBlock) {
-      return this._storeMediaBlock(block, key, `application/${block.format}`, block.name)
+    if (block instanceof ImageBlock || block instanceof VideoBlock || block instanceof DocumentBlock) {
+      const bytes = getBytes(block)
+      const contentType =
+        block instanceof ImageBlock
+          ? `image/${block.format}`
+          : block instanceof VideoBlock
+            ? `video/${block.format}`
+            : `application/${block.format}`
+      const label = block instanceof DocumentBlock ? block.name : contentType
+      if (bytes) {
+        const ref = await this._storage.store(key, bytes, contentType)
+        return { ref, contentType, description: `${label}, ${bytes.length.toLocaleString()} bytes` }
+      }
+      return { ref: '', contentType, description: `${label}, 0 bytes` }
     }
     return { ref: '', contentType: 'unknown', description: 'unknown block type' }
-  }
-
-  private async _storeMediaBlock(
-    block: ToolResultContent,
-    key: string,
-    contentType: string,
-    label: string
-  ): Promise<{ ref: string; contentType: string; description: string }> {
-    const bytes = getBytes(block)
-    if (bytes) {
-      const ref = await this._storage.store(key, bytes, contentType)
-      return { ref, contentType, description: `${label}, ${bytes.length.toLocaleString()} bytes` }
-    }
-    return { ref: '', contentType, description: `${label}, 0 bytes` }
-  }
-
-  private _buildMediaPlaceholder(block: ToolResultContent, ref: string): string | undefined {
-    let label: string | undefined
-    if (block instanceof ImageBlock) {
-      label = `image: ${block.format}`
-    } else if (block instanceof VideoBlock) {
-      label = `video: ${block.format}`
-    } else if (block instanceof DocumentBlock) {
-      label = `document: ${block.format}, ${block.name}`
-    }
-    if (!label) return undefined
-
-    const bytes = getBytes(block)
-    let placeholder = `[${label}, ${bytes ? bytes.length : 0} bytes`
-    if (ref) placeholder += ` | ref: ${ref}`
-    placeholder += ']'
-    return placeholder
   }
 
   private _buildPreviewText(
@@ -231,27 +200,26 @@ export class ContextOffloader implements Plugin {
 
     const content = event.result.content
     const toolUseId = event.result.toolUseId
-    const tokenCount = await this._estimateTokens(event)
+
+    // Cast: LocalAgent doesn't expose model yet. Tracked in https://github.com/strands-agents/sdk-typescript/pull/938
+    // Falls back to 0 (no offloading) if model is unavailable — only affects non-Agent LocalAgent implementations.
+    const model = (event.agent as unknown as { model?: Model }).model
+    const tokenCount = model ? await model.countTokens([new Message({ role: 'user', content: [event.result] })]) : 0
 
     if (tokenCount <= this._maxResultTokens) return
 
     // Extract text preview from text/JSON blocks
-    const textPreviewParts: string[] = []
+    const textParts: string[] = []
     for (const block of content) {
-      if (block instanceof TextBlock && block.text) {
-        textPreviewParts.push(block.text)
-      } else if (block instanceof JsonBlock) {
-        textPreviewParts.push(JSON.stringify(block.json, null, 2))
-      }
+      if (block instanceof TextBlock && block.text) textParts.push(block.text)
+      else if (block instanceof JsonBlock) textParts.push(JSON.stringify(block.json, null, 2))
     }
-    const fullText = textPreviewParts.join('\n')
+    const fullText = textParts.join('\n')
 
     // Store each content block to the storage backend
     let references: Array<{ ref: string; contentType: string; description: string }>
     try {
-      references = await Promise.all(
-        content.map((block, i) => this._storeBlock(block, `${toolUseId}_${i}`))
-      )
+      references = await Promise.all(content.map((block, i) => this._storeBlock(block, `${toolUseId}_${i}`)))
     } catch (err) {
       logger.warn(`tool_use_id=<${toolUseId}> | failed to offload tool result, keeping original`, err)
       return
@@ -262,13 +230,22 @@ export class ContextOffloader implements Plugin {
     )
 
     // Build replacement content: preview text + media placeholders
-    const previewText = this._buildPreviewText(content, references, tokenCount, fullText)
-    const newContent: ToolResultContent[] = [new TextBlock(previewText)]
-
+    const newContent: ToolResultContent[] = [
+      new TextBlock(this._buildPreviewText(content, references, tokenCount, fullText)),
+    ]
     for (let i = 0; i < content.length; i++) {
-      const placeholder = this._buildMediaPlaceholder(content[i]!, references[i]?.ref ?? '')
-      if (placeholder) {
-        newContent.push(new TextBlock(placeholder))
+      const block = content[i]!
+      const ref = references[i]?.ref ?? ''
+      if (block instanceof TextBlock || block instanceof JsonBlock) continue
+
+      const bytes = getBytes(block)
+      const size = bytes ? bytes.length : 0
+      let label: string | undefined
+      if (block instanceof ImageBlock) label = `image: ${block.format}`
+      else if (block instanceof VideoBlock) label = `video: ${block.format}`
+      else if (block instanceof DocumentBlock) label = `document: ${block.format}, ${block.name}`
+      if (label) {
+        newContent.push(new TextBlock(`[${label}, ${size} bytes${ref ? ` | ref: ${ref}` : ''}]`))
       }
     }
 

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -1,7 +1,6 @@
 import type { Plugin } from '../../plugins/plugin.js'
 import type { Tool } from '../../tools/tool.js'
 import type { LocalAgent } from '../../types/agent.js'
-import type { Model } from '../../models/model.js'
 import { AfterToolCallEvent } from '../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
 import type { ToolResultContent } from '../../types/messages.js'
@@ -232,10 +231,7 @@ export class ContextOffloader implements Plugin {
     const content = event.result.content
     const toolUseId = event.result.toolUseId
 
-    // Cast: LocalAgent doesn't expose model yet. Tracked in https://github.com/strands-agents/sdk-typescript/pull/938
-    // Falls back to 0 (no offloading) if model is unavailable — only affects non-Agent LocalAgent implementations.
-    const model = (event.agent as unknown as { model?: Model }).model
-    const tokenCount = model ? await model.countTokens([new Message({ role: 'user', content: [event.result] })]) : 0
+    const tokenCount = await event.agent.model.countTokens([new Message({ role: 'user', content: [event.result] })])
 
     if (tokenCount <= this._maxResultTokens) return
 

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -6,7 +6,6 @@ import { AfterToolCallEvent } from '../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
 import type { ToolResultContent } from '../../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock } from '../../types/media.js'
-import type { ImageFormat, DocumentFormat } from '../../types/media.js'
 import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
 import { logger } from '../../logging/logger.js'
@@ -38,11 +37,7 @@ function getBytes(block: ToolResultContent): Uint8Array | undefined {
   return undefined
 }
 
-function decodeStoredContent(
-  content: Uint8Array,
-  contentType: string,
-  reference: string
-): JSONValue | ImageBlock | DocumentBlock {
+function decodeStoredContent(content: Uint8Array, contentType: string, reference: string): JSONValue {
   if (contentType.startsWith('text/')) {
     return new TextDecoder().decode(content)
   }
@@ -54,29 +49,63 @@ function decodeStoredContent(
       return text
     }
   }
+  // Return native content blocks for binary types so the agent sees the actual content.
+  // FunctionTool._wrapInToolResult passes ImageBlock/VideoBlock/DocumentBlock through as-is
+  // at runtime, even though the callback type signature only accepts JSONValue.
   if (contentType.startsWith('image/')) {
+    const format = contentType.split('/').pop()!
     return new ImageBlock({
-      format: contentType.split('/').pop()! as ImageFormat,
+      format: format as import('../../types/media.js').ImageFormat,
       source: { bytes: content },
-    })
+    }) as unknown as JSONValue
+  }
+  if (contentType.startsWith('video/')) {
+    const format = contentType.split('/').pop()!
+    return new VideoBlock({
+      format: format as import('../../types/media.js').VideoFormat,
+      source: { bytes: content },
+    }) as unknown as JSONValue
   }
   if (contentType.startsWith('application/')) {
+    const format = contentType.split('/').pop()!
     return new DocumentBlock({
-      format: contentType.split('/').pop()! as DocumentFormat,
+      format: format as import('../../types/media.js').DocumentFormat,
       name: reference,
       source: { bytes: content },
-    })
+    }) as unknown as JSONValue
   }
   return new TextDecoder('utf-8', { fatal: false }).decode(content)
 }
 
+/** Configuration for the {@link ContextOffloader} plugin. */
 export interface ContextOffloaderConfig {
+  /** Storage backend for persisting offloaded content. */
   storage: Storage
+  /** Token threshold above which tool results are offloaded. Defaults to 2,500. */
   maxResultTokens?: number
+  /** Number of tokens to keep as an inline preview. Defaults to 1,000. */
   previewTokens?: number
+  /** Whether to register the `retrieve_offloaded_content` tool. Defaults to true. */
   includeRetrievalTool?: boolean
 }
 
+/**
+ * Plugin that offloads oversized tool results to reduce context consumption.
+ *
+ * When a tool result exceeds the configured token threshold, this plugin stores
+ * each content block to a storage backend and replaces the in-context result with
+ * a truncated text preview plus per-block storage references.
+ *
+ * @example
+ * ```typescript
+ * import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+ *
+ * const agent = new Agent({
+ *   model,
+ *   plugins: [new ContextOffloader({ storage: new InMemoryStorage() })],
+ * })
+ * ```
+ */
 export class ContextOffloader implements Plugin {
   readonly name = 'strands:context-offloader'
 
@@ -124,7 +153,7 @@ export class ContextOffloader implements Plugin {
       callback: async (input) => {
         try {
           const result = await storage.retrieve(input.reference)
-          return decodeStoredContent(result.content, result.contentType, input.reference) as JSONValue
+          return decodeStoredContent(result.content, result.contentType, input.reference)
         } catch {
           return `Error: reference not found: ${input.reference}`
         }
@@ -161,6 +190,7 @@ export class ContextOffloader implements Plugin {
       }
       return { ref: '', contentType, description: `${label}, 0 bytes` }
     }
+    logger.warn(`Unsupported content block type encountered during offloading, skipping`)
     return { ref: '', contentType: 'unknown', description: 'unknown block type' }
   }
 

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -1,0 +1,206 @@
+export interface Storage {
+  store(key: string, content: Uint8Array, contentType?: string): string | Promise<string>
+  retrieve(
+    reference: string
+  ): { content: Uint8Array; contentType: string } | Promise<{ content: Uint8Array; contentType: string }>
+}
+
+function sanitizeId(rawId: string): string {
+  return rawId
+    .replace(/\.\./g, '_')
+    .replace(/[/\\]/g, '_')
+    .replace(/[^\w\-.]/g, '_')
+}
+
+export class InMemoryStorage implements Storage {
+  private _store = new Map<string, { content: Uint8Array; contentType: string }>()
+  private _counter = 0
+
+  store(key: string, content: Uint8Array, contentType: string = 'text/plain'): string {
+    this._counter++
+    const reference = `mem_${this._counter}_${key}`
+    this._store.set(reference, { content, contentType })
+    return reference
+  }
+
+  retrieve(reference: string): { content: Uint8Array; contentType: string } {
+    const entry = this._store.get(reference)
+    if (!entry) {
+      throw new Error(`Reference not found: ${reference}`)
+    }
+    return entry
+  }
+
+  clear(): void {
+    this._store.clear()
+  }
+}
+
+export class FileStorage implements Storage {
+  private static readonly METADATA_FILE = '.metadata.json'
+  private readonly _artifactDir: string
+  private _counter = 0
+  private _contentTypes: Record<string, string> = {}
+  private _metadataLoaded = false
+
+  constructor(artifactDir: string = './artifacts') {
+    this._artifactDir = artifactDir
+  }
+
+  private static _extensionFor(contentType: string): string {
+    if (contentType === 'text/plain') return '.txt'
+    return `.${contentType.split('/').pop()}`
+  }
+
+  private async _ensureDir(): Promise<typeof import('node:fs/promises')> {
+    const fs = await import('node:fs/promises')
+    await fs.mkdir(this._artifactDir, { recursive: true })
+    if (!this._metadataLoaded) {
+      this._contentTypes = await this._loadMetadata(fs)
+      this._metadataLoaded = true
+    }
+    return fs
+  }
+
+  private async _loadMetadata(fs: typeof import('node:fs/promises')): Promise<Record<string, string>> {
+    const path = await import('node:path')
+    const metadataPath = path.join(this._artifactDir, FileStorage.METADATA_FILE)
+    try {
+      const raw = await fs.readFile(metadataPath, 'utf-8')
+      return JSON.parse(raw) as Record<string, string>
+    } catch {
+      return {}
+    }
+  }
+
+  private async _saveMetadata(fs: typeof import('node:fs/promises')): Promise<void> {
+    const path = await import('node:path')
+    const metadataPath = path.join(this._artifactDir, FileStorage.METADATA_FILE)
+    await fs.writeFile(metadataPath, JSON.stringify(this._contentTypes), 'utf-8')
+  }
+
+  async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
+    const fs = await this._ensureDir()
+    const path = await import('node:path')
+
+    const sanitizedKey = sanitizeId(key)
+    const timestampMs = Date.now()
+    this._counter++
+    const ext = FileStorage._extensionFor(contentType)
+    const filename = `${timestampMs}_${this._counter}_${sanitizedKey}${ext}`
+
+    this._contentTypes[filename] = contentType
+    await this._saveMetadata(fs)
+
+    const filePath = path.join(this._artifactDir, filename)
+    await fs.writeFile(filePath, content)
+
+    return filePath
+  }
+
+  async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
+    const fs = await this._ensureDir()
+    const path = await import('node:path')
+
+    const filePath = path.resolve(this._artifactDir, reference)
+    const resolvedDir = path.resolve(this._artifactDir)
+    if (!filePath.startsWith(resolvedDir)) {
+      throw new Error(`Reference not found: ${reference}`)
+    }
+
+    const filename = path.basename(filePath)
+
+    try {
+      const content = await fs.readFile(filePath)
+      const contentType = this._contentTypes[filename] ?? 'application/octet-stream'
+      return { content: new Uint8Array(content), contentType }
+    } catch {
+      throw new Error(`Reference not found: ${reference}`)
+    }
+  }
+}
+
+export class S3Storage implements Storage {
+  private readonly _bucket: string
+  private _prefix: string
+  private _s3: import('@aws-sdk/client-s3').S3Client | undefined
+  private readonly _s3Client: import('@aws-sdk/client-s3').S3Client | undefined
+  private readonly _region: string
+  private _counter = 0
+
+  constructor(
+    bucket: string,
+    options?: { prefix?: string; region?: string; s3Client?: import('@aws-sdk/client-s3').S3Client }
+  ) {
+    this._bucket = bucket
+    this._prefix = options?.prefix?.replace(/\/+$/, '') ?? ''
+    if (this._prefix) this._prefix += '/'
+    this._s3Client = options?.s3Client
+    this._region = options?.region ?? 'us-east-1'
+  }
+
+  private async _getClient(): Promise<import('@aws-sdk/client-s3').S3Client> {
+    if (this._s3) return this._s3
+    if (this._s3Client) {
+      this._s3 = this._s3Client
+      return this._s3
+    }
+    const { S3Client } = await import('@aws-sdk/client-s3')
+    this._s3 = new S3Client({ region: this._region })
+    return this._s3
+  }
+
+  async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
+    const client = await this._getClient()
+    const { PutObjectCommand } = await import('@aws-sdk/client-s3')
+
+    const sanitizedKey = sanitizeId(key)
+    const timestampMs = Date.now()
+    this._counter++
+    const s3Key = `${this._prefix}${timestampMs}_${this._counter}_${sanitizedKey}`
+
+    await client.send(
+      new PutObjectCommand({
+        Bucket: this._bucket,
+        Key: s3Key,
+        Body: content,
+        ContentType: contentType,
+      })
+    )
+
+    return `s3://${this._bucket}/${s3Key}`
+  }
+
+  async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
+    const client = await this._getClient()
+    const { GetObjectCommand } = await import('@aws-sdk/client-s3')
+
+    // Accept both s3:// URIs and raw keys
+    let s3Key = reference
+    const uriMatch = reference.match(/^s3:\/\/([^/]+)\/(.+)$/)
+    if (uriMatch?.[1] && uriMatch[2]) {
+      if (uriMatch[1] !== this._bucket) {
+        throw new Error(`Reference not found: ${reference} (bucket mismatch)`)
+      }
+      s3Key = uriMatch[2]
+    }
+
+    try {
+      const response = await client.send(
+        new GetObjectCommand({
+          Bucket: this._bucket,
+          Key: s3Key,
+        })
+      )
+      const body = await response.Body?.transformToByteArray()
+      if (!body) throw new Error(`Reference not found: ${reference}`)
+      const contentType = response.ContentType ?? 'application/octet-stream'
+      return { content: new Uint8Array(body), contentType }
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'NoSuchKey') {
+        throw new Error(`Reference not found: ${reference}`)
+      }
+      throw error
+    }
+  }
+}

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -51,7 +51,7 @@ export class InMemoryStorage implements Storage {
   private _store = new Map<string, { content: Uint8Array; contentType: string }>()
   private _counter = 0
 
-  /** @inheritdoc */
+  /** {@inheritdoc} */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     this._counter++
     const reference = `mem_${this._counter}_${key}`
@@ -59,7 +59,7 @@ export class InMemoryStorage implements Storage {
     return reference
   }
 
-  /** @inheritdoc */
+  /** {@inheritdoc} */
   async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const entry = this._store.get(reference)
     if (!entry) {
@@ -127,7 +127,7 @@ export class FileStorage implements Storage {
     await fs.writeFile(metadataPath, JSON.stringify(this._contentTypes), 'utf-8')
   }
 
-  /** @inheritdoc */
+  /** {@inheritdoc} */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     const fs = await this._ensureDir()
     const path = await import('node:path')
@@ -148,7 +148,7 @@ export class FileStorage implements Storage {
     return filePath
   }
 
-  /** @inheritdoc */
+  /** {@inheritdoc} */
   async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const fs = await this._ensureDir()
     const path = await import('node:path')
@@ -204,7 +204,7 @@ export class S3Storage implements Storage {
     return this._client
   }
 
-  /** @inheritdoc */
+  /** {@inheritdoc} */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     const client = await this._getClient()
     const { PutObjectCommand } = await import('@aws-sdk/client-s3')
@@ -226,7 +226,7 @@ export class S3Storage implements Storage {
     return `s3://${this._bucket}/${s3Key}`
   }
 
-  /** @inheritdoc */
+  /** {@inheritdoc} */
   async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const client = await this._getClient()
     const { GetObjectCommand } = await import('@aws-sdk/client-s3')

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -1,5 +1,36 @@
+/**
+ * Storage backends for offloaded tool result content.
+ *
+ * This module defines the {@link Storage} interface and provides three built-in
+ * implementations: {@link InMemoryStorage}, {@link FileStorage}, and {@link S3Storage}.
+ * Each content block from a tool result is stored individually with its content type preserved.
+ */
+
+/**
+ * Backend for storing and retrieving offloaded content blocks.
+ *
+ * Implement this interface to create custom storage backends (e.g., Redis, DynamoDB).
+ * The SDK ships three built-in implementations: {@link InMemoryStorage},
+ * {@link FileStorage}, and {@link S3Storage}.
+ */
 export interface Storage {
+  /**
+   * Store content and return a reference identifier.
+   *
+   * @param key - Unique key for this content block
+   * @param content - Raw content bytes to store
+   * @param contentType - MIME type of the content (e.g., "text/plain", "image/png")
+   * @returns Reference string for later retrieval
+   */
   store(key: string, content: Uint8Array, contentType?: string): Promise<string>
+
+  /**
+   * Retrieve previously stored content by reference.
+   *
+   * @param reference - Reference returned by a previous {@link store} call
+   * @returns Content bytes and content type
+   * @throws Error if the reference is not found
+   */
   retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }>
 }
 
@@ -10,10 +41,17 @@ function sanitizeId(rawId: string): string {
     .replace(/[^\w\-.]/g, '_')
 }
 
+/**
+ * In-memory storage backend.
+ *
+ * Useful for testing and serverless environments where disk access is not available.
+ * Content accumulates for the lifetime of this instance; call {@link clear} to free memory.
+ */
 export class InMemoryStorage implements Storage {
   private _store = new Map<string, { content: Uint8Array; contentType: string }>()
   private _counter = 0
 
+  /** @inheritdoc */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     this._counter++
     const reference = `mem_${this._counter}_${key}`
@@ -21,6 +59,7 @@ export class InMemoryStorage implements Storage {
     return reference
   }
 
+  /** @inheritdoc */
   async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const entry = this._store.get(reference)
     if (!entry) {
@@ -29,17 +68,28 @@ export class InMemoryStorage implements Storage {
     return entry
   }
 
+  /** Remove all stored content. */
   clear(): void {
     this._store.clear()
   }
 }
 
+/**
+ * File-based storage backend.
+ *
+ * Stores offloaded content as files on disk. File extensions are derived from the
+ * content type. A `.metadata.json` sidecar file tracks content types across restarts.
+ * References are file paths preserving the configured artifact directory form.
+ *
+ * @param artifactDir - Directory path where artifact files will be stored
+ */
 export class FileStorage implements Storage {
   private static readonly METADATA_FILE = '.metadata.json'
   private readonly _artifactDir: string
   private _counter = 0
   private _contentTypes: Record<string, string> = {}
   private _metadataLoaded = false
+  private _metadataWriteChain: Promise<void> = Promise.resolve()
 
   constructor(artifactDir: string = './artifacts') {
     this._artifactDir = artifactDir
@@ -77,6 +127,7 @@ export class FileStorage implements Storage {
     await fs.writeFile(metadataPath, JSON.stringify(this._contentTypes), 'utf-8')
   }
 
+  /** @inheritdoc */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     const fs = await this._ensureDir()
     const path = await import('node:path')
@@ -88,7 +139,8 @@ export class FileStorage implements Storage {
     const filename = `${timestampMs}_${this._counter}_${sanitizedKey}${ext}`
 
     this._contentTypes[filename] = contentType
-    await this._saveMetadata(fs)
+    this._metadataWriteChain = this._metadataWriteChain.then(() => this._saveMetadata(fs))
+    await this._metadataWriteChain
 
     const filePath = path.join(this._artifactDir, filename)
     await fs.writeFile(filePath, content)
@@ -96,6 +148,7 @@ export class FileStorage implements Storage {
     return filePath
   }
 
+  /** @inheritdoc */
   async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const fs = await this._ensureDir()
     const path = await import('node:path')
@@ -118,11 +171,19 @@ export class FileStorage implements Storage {
   }
 }
 
+/**
+ * S3-based storage backend.
+ *
+ * Stores offloaded content as S3 objects. Content type is preserved as S3 object metadata.
+ * References are `s3://` URIs for direct access via AWS CLI or SDK.
+ *
+ * @param bucket - S3 bucket name
+ * @param options - Optional configuration (prefix, region, pre-configured S3Client)
+ */
 export class S3Storage implements Storage {
   private readonly _bucket: string
-  private _prefix: string
-  private _s3: import('@aws-sdk/client-s3').S3Client | undefined
-  private readonly _s3Client: import('@aws-sdk/client-s3').S3Client | undefined
+  private readonly _prefix: string
+  private _client: import('@aws-sdk/client-s3').S3Client | undefined
   private readonly _region: string
   private _counter = 0
 
@@ -131,23 +192,19 @@ export class S3Storage implements Storage {
     options?: { prefix?: string; region?: string; s3Client?: import('@aws-sdk/client-s3').S3Client }
   ) {
     this._bucket = bucket
-    this._prefix = options?.prefix?.replace(/\/+$/, '') ?? ''
-    if (this._prefix) this._prefix += '/'
-    this._s3Client = options?.s3Client
+    this._prefix = options?.prefix ? options.prefix.replace(/\/+$/, '') + '/' : ''
+    this._client = options?.s3Client
     this._region = options?.region ?? 'us-east-1'
   }
 
   private async _getClient(): Promise<import('@aws-sdk/client-s3').S3Client> {
-    if (this._s3) return this._s3
-    if (this._s3Client) {
-      this._s3 = this._s3Client
-      return this._s3
-    }
+    if (this._client) return this._client
     const { S3Client } = await import('@aws-sdk/client-s3')
-    this._s3 = new S3Client({ region: this._region })
-    return this._s3
+    this._client = new S3Client({ region: this._region })
+    return this._client
   }
 
+  /** @inheritdoc */
   async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     const client = await this._getClient()
     const { PutObjectCommand } = await import('@aws-sdk/client-s3')
@@ -169,6 +226,7 @@ export class S3Storage implements Storage {
     return `s3://${this._bucket}/${s3Key}`
   }
 
+  /** @inheritdoc */
   async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const client = await this._getClient()
     const { GetObjectCommand } = await import('@aws-sdk/client-s3')

--- a/strands-ts/src/vended-plugins/context-offloader/storage.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/storage.ts
@@ -1,8 +1,6 @@
 export interface Storage {
-  store(key: string, content: Uint8Array, contentType?: string): string | Promise<string>
-  retrieve(
-    reference: string
-  ): { content: Uint8Array; contentType: string } | Promise<{ content: Uint8Array; contentType: string }>
+  store(key: string, content: Uint8Array, contentType?: string): Promise<string>
+  retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }>
 }
 
 function sanitizeId(rawId: string): string {
@@ -16,14 +14,14 @@ export class InMemoryStorage implements Storage {
   private _store = new Map<string, { content: Uint8Array; contentType: string }>()
   private _counter = 0
 
-  store(key: string, content: Uint8Array, contentType: string = 'text/plain'): string {
+  async store(key: string, content: Uint8Array, contentType: string = 'text/plain'): Promise<string> {
     this._counter++
     const reference = `mem_${this._counter}_${key}`
     this._store.set(reference, { content, contentType })
     return reference
   }
 
-  retrieve(reference: string): { content: Uint8Array; contentType: string } {
+  async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string }> {
     const entry = this._store.get(reference)
     if (!entry) {
       throw new Error(`Reference not found: ${reference}`)

--- a/strands-ts/vitest.config.ts
+++ b/strands-ts/vitest.config.ts
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // Conditionally exclude bash tool from coverage on Windows
 // since tests are skipped on Windows (bash not available)
-const coverageExclude = ['src/**/__tests__/**', 'src/**/__fixtures__/**', 'src/vended-tools/**/__tests__/**']
+const coverageExclude = ['src/**/__tests__/**', 'src/**/__fixtures__/**', 'src/vended-tools/**/__tests__/**', 'src/vended-plugins/**/__tests__/**']
 if (process.platform === 'win32') {
   coverageExclude.push('src/vended-tools/bash/**')
 }
@@ -28,6 +28,8 @@ export default defineConfig({
             'src/**/__tests__/**/*.test.node.ts',
             'src/vended-tools/**/__tests__/**/*.test.ts',
             'src/vended-tools/**/__tests__/**/*.test.node.ts',
+            'src/vended-plugins/**/__tests__/**/*.test.ts',
+            'src/vended-plugins/**/__tests__/**/*.test.node.ts',
           ],
           name: { label: 'unit-node', color: 'green' },
           typecheck: {
@@ -44,6 +46,8 @@ export default defineConfig({
             'src/**/__tests__/**/*.test.browser.ts',
             'src/vended-tools/**/__tests__/**/*.test.ts',
             'src/vended-tools/**/__tests__/**/*.test.browser.ts',
+            'src/vended-plugins/**/__tests__/**/*.test.ts',
+            'src/vended-plugins/**/__tests__/**/*.test.browser.ts',
           ],
           name: { label: 'unit-browser', color: 'cyan' },
           browser: {
@@ -112,7 +116,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: 'test/.artifacts/coverage',
-      include: ['src/**/*.{ts,js}', 'src/vended-tools/**/*.{ts,js}'],
+      include: ['src/**/*.{ts,js}', 'src/vended-tools/**/*.{ts,js}', 'src/vended-plugins/**/*.{ts,js}'],
       exclude: coverageExclude,
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## Description

TypeScript port of [sdk-python#2162](https://github.com/strands-agents/sdk-python/pull/2162) and [sdk-python#2222](https://github.com/strands-agents/sdk-python/pull/2222). Adds a `ContextOffloader` plugin that proactively intercepts oversized tool results via `AfterToolCallEvent`, stores them in an external storage backend, and replaces the in-context result with a truncated preview plus per-block storage references.

**What it does:**
- Estimates token count of tool results using `model.countTokens()` (same approach as Python's `count_tokens`)
- When a result exceeds `maxResultTokens` (default: 2,500), offloads each content block to storage
- Replaces text/JSON blocks with a truncated preview and stored references
- Replaces image/video/document blocks with metadata placeholders and stored references
- Registers a `retrieve_offloaded_content` tool by default so the agent can fetch full content on demand (can be disabled via `includeRetrievalTool: false`)
- Retrieval tool returns native content blocks (ImageBlock, DocumentBlock) for binary content
- Storage references are actionable — FileStorage returns file paths, S3Storage returns `s3://` URIs — so agents can use existing tools (file_read, bash) directly
- Gracefully degrades — if storage fails, the original result is preserved

**Includes:**
- `Storage` interface with `InMemoryStorage`, `FileStorage`, and `S3Storage` implementations (mirrors all three Python backends)
- `ContextOffloader` plugin implementing the `Plugin` interface
- 39 unit tests covering offloading behavior, storage backends, retrieval tool, constructor validation, and edge cases

**Usage:**
```typescript
import { Agent } from '@strands-agents/sdk'
import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'

const agent = new Agent({
  model,
  plugins: [new ContextOffloader({ storage: new InMemoryStorage() })],
})
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

https://github.com/strands-agents/docs/pull/772 (Python docs — TS docs TBD)

## Type of Change

New feature

## Testing

How have you tested the change?

- [X] I ran `npm run check`
- 39 new unit tests (plugin behavior, InMemoryStorage, FileStorage, retrieval tool)
- All existing tests pass with no regressions
- TypeScript build compiles cleanly

## Checklist
- [X] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.