### PR TITLE
feat(hooks): add endTurn decision field to AfterToolsEvent

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -887,7 +887,7 @@ describe('Agent Hooks Integration', () => {
         .addTurn({ type: 'textBlock', text: 'Should not reach this' }),
     })
 
-    it('halts the loop when endTurn is true', async () => {
+    it('halts the loop when endTurn is true with default message', async () => {
       const { tool, model } = makeSingleToolSetup()
       const agent = new Agent({ model, tools: [tool], plugins: [mockPlugin] })
       agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
@@ -900,7 +900,12 @@ describe('Agent Hooks Integration', () => {
         expect.objectContaining({
           type: 'agentResult',
           stopReason: 'endTurn',
-          lastMessage: expect.objectContaining({ role: 'assistant' }),
+          lastMessage: expect.objectContaining({
+            role: 'assistant',
+            content: expect.arrayContaining([
+              expect.objectContaining({ type: 'textBlock', text: 'Turn ended early by hook after tool execution' }),
+            ]),
+          }),
         })
       )
       expect(model.callCount).toBe(1)
@@ -965,7 +970,7 @@ describe('Agent Hooks Integration', () => {
       expect(model.callCount).toBe(2)
     })
 
-    it('appends tool results to conversation history even on endTurn', async () => {
+    it('appends tool results and default endTurn message to conversation history', async () => {
       const { tool, model } = makeSingleToolSetup()
       const agent = new Agent({ model, tools: [tool] })
       agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
@@ -974,7 +979,7 @@ describe('Agent Hooks Integration', () => {
 
       await agent.invoke('Test')
 
-      expect(agent.messages).toHaveLength(3)
+      expect(agent.messages).toHaveLength(4)
 
       expect(agent.messages[0]!.role).toBe('user')
       expect(agent.messages[1]!.role).toBe('assistant')
@@ -984,6 +989,12 @@ describe('Agent Hooks Integration', () => {
       expect(agent.messages[2]!.role).toBe('user')
       expect(agent.messages[2]!.content).toEqual(
         expect.arrayContaining([expect.objectContaining({ type: 'toolResultBlock' })])
+      )
+      expect(agent.messages[3]!.role).toBe('assistant')
+      expect(agent.messages[3]!.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'textBlock', text: 'Turn ended early by hook after tool execution' }),
+        ])
       )
     })
 

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -24,6 +24,7 @@ import { expectAgentResult } from '../../__fixtures__/agent-helpers.js'
 import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
 import type { Plugin } from '../../plugins/plugin.js'
 import type { LocalAgent } from '../../types/agent.js'
+import type { Tool } from '../../tools/tool.js'
 
 describe('Agent Hooks Integration', () => {
   let mockPlugin: MockPlugin
@@ -873,6 +874,189 @@ describe('Agent Hooks Integration', () => {
           content: [new TextBlock('replaced result')],
         })
       )
+    })
+  })
+
+  describe('AfterToolsEvent.endTurn', () => {
+    const makeSingleToolSetup = (): { tool: Tool; model: MockMessageModel } => ({
+      tool: createMockTool('myTool', () => {
+        return new ToolResultBlock({ toolUseId: 'tool-1', status: 'success', content: [new TextBlock('result')] })
+      }),
+      model: new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Should not reach this' }),
+    })
+
+    it('halts the loop when endTurn is true', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool], plugins: [mockPlugin] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({ role: 'assistant' }),
+        })
+      )
+      expect(model.callCount).toBe(1)
+    })
+
+    it('halts the loop with custom assistant message when endTurn is a string', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = 'enough information gathered'
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({
+            role: 'assistant',
+            content: expect.arrayContaining([
+              expect.objectContaining({ type: 'textBlock', text: 'enough information gathered' }),
+            ]),
+          }),
+        })
+      )
+      expect(model.callCount).toBe(1)
+    })
+
+    it('does not halt when endTurn is false (default)', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({ role: 'assistant' }),
+        })
+      )
+      expect(model.callCount).toBe(2)
+    })
+
+    it('treats empty string endTurn as falsy (does not halt)', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = ''
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({ role: 'assistant' }),
+        })
+      )
+      expect(model.callCount).toBe(2)
+    })
+
+    it('appends tool results to conversation history even on endTurn', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = true
+      })
+
+      await agent.invoke('Test')
+
+      expect(agent.messages).toHaveLength(3)
+
+      expect(agent.messages[0]!.role).toBe('user')
+      expect(agent.messages[1]!.role).toBe('assistant')
+      expect(agent.messages[1]!.content).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'toolUseBlock' })])
+      )
+      expect(agent.messages[2]!.role).toBe('user')
+      expect(agent.messages[2]!.content).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'toolResultBlock' })])
+      )
+    })
+
+    it('halts the loop with concurrent tool execution', async () => {
+      const tool1 = createMockTool('tool1', () => {
+        return new ToolResultBlock({ toolUseId: 'tool-1', status: 'success', content: [new TextBlock('Result 1')] })
+      })
+      const tool2 = createMockTool('tool2', () => {
+        return new ToolResultBlock({ toolUseId: 'tool-2', status: 'success', content: [new TextBlock('Result 2')] })
+      })
+
+      const model = new MockMessageModel()
+        .addTurn([
+          { type: 'toolUseBlock', name: 'tool1', toolUseId: 'tool-1', input: {} },
+          { type: 'toolUseBlock', name: 'tool2', toolUseId: 'tool-2', input: {} },
+        ])
+        .addTurn({ type: 'textBlock', text: 'Should not reach this' })
+
+      const agent = new Agent({ model, tools: [tool1, tool2], toolExecutor: 'concurrent' })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({ role: 'assistant' }),
+        })
+      )
+      expect(model.callCount).toBe(1)
+    })
+
+    it('emits AfterToolsEvent with endTurn via stream()', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = true
+      })
+
+      const items = await collectIterator(agent.stream('Test'))
+
+      const afterToolsEvents = items.filter((e) => e instanceof AfterToolsEvent)
+      expect(afterToolsEvents).toHaveLength(1)
+      expect((afterToolsEvents[0] as AfterToolsEvent).endTurn).toBe(true)
+
+      const resultEvents = items.filter((e) => e instanceof AgentResultEvent)
+      expect(resultEvents).toHaveLength(1)
+      expect((resultEvents[0] as AgentResultEvent).result.stopReason).toBe('endTurn')
+    })
+
+    it('halts even when set on a cancelled-tools AfterToolsEvent', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(BeforeToolsEvent, (event: BeforeToolsEvent) => {
+        event.cancel = true
+      })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({ role: 'assistant' }),
+        })
+      )
+      expect(model.callCount).toBe(1)
     })
   })
 

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1493,6 +1493,30 @@ describe('Agent', () => {
       const second = await agent.invoke('Second')
       expect(second.structuredOutput).toEqual({ name: 'Bob' })
     })
+
+    it('skips structured output extraction when AfterToolsEvent.endTurn halts the loop', async () => {
+      const schema = z.object({ name: z.string() })
+
+      const model = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'strands_structured_output',
+          toolUseId: 'tool-1',
+          input: { name: 'John' },
+        })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const agent = new Agent({ model, structuredOutputSchema: schema })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = true
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.structuredOutput).toBeUndefined()
+      expect(model.callCount).toBe(1)
+    })
   })
 })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -906,14 +906,12 @@ export class Agent implements LocalAgent, InvokableAgent {
           // Hook requested halt: exit without calling the model again
           const { afterToolsEvent } = toolsResult
           if (afterToolsEvent.endTurn) {
-            let lastMessage: Message
-            if (typeof afterToolsEvent.endTurn === 'string') {
-              lastMessage = new Message({ role: 'assistant', content: [new TextBlock(afterToolsEvent.endTurn)] })
-              yield this._appendMessage(lastMessage, invocationState)
-            } else {
-              // Boolean true: lastMessage is the assistant message with toolUseBlock items, not natural-language text.
-              lastMessage = assistantMessage
-            }
+            const endTurnText =
+              typeof afterToolsEvent.endTurn === 'string'
+                ? afterToolsEvent.endTurn
+                : 'Turn ended early by hook after tool execution'
+            const lastMessage = new Message({ role: 'assistant', content: [new TextBlock(endTurnText)] })
+            yield this._appendMessage(lastMessage, invocationState)
 
             result = new AgentResult({
               stopReason: 'endTurn',

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -202,6 +202,9 @@ const DEFAULT_AGENT_NAME = 'Strands Agent'
 /** Default identifier assigned to agents when none is provided. */
 const DEFAULT_AGENT_ID = 'agent'
 
+/** Result returned by tool-execution generators, threading the AfterToolsEvent back to the main loop. */
+type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent }
+
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
  * The Agent is responsible for managing the lifecycle of tools and clients
@@ -866,12 +869,21 @@ export class Agent implements LocalAgent, InvokableAgent {
           }
 
           // Execute tools
-          const toolResultMessage = yield* this.executeTools(
+          const toolsResult = yield* this.executeTools(
             assistantMessage,
             this._toolRegistry,
             invocationState,
             completedToolResults
           )
+
+          // When the consumer breaks the stream (e.g. agent.cancel() + break),
+          // yield* returns undefined because the inner generator was closed.
+          if (!toolsResult) {
+            this._meter.endCycle(cycleStartTime)
+            this._tracer.endAgentLoopSpan(cycleSpan)
+            continue
+          }
+          const toolResultMessage = toolsResult.message
 
           /**
            * Deferred append: both messages are added AFTER tool execution completes.
@@ -890,6 +902,28 @@ export class Agent implements LocalAgent, InvokableAgent {
 
           this._meter.endCycle(cycleStartTime)
           this._tracer.endAgentLoopSpan(cycleSpan)
+
+          // Hook requested halt: exit without calling the model again
+          const { afterToolsEvent } = toolsResult
+          if (afterToolsEvent.endTurn) {
+            let lastMessage: Message
+            if (typeof afterToolsEvent.endTurn === 'string') {
+              lastMessage = new Message({ role: 'assistant', content: [new TextBlock(afterToolsEvent.endTurn)] })
+              yield this._appendMessage(lastMessage, invocationState)
+            } else {
+              // Boolean true: lastMessage is the assistant message with toolUseBlock items, not natural-language text.
+              lastMessage = assistantMessage
+            }
+
+            result = new AgentResult({
+              stopReason: 'endTurn',
+              lastMessage,
+              traces: this._tracer.localTraces,
+              metrics: this._meter.metrics,
+              invocationState,
+            })
+            return result
+          }
 
           // Structured output captured: exit
           const structuredOutput = structuredOutputTool
@@ -1297,14 +1331,14 @@ export class Agent implements LocalAgent, InvokableAgent {
    *
    * @param assistantMessage - The assistant message containing tool use blocks
    * @param toolRegistry - Registry containing available tools
-   * @returns User message containing tool results
+   * @returns Tool-result message and the dispatched AfterToolsEvent
    */
   private async *executeTools(
     assistantMessage: Message,
     toolRegistry: ToolRegistry,
     invocationState: InvocationState,
     completedToolResults?: Map<string, ToolResultBlock>
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
     const beforeToolsEvent = new BeforeToolsEvent({ agent: this, message: assistantMessage, invocationState })
     try {
       yield beforeToolsEvent
@@ -1369,21 +1403,22 @@ export class Agent implements LocalAgent, InvokableAgent {
 
   /**
    * Emits a `ToolResultEvent` for every block plus an `AfterToolsEvent`, and
-   * returns the resulting tool-result message. Used by the pre-launch cancel
+   * returns the resulting tool-result message and dispatched event. Used by the pre-launch cancel
    * paths shared across executors.
    */
   private async *_yieldCancelledToolResults(
     toolUseBlocks: ToolUseBlock[],
     message: string,
     invocationState: InvocationState
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
     const cancelBlocks = this._cancelAllAsResults(toolUseBlocks, message)
     for (const result of cancelBlocks) {
       yield new ToolResultEvent({ agent: this, result, invocationState })
     }
     const toolResultMessage = new Message({ role: 'user', content: cancelBlocks })
-    yield new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
-    return toolResultMessage
+    const afterToolsEvent = new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
+    yield afterToolsEvent
+    return { message: toolResultMessage, afterToolsEvent }
   }
 
   /**
@@ -1396,9 +1431,10 @@ export class Agent implements LocalAgent, InvokableAgent {
     invocationState: InvocationState,
     completedToolResults?: Map<string, ToolResultBlock>,
     assistantMessage?: Message
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
     const toolResultBlocks: ToolResultBlock[] = []
     let toolResultMessage: Message
+    let afterToolsEvent: AfterToolsEvent
 
     try {
       for (const toolUseBlock of toolUseBlocks) {
@@ -1450,10 +1486,11 @@ export class Agent implements LocalAgent, InvokableAgent {
       }
     } finally {
       toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
+      afterToolsEvent = new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
+      yield afterToolsEvent
     }
 
-    return toolResultMessage
+    return { message: toolResultMessage, afterToolsEvent }
   }
 
   /**
@@ -1487,8 +1524,9 @@ export class Agent implements LocalAgent, InvokableAgent {
     invocationState: InvocationState,
     completedToolResults?: Map<string, ToolResultBlock>,
     assistantMessage?: Message
-  ): AsyncGenerator<AgentStreamEvent, Message, undefined> {
+  ): AsyncGenerator<AgentStreamEvent, ToolsExecutionResult, undefined> {
     let toolResultMessage: Message
+    let afterToolsEvent: AfterToolsEvent
 
     // Wrap each in-flight `.next()` so the raced promise always resolves to a
     // tagged Step. That prevents one generator rejection from rejecting the
@@ -1615,10 +1653,11 @@ export class Agent implements LocalAgent, InvokableAgent {
       }
 
       toolResultMessage = new Message({ role: 'user', content: toolResultBlocks })
-      yield new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
+      afterToolsEvent = new AfterToolsEvent({ agent: this, message: toolResultMessage, invocationState })
+      yield afterToolsEvent
     }
 
-    return toolResultMessage
+    return { message: toolResultMessage, afterToolsEvent }
   }
 
   /**

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -727,6 +727,7 @@ describe('AfterToolsEvent', () => {
       agent: agent,
       message: message,
       invocationState: {},
+      endTurn: false,
     })
     // @ts-expect-error verifying that property is readonly
     event.agent = new Agent()
@@ -739,6 +740,20 @@ describe('AfterToolsEvent', () => {
     const message = new Message({ role: 'user', content: [] })
     const event = new AfterToolsEvent({ agent, message, invocationState: {} })
     expect(event._shouldReverseCallbacks()).toBe(true)
+  })
+
+  it('defaults endTurn to false and accepts boolean or string', () => {
+    const agent = new Agent()
+    const message = new Message({ role: 'user', content: [] })
+    const event = new AfterToolsEvent({ agent, message, invocationState: {} })
+
+    expect(event.endTurn).toBe(false)
+
+    event.endTurn = true
+    expect(event.endTurn).toBe(true)
+
+    event.endTurn = 'enough information gathered'
+    expect(event.endTurn).toBe('enough information gathered')
   })
 })
 
@@ -1077,6 +1092,7 @@ describe('toJSON serialization completeness', () => {
     'invocationState',
     'selectedTool',
     'resume',
+    'endTurn',
   ])
 
   /**

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -737,6 +737,18 @@ export class AfterToolsEvent extends HookableEvent {
   readonly message: Message
   readonly invocationState: InvocationState
 
+  /**
+   * When set to `true`, the agent loop halts after this tool batch completes
+   * without calling the model again. When set to a string, that string is
+   * appended as a final assistant message before halting — the string becomes
+   * literal assistant content (a `TextBlock`), not a reason or label. Contrast
+   * with {@link BeforeToolCallEvent.cancel | cancel} fields on other events,
+   * where the string is a cancellation reason.
+   *
+   * In both cases `stopReason` on the returned `AgentResult` is `'endTurn'`.
+   */
+  endTurn: boolean | string = false
+
   constructor(data: { agent: LocalAgent; message: Message; invocationState: InvocationState }) {
     super()
     this.agent = data.agent
@@ -749,7 +761,8 @@ export class AfterToolsEvent extends HookableEvent {
   }
 
   /**
-   * Serializes for wire transport, excluding the agent reference and invocationState.
+   * Serializes for wire transport, excluding the agent reference, invocationState,
+   * and mutable endTurn field.
    * Called automatically by JSON.stringify().
    */
   toJSON(): Pick<AfterToolsEvent, 'type' | 'message'> {

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -739,11 +739,13 @@ export class AfterToolsEvent extends HookableEvent {
 
   /**
    * When set to `true`, the agent loop halts after this tool batch completes
-   * without calling the model again. When set to a string, that string is
-   * appended as a final assistant message before halting — the string becomes
-   * literal assistant content (a `TextBlock`), not a reason or label. Contrast
-   * with {@link BeforeToolCallEvent.cancel | cancel} fields on other events,
-   * where the string is a cancellation reason.
+   * without calling the model again and a default message
+   * (`"Turn ended early by hook after tool execution"`) is appended as the
+   * final assistant message. When set to a string, that string is used instead
+   * of the default — the string becomes literal assistant content (a
+   * `TextBlock`), not a reason or label. Contrast with
+   * {@link BeforeToolCallEvent.cancel | cancel} fields on other events, where
+   * the string is a cancellation reason.
    *
    * In both cases `stopReason` on the returned `AgentResult` is `'endTurn'`.
    */


### PR DESCRIPTION
## Motivation

`AfterToolsEvent` is the only `After*` lifecycle event without a mutable decision field. Hooks that need to halt the agent loop between tool completion and the next model call have no clean way to do so — the only workaround is `agent.cancel()`, which yields `stopReason: 'cancelled'` instead of a clean `'endTurn'`.

This is needed for use cases like budget/quota enforcement, early-exit optimization, or guardrail hooks that determine after inspecting tool results that no further model calls are necessary.

## Public API Changes

`AfterToolsEvent` gains a mutable `endTurn` field (`boolean | string`, default `false`):

```typescript
import { Agent, AfterToolsEvent } from '@strands-agents/sdk'

const agent = new Agent({ model, tools })

// Boolean: halt silently
agent.addHook(AfterToolsEvent, (event) => {
  event.endTurn = true
})

// String: halt with a final assistant message
agent.addHook(AfterToolsEvent, (event) => {
  event.endTurn = 'enough information gathered'
})
```

When `endTurn` is truthy, the agent loop exits with `stopReason: 'endTurn'`. Tool results and any assistant message are always committed to conversation history before halting. The change is backward compatible — the default value is `false`, preserving existing behavior.

## Use Cases

- **Budget/quota enforcement**: A hook inspects cumulative token usage after each tool batch and halts the loop before incurring another model call.
- **Guardrail hooks**: After tools return, a hook evaluates results against policy constraints and stops the agent cleanly.
- **Early-exit optimization**: When tool results already contain a complete answer, skip the redundant model round-trip.