### PR TITLE
fix(mcp): paginate listTools(), improve fallback description

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -254,6 +254,50 @@ describe('MCP Integration', () => {
       expect(tools[0]!.name).toBe('weather')
     })
 
+    it('paginates through all pages of tools', async () => {
+      sdkClientMock.listTools
+        .mockResolvedValueOnce({
+          tools: [{ name: 'tool_a', description: 'A', inputSchema: {} }],
+          nextCursor: 'page2',
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: 'tool_b', description: 'B', inputSchema: {} }],
+          nextCursor: 'page3',
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: 'tool_c', description: 'C', inputSchema: {} }],
+        })
+
+      const tools = await client.listTools()
+
+      expect(tools).toHaveLength(3)
+      expect(tools.map((t) => t.name)).toEqual(['tool_a', 'tool_b', 'tool_c'])
+      expect(sdkClientMock.listTools).toHaveBeenCalledTimes(3)
+      expect(sdkClientMock.listTools).toHaveBeenNthCalledWith(1, undefined)
+      expect(sdkClientMock.listTools).toHaveBeenNthCalledWith(2, { cursor: 'page2' })
+      expect(sdkClientMock.listTools).toHaveBeenNthCalledWith(3, { cursor: 'page3' })
+    })
+
+    it('generates description fallback when description is missing', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'my_tool', inputSchema: {} }],
+      })
+
+      const tools = await client.listTools()
+
+      expect(tools[0]!.description).toBe('Tool which performs my_tool')
+    })
+
+    it('generates description fallback when description is empty string', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'my_tool', description: '', inputSchema: {} }],
+      })
+
+      const tools = await client.listTools()
+
+      expect(tools[0]!.description).toBe('Tool which performs my_tool')
+    })
+
     it('uses callTool when tasksConfig is undefined (default)', async () => {
       const tool = new McpTool({ name: 'calc', description: '', inputSchema: {}, client })
       sdkClientMock.callTool.mockResolvedValue({ content: [] })

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -157,17 +157,28 @@ export class McpClient {
   public async listTools(): Promise<McpTool[]> {
     await this.connect()
 
-    const result = await this._client.listTools()
+    const tools: McpTool[] = []
+    let cursor: string | undefined
 
-    // Map the tool specifications to fully functional McpTool instances
-    return result.tools.map((toolSpec) => {
-      return new McpTool({
-        name: toolSpec.name,
-        description: toolSpec.description ?? '',
-        inputSchema: toolSpec.inputSchema as JSONSchema,
-        client: this,
-      })
-    })
+    do {
+      const result = await this._client.listTools(cursor ? { cursor } : undefined)
+
+      tools.push(
+        ...result.tools.map(
+          (toolSpec) =>
+            new McpTool({
+              name: toolSpec.name,
+              description: toolSpec.description || `Tool which performs ${toolSpec.name}`,
+              inputSchema: toolSpec.inputSchema as JSONSchema,
+              client: this,
+            })
+        )
+      )
+
+      cursor = result.nextCursor
+    } while (cursor)
+
+    return tools
   }
 
   /**


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

- Add pagination for MCP tool retrieval (had been silently dropping after the first result batch) (matches Python)
- Improve fallback description for tools if nothing is provided (matches Python)

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
