### PR TITLE
fix(wasm): mapEvent interrupt guard, broken test imports

### DIFF
--- a/strands-wasm/__tests__/lifecycle.test.ts
+++ b/strands-wasm/__tests__/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { LifecycleBridge } from '../../entry'
+import { LifecycleBridge } from '../entry'
 import { Agent, FunctionTool } from '@strands-agents/sdk'
 import { MockMessageModel } from '$/fixtures/mock-message-model'
 

--- a/strands-wasm/__tests__/mapping.test.ts
+++ b/strands-wasm/__tests__/mapping.test.ts
@@ -10,7 +10,7 @@ import {
   mapToolStreamEvent,
   parseInput,
   parseSaveLatestStrategy,
-} from '../../entry'
+} from '../entry'
 import type { AgentStreamEvent, ModelStreamEvent, StopReason } from '@strands-agents/sdk'
 import { ToolStreamEvent, ToolUseBlock, ToolResultBlock, TextBlock, ReasoningBlock } from '@strands-agents/sdk'
 
@@ -333,6 +333,11 @@ describe('mapEvent', () => {
         tag: 'interrupt',
         val: JSON.stringify(event),
       })
+    })
+
+    it('does not treat hook events with interrupt() method as interrupt stream events', () => {
+      const event = { type: 'beforeToolCallEvent', interrupt: () => {} }
+      expect(mapEvent(event as unknown as AgentStreamEvent)).toBeNull()
     })
   })
 

--- a/strands-wasm/__tests__/stream.test.ts
+++ b/strands-wasm/__tests__/stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { api, LifecycleBridge } from '../../entry'
+import { api, LifecycleBridge } from '../entry'
 import { Agent } from '@strands-agents/sdk'
 import { MockMessageModel } from '$/fixtures/mock-message-model'
 

--- a/strands-wasm/__tests__/tool-bridge.test.ts
+++ b/strands-wasm/__tests__/tool-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createTools } from '../../entry'
+import { createTools } from '../entry'
 import { callTool } from 'strands:agent/tool-provider'
 
 const emptyToolContext = { toolUse: { toolUseId: '' } } as any

--- a/strands-wasm/entry.ts
+++ b/strands-wasm/entry.ts
@@ -145,7 +145,7 @@ function mapStopReason(
 
 /** Convert a TS SDK AgentStreamEvent to a WIT StreamEvent for the host. */
 function mapEvent(event: AgentStreamEvent): StreamEvent | null {
-  if ('interrupt' in event) {
+  if ('interrupt' in event && typeof (event as unknown as Record<string, unknown>).interrupt !== 'function') {
     return { tag: 'interrupt', val: JSON.stringify(event) }
   }
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Fix 2 issues causing build checks to fail:

- Tighten the 'interrupt' in event guard in mapEvent to exclude hook events (BeforeToolCallEvent, BeforeToolsEvent) that now implement Interruptible after PR #784, causing them to be falsely caught before reaching the switch and making their cases unreachable (TS2678)
- Update broken import paths in wasm unit tests: ../../entry -> ../entry

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
