### PR TITLE
refactor(wasm): decompose mapEvent into typed functions

### DIFF
--- a/strands-wasm/__tests__/mapping.test.ts
+++ b/strands-wasm/__tests__/mapping.test.ts
@@ -5,9 +5,14 @@ import {
   mapStopReasonTag,
   mapStopReason,
   mapEvent,
+  mapModelStreamEvent,
+  mapContentBlock,
+  mapToolStreamEvent,
   parseInput,
   parseSaveLatestStrategy,
 } from '../../entry'
+import type { AgentStreamEvent, ModelStreamEvent, StopReason } from '@strands-agents/sdk'
+import { ToolStreamEvent, ToolUseBlock, ToolResultBlock, TextBlock, ReasoningBlock } from '@strands-agents/sdk'
 
 describe('mapUsage', () => {
   it.each([null, undefined])('returns undefined for %s input', (input) => {
@@ -72,19 +77,7 @@ describe('mapMetrics', () => {
 })
 
 describe('mapStopReasonTag', () => {
-  const witStopReasons: string[] = [
-    'end-turn',
-    'tool-use',
-    'max-tokens',
-    'error',
-    'content-filtered',
-    'guardrail-intervened',
-    'stop-sequence',
-    'model-context-window-exceeded',
-    'cancelled',
-  ]
-
-  it.each([
+  const mappings: [string, string][] = [
     ['endTurn', 'end-turn'],
     ['toolUse', 'tool-use'],
     ['maxTokens', 'max-tokens'],
@@ -93,25 +86,29 @@ describe('mapStopReasonTag', () => {
     ['stopSequence', 'stop-sequence'],
     ['modelContextWindowExceeded', 'model-context-window-exceeded'],
     ['cancelled', 'cancelled'],
-  ])("maps '%s' to '%s'", (input, expected) => {
-    expect(mapStopReasonTag(input as any)).toBe(expected)
+  ]
+
+  it.each(mappings)("maps '%s' to '%s'", (input, expected) => {
+    expect(mapStopReasonTag(input as StopReason)).toBe(expected)
   })
 
   it("maps unknown reason to 'error'", () => {
-    expect(mapStopReasonTag('unknownReason' as any)).toBe('error')
+    expect(mapStopReasonTag('unknownReason' as unknown as StopReason)).toBe('error')
   })
 
   it('covers every WIT StopReason variant except error', () => {
-    const mappedOutputs = [
+    const witStopReasons = [
       'end-turn',
       'tool-use',
       'max-tokens',
+      'error',
       'content-filtered',
       'guardrail-intervened',
       'stop-sequence',
       'model-context-window-exceeded',
       'cancelled',
     ]
+    const mappedOutputs = mappings.map(([, wit]) => wit)
     const nonErrorVariants = witStopReasons.filter((r) => r !== 'error')
     expect(mappedOutputs.sort()).toStrictEqual(nonErrorVariants.sort())
   })
@@ -146,128 +143,215 @@ describe('mapStopReason', () => {
   })
 })
 
-describe('mapEvent', () => {
-  describe('leaf events', () => {
-    it('maps text delta', () => {
-      expect(
-        mapEvent({ type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } } as any)
-      ).toStrictEqual({ tag: 'text-delta', val: 'hello' })
-    })
+describe('mapModelStreamEvent', () => {
+  it('maps text delta', () => {
+    const event: ModelStreamEvent = { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } }
+    expect(mapModelStreamEvent(event)).toStrictEqual({ tag: 'text-delta', val: 'hello' })
+  })
 
-    it('maps toolUseBlock', () => {
-      expect(mapEvent({ type: 'toolUseBlock', name: 'calc', toolUseId: 'tu-1', input: { x: 1 } } as any)).toStrictEqual(
-        {
-          tag: 'tool-use',
-          val: { name: 'calc', toolUseId: 'tu-1', input: '{"x":1}' },
-        }
-      )
-    })
+  it('returns null for non-text delta', () => {
+    const event: ModelStreamEvent = {
+      type: 'modelContentBlockDeltaEvent',
+      delta: { type: 'toolUseInputDelta', input: '{}' },
+    }
+    expect(mapModelStreamEvent(event)).toBeNull()
+  })
 
-    it('maps modelContentBlockStartEvent with tool_use contentBlock', () => {
-      expect(
-        mapEvent({
-          type: 'modelContentBlockStartEvent',
-          contentBlock: { type: 'tool_use', name: 'calc', id: 'tu-5', input: { x: 1 } },
-        } as any)
-      ).toStrictEqual({
-        tag: 'tool-use',
-        val: { name: 'calc', toolUseId: 'tu-5', input: '{"x":1}' },
-      })
-    })
+  it('returns null for reasoningContentDelta', () => {
+    const event: ModelStreamEvent = {
+      type: 'modelContentBlockDeltaEvent',
+      delta: { type: 'reasoningContentDelta', text: 'thinking...' },
+    }
+    expect(mapModelStreamEvent(event)).toBeNull()
+  })
 
-    it('maps toolResultBlock', () => {
-      expect(
-        mapEvent({
-          type: 'toolResultBlock',
-          toolUseId: 'tu-1',
-          status: 'success',
-          content: [{ text: 'ok' }],
-        } as any)
-      ).toStrictEqual({
-        tag: 'tool-result',
-        val: { toolUseId: 'tu-1', status: 'success', content: '[{"text":"ok"}]' },
-      })
-    })
-
-    it('maps toolStreamEvent', () => {
-      expect(mapEvent({ type: 'toolStreamEvent', data: { value: 42 } } as any)).toStrictEqual({
-        tag: 'tool-result',
-        val: { toolUseId: '', status: 'success', content: '{"data":{"value":42}}' },
-      })
-    })
-
-    it('maps modelMetadataEvent', () => {
-      expect(
-        mapEvent({
-          type: 'modelMetadataEvent',
-          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-          metrics: { latencyMs: 50 },
-        } as any)
-      ).toStrictEqual({
-        tag: 'metadata',
-        val: {
-          usage: {
-            inputTokens: 10,
-            outputTokens: 20,
-            totalTokens: 30,
-            cacheReadInputTokens: undefined,
-            cacheWriteInputTokens: undefined,
-          },
-          metrics: { latencyMs: 50 },
-        },
-      })
-    })
-
-    it('maps interrupt event', () => {
-      const event = { interrupt: { reason: 'user' } }
-      expect(mapEvent(event as any)).toStrictEqual({ tag: 'interrupt', val: JSON.stringify(event) })
-    })
-
-    it('returns null for unrecognized event type', () => {
-      expect(mapEvent({ type: 'unknownEvent' } as any)).toBeNull()
-    })
-
-    it('returns null for non-text delta', () => {
-      expect(mapEvent({ type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta' } } as any)).toBeNull()
+  it('maps modelContentBlockStartEvent with toolUseStart', () => {
+    const event: ModelStreamEvent = {
+      type: 'modelContentBlockStartEvent',
+      start: { type: 'toolUseStart', name: 'calc', toolUseId: 'tu-5' },
+    }
+    expect(mapModelStreamEvent(event)).toStrictEqual({
+      tag: 'tool-use',
+      val: { name: 'calc', toolUseId: 'tu-5', input: '{}' },
     })
   })
 
+  it('returns null for modelContentBlockStartEvent without start', () => {
+    const event: ModelStreamEvent = { type: 'modelContentBlockStartEvent' }
+    expect(mapModelStreamEvent(event)).toBeNull()
+  })
+
+  it('maps modelMetadataEvent', () => {
+    const event: ModelStreamEvent = {
+      type: 'modelMetadataEvent',
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      metrics: { latencyMs: 50 },
+    }
+    expect(mapModelStreamEvent(event)).toStrictEqual({
+      tag: 'metadata',
+      val: {
+        usage: {
+          inputTokens: 10,
+          outputTokens: 20,
+          totalTokens: 30,
+          cacheReadInputTokens: undefined,
+          cacheWriteInputTokens: undefined,
+        },
+        metrics: { latencyMs: 50 },
+      },
+    })
+  })
+
+  it('returns null for unrecognized model event', () => {
+    const event: ModelStreamEvent = { type: 'modelMessageStartEvent', role: 'assistant' }
+    expect(mapModelStreamEvent(event)).toBeNull()
+  })
+
+  it('maps modelMetadataEvent without usage or metrics', () => {
+    const event: ModelStreamEvent = { type: 'modelMetadataEvent' }
+    expect(mapModelStreamEvent(event)).toStrictEqual({
+      tag: 'metadata',
+      val: { usage: undefined, metrics: undefined },
+    })
+  })
+})
+
+describe('mapContentBlock', () => {
+  it('maps toolUseBlock', () => {
+    const block = new ToolUseBlock({ name: 'calc', toolUseId: 'tu-1', input: { x: 1 } })
+    expect(mapContentBlock(block)).toStrictEqual({
+      tag: 'tool-use',
+      val: { name: 'calc', toolUseId: 'tu-1', input: '{"x":1}' },
+    })
+  })
+
+  it('maps toolUseBlock with null input to empty object', () => {
+    const block = new ToolUseBlock({ name: 'calc', toolUseId: 'tu-1', input: null })
+    expect(mapContentBlock(block)).toStrictEqual({
+      tag: 'tool-use',
+      val: { name: 'calc', toolUseId: 'tu-1', input: '{}' },
+    })
+  })
+
+  it('maps toolResultBlock', () => {
+    const block = new ToolResultBlock({
+      toolUseId: 'tu-1',
+      status: 'success',
+      content: [new TextBlock('ok')],
+    })
+    expect(mapContentBlock(block)).toStrictEqual({
+      tag: 'tool-result',
+      val: { toolUseId: 'tu-1', status: 'success', content: '[{"text":"ok"}]' },
+    })
+  })
+
+  it('returns null for textBlock', () => {
+    const block = new TextBlock('hello')
+    expect(mapContentBlock(block)).toBeNull()
+  })
+
+  it('returns null for reasoningBlock', () => {
+    const block = new ReasoningBlock({ text: '' })
+    expect(mapContentBlock(block)).toBeNull()
+  })
+})
+
+describe('mapToolStreamEvent', () => {
+  it('maps event with data', () => {
+    const event = new ToolStreamEvent({ data: { value: 42 } })
+    expect(mapToolStreamEvent(event)).toStrictEqual({
+      tag: 'tool-result',
+      val: { toolUseId: '', status: 'success', content: '{"data":{"value":42}}' },
+    })
+  })
+
+  it('maps event without data', () => {
+    const event = new ToolStreamEvent({})
+    expect(mapToolStreamEvent(event)).toStrictEqual({
+      tag: 'tool-result',
+      val: { toolUseId: '', status: 'success', content: '{"data":null}' },
+    })
+  })
+
+  it('maps event with string data', () => {
+    const event = new ToolStreamEvent({ data: 'processing step 1' })
+    expect(mapToolStreamEvent(event)).toStrictEqual({
+      tag: 'tool-result',
+      val: { toolUseId: '', status: 'success', content: '{"data":"processing step 1"}' },
+    })
+  })
+})
+
+describe('mapEvent', () => {
   describe('wrapper events', () => {
-    it('unwraps modelStreamUpdateEvent', () => {
-      expect(
-        mapEvent({
-          type: 'modelStreamUpdateEvent',
-          event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'wrapped' } },
-        } as any)
-      ).toStrictEqual({ tag: 'text-delta', val: 'wrapped' })
+    it('unwraps modelStreamUpdateEvent to mapModelStreamEvent', () => {
+      const event = {
+        type: 'modelStreamUpdateEvent',
+        event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'wrapped' } },
+      } as unknown as AgentStreamEvent
+      expect(mapEvent(event)).toStrictEqual({ tag: 'text-delta', val: 'wrapped' })
     })
 
-    it('unwraps contentBlockEvent wrapping toolUseBlock', () => {
-      expect(
-        mapEvent({
-          type: 'contentBlockEvent',
-          contentBlock: { type: 'toolUseBlock', name: 'tool1', toolUseId: 'tu-2', input: {} },
-        } as any)
-      ).toStrictEqual({
+    it('unwraps contentBlockEvent to mapContentBlock', () => {
+      const event = {
+        type: 'contentBlockEvent',
+        contentBlock: new ToolUseBlock({ name: 'tool1', toolUseId: 'tu-2', input: {} }),
+      } as unknown as AgentStreamEvent
+      expect(mapEvent(event)).toStrictEqual({
         tag: 'tool-use',
         val: { name: 'tool1', toolUseId: 'tu-2', input: '{}' },
       })
     })
 
-    it('unwraps toolResultEvent', () => {
-      expect(
-        mapEvent({
-          type: 'toolResultEvent',
-          result: { type: 'toolResultBlock', toolUseId: 'tu-3', status: 'error', content: [] },
-        } as any)
-      ).toStrictEqual({
+    it('unwraps toolResultEvent to mapContentBlock', () => {
+      const event = {
+        type: 'toolResultEvent',
+        result: new ToolResultBlock({ toolUseId: 'tu-3', status: 'error', content: [] }),
+      } as unknown as AgentStreamEvent
+      expect(mapEvent(event)).toStrictEqual({
         tag: 'tool-result',
         val: { toolUseId: 'tu-3', status: 'error', content: '[]' },
       })
     })
 
-    it('returns null for event without type property', () => {
-      expect(mapEvent({ someField: 'value' } as any)).toBeNull()
+    it('unwraps toolStreamUpdateEvent to mapToolStreamEvent', () => {
+      const event = {
+        type: 'toolStreamUpdateEvent',
+        event: new ToolStreamEvent({ data: { progress: 50 } }),
+      } as unknown as AgentStreamEvent
+      expect(mapEvent(event)).toStrictEqual({
+        tag: 'tool-result',
+        val: { toolUseId: '', status: 'success', content: '{"data":{"progress":50}}' },
+      })
+    })
+  })
+
+  describe('special events', () => {
+    it('maps interrupt event', () => {
+      const event = { interrupt: { reason: 'user' } }
+      expect(mapEvent(event as unknown as AgentStreamEvent)).toStrictEqual({
+        tag: 'interrupt',
+        val: JSON.stringify(event),
+      })
+    })
+  })
+
+  describe('dropped events', () => {
+    it.each([
+      'beforeInvocationEvent',
+      'afterInvocationEvent',
+      'beforeModelCallEvent',
+      'afterModelCallEvent',
+      'beforeToolCallEvent',
+      'afterToolCallEvent',
+      'messageAddedEvent',
+      'modelMessageEvent',
+      'agentResultEvent',
+      'beforeToolsEvent',
+      'afterToolsEvent',
+    ])('returns null for %s', (type) => {
+      const event = { type } as unknown as AgentStreamEvent
+      expect(mapEvent(event)).toBeNull()
     })
   })
 })

--- a/strands-wasm/__tests__/stream.test.ts
+++ b/strands-wasm/__tests__/stream.test.ts
@@ -35,7 +35,10 @@ describe('ResponseStreamImpl.readNext', () => {
     it('returns lifecycle events interleaved with mapped event', async () => {
       const { stream } = setupStream(
         async function* () {
-          yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } }
+          yield {
+            type: 'modelStreamUpdateEvent',
+            event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } },
+          }
         },
         [beforeModelCallEvent]
       )
@@ -136,8 +139,14 @@ describe('ResponseStreamImpl.readNext', () => {
   describe('cancel', () => {
     it('cancel sets done state', async () => {
       const { stream } = setupStream(async function* () {
-        yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } }
-        yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'world' } }
+        yield {
+          type: 'modelStreamUpdateEvent',
+          event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } },
+        }
+        yield {
+          type: 'modelStreamUpdateEvent',
+          event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'world' } },
+        }
       })
       stream.cancel()
       const batch = await stream.readNext()
@@ -154,7 +163,10 @@ describe('ResponseStreamImpl.readNext', () => {
 
       vi.spyOn(agent, 'stream').mockReturnValue(
         (async function* () {
-          yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } }
+          yield {
+            type: 'modelStreamUpdateEvent',
+            event: { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'hello' } },
+          }
         })()
       )
 

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -52,6 +52,8 @@ import type {
   StreamOptions,
   ToolChoice,
   ModelStreamEvent,
+  ContentBlock,
+  ToolStreamEvent,
   SaveLatestStrategy,
   JSONValue,
 } from '@strands-agents/sdk'
@@ -143,80 +145,121 @@ function mapStopReason(
 
 /** Convert a TS SDK AgentStreamEvent to a WIT StreamEvent for the host. */
 function mapEvent(event: AgentStreamEvent): StreamEvent | null {
-  if ('interrupt' in event || ('type' in event && (event as any).type === 'interrupt')) {
+  if ('interrupt' in event) {
     return { tag: 'interrupt', val: JSON.stringify(event) }
   }
 
-  if (!('type' in event)) {
-    return null
-  }
+  switch (event.type) {
+    // Mapped to WIT stream events for the Python host
+    case 'modelStreamUpdateEvent':
+      return mapModelStreamEvent(event.event)
+    case 'contentBlockEvent':
+      return mapContentBlock(event.contentBlock)
+    case 'toolResultEvent':
+      return mapContentBlock(event.result)
+    case 'toolStreamUpdateEvent':
+      return mapToolStreamEvent(event.event)
 
-  const ev = event as any
+    // Handled by LifecycleBridge via hook subscriptions
+    case 'beforeInvocationEvent':
+    case 'afterInvocationEvent':
+    case 'beforeModelCallEvent':
+    case 'afterModelCallEvent':
+    case 'beforeToolCallEvent':
+    case 'afterToolCallEvent':
+    case 'messageAddedEvent':
 
-  if (ev.type === 'modelContentBlockDeltaEvent') {
-    const delta = ev.delta
-    if (delta?.type === 'textDelta' && typeof delta.text === 'string') {
-      return { tag: 'text-delta', val: delta.text }
+    // No WIT representation — data available through other channels
+    case 'modelMessageEvent':
+    case 'agentResultEvent':
+    case 'beforeToolsEvent':
+    case 'afterToolsEvent':
+      return null
+
+    default: {
+      const _: never = event
+      return null
     }
-    return null
   }
+}
 
-  if (ev.type === 'modelStreamUpdateEvent' && ev.event) {
-    return mapEvent(ev.event)
+/** Convert a ModelStreamEvent to a WIT StreamEvent. */
+function mapModelStreamEvent(event: ModelStreamEvent): StreamEvent | null {
+  switch (event.type) {
+    case 'modelContentBlockDeltaEvent':
+      return event.delta.type === 'textDelta' ? { tag: 'text-delta', val: event.delta.text } : null
+    case 'modelContentBlockStartEvent':
+      return event.start?.type === 'toolUseStart'
+        ? {
+            tag: 'tool-use',
+            val: {
+              name: event.start.name,
+              toolUseId: event.start.toolUseId,
+              input: JSON.stringify({}),
+            },
+          }
+        : null
+    case 'modelMetadataEvent':
+      return { tag: 'metadata', val: { usage: mapUsage(event.usage), metrics: mapMetrics(event.metrics) } }
+    case 'modelContentBlockStopEvent':
+    case 'modelMessageStartEvent':
+    case 'modelMessageStopEvent':
+    case 'modelRedactionEvent':
+      return null
+    default: {
+      const _: never = event
+      return null
+    }
   }
+}
 
-  if (ev.type === 'contentBlockEvent' && ev.contentBlock) {
-    return mapEvent(ev.contentBlock)
-  }
-
-  if (ev.type === 'toolResultEvent' && ev.result) {
-    return mapEvent(ev.result)
-  }
-
-  if (
-    ev.type === 'toolUseBlock' ||
-    (ev.type === 'modelContentBlockStartEvent' && ev.contentBlock?.type === 'tool_use')
-  ) {
-    const block = ev.type === 'toolUseBlock' ? ev : ev.contentBlock
-    if (block?.name) {
+/** Convert a ContentBlock to a WIT StreamEvent. */
+function mapContentBlock(block: ContentBlock): StreamEvent | null {
+  switch (block.type) {
+    case 'toolUseBlock':
       return {
         tag: 'tool-use',
         val: {
           name: block.name,
-          toolUseId: block.id ?? block.toolUseId ?? '',
+          toolUseId: block.toolUseId,
           input: JSON.stringify(block.input ?? {}),
         },
       }
+    case 'toolResultBlock':
+      return {
+        tag: 'tool-result',
+        val: {
+          toolUseId: block.toolUseId,
+          status: block.status,
+          content: JSON.stringify(block.content ?? []),
+        },
+      }
+    case 'textBlock':
+    case 'reasoningBlock':
+    case 'cachePointBlock':
+    case 'guardContentBlock':
+    case 'imageBlock':
+    case 'videoBlock':
+    case 'documentBlock':
+    case 'citationsBlock':
+      return null
+    default: {
+      const _: never = block
+      return null
     }
   }
+}
 
-  if (ev.type === 'toolResultBlock') {
-    return {
-      tag: 'tool-result',
-      val: {
-        toolUseId: ev.toolUseId ?? '',
-        status: ev.status ?? 'success',
-        content: JSON.stringify(ev.content ?? []),
-      },
-    }
+/** Convert a ToolStreamEvent to a WIT StreamEvent. */
+function mapToolStreamEvent(event: ToolStreamEvent): StreamEvent {
+  return {
+    tag: 'tool-result',
+    val: {
+      toolUseId: '',
+      status: 'success',
+      content: JSON.stringify({ data: event.data ?? null }),
+    },
   }
-
-  if (ev.type === 'toolStreamEvent') {
-    return {
-      tag: 'tool-result',
-      val: {
-        toolUseId: '',
-        status: 'success',
-        content: JSON.stringify({ data: ev.data ?? null }),
-      },
-    }
-  }
-
-  if (ev.type === 'modelMetadataEvent') {
-    return { tag: 'metadata', val: { usage: mapUsage(ev.usage), metrics: mapMetrics(ev.metrics) } }
-  }
-
-  return null
 }
 
 /** Extract WIT ModelParams into a plain config object for TS model constructors. */
@@ -673,6 +716,9 @@ export const api = {
 // Additional ESM exports in bundle.js are inaccessible from the WASM boundary.
 export {
   mapEvent,
+  mapModelStreamEvent,
+  mapContentBlock,
+  mapToolStreamEvent,
   mapStopReason,
   mapStopReasonTag,
   mapUsage,


### PR DESCRIPTION
## Description

Stacked on #988 — review and merge #988 first. The diff will reduce to a single commit once #988 lands.

`mapEvent` casts its input to `any` on the first line, making every property access in the function untyped. It handles four distinct type hierarchies through recursive calls, and a dead code path checks for `toolStreamEvent` — a type string no `AgentStreamEvent` member carries — silently dropping tool stream events.

This decomposes `mapEvent` into four typed functions matching the SDK's type hierarchy: `mapModelStreamEvent` for `ModelStreamEvent`, `mapContentBlock` for `ContentBlock`, and `mapToolStreamEvent` for `ToolStreamEvent`. The top-level `mapEvent` dispatches via a switch on `AgentStreamEvent.type`. All three switches use exhaustive `never` guards so new SDK variants produce compile-time errors in the WASM bridge, forcing explicit handling rather than silent drops.

The `toolStreamUpdateEvent` case is now handled, fixing tool stream events being silently dropped.

No public API changes.

## Related Issues

Continuation of #988. Implements the "mapEvent decomposition" section of `docs/wasm-type-safety-design.md`.

## Type of Change

Other (please describe): Refactor — eliminates remaining `as any` casts and dead code in the WASM bridge

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.