### PR TITLE
feat: add npm-pack test to ci-cd

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -33,3 +33,10 @@ jobs:
       contents: read
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+
+  call-test-package-pack:
+    uses: ./.github/workflows/test-package-pack.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-package-pack.yml
+++ b/.github/workflows/test-package-pack.yml
@@ -1,0 +1,72 @@
+# End-to-end package install smoke test.
+#
+# At RC.0 the SDK published a main-entry re-export from an optional peer
+# dependency. A real user's `npm install @strands-agents/sdk` succeeded, then
+# crashed at module load because the optional peer was not installed.
+#
+# The existing `test:package` doesn't catch this: it resolves the SDK via
+# `file:../../..` and the monorepo's root `node_modules` hoists every optional
+# peer (they're devDependencies of the repo), silently satisfying the bad
+# re-export. This workflow reproduces a real user's install: `npm pack` the
+# SDK, install the tarball in a tempdir OUTSIDE the monorepo tree so nothing
+# hoists, then type-check and run a consumer script that touches the public
+# surface. A missing optional peer fails at module load the same way it would
+# for an end user.
+name: Test Package Pack
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+jobs:
+  test-package-pack:
+    name: Pack Install
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack, install in tmpdir, type-check, and run
+        # The tempdir MUST live outside the monorepo — otherwise npm hoists
+        # devDependencies from the repo root into resolution and silently
+        # satisfies missing optional peers, defeating the test.
+        run: |
+          set -euo pipefail
+          TARBALL=$(cd strands-ts && npm pack --silent)
+          TARBALL_PATH="$GITHUB_WORKSPACE/strands-ts/$TARBALL"
+          echo "Packed: $TARBALL_PATH"
+
+          WORK=$(mktemp -d)
+          echo "Workspace: $WORK"
+          cp strands-ts/test/packages/npm-pack/package.json \
+             strands-ts/test/packages/npm-pack/tsconfig.json \
+             strands-ts/test/packages/npm-pack/verify.ts \
+             "$WORK/"
+          cd "$WORK"
+
+          npm install --ignore-scripts --no-audit --no-fund
+          npm install --ignore-scripts --no-audit --no-fund "$TARBALL_PATH"
+
+          npx tsc --noEmit
+          npx tsx verify.ts

--- a/.github/workflows/test-package-pack.yml
+++ b/.github/workflows/test-package-pack.yml
@@ -58,6 +58,7 @@ jobs:
           echo "Packed: $TARBALL_PATH"
 
           WORK=$(mktemp -d)
+          trap 'rm -rf "$WORK"' EXIT
           echo "Workspace: $WORK"
           cp strands-ts/test/packages/npm-pack/package.json \
              strands-ts/test/packages/npm-pack/tsconfig.json \

--- a/strands-ts/test/packages/README.md
+++ b/strands-ts/test/packages/README.md
@@ -1,6 +1,9 @@
 # Package Import Tests
 
-This directory contains verification tests to ensure `@strands-agents/sdk` can be imported correctly in both ESM and CommonJS module formats.
+This directory contains verification tests to ensure `@strands-agents/sdk` can be imported correctly. There are two flavors, catching different classes of packaging bug:
+
+- **`esm-module/` and `cjs-module/`** — fast local tests. Install the SDK via `file:../../..` and exercise ESM `import` + CommonJS `require`. Run by `npm run test:package`. These resolve through the monorepo, so they share the root `node_modules` and cannot detect missing-optional-peer regressions.
+- **`npm-pack/`** — CI-only smoke test (`.github/workflows/test-package-pack.yml`). Runs `npm pack` and installs the tarball in a tempdir outside the monorepo, mirroring an end-user install. Catches the RC.0 class of bug where the main entry re-exports a symbol from an optional peer dependency.
 
 ## Running the Tests
 
@@ -10,17 +13,21 @@ From the root of the project:
 npm run test:package
 ```
 
-This command builds and installs the SDK locally, then runs both ESM and CJS import tests.
+This command builds and installs the SDK locally, then runs both ESM and CJS import tests. The tarball test is not wired into this script — see `.github/workflows/test-package-pack.yml` for its invocation.
 
 ## Test Structure
 
 ```
 test/packages/
-├── esm-module/     # ES Module import test
+├── esm-module/     # ES Module import test (file: install)
 │   ├── esm.js      # Uses `import { ... } from '@strands-agents/sdk'`
 │   └── package.json
-├── cjs-module/     # CommonJS import test
+├── cjs-module/     # CommonJS import test (file: install)
 │   ├── cjs.js      # Uses `require('@strands-agents/sdk')`
 │   └── package.json
+├── npm-pack/       # Packed-tarball install smoke test (CI-only)
+│   ├── verify.ts   # Type-checked consumer script
+│   ├── package.json
+│   └── tsconfig.json
 └── README.md
 ```

--- a/strands-ts/test/packages/npm-pack/package.json
+++ b/strands-ts/test/packages/npm-pack/package.json
@@ -1,0 +1,10 @@
+{
+  "//": "Fixture for .github/workflows/test-package-pack.yml. Copied to a tempdir outside the monorepo, then the SDK tarball is installed on top. Only dev tooling lives here — required peer deps are auto-installed from the tarball's peerDependencies metadata; optional peers are deliberately omitted so module-load-time references to them fail the test.",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^6.0.2",
+    "tsx": "^4.21.0",
+    "@types/node": "^25.6.0"
+  }
+}

--- a/strands-ts/test/packages/npm-pack/tsconfig.json
+++ b/strands-ts/test/packages/npm-pack/tsconfig.json
@@ -1,0 +1,21 @@
+// Consumer-side type-check config for the packaging smoke test. Runs against
+// the installed @strands-agents/sdk tarball's .d.ts surface, not the SDK
+// source. Kept minimal on purpose — we want errors in verify.ts, not false
+// positives from stricter-than-needed options.
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["verify.ts"]
+}

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -1,0 +1,119 @@
+/**
+ * Consumer fixture for .github/workflows/test-package-pack.yml. Runs against
+ * the packed tarball with only non-optional peers installed, so any import
+ * that transitively pulls an optional peer fails at module load.
+ *
+ * Subpaths deliberately NOT imported because they require optional peers:
+ *   models/{anthropic,openai,google,vercel}, a2a, a2a/express,
+ *   session/s3-storage, telemetry. Those are covered by the sibling
+ *   `../esm-module` and `../cjs-module` suites.
+ */
+
+import {
+  Agent,
+  AgentResult,
+  BedrockModel,
+  ContextWindowOverflowError,
+  FunctionTool,
+  Model,
+  StateStore,
+  Tool,
+  ZodTool,
+  tool,
+} from '@strands-agents/sdk'
+
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
+import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
+import { bash } from '@strands-agents/sdk/vended-tools/bash'
+
+import { BedrockModel as BedrockFromSubpath } from '@strands-agents/sdk/models/bedrock'
+import { Graph, Swarm, MultiAgentState } from '@strands-agents/sdk/multiagent'
+import { AgentSkills } from '@strands-agents/sdk/vended-plugins/skills'
+import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+
+import { z } from 'zod'
+
+console.log('[pack-test] Imports resolved')
+
+const model = new BedrockModel({ region: 'us-west-2' })
+if (!model.getConfig()) {
+  throw new Error('BedrockModel config is invalid')
+}
+console.log('[pack-test] BedrockModel constructed')
+
+const weatherTool = tool({
+  name: 'get_weather',
+  description: 'Get the current weather for a specific location.',
+  inputSchema: z.object({
+    location: z.string().describe('The city and state, e.g., San Francisco, CA'),
+  }),
+  callback: (input) => `The weather in ${input.location} is 72F and sunny.`,
+})
+
+const response = await weatherTool.invoke({ location: 'New York' })
+if (response !== 'The weather in New York is 72F and sunny.') {
+  throw new Error(`Tool returned invalid response: ${String(response)}`)
+}
+console.log('[pack-test] Tool invocation produced expected output')
+
+const agent = new Agent({ tools: [weatherTool] })
+if (agent.tools.length === 0) {
+  throw new Error('Tool was not correctly added to the agent')
+}
+console.log('[pack-test] Agent constructed with tool')
+
+const vendedTools: Record<string, Tool> = { notebook, fileEditor, httpRequest, bash }
+for (const [name, t] of Object.entries(vendedTools)) {
+  if (!(t instanceof Tool)) {
+    throw new Error(`Vended tool '${name}' is not a Tool instance`)
+  }
+}
+console.log('[pack-test] All vended tools are Tool instances')
+
+if (BedrockFromSubpath !== BedrockModel) {
+  throw new Error('BedrockModel from subpath does not match main export')
+}
+if (!(model instanceof Model)) {
+  throw new Error('BedrockModel is not a Model instance')
+}
+if (!(weatherTool instanceof FunctionTool) && !(weatherTool instanceof ZodTool)) {
+  throw new Error('tool() factory returned an unexpected Tool subclass')
+}
+console.log('[pack-test] Subpath export identity + model/tool hierarchy verified')
+
+const store = new StateStore({ count: 0 })
+store.set('count', 1)
+if (store.get('count') !== 1) {
+  throw new Error('StateStore did not round-trip value')
+}
+console.log('[pack-test] StateStore round-trip verified')
+
+const multiAgentState = new MultiAgentState()
+if (!(multiAgentState instanceof MultiAgentState)) {
+  throw new Error('MultiAgentState construction failed')
+}
+const skills = new AgentSkills({ skills: [] })
+if (!(skills instanceof AgentSkills)) {
+  throw new Error('AgentSkills construction failed')
+}
+const offloader = new ContextOffloader({ storage: new InMemoryStorage() })
+if (!(offloader instanceof ContextOffloader)) {
+  throw new Error('ContextOffloader construction failed')
+}
+for (const [name, ctor] of Object.entries({ Graph, Swarm })) {
+  if (typeof ctor !== 'function') {
+    throw new Error(`${name} subpath export is not a constructor`)
+  }
+}
+console.log('[pack-test] multiagent + vended-plugin subpaths constructible')
+
+const ctxErr = new ContextWindowOverflowError('test')
+if (!(ctxErr instanceof Error)) {
+  throw new Error('ContextWindowOverflowError is not an Error subclass')
+}
+
+void AgentResult
+console.log('[pack-test] Error + result types importable')
+
+console.log('[pack-test] OK')

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -57,7 +57,7 @@ if (response !== 'The weather in New York is 72F and sunny.') {
 }
 console.log('[pack-test] Tool invocation produced expected output')
 
-const agent = new Agent({ tools: [weatherTool] })
+const agent = new Agent({ model, tools: [weatherTool] })
 if (agent.tools.length === 0) {
   throw new Error('Tool was not correctly added to the agent')
 }


### PR DESCRIPTION
## Description

At RC.0 the SDK shipped a main-entry re-export from an optional peer dependency. A real user's `npm install @strands-agents/sdk` succeeded, then crashed at module load because the optional peer wasn't installed — `ERR_MODULE_NOT_FOUND` on first `import`.

The existing `test:package` can't catch this. It installs the SDK into its sibling workspaces via `"@strands-agents/sdk": "file:../../.."`, which resolves through the monorepo and hoists the root `node_modules` — where every optional peer already lives as a devDependency. The bad re-export was silently satisfied.

This PR adds a CI-only smoke test that mirrors a real end-user install. `npm pack` produces the publishable tarball; it's installed in a tempdir outside the monorepo so nothing hoists; only the SDK and its non-optional peers are present. A typed consumer script is then type-checked against the published `.d.ts` surface and executed. Any module-load-time reference to an uninstalled optional peer fails the job, exactly as it would fail for an end user.

Verified the negative path locally by injecting `export { Anthropic } from '@anthropic-ai/sdk'` into `src/index.ts` — the test fails with `ERR_MODULE_NOT_FOUND: Cannot find package '@anthropic-ai/sdk'`, catching the regression class.

## Time added to CI flow

Since jobs run in parallel this shouldn't increase the overall CI runtime.

## Related Issues

Resolves #750

## Documentation PR

N/A

## Type of Change

New feature (CI/test infrastructure)

## Testing

- Local smoke: packed, installed in tempdir, type-checked, ran — all green.
- Negative smoke: injected a bad re-export from an optional peer, confirmed the test fails loudly at module load. Reverted.

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
