### PR TITLE
fix: run generate before type-check in strands-wasm

### DIFF
--- a/strands-wasm/package.json
+++ b/strands-wasm/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "generate": "jco guest-types ../wit --name strands:agent --world-name agent --out-dir generated",
     "build": "node build.js",
-    "type-check": "tsc",
+    "type-check": "npm run generate && tsc",
     "clean": "rm -rf dist node_modules package-lock.json"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

The `type-check` script added in #979 runs `tsc` directly, but the generated type declarations from `jco guest-types` don't exist yet. This causes every PR's CI to fail on the `type-check` step.
  
Fix: run `npm run generate` before `tsc` in strands-wasm's `type-check` script.


## Related Issues

NA

## Documentation PR

NA

## Type of Change


Bug fix


## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
