### PR TITLE
fix: cache unsupported models for bedrocks token counting

### DIFF
--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -4137,6 +4137,7 @@ describe('BedrockModel', () => {
 
     beforeEach(() => {
       vi.clearAllMocks()
+      BedrockModel.clearCountTokensCache()
     })
 
     it('should return native token count on success', async () => {
@@ -4242,6 +4243,39 @@ describe('BedrockModel', () => {
 
       expect(typeof result).toBe('number')
       expect(result).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should cache model ID and skip API call when model does not support counting tokens', async () => {
+      const unsupportedError = new Error("The provided model doesn't support counting tokens")
+      unsupportedError.name = 'ValidationException'
+      const mockSend = vi.fn(async () => {
+        throw unsupportedError
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      // First call: hits API, gets error, caches
+      await model.countTokens(messages)
+      expect(mockSend).toHaveBeenCalledOnce()
+
+      // Second call: skips API entirely
+      await model.countTokens(messages)
+      expect(mockSend).toHaveBeenCalledOnce()
+    })
+
+    it('should not cache model ID for other errors', async () => {
+      const mockSend = vi.fn(async () => {
+        throw new Error('Transient network error')
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      await model.countTokens(messages)
+      expect(mockSend).toHaveBeenCalledTimes(1)
+
+      // Second call should still attempt the API
+      await model.countTokens(messages)
+      expect(mockSend).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -90,6 +90,12 @@ const BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
 ]
 
 /**
+ * Cache of model IDs that do not support the CountTokens API.
+ * Prevents repeated failing API calls for models that will never support token counting.
+ */
+const UNSUPPORTED_COUNT_TOKENS_MODELS = new Set<string>()
+
+/**
  * Mapping of Bedrock stop reasons to SDK stop reasons.
  */
 const STOP_REASON_MAP = {
@@ -327,6 +333,14 @@ export class BedrockModel extends Model<BedrockModelConfig> {
   private _client: BedrockRuntimeClient
 
   /**
+   * Clears the cache of model IDs that do not support the CountTokens API.
+   * After calling this, the next countTokens invocation will attempt the API again.
+   */
+  static clearCountTokensCache(): void {
+    UNSUPPORTED_COUNT_TOKENS_MODELS.clear()
+  }
+
+  /**
    * Creates a new BedrockModel instance.
    *
    * @param options - Optional configuration for model and client
@@ -478,6 +492,12 @@ export class BedrockModel extends Model<BedrockModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    const modelId = this._config.modelId ?? MODEL_DEFAULTS.bedrock.modelId
+
+    if (UNSUPPORTED_COUNT_TOKENS_MODELS.has(modelId)) {
+      return super.countTokens(messages, options)
+    }
+
     try {
       const request = this._formatRequest(messages, options)
       const converseInput: Record<string, unknown> = {}
@@ -499,7 +519,18 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       logger.debug(`total_tokens=<${response.inputTokens}> | native token count`)
       return response.inputTokens
     } catch (error) {
-      logger.debug(`error=<${error}> | native token counting failed, falling back to estimation`)
+      if (
+        error instanceof Error &&
+        error.name === 'ValidationException' &&
+        error.message.includes("doesn't support counting tokens")
+      ) {
+        logger.debug(
+          `model_id=<${modelId}> | model does not support CountTokens, caching for future calls, falling back to estimation`
+        )
+        UNSUPPORTED_COUNT_TOKENS_MODELS.add(modelId)
+      } else {
+        logger.debug(`error=<${error}> | native token counting failed, falling back to estimation`)
+      }
       return super.countTokens(messages, options)
     }
   }

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -335,6 +335,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
   /**
    * Clears the cache of model IDs that do not support the CountTokens API.
    * After calling this, the next countTokens invocation will attempt the API again.
+   *
+   * @internal
    */
   static clearCountTokensCache(): void {
     UNSUPPORTED_COUNT_TOKENS_MODELS.clear()


### PR DESCRIPTION
## Description

When a Bedrock model does not support the `CountTokens` API, it returns a `ValidationException` with the message "The provided model doesn'\''t support counting tokens". Today, every invocation of `countTokens` makes this failing API call before falling back to the heuristic estimator, causing polluted debug logs and Bedrock error logging.

This change caches the model ID on the first failure and skips the API call entirely on subsequent invocations, falling back directly to the base class heuristic.

## Related Issues

NA

## Documentation PR

NA

## Type of Change

Bug fix


## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
