### PR TITLE
feat: add structured output implementation for wasm

### DIFF
--- a/strands-py/strands/_wasm_host.py
+++ b/strands-py/strands/_wasm_host.py
@@ -279,6 +279,7 @@ def _build_agent_config(
     system_prompt_blocks: str | None,
     tools: list[ToolSpec] | None,
     conversation_manager_config: dict[str, typing.Any] | None = None,
+    structured_output_schema: str | None = None,
 ) -> Record:
     model_variant = None
     if model is not None:
@@ -297,6 +298,7 @@ def _build_agent_config(
         "trace-context": None,
         "session": None,
         "conversation-manager": cm_variant,
+        "structured-output-schema": structured_output_schema,
     }
 
     return _rec(
@@ -310,9 +312,17 @@ def _build_stream_args(
     input_text: str,
     tools: list[ToolSpec] | None,
     tool_choice: str | None,
+    structured_output_schema: str | None = None,
 ) -> Record:
     tool_recs = [_build_tool_spec(t) for t in tools] if tools else None
-    return _rec(input=input_text, tools=tool_recs, **{"tool-choice": tool_choice})
+    return _rec(
+        input=input_text,
+        tools=tool_recs,
+        **{
+            "tool-choice": tool_choice,
+            "structured-output-schema": structured_output_schema,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +398,7 @@ def _convert_stream_event(v: Variant) -> StreamEvent:
             reason=_stop_reason_from_str(getattr(p, "reason")),
             usage=_convert_usage(_opt_attr(p, "usage")),
             metrics=_convert_metrics(_opt_attr(p, "metrics")),
+            structured_output=_opt_attr(p, "structured-output"),
         )
         return StreamEvent_Stop(value=sd)
 
@@ -553,6 +564,7 @@ class WasmAgent:
         tool_dispatcher: ToolDispatcherBase | None,
         log_handler: LogHandlerBase | None,
         conversation_manager_config: dict[str, typing.Any] | None = None,
+        structured_output_schema: str | None = None,
         use_callback_relay: bool = False,
     ):
         engine, component = _get_engine_and_component()
@@ -584,7 +596,7 @@ class WasmAgent:
         self._component = component
 
         # --- instantiate + construct agent (async, run synchronously) ---
-        agent_config = _build_agent_config(model, system_prompt, system_prompt_blocks, tools, conversation_manager_config)
+        agent_config = _build_agent_config(model, system_prompt, system_prompt_blocks, tools, conversation_manager_config, structured_output_schema)
         _run_sync(self._init_async(linker, store, component, agent_config))
 
     async def _init_async(
@@ -631,8 +643,9 @@ class WasmAgent:
         input_text: str,
         tools: list[ToolSpec] | None,
         tool_choice: str | None,
+        structured_output_schema: str | None = None,
     ) -> typing.Any:
-        args = _build_stream_args(input_text, tools, tool_choice)
+        args = _build_stream_args(input_text, tools, tool_choice, structured_output_schema)
         return await self._generate_fn.call_async(
             self._store, self._agent_handle, args
         )

--- a/strands-py/strands/agent/__init__.py
+++ b/strands-py/strands/agent/__init__.py
@@ -673,7 +673,12 @@ class Agent:
         structured_output = None
         if sr.structured_output_json and so_model:
             data = json.loads(sr.structured_output_json)
-            structured_output = so_model(**data)
+            try:
+                structured_output = so_model(**data)
+            except Exception as exc:
+                raise StructuredOutputError(
+                    f"Pydantic validation failed for {so_model.__name__}: {exc}"
+                ) from exc
 
         return AgentResult(
             text="".join(sr.text_parts),
@@ -719,6 +724,11 @@ class Agent:
         return result.structured_output if result.structured_output is not None else result
 
     async def stream_async(self, prompt: Any, **kwargs: Any) -> Any:
+        """Stream agent events. When structured_output is set, intermediate events
+        are not yielded — only the final result is produced after the agent loop completes.
+        This matches the TS SDK behavior where structured output requires the full
+        agent loop to finish before the validated result is available.
+        """
         per_invocation_so = kwargs.pop("structured_output", None)
         so_model = per_invocation_so or self._structured_output_model
 

--- a/strands-py/strands/agent/__init__.py
+++ b/strands-py/strands/agent/__init__.py
@@ -39,7 +39,7 @@ from strands._generated.types import (
 )
 from strands.hooks import AfterToolCallEvent, HookProvider, HookRegistry
 from strands.tools import DecoratedTool
-from strands.types.exceptions import ContextOverflowError, MaxTokensReachedException, ToolProviderException
+from strands.types.exceptions import ContextOverflowError, MaxTokensReachedException, StructuredOutputError, ToolProviderException
 from strands.types.tools import ToolContext
 
 log = logging.getLogger(__name__)
@@ -102,6 +102,7 @@ class StreamResult:
     stop_reason: str = "end_turn"
     usage: Any = None
     metrics: Metrics = field(default_factory=Metrics)
+    structured_output_json: str | None = None
 
 
 class AgentResult:
@@ -244,7 +245,7 @@ class Agent:
         hooks: list[HookProvider] | None = None,
         load_tools_from_directory: bool = False,
         printer: bool = True,
-        structured_output_model: type | None = None,
+        structured_output: type | None = None,
         agent_id: str | None = None,
         session_manager: Any = None,
         conversation_manager: Union[
@@ -270,7 +271,12 @@ class Agent:
         if hooks:
             for provider in hooks:
                 provider.register_hooks(self.hooks)
-        self._default_structured_output_model = structured_output_model
+        self._structured_output_model: type | None = None
+        self._structured_output_schema_json: str | None = None
+        if structured_output is not None:
+            schema = flatten_pydantic_schema(structured_output.model_json_schema())
+            self._structured_output_schema_json = json.dumps(schema)
+            self._structured_output_model = structured_output
         self._load_tools_from_directory = load_tools_from_directory
         self._tools_dir_mtimes: dict[str, float] = {}
         self._printer = printer
@@ -345,6 +351,7 @@ class Agent:
             tool_dispatcher=self._dispatcher,
             log_handler=_LogHandler(),
             conversation_manager_config=cm_config,
+            structured_output_schema=self._structured_output_schema_json,
             use_callback_relay=False,
         )
 
@@ -524,6 +531,7 @@ class Agent:
         *,
         tools: Any = None,
         tool_choice: Any = None,
+        structured_output_schema: str | None = None,
     ) -> StreamResult:
         import time as _time
 
@@ -531,7 +539,7 @@ class Agent:
         tool_metrics: list[dict[str, Any]] = []
         pending_tool_start: dict[str, float] = {}
 
-        if tools is not None or tool_choice is not None:
+        if tools is not None or tool_choice is not None or structured_output_schema is not None:
             wasm_tool_specs = (
                 [
                     _ToolSpec(
@@ -545,7 +553,7 @@ class Agent:
                 else None
             )
             stream = await self._wasm_agent.start_stream_with_options(
-                prompt, wasm_tool_specs, tool_choice,
+                prompt, wasm_tool_specs, tool_choice, structured_output_schema,
             )
         else:
             stream = await self._wasm_agent.start_stream(prompt)
@@ -581,6 +589,7 @@ class Agent:
                         result.usage = sd.usage
                         latency = sd.metrics.latency_ms if sd.metrics else 0.0
                         result.metrics = Metrics(latency_ms=latency)
+                        result.structured_output_json = sd.structured_output
                         if self._printer and result.text_parts:
                             print()
 
@@ -610,6 +619,8 @@ class Agent:
                             raise ContextOverflowError(err_msg)
                         if "maximum token" in err_msg.lower():
                             raise MaxTokensReachedException(err_msg)
+                        if "failed to invoke the structured output tool" in err_msg:
+                            raise StructuredOutputError(err_msg)
                         if self._printer:
                             print(f"\n[error: {err_msg}]", file=sys.stderr)
 
@@ -624,17 +635,21 @@ class Agent:
         return result
 
     async def _call_async(self, prompt: str, **kwargs: Any) -> AgentResult:
-        structured_output_model = kwargs.pop("structured_output_model", None)
-        so_model = structured_output_model or self._default_structured_output_model
+        per_invocation_so = kwargs.pop("structured_output", None)
+        so_model = per_invocation_so or self._structured_output_model
 
-        if so_model is not None:
-            return await self._call_with_structured_output_async(prompt, so_model)
+        so_schema_json: str | None = None
+        if per_invocation_so is not None:
+            schema = flatten_pydantic_schema(per_invocation_so.model_json_schema())
+            so_schema_json = json.dumps(schema)
+        elif self._structured_output_schema_json:
+            so_schema_json = self._structured_output_schema_json
 
         try:
-            sr = await self._consume_stream_async(prompt)
+            sr = await self._consume_stream_async(prompt, structured_output_schema=so_schema_json)
         except ContextOverflowError:
             await self._wasm_agent.set_messages_async("[]")
-            sr = await self._consume_stream_async(prompt)
+            sr = await self._consume_stream_async(prompt, structured_output_schema=so_schema_json)
         except MaxTokensReachedException:
             raw = await self._wasm_agent.get_messages_async()
             msgs = [convert_message(m) for m in json.loads(raw)]
@@ -655,64 +670,18 @@ class Agent:
             await self._wasm_agent.set_messages_async(json.dumps(msgs))
             raise MaxTokensReachedException("max tokens reached")
 
+        structured_output = None
+        if sr.structured_output_json and so_model:
+            data = json.loads(sr.structured_output_json)
+            structured_output = so_model(**data)
+
         return AgentResult(
             text="".join(sr.text_parts),
             stop_reason=sr.stop_reason,
             usage=sr.usage,
             metrics=sr.metrics,
+            structured_output=structured_output,
         )
-
-    async def _call_with_structured_output_async(
-        self, prompt: str, so_model: type,
-    ) -> AgentResult:
-        so_tool_name = so_model.__name__
-        schema = flatten_pydantic_schema(so_model.model_json_schema())  # type: ignore[attr-defined]
-        so_tool_spec: dict[str, Any] = {
-            "name": so_tool_name,
-            "description": (getattr(so_model, "__doc__", None) or so_tool_name)
-            + " -- You MUST call this tool to return structured output.",
-            "inputSchema": schema,
-        }
-
-        so_result: Any = None
-
-        def so_handler(input_json: str, _tool_use_id: str = "") -> str:
-            nonlocal so_result
-            data = json.loads(input_json)
-            try:
-                so_result = so_model(**data)
-                return json.dumps({"status": "success", "content": [{"text": json.dumps(data)}]})
-            except Exception as exc:
-                raise ValueError(f"Validation error: {exc}") from exc
-
-        self._dispatcher.register(so_tool_name, so_handler)
-        try:
-            existing_tools = [entry.spec for entry in self._tool_map.values()]
-            all_tools = existing_tools + [so_tool_spec]
-            sr = await self._consume_stream_async(prompt, tools=all_tools)
-
-            if so_result is None and sr.stop_reason != "max_tokens":
-                sr = await self._consume_stream_async(
-                    json.dumps([{
-                        "text": "You must format the previous response as structured output. "
-                        f"Call the {so_tool_name} tool now.",
-                    }]),
-                    tools=[so_tool_spec],
-                    tool_choice=json.dumps({"any": {}}),
-                )
-
-            if sr.stop_reason == "max_tokens":
-                raise MaxTokensReachedException("max tokens reached")
-
-            return AgentResult(
-                text="".join(sr.text_parts),
-                stop_reason=sr.stop_reason,
-                usage=sr.usage,
-                metrics=sr.metrics,
-                structured_output=so_result,
-            )
-        finally:
-            self._dispatcher.unregister(so_tool_name)
 
     def __call__(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
         import asyncio
@@ -739,22 +708,22 @@ class Agent:
 
     def structured_output(self, output_model: type, prompt: Any, **kwargs: Any) -> Any:
         """Invoke the agent with structured output validation. Returns the parsed model instance."""
-        result = self(prompt, structured_output_model=output_model, **kwargs)
+        result = self(prompt, structured_output=output_model, **kwargs)
         return result.structured_output if result.structured_output is not None else result
 
     async def structured_output_async(self, output_model: type, prompt: Any, **kwargs: Any) -> Any:
         """Invoke the agent with structured output validation (async). Returns the parsed model instance."""
         if isinstance(prompt, list):
             prompt = json.dumps(prompt)
-        result = await self._call_async(str(prompt), structured_output_model=output_model, **kwargs)
+        result = await self._call_async(str(prompt), structured_output=output_model, **kwargs)
         return result.structured_output if result.structured_output is not None else result
 
     async def stream_async(self, prompt: Any, **kwargs: Any) -> Any:
-        structured_output_model = kwargs.pop("structured_output_model", None)
-        so_model = structured_output_model or self._default_structured_output_model
+        per_invocation_so = kwargs.pop("structured_output", None)
+        so_model = per_invocation_so or self._structured_output_model
 
         if so_model is not None:
-            result = await self._call_async(str(prompt), structured_output_model=so_model)
+            result = await self._call_async(str(prompt), structured_output=so_model)
             yield {"result": result}
             return
 

--- a/strands-py/strands/types/exceptions.py
+++ b/strands-py/strands/types/exceptions.py
@@ -25,3 +25,7 @@ class ToolProviderException(Exception):
 class SessionException(Exception):
     """Raised when session operations fail."""
 
+
+class StructuredOutputError(Exception):
+    """Raised when the model fails to produce valid structured output after force-retry."""
+

--- a/strands-py/tests_integ/test_structured_output_agent_loop.py
+++ b/strands-py/tests_integ/test_structured_output_agent_loop.py
@@ -3,7 +3,7 @@ Comprehensive integration tests for structured output passed into the agent func
 """
 
 import pytest
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from strands import Agent
 from strands.tools import tool
@@ -113,16 +113,9 @@ class Task(BaseModel):
 
 
 class NameWithValidation(BaseModel):
-    """Name model with validation that forces retry."""
+    """Name model with validation that forces retry via JSON schema pattern constraint."""
 
-    first_name: str
-
-    @field_validator("first_name")
-    @classmethod
-    def validate_first_name(cls, value: str) -> str:
-        if not value.endswith("abc"):
-            raise ValueError("You must append 'abc' to the end of my name")
-        return value
+    first_name: str = Field(pattern=r".*abc$", description="Must end with 'abc'")
 
 
 # ========== Tool Definitions ==========
@@ -164,14 +157,14 @@ class TestBasicStructuredOutput:
         result = agent("What can you do for me?")
 
         assert result.structured_output is None
-        assert agent._default_structured_output_model is None
+        assert agent._structured_output_model is None
 
     def test_simple_structured_output(self):
         """Test basic structured output with UserProfile."""
         agent = Agent()
 
         result = agent(
-            "Create a profile for John Doe who is a 25 year old dentist", structured_output_model=UserProfile
+            "Create a profile for John Doe who is a 25 year old dentist", structured_output=UserProfile
         )
 
         assert result.structured_output is not None
@@ -186,7 +179,7 @@ class TestBasicStructuredOutput:
 
         # First call with structured output
         result1 = agent(
-            "Create a profile for John Doe who is a 25 year old dentist", structured_output_model=UserProfile
+            "Create a profile for John Doe who is a 25 year old dentist", structured_output=UserProfile
         )
         assert result1.structured_output is not None
 
@@ -213,7 +206,7 @@ class TestToolUsage:
         """Test tool usage with structured output."""
         agent = Agent(tools=[calculator])
 
-        result = agent("Calculate 2 + 2 using the calculator tool", structured_output_model=MathResult)
+        result = agent("Calculate 2 + 2 using the calculator tool", structured_output=MathResult)
 
         assert result.structured_output is not None
         assert isinstance(result.structured_output, MathResult)
@@ -239,7 +232,7 @@ class TestAsyncOperations:
             is reasonable too. I'd definitely buy it again and recommend it to others.
             Rating: 5 stars"
             """,
-            structured_output_model=ProductReview,
+            structured_output=ProductReview,
         )
 
         assert result.structured_output is not None
@@ -262,7 +255,7 @@ class TestStreamingOperations:
 
         async for event in agent.stream_async(
             "Generate a weather forecast for Seattle: 68°F, partly cloudy, 55% humidity, 8 mph winds, for tomorrow",
-            structured_output_model=WeatherForecast,
+            structured_output=WeatherForecast,
         ):
             if "result" in event:
                 result_found = True
@@ -284,14 +277,14 @@ class TestMultipleInvocations:
         agent = Agent()
 
         # First invocation with Person model
-        person_result = agent("Extract person: John Doe, 35, john@test.com", structured_output_model=Person)
+        person_result = agent("Extract person: John Doe, 35, john@test.com", structured_output=Person)
         assert person_result.structured_output is not None
         assert isinstance(person_result.structured_output, Person)
         assert person_result.structured_output.name == "John Doe"
         assert person_result.structured_output.age == 35
 
         # Second invocation with Task model
-        task_result = agent("Create task: Review code, high priority, completed", structured_output_model=Task)
+        task_result = agent("Create task: Review code, high priority, completed", structured_output=Task)
         assert task_result.structured_output is not None
         assert isinstance(task_result.structured_output, Task)
         assert task_result.structured_output.title == "Review code"
@@ -308,7 +301,7 @@ class TestAgentInitialization:
 
     def test_agent_with_default_structured_output(self):
         """Test agent initialized with default structured output model."""
-        agent = Agent(structured_output_model=UserProfile)
+        agent = Agent(structured_output=UserProfile)
 
         result = agent("Create a profile for John Doe who is a 25 year old dentist")
 
@@ -326,7 +319,7 @@ class TestValidationRetry:
         """Test that validation errors force the model to retry."""
         agent = Agent()
 
-        result = agent("What's Aaron's name?", structured_output_model=NameWithValidation)
+        result = agent("What's Aaron's name?", structured_output=NameWithValidation)
 
         assert result.structured_output is not None
         assert isinstance(result.structured_output, NameWithValidation)

--- a/strands-wasm/docs/python-api-changes.md
+++ b/strands-wasm/docs/python-api-changes.md
@@ -225,3 +225,121 @@ Model config dict format:
     "api_key": "...",            # anthropic, openai, gemini only
 }
 ```
+
+---
+
+## Structured Output
+
+### Overview
+
+Structured output validation runs inside the TypeScript SDK WASM guest using `StructuredOutputTool`. Python sends a flattened JSON schema through the WIT contract. The TS agent loop registers the tool, handles force-retry when the model doesn't call it, validates with Zod, and returns the validated JSON on the stop event. Python instantiates the Pydantic model from the validated JSON.
+
+### 1. Parameter name changed
+
+**TS design:** The TS Agent accepts `structuredOutputSchema` (a Zod schema) on `AgentConfig` and `InvokeOptions`.
+
+```typescript
+// strands-ts/src/types/agent.ts:165
+structuredOutputSchema?: z.ZodSchema
+```
+
+**WASM bridge:** Python sends the JSON schema as a string through `structured-output-schema` on `agent-config` and `stream-args`. `entry.ts` reconstructs a Zod schema via `z.fromJSONSchema()`.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x)
+agent = Agent(structured_output_model=MyModel)
+result = agent("prompt", structured_output_model=MyModel)
+
+# WASM bridged Python SDK (2.x)
+agent = Agent(structured_output=MyModel)
+result = agent("prompt", structured_output=MyModel)
+```
+
+### 2. Tool name is fixed
+
+**TS design:** `StructuredOutputTool` uses a fixed name defined in `strands-ts/src/tools/structured-output-tool.ts:9`:
+
+```typescript
+export const STRUCTURED_OUTPUT_TOOL_NAME = 'strands_structured_output'
+```
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — tool name was the Pydantic model class name
+# Conversation history shows: toolUse name="MyModel"
+
+# WASM bridged Python SDK (2.x) — fixed tool name
+# Conversation history shows: toolUse name="strands_structured_output"
+```
+
+This does not affect user code. The tool name appears in conversation history but users do not reference it directly.
+
+### 3. Force-retry uses toolChoice, not a user message
+
+**TS design:** When the model stops without calling the structured output tool, the TS agent loop sets `toolChoice: { tool: { name: 'strands_structured_output' } }` and continues the loop (`strands-ts/src/agent/agent.ts:771`). No user message is appended.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — customizable force prompt
+agent = Agent()
+result = agent("prompt", structured_output_model=MyModel, structured_output_prompt="Format as MyModel now.")
+
+# WASM bridged Python SDK (2.x) — structured_output_prompt not available
+agent = Agent()
+result = agent("prompt", structured_output=MyModel)
+# Force-retry handled automatically by TS SDK via toolChoice
+```
+
+The TS mechanism is more reliable because it forces the model to call the specific tool rather than relying on a text prompt.
+
+### 4. Validation runs in Zod, instantiation in Pydantic
+
+**TS design:** `StructuredOutputTool.stream()` validates via `this._schema.parse(toolUse.input)` (Zod) at `strands-ts/src/tools/structured-output-tool.ts:59`. On success, returns a `JsonBlock` with the validated data. On error, returns the error message for LLM retry.
+
+**WASM bridge:** The validated JSON returns through `stop-data.structured-output` as a JSON string. Python instantiates the Pydantic model from it: `so_model(**json.loads(json_str))`.
+
+**Python API change:**
+
+```python
+# Both versions — same user experience
+result = agent("Describe a person", structured_output=Person)
+result.structured_output  # Person(name="Alice", age=30) — Pydantic instance
+```
+
+Validation errors from Zod trigger model retry inside the TS guest (the model sees the error message and corrects its output). Custom Pydantic `@field_validator` logic that goes beyond JSON schema constraints cannot be enforced by Zod. Zod validates schema structure; Pydantic adds business logic on instantiation.
+
+### 5. Deprecated method removed
+
+**TS design:** No equivalent to `agent.structured_output(model, prompt)`. Structured output is configured via the constructor or per-invocation options.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x) — deprecated method
+result = agent.structured_output(MyModel, "prompt")
+
+# WASM bridged Python SDK (2.x) — use standard invocation
+result = agent("prompt", structured_output=MyModel)
+# Or via helper method:
+result = agent.structured_output(MyModel, "prompt")  # still available, delegates to above
+```
+
+### 6. Error on force failure
+
+**TS design:** Throws `StructuredOutputError` (`strands-ts/src/errors.ts:203`) with message `"The model failed to invoke the structured output tool even after it was forced."`.
+
+**Python API change:**
+
+```python
+# Standalone Python SDK (1.x)
+from strands.types.exceptions import StructuredOutputException
+
+# WASM bridged Python SDK (2.x)
+from strands.types.exceptions import StructuredOutputError
+```
+
+The exception is raised when the TS SDK's error message is detected in the stream.

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -536,6 +536,16 @@ function createConversationManager(config: AgentConfig): ConversationManager | u
   }
 }
 
+/** Parse a JSON Schema string into a Zod schema for structured output validation. */
+function parseStructuredOutputSchema(jsonStr: string | undefined): z.ZodSchema | undefined {
+  if (!jsonStr) return undefined
+  try {
+    return z.fromJSONSchema(JSON.parse(jsonStr))
+  } catch (e) {
+    throw new Error(`Invalid structured output schema: ${e instanceof Error ? e.message : String(e)}`)
+  }
+}
+
 class AgentImpl {
   private agent: Agent
   private defaultTools: FunctionTool[] | undefined
@@ -556,14 +566,7 @@ class AgentImpl {
     this.sessionManager = createSessionManager(config)
     const conversationManager = createConversationManager(config)
 
-    let structuredOutputSchema: z.ZodSchema | undefined
-    if ((config as any).structuredOutputSchema) {
-      try {
-        structuredOutputSchema = z.fromJSONSchema(JSON.parse((config as any).structuredOutputSchema))
-      } catch (e) {
-        throw new Error(`Invalid structured output schema: ${e instanceof Error ? e.message : String(e)}`)
-      }
-    }
+    const structuredOutputSchema = parseStructuredOutputSchema(config.structuredOutputSchema)
 
     const plugins: Plugin[] = [this.lifecycleBridge]
 
@@ -601,14 +604,7 @@ class AgentImpl {
       this.agent.model = createToolChoiceProxy(originalModel, tc)
     }
 
-    let structuredOutputSchema: z.ZodSchema | undefined
-    if ((args as any).structuredOutputSchema) {
-      try {
-        structuredOutputSchema = z.fromJSONSchema(JSON.parse((args as any).structuredOutputSchema))
-      } catch (e) {
-        throw new Error(`Invalid structured output schema: ${e instanceof Error ? e.message : String(e)}`)
-      }
-    }
+    const structuredOutputSchema = parseStructuredOutputSchema(args.structuredOutputSchema)
 
     return new ResponseStreamImpl(
       this.agent,

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -71,6 +71,7 @@ import {
   BeforeToolCallEvent,
   MessageAddedEvent,
 } from '@strands-agents/sdk'
+import { z } from 'zod'
 
 // All log calls go through `hostLog` (the WIT import).  The host can
 // route them to the host language's logging framework (e.g. Python `logging`).
@@ -134,12 +135,13 @@ function mapStopReasonTag(reason: StopReason): StopData['reason'] {
 /** Convert a TS SDK StopReason to a WIT StopData with usage/metrics. */
 function mapStopReason(
   reason: StopReason,
-  stopData?: { usage?: Partial<Usage>; metrics?: Partial<Metrics> }
+  stopData?: { usage?: Partial<Usage>; metrics?: Partial<Metrics>; structuredOutput?: unknown }
 ): StopData {
   return {
     reason: mapStopReasonTag(reason),
     usage: mapUsage(stopData?.usage),
     metrics: mapMetrics(stopData?.metrics),
+    structuredOutput: stopData?.structuredOutput !== undefined ? JSON.stringify(stopData.structuredOutput) : undefined,
   }
 }
 
@@ -554,6 +556,15 @@ class AgentImpl {
     this.sessionManager = createSessionManager(config)
     const conversationManager = createConversationManager(config)
 
+    let structuredOutputSchema: z.ZodSchema | undefined
+    if ((config as any).structuredOutputSchema) {
+      try {
+        structuredOutputSchema = z.fromJSONSchema(JSON.parse((config as any).structuredOutputSchema))
+      } catch (e) {
+        throw new Error(`Invalid structured output schema: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+
     const plugins: Plugin[] = [this.lifecycleBridge]
 
     this.agent = new Agent({
@@ -563,6 +574,7 @@ class AgentImpl {
       plugins,
       sessionManager: this.sessionManager,
       conversationManager,
+      structuredOutputSchema,
       printer: false,
     })
   }
@@ -589,7 +601,23 @@ class AgentImpl {
       this.agent.model = createToolChoiceProxy(originalModel, tc)
     }
 
-    return new ResponseStreamImpl(this.agent, args.input, this.lifecycleBridge, this.defaultTools, originalModel)
+    let structuredOutputSchema: z.ZodSchema | undefined
+    if ((args as any).structuredOutputSchema) {
+      try {
+        structuredOutputSchema = z.fromJSONSchema(JSON.parse((args as any).structuredOutputSchema))
+      } catch (e) {
+        throw new Error(`Invalid structured output schema: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+
+    return new ResponseStreamImpl(
+      this.agent,
+      args.input,
+      this.lifecycleBridge,
+      this.defaultTools,
+      originalModel,
+      structuredOutputSchema
+    )
   }
 
   getMessages(): string {
@@ -634,13 +662,16 @@ class ResponseStreamImpl {
     input: string,
     bridge: LifecycleBridge,
     defaultTools?: FunctionTool[],
-    originalModel?: Model<BaseModelConfig>
+    originalModel?: Model<BaseModelConfig>,
+    structuredOutputSchema?: z.ZodSchema
   ) {
     this.agent = agent
     this.bridge = bridge
     this.defaultTools = defaultTools
     this.originalModel = originalModel
-    this.generator = agent.stream(parseInput(input))
+    this.generator = agent.stream(parseInput(input), {
+      structuredOutputSchema,
+    })
   }
 
   private restoreDefaults(): void {
@@ -672,6 +703,7 @@ class ResponseStreamImpl {
               val: mapStopReason(agentResult.stopReason, {
                 usage: agentResult.metrics?.accumulatedUsage,
                 metrics: agentResult.metrics?.accumulatedMetrics,
+                structuredOutput: agentResult.structuredOutput,
               }),
             },
           ]

--- a/strands-wasm/package.json
+++ b/strands-wasm/package.json
@@ -15,7 +15,8 @@
     "clean": "rm -rf dist node_modules package-lock.json"
   },
   "dependencies": {
-    "@strands-agents/sdk": "*"
+    "@strands-agents/sdk": "*",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@bytecodealliance/jco": "^1.16.1",

--- a/wit/agent.wit
+++ b/wit/agent.wit
@@ -61,6 +61,8 @@ interface types {
     reason: stop-reason,
     usage: option<usage>,
     metrics: option<metrics>,
+    /// JSON-serialized structured output from the agent, if a schema was provided.
+    structured-output: option<string>,
   }
 
   /// Hook event types fired during the agent loop.
@@ -192,6 +194,8 @@ interface types {
     trace-context: option<string>,
     session: option<session-config>,
     conversation-manager: option<conversation-manager-config>,
+    /// JSON-serialized JSON Schema for structured output validation.
+    structured-output-schema: option<string>,
   }
 
   /// Arguments for a single tool call from guest to host.
@@ -211,6 +215,8 @@ interface types {
     input: string,
     tools: option<list<tool-spec>>,
     tool-choice: option<string>,
+    /// Per-invocation JSON Schema for structured output. Overrides agent-config schema.
+    structured-output-schema: option<string>,
   }
 
   /// Payload for responding to an interrupt.


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The WASM bridge had no structured output support. Python users could not pass a Pydantic model to  
  the Agent and receive validated structured output powered by the TS SDK. The TS SDK already has a
  complete structured output implementation (`StructuredOutputTool` with Zod validation, force-retry 
  via `toolChoice`, and result extraction) running inside the agent loop, The change in this bridges it
  through WASM so Python users can use it.


## Public API Changes

  Python users can now pass a `structured_output` parameter to `Agent`:                              
   
  ```python                                                                                          
  from pydantic import BaseModel, Field
  from strands import Agent                                                                          
                                                                                                     
  class Person(BaseModel):                                                                           
      name: str = Field(description="Full name")                                                     
      age: int = Field(ge=0, le=150)                                                                 
                                                                                                     
  # Per-invocation                                                                                   
  agent = Agent()                                                                                    
  result = agent("Describe John who is 30", structured_output=Person)                                
  result.structured_output  # Person(name="John", age=30)                                            
                                                                                                     
  # Constructor-level (applies to every invocation)                                                  
  agent = Agent(structured_output=Person)                                                            
  result = agent("Describe Jane who is 25")                                                          
  result.structured_output  # Person(name="Jane", age=25)
```                                            
## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/2502

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->


New feature
Breaking change

## Testing

How have you tested the change?

- [ ] I ran `npm run check`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
