### PR TITLE
feat(wasm): add tsc type-checking to strands-wasm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This document provides guidance specifically for AI agents working on the Strand
 ## Purpose and Scope
 
 **AGENTS.md** contains agent-specific repository information including:
+
 - Directory structure with summaries of what is included in each directory
 - Development workflow instructions for agents to follow when developing features
 - Coding patterns and testing patterns to follow when writing code
@@ -220,7 +221,8 @@ sdk-typescript/
 │   ├── build.js                  # Build script for WASM compilation
 │   ├── patches/                  # Runtime patches for WASM compatibility
 │   │   └── getChunkedStream.js
-│   └── package.json              # WASM package configuration
+│   ├── package.json              # WASM package configuration
+│   └── tsconfig.json             # TypeScript type-check configuration
 │
 ├── strands-dev/                  # Developer CLI tooling
 │   ├── src/
@@ -289,6 +291,7 @@ sdk-typescript/
 ### 1. Environment Setup
 
 See [CONTRIBUTING.md - Development Environment](CONTRIBUTING.md#development-environment) for:
+
 - Prerequisites (Node.js 20+, npm)
 - Installation steps
 - Verification commands
@@ -317,6 +320,7 @@ See [PR.md](docs/PR.md) for the complete guidance and template.
 ### 4. Quality Gates
 
 Pre-commit hooks automatically run:
+
 - Build (via npm run build, required for workspace type resolution)
 - Unit tests (via npm test)
 - Linting (via npm run lint)
@@ -344,6 +348,7 @@ See [TESTING.md](docs/TESTING.md) for the complete testing reference.
 The SDK uses a structured logging format consistent with the Python SDK for better log parsing and searchability.
 
 **Format**:
+
 ```typescript
 // With context fields
 logger.warn(`field1=<${value1}>, field2=<${value2}> | human readable message`)
@@ -406,6 +411,7 @@ import { something } from 'external-package'
 ### File Organization Pattern
 
 **For source files**:
+
 ```
 strands-ts/src/
 ├── module.ts              # Source file
@@ -414,12 +420,14 @@ strands-ts/src/
 ```
 
 **Function ordering within files**:
+
 - Functions MUST be ordered from most general to most specific (top-down reading)
 - Public/exported functions MUST appear before private helper functions
 - Main entry point functions MUST be at the top of the file
 - Helper functions SHOULD follow in order of their usage
 
 **Example**:
+
 ```typescript
 // Good: Main function first, helpers follow
 export async function* mainFunction() {
@@ -447,6 +455,7 @@ export async function* mainFunction() {
 ```
 
 **For integration tests**:
+
 ```
 strands-ts/test/integ/
 └── feature.test.ts        # Tests public API
@@ -468,6 +477,7 @@ return undefined
 ```
 
 **Strict requirements**:
+
 ```typescript
 // Good: Explicit return types
 export function process(input: string): string {
@@ -491,6 +501,7 @@ export function getData(): any {
 ```
 
 **Rules**:
+
 - Always provide explicit return types
 - Never use `any` type (enforced by ESLint)
 - Use TypeScript strict mode features
@@ -518,7 +529,7 @@ export class Example {
 
 // Bad: No underscore for private fields
 export class Example {
-  private readonly config: Config  // Missing underscore
+  private readonly config: Config // Missing underscore
 
   constructor(config: Config) {
     this.config = config
@@ -527,6 +538,7 @@ export class Example {
 ```
 
 **Rules**:
+
 - Private fields MUST use underscore prefix (e.g., `_field`)
 - Public fields MUST NOT use underscore prefix
 - This convention improves code readability and makes the distinction between public and private members immediately visible
@@ -556,14 +568,14 @@ Same rule for the associated config (`AgentSkillsConfig`, not `AgentSkillsPlugin
 
 **TSDoc format** (required for all exported functions):
 
-```typescript
+````typescript
 /**
  * Brief description of what the function does.
- * 
+ *
  * @param paramName - Description of the parameter
  * @param optionalParam - Description of optional parameter
  * @returns Description of what is returned
- * 
+ *
  * @example
  * ```typescript
  * const result = functionName('input')
@@ -573,7 +585,7 @@ Same rule for the associated config (`AgentSkillsConfig`, not `AgentSkillsPlugin
 export function functionName(paramName: string, optionalParam?: number): string {
   // Implementation
 }
-```
+````
 
 **Interface property documentation**:
 
@@ -596,6 +608,7 @@ export interface MyConfig {
 ```
 
 **Requirements**:
+
 - All exported functions, classes, and interfaces must have TSDoc
 - Include `@param` for all parameters
 - Include `@returns` for return values
@@ -608,6 +621,7 @@ export interface MyConfig {
 ### Code Style Guidelines
 
 **Formatting** (enforced by Prettier):
+
 - No semicolons
 - Single quotes
 - Line length: 120 characters
@@ -615,6 +629,7 @@ export interface MyConfig {
 - Trailing commas in ES5 style
 
 **Example**:
+
 ```typescript
 export function example(name: string, options?: Options): Result {
   const config = {
@@ -633,6 +648,7 @@ export function example(name: string, options?: Options): Result {
 ### Import Organization
 
 Organize imports in this order:
+
 ```typescript
 // 1. External dependencies
 import { something } from 'external-package'
@@ -663,7 +679,9 @@ export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock
 export class TextBlock {
   readonly type = 'textBlock' as const
   readonly text: string
-  constructor(data: { text: string }) { this.text = data.text }
+  constructor(data: { text: string }) {
+    this.text = data.text
+  }
 }
 
 export class ToolUseBlock {
@@ -697,7 +715,8 @@ export interface TextBlockData {
   text: string
 }
 
-export interface Message {  // Top-level should come first
+export interface Message {
+  // Top-level should come first
   role: Role
   content: ContentBlock[]
 }
@@ -712,22 +731,26 @@ export interface Message {  // Top-level should come first
 ```typescript
 // Correct - type matches class name (first letter lowercase)
 export class TextBlock {
-  readonly type = 'textBlock' as const  // Matches 'TextBlock' class name
+  readonly type = 'textBlock' as const // Matches 'TextBlock' class name
   readonly text: string
-  constructor(data: { text: string }) { this.text = data.text }
+  constructor(data: { text: string }) {
+    this.text = data.text
+  }
 }
 
 export class CachePointBlock {
-  readonly type = 'cachePointBlock' as const  // Matches 'CachePointBlock' class name
+  readonly type = 'cachePointBlock' as const // Matches 'CachePointBlock' class name
   readonly cacheType: 'default'
-  constructor(data: { cacheType: 'default' }) { this.cacheType = data.cacheType }
+  constructor(data: { cacheType: 'default' }) {
+    this.cacheType = data.cacheType
+  }
 }
 
 export type ContentBlock = TextBlock | ToolUseBlock | CachePointBlock
 
 // Wrong - type doesn't match class name
 export class CachePointBlock {
-  readonly type = 'cachePoint' as const  // Should be 'cachePointBlock'
+  readonly type = 'cachePoint' as const // Should be 'cachePointBlock'
   readonly cacheType: 'default'
 }
 ```
@@ -770,6 +793,7 @@ export interface CitationSourceContent {
 ```
 
 **Key points**:
+
 - Use `type` alias (not `interface`) so it can be expanded to a union later
 - Each variant's field is **required** within that variant
 - Use object-key discrimination (`'text' in source`) to narrow variants at runtime
@@ -796,6 +820,7 @@ export class ValidationError extends Error {
 ```
 
 **Key Features:**
+
 - Automatic tool discovery and registration
 - Lazy connection (connects on first use)
 - Supports stdio and HTTP transports
@@ -834,6 +859,7 @@ When adding or modifying dependencies, you **MUST** follow the guidelines in [do
 ## Things to Do
 
 **Do**:
+
 - Use relative imports for internal modules
 - Co-locate unit tests with source under `__tests__` directories
 - Follow nested describe pattern for test organization
@@ -847,6 +873,7 @@ When adding or modifying dependencies, you **MUST** follow the guidelines in [do
 ## Things NOT to Do
 
 **Don't**:
+
 - Use `any` type (enforced by ESLint)
 - Put unit tests in separate `tests/` directory (use `strands-ts/src/**/__tests__/**`)
 - Skip documentation for exported functions
@@ -861,6 +888,7 @@ When adding or modifying dependencies, you **MUST** follow the guidelines in [do
 For detailed command usage, see [CONTRIBUTING.md - Testing Instructions](CONTRIBUTING.md#testing-instructions-and-best-practices).
 
 Quick reference:
+
 ```bash
 npm test              # Run unit tests in Node.js
 npm run test:browser  # Run unit tests in browser (Chromium via Playwright)
@@ -876,6 +904,7 @@ npm run build         # Compile TypeScript
 ## Troubleshooting Common Issues
 
 If TypeScript compilation fails:
+
 1. Run `npm run type-check` to see all type errors
 2. Ensure all functions have explicit return types
 3. Verify no `any` types are used
@@ -894,8 +923,8 @@ If TypeScript compilation fails:
 4. **Document as you go** with TSDoc comments
 5. **Run all checks** before committing (pre-commit hooks will enforce this)
 
-
 ### Writing code
+
 - YOU MUST make the SMALLEST reasonable changes to achieve the desired outcome.
 - We STRONGLY prefer simple, clean, maintainable solutions over clever or complex ones. Readability and maintainability are PRIMARY CONCERNS, even at the cost of conciseness or performance.
 - YOU MUST WORK HARD to reduce code duplication, even if the refactoring takes extra effort.
@@ -903,18 +932,18 @@ If TypeScript compilation fails:
 - YOU MUST NOT manually change whitespace that does not affect execution or output. Otherwise, use a formatting tool.
 - Fix broken things immediately when you find them. Don't ask permission to fix bugs.
 
-
 #### Code Comments
- - NEVER add comments explaining that something is "improved", "better", "new", "enhanced", or referencing what it used to be
- - Comments should explain WHAT the code does or WHY it exists, not how it's better than something else
- - YOU MUST NEVER add comments about what used to be there or how something has changed. 
- - YOU MUST NEVER refer to temporal context in comments (like "recently refactored" "moved") or code. Comments should be evergreen and describe the code as it is.
- - YOU MUST NEVER write overly verbose comments. Use concise language.
 
+- NEVER add comments explaining that something is "improved", "better", "new", "enhanced", or referencing what it used to be
+- Comments should explain WHAT the code does or WHY it exists, not how it's better than something else
+- YOU MUST NEVER add comments about what used to be there or how something has changed.
+- YOU MUST NEVER refer to temporal context in comments (like "recently refactored" "moved") or code. Comments should be evergreen and describe the code as it is.
+- YOU MUST NEVER write overly verbose comments. Use concise language.
 
 ### Code Review Considerations
 
 When responding to PR feedback:
+
 - Address all review comments
 - Test changes thoroughly
 - Update documentation if behavior changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "strands",
   "version": "0.0.0",
   "private": true,
-  "workspaces": ["strands-dev", "strands-ts", "strands-wasm"],
+  "workspaces": [
+    "strands-dev",
+    "strands-ts",
+    "strands-wasm"
+  ],
   "devDependencies": {
     "husky": "^9.1.7",
     "prettier": "^3.7.4"
@@ -22,7 +26,7 @@
     "lint": "npm run lint -w strands-ts",
     "format": "npm run format -w strands-ts",
     "format:check": "npm run format:check -w strands-ts",
-    "type-check": "npm run type-check -w strands-ts",
+    "type-check": "npm run type-check -w strands-ts && npm run type-check -w strands-wasm",
     "check": "npm run check -w strands-ts",
     "check:browser-bundle": "npm run check:browser-bundle -w strands-ts"
   }

--- a/strands-dev/package.json
+++ b/strands-dev/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "commander": "^12",
-    "smol-toml": "^1.6.0",
     "tsx": "^4.21.0"
   },
   "devDependencies": {

--- a/strands-dev/src/cli.ts
+++ b/strands-dev/src/cli.ts
@@ -1,171 +1,162 @@
 #!/usr/bin/env tsx
 
-import { execSync } from "node:child_process";
-import { existsSync, globSync, readFileSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { program } from "commander";
-import { parse as parseTOML } from "smol-toml";
+import { execSync } from 'node:child_process'
+import { existsSync, globSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { program } from 'commander'
 
-const ROOT = resolve(import.meta.dirname, "../..");
-const PY = `${ROOT}/strands-py`;
+const ROOT = resolve(import.meta.dirname, '../..')
+const PY = `${ROOT}/strands-py`
 
-process.env.PYTHONPYCACHEPREFIX ??= ".pycache";
+process.env.PYTHONPYCACHEPREFIX ??= '.pycache'
 
-program.name("strands-dev").description(
+program.name('strands-dev').description(
   `Strands monorepo development CLI
 
 Build pipeline (each step feeds the next):
   wit/agent.wit -> strands-ts -> strands-wasm -> strands-py
 
-Most commands accept layer flags (--ts, --rs, --py, --wasm).
-No flags = run all layers.`,
-);
+Most commands accept layer flags (--ts, --wasm, --py).
+No flags = run all layers.`
+)
 
 program
-  .command("setup")
-  .description("Install toolchains and dependencies")
-  .option("--node", "npm install")
-  .option("--python", "Create venv and install ruff")
-  .action((opts) => setup(opts));
+  .command('setup')
+  .description('Install toolchains and dependencies')
+  .option('--node', 'npm install')
+  .option('--python', 'Create venv and install ruff')
+  .action((opts) => setup(opts))
 
 program
-  .command("build")
-  .description("Compile one or more layers")
-  .option("--ts", "TypeScript SDK")
-  .option("--wasm", "WASM component (rebuilds TS first)")
-  .option("--py", "Python package")
-  .option("--release", "Release build")
-  .action((opts) => build(opts));
+  .command('build')
+  .description('Compile one or more layers')
+  .option('--ts', 'TypeScript SDK')
+  .option('--wasm', 'WASM component (rebuilds TS first)')
+  .option('--py', 'Python package')
+  .action((opts) => build(opts))
 
 program
-  .command("test")
-  .description("Run tests")
-  .option("--py", "Python tests")
-  .option("--ts", "TypeScript tests")
-  .argument("[file]", "Specific Python test file")
-  .action((file, opts) => test({ ...opts, file }));
+  .command('test')
+  .description('Run tests')
+  .option('--py', 'Python tests')
+  .option('--ts', 'TypeScript tests')
+  .argument('[file]', 'Specific Python test file')
+  .action((file, opts) => test({ ...opts, file }))
 
 program
-  .command("check")
-  .description("Lint and type-check without building")
-  .option("--ts", "TypeScript type-check")
-  .option("--py", "Python ruff")
-  .action((opts) => check(opts));
+  .command('check')
+  .description('Lint and type-check without building')
+  .option('--ts', 'TypeScript type-check')
+  .option('--wasm', 'WASM bridge type-check')
+  .option('--py', 'Python ruff')
+  .action((opts) => check(opts))
 
 program
-  .command("fmt")
-  .description("Format all code")
-  .option("--check", "Fail if anything would change")
-  .action((opts) => fmt(opts));
+  .command('fmt')
+  .description('Format all code')
+  .option('--check', 'Fail if anything would change')
+  .action((opts) => fmt(opts))
 
 program
-  .command("generate")
-  .description("Regenerate type declarations from WIT")
-  .option("--check", "Fail if generated files are out of date")
-  .action((opts) => generate(opts));
+  .command('generate')
+  .description('Regenerate type declarations from WIT')
+  .option('--check', 'Fail if generated files are out of date')
+  .action((opts) => generate(opts))
 
 program
-  .command("example")
-  .description("Run an example by name")
-  .argument("<name>", "Example name")
-  .option("--py", "Run a Python example")
-  .option("--ts", "Run a TypeScript example")
+  .command('example')
+  .description('Run an example by name')
+  .argument('<name>', 'Example name')
+  .option('--py', 'Run a Python example')
+  .option('--ts', 'Run a TypeScript example')
   .action((name, opts) => {
-    if (opts.py) py(`.venv/bin/python examples/${name}.py`);
-    else if (opts.ts)
-      run("npm start", { cwd: `${ROOT}/strands-ts/examples/${name}` });
-  });
+    if (opts.py) py(`.venv/bin/python examples/${name}.py`)
+    else if (opts.ts) run('npm start', { cwd: `${ROOT}/strands-ts/examples/${name}` })
+  })
 
 program
-  .command("clean")
-  .description("Remove all build artifacts")
-  .action(() => clean());
+  .command('clean')
+  .description('Remove all build artifacts')
+  .action(() => clean())
 
 program
-  .command("ci")
-  .description("Full CI pipeline")
+  .command('ci')
+  .description('Full CI pipeline')
   .action(() => {
-    generate({ check: true });
-    fmt({ check: true });
-    check();
-    build();
-    test();
-  });
+    generate({ check: true })
+    fmt({ check: true })
+    check()
+    build()
+    test()
+  })
 
 program
-  .command("bootstrap")
-  .description("First-time setup, generate, build, and test")
+  .command('bootstrap')
+  .description('First-time setup, generate, build, and test')
   .action(() => {
-    setup();
-    generate();
-    build();
-    test();
-  });
+    setup()
+    generate()
+    build()
+    test()
+  })
 
 program
-  .command("rebuild")
-  .description("Clean rebuild from scratch")
+  .command('rebuild')
+  .description('Clean rebuild from scratch')
   .action(() => {
-    clean();
-    generate();
-    build();
-  });
+    clean()
+    generate()
+    build()
+  })
 
-const VALIDATE_LAYERS = [
-  "wit",
-  "ts",
-  "ts-api",
-  "wasm",
-  "py",
-] as const;
+const VALIDATE_LAYERS = ['wit', 'ts', 'ts-api', 'wasm', 'py'] as const
 
 program
-  .command("validate")
-  .description("Validate changes to a specific layer")
-  .argument("<layer>", `Layer: ${VALIDATE_LAYERS.join(", ")}`)
+  .command('validate')
+  .description('Validate changes to a specific layer')
+  .argument('<layer>', `Layer: ${VALIDATE_LAYERS.join(', ')}`)
   .action((layer: string) => {
     switch (layer) {
-      case "wit":
-        generate();
-        build();
-        test();
-        break;
-      case "ts":
-        build({ ts: true });
-        test({ ts: true });
-        break;
-      case "ts-api":
-        build({ wasm: true });
-        test({ ts: true });
-        break;
-      case "wasm":
-        build({ wasm: true });
-        break;
-      case "py":
-        check({ py: true });
-        test({ py: true });
-        break;
+      case 'wit':
+        generate()
+        build()
+        test()
+        break
+      case 'ts':
+        build({ ts: true })
+        test({ ts: true })
+        break
+      case 'ts-api':
+        build({ wasm: true })
+        test({ ts: true })
+        break
+      case 'wasm':
+        build({ wasm: true })
+        check({ wasm: true })
+        break
+      case 'py':
+        check({ py: true })
+        test({ py: true })
+        break
       default:
-        console.error(
-          `Unknown layer: ${layer}\nValid layers: ${VALIDATE_LAYERS.join(", ")}`,
-        );
-        process.exit(1);
+        console.error(`Unknown layer: ${layer}\nValid layers: ${VALIDATE_LAYERS.join(', ')}`)
+        process.exit(1)
     }
-  });
+  })
 
-program.parse();
+program.parse()
 
 function run(cmd: string, opts?: { cwd?: string; env?: Record<string, string> }): void {
   try {
     execSync(cmd, {
-      stdio: "inherit",
+      stdio: 'inherit',
       cwd: opts?.cwd ?? ROOT,
       env: opts?.env ? { ...process.env, ...opts.env } : undefined,
-    });
+    })
   } catch (e: unknown) {
-    const status = (e as { status?: number }).status ?? 1;
-    console.error(`\nfailed: ${cmd} (exit ${status})`);
-    process.exit(status);
+    const status = (e as { status?: number }).status ?? 1
+    console.error(`\nfailed: ${cmd} (exit ${status})`)
+    process.exit(status)
   }
 }
 
@@ -173,132 +164,92 @@ function py(cmd: string): void {
   run(cmd, {
     cwd: PY,
     env: { VIRTUAL_ENV: `${PY}/.venv`, PATH: `${PY}/.venv/bin:${process.env.PATH}` },
-  });
+  })
 }
 
-function setup(opts?: {
-  node?: boolean;
-  python?: boolean;
-}): void {
-  const all = !opts?.node && !opts?.python;
-  if (all || opts?.node) run("npm install");
+function setup(opts?: { node?: boolean; python?: boolean }): void {
+  const all = !opts?.node && !opts?.python
+  if (all || opts?.node) run('npm install')
   if (all || opts?.python) {
-    py("python3 -m venv .venv");
-    py(".venv/bin/pip install -e '.[test,dev]' ruff");
+    py('python3 -m venv .venv')
+    py(".venv/bin/pip install -e '.[test,dev]' ruff")
   }
 }
 
-function build(opts?: {
-  ts?: boolean;
-  wasm?: boolean;
-  py?: boolean;
-  release?: boolean;
-}): void {
-  const all = !opts?.ts && !opts?.wasm && !opts?.py;
-  const rel = opts?.release ? " --release" : "";
+function build(opts?: { ts?: boolean; wasm?: boolean; py?: boolean }): void {
+  const all = !opts?.ts && !opts?.wasm && !opts?.py
 
-  if (all || opts?.ts || opts?.wasm) run("npm install");
-  if (all || opts?.ts) run("npm run build -w strands-ts");
+  if (all || opts?.ts || opts?.wasm) run('npm install')
+  if (all || opts?.ts) run('npm run build -w strands-ts')
   if (all || opts?.wasm) {
-    if (!all && !opts?.ts) run("npm run build -w strands-ts");
-    run("npm run build -w strands-wasm");
+    if (!all && !opts?.ts) run('npm run build -w strands-ts')
+    run('npm run build -w strands-wasm')
   }
 }
 
-function test(opts?: {
-  py?: boolean;
-  ts?: boolean;
-  file?: string;
-}): void {
-  const all = !opts?.py && !opts?.ts;
-  if (all || opts?.py)
-    py(
-      opts?.file
-        ? `.venv/bin/pytest tests_integ/${opts.file} -v`
-        : ".venv/bin/pytest",
-    );
-  if (all || opts?.ts) run("npm test -w strands-ts");
+function test(opts?: { py?: boolean; ts?: boolean; file?: string }): void {
+  const all = !opts?.py && !opts?.ts
+  if (all || opts?.py) py(opts?.file ? `.venv/bin/pytest tests_integ/${opts.file} -v` : '.venv/bin/pytest')
+  if (all || opts?.ts) run('npm test -w strands-ts')
 }
 
-function check(opts?: {
-  ts?: boolean;
-  py?: boolean;
-}): void {
-  const all = !opts?.ts && !opts?.py;
-  if (all || opts?.py) py(".venv/bin/ruff check strands/ tests_integ/");
-  if (all || opts?.ts) run("npm run type-check --workspaces --if-present");
+function check(opts?: { ts?: boolean; wasm?: boolean; py?: boolean }): void {
+  const all = !opts?.ts && !opts?.wasm && !opts?.py
+  if (all || opts?.py) py('.venv/bin/ruff check strands/ tests_integ/')
+  if (all || opts?.ts) run('npm run type-check -w strands-ts')
+  if (all || opts?.wasm) run('npm run type-check -w strands-wasm')
 }
 
 function fmt(opts?: { check?: boolean }): void {
-  const flag = opts?.check ? " --check" : "";
+  const flag = opts?.check ? ' --check' : ''
   run(
-    `npx prettier ${opts?.check ? "--check" : "--write"} 'strands-wasm/**/*.ts' 'strands-ts/**/*.ts' --ignore-path .gitignore`,
-  );
-  py(`.venv/bin/ruff format${flag} strands/ tests_integ/`);
+    `npx prettier ${opts?.check ? '--check' : '--write'} 'strands-wasm/**/*.ts' 'strands-ts/**/*.ts' --ignore-path .gitignore`
+  )
+  py(`.venv/bin/ruff format${flag} strands/ tests_integ/`)
 }
 
 function generate(opts?: { check?: boolean }): void {
-  run("npm install");
-  run("npx jco guest-types wit --name strands:agent --world-name agent --out-dir strands-ts/generated", { cwd: ROOT });
-  run("npx jco guest-types wit --name strands:agent --world-name agent --out-dir strands-wasm/generated", { cwd: ROOT });
+  run('npm install')
+  run('npx jco guest-types wit --name strands:agent --world-name agent --out-dir strands-ts/generated', { cwd: ROOT })
+  run('npx jco guest-types wit --name strands:agent --world-name agent --out-dir strands-wasm/generated', { cwd: ROOT })
 
   // Tag generated TS/WASM type declarations.
-  for (const dir of ["strands-wasm/generated", "strands-ts/generated"]) {
-    for (const file of globSync("**/*.d.ts", { cwd: join(ROOT, dir) })) {
-      const path = join(ROOT, dir, file);
-      const content = readFileSync(path, "utf-8");
-      if (!content.startsWith("// @generated")) {
-        writeFileSync(
-          path,
-          `// @generated from wit/agent.wit -- do not edit\n\n${content}`,
-        );
+  for (const dir of ['strands-wasm/generated', 'strands-ts/generated']) {
+    for (const file of globSync('**/*.d.ts', { cwd: join(ROOT, dir) })) {
+      const path = join(ROOT, dir, file)
+      const content = readFileSync(path, 'utf-8')
+      if (!content.startsWith('// @generated')) {
+        writeFileSync(path, `// @generated from wit/agent.wit -- do not edit\n\n${content}`)
       }
     }
   }
 
   // Generate Python types from WIT.
-  py("python scripts/generate_types.py");
+  py('python scripts/generate_types.py')
 
   // Ensure TS + WASM are built first.
-  if (!existsSync(join(ROOT, "strands-wasm/dist/strands-agent.wasm"))) {
-    build({ ts: true, wasm: true });
+  if (!existsSync(join(ROOT, 'strands-wasm/dist/strands-agent.wasm'))) {
+    build({ ts: true, wasm: true })
   }
 
   if (opts?.check) {
     try {
-      execSync(
-        "git diff --quiet -- strands-wasm/generated/ strands-ts/generated/ strands-py/strands/_generated/",
-        { cwd: ROOT },
-      );
+      execSync('git diff --quiet -- strands-wasm/generated/ strands-ts/generated/ strands-py/strands/_generated/', {
+        cwd: ROOT,
+      })
     } catch {
-      console.error(
-        "error: generated files are out of date -- run 'strands-dev generate' and commit",
-      );
-      run(
-        "git diff --stat -- strands-wasm/generated/ strands-ts/generated/ strands-py/strands/_generated/",
-      );
-      process.exit(1);
+      console.error("error: generated files are out of date -- run 'strands-dev generate' and commit")
+      run('git diff --stat -- strands-wasm/generated/ strands-ts/generated/ strands-py/strands/_generated/')
+      process.exit(1)
     }
   }
 }
 
 function clean(): void {
   try {
-    run("npm run clean --workspaces");
+    run('npm run clean --workspaces')
   } catch (e) {
-    console.warn("workspace clean failed (continuing):", (e as Error).message);
+    console.warn('workspace clean failed (continuing):', (e as Error).message)
   }
-  run("rm -rf strands-py/target strands-py/.venv");
-}
-
-interface Task {
-  title: string;
-  status: string;
-  size?: string;
-  author?: string;
-  notes?: string;
-}
-
-interface Group {
-  description: string;
+  run('rm -rf strands-py/target strands-py/.venv')
 }

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -11,6 +11,7 @@
 
 /// <reference path="./generated/interfaces/strands-agent-types.d.ts" />
 /// <reference path="./generated/interfaces/strands-agent-host-log.d.ts" />
+/// <reference path="./generated/interfaces/strands-agent-tool-provider.d.ts" />
 
 import type {
   AgentConfig,
@@ -523,7 +524,7 @@ class AgentImpl {
     const location = (this.sessionManager as any)._location?.(this.agent) ?? {
       sessionId: (this.sessionManager as any)._sessionId,
       scope: 'agent',
-      scopeId: this.agent.agentId,
+      scopeId: this.agent.id,
     }
     return storage.listSnapshotIds({ location })
   }

--- a/strands-wasm/package.json
+++ b/strands-wasm/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "generate": "jco guest-types ../wit --name strands:agent --world-name agent --out-dir generated",
     "build": "node build.js",
+    "type-check": "tsc",
     "clean": "rm -rf dist node_modules package-lock.json"
   },
   "dependencies": {
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@bytecodealliance/jco": "^1.16.1",
     "@chaynabors/componentize-js": "^0.19.3",
-    "esbuild": "^0.27.4"
+    "esbuild": "^0.27.4",
+    "typescript": "^6.0.2"
   }
 }

--- a/strands-wasm/tsconfig.json
+++ b/strands-wasm/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["entry.ts", "generated/**/*.d.ts"]
+}


### PR DESCRIPTION
## Motivation

The WASM bridge (`strands-wasm/entry.ts`) had no type checking. The build pipeline is esbuild → componentize-js, neither of which validates types. Any API drift between the SDK and the bridge — renamed exports, deleted interfaces, wrong config fields — went undetected until runtime (or never, if the failure mode was silent).

This is how the bugs fixed in #967 and #973 shipped: the bridge imported a deleted interface (`HookProvider`), passed to a nonexistent config field (`hooks:` instead of `plugins:`), and called methods that don't exist (`toolRegistry.addAll()`). All of it compiled fine through esbuild because esbuild strips types without checking them.

Adding `tsc --noEmit` as a type-check gate immediately found a real bug in the current code: `agent.agentId` (doesn't exist) instead of `agent.id`, causing `listSnapshots()` to silently build a wrong location object.

## Public API Changes

No public API changes. This adds a development-time type-checking gate only.

## What Changed

**`strands-wasm/tsconfig.json`** — New standalone noEmit config. Resolves both WIT-generated ambient modules (`strands:agent/*`) and SDK workspace imports (`@strands-agents/sdk`).

**`strands-wasm/package.json`** — Added `type-check` script and `typescript` devDep.

**`strands-dev/src/cli.ts`** — Added `--wasm` flag to the `check` command. Replaced `--workspaces --if-present` with explicit ordered workspace calls (strands-wasm depends on strands-ts dist existing). Added type-check step to `validate wasm`. Removed dead code: unused `--release` flag, `parseTOML` import, `Task`/`Group` interfaces, and stale `--rs` in help text.

**Root `package.json`** — Updated `type-check` script to include strands-wasm so GitHub CI (`code-quality.yml`) gates PRs against WASM type errors.

**`strands-wasm/entry.ts`** — Fixed `agent.agentId` → `agent.id` (bug found by tsc). Added missing `/// <reference path>` for `strands-agent-tool-provider.d.ts`.

**`AGENTS.md`** — Added `tsconfig.json` to strands-wasm directory listing.