### PR TITLE
fix(wasm): fix broken unit tests and enable in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:all:coverage
 
+      - name: Run WASM unit tests
+        run: npm run test -w strands-wasm
+
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/strands-wasm/__tests__/lifecycle.test.ts
+++ b/strands-wasm/__tests__/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { LifecycleBridge } from '../../entry'
+import { LifecycleBridge } from '../entry'
 import { Agent, FunctionTool } from '@strands-agents/sdk'
 import { MockMessageModel } from '$/fixtures/mock-message-model'
 

--- a/strands-wasm/__tests__/mapping.test.ts
+++ b/strands-wasm/__tests__/mapping.test.ts
@@ -10,7 +10,7 @@ import {
   mapToolStreamEvent,
   parseInput,
   parseSaveLatestStrategy,
-} from '../../entry'
+} from '../entry'
 import type { AgentStreamEvent, ModelStreamEvent, StopReason } from '@strands-agents/sdk'
 import { ToolStreamEvent, ToolUseBlock, ToolResultBlock, TextBlock, ReasoningBlock } from '@strands-agents/sdk'
 
@@ -120,6 +120,7 @@ describe('mapStopReason', () => {
       reason: 'end-turn',
       usage: undefined,
       metrics: undefined,
+      structuredOutput: undefined,
     })
   })
 
@@ -139,6 +140,7 @@ describe('mapStopReason', () => {
         cacheWriteInputTokens: undefined,
       },
       metrics: { latencyMs: 100 },
+      structuredOutput: undefined,
     })
   })
 })

--- a/strands-wasm/__tests__/stream.test.ts
+++ b/strands-wasm/__tests__/stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { api, LifecycleBridge } from '../../entry'
+import { api, LifecycleBridge } from '../entry'
 import { Agent } from '@strands-agents/sdk'
 import { MockMessageModel } from '$/fixtures/mock-message-model'
 
@@ -83,6 +83,7 @@ describe('ResponseStreamImpl.readNext', () => {
               cacheWriteInputTokens: undefined,
             },
             metrics: { latencyMs: 100 },
+            structuredOutput: undefined,
           },
         },
       ])

--- a/strands-wasm/__tests__/tool-bridge.test.ts
+++ b/strands-wasm/__tests__/tool-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createTools } from '../../entry'
+import { createTools } from '../entry'
 import { callTool } from 'strands:agent/tool-provider'
 
 const emptyToolContext = { toolUse: { toolUseId: '' } } as any


### PR DESCRIPTION
## Summary

- Fix import paths in WASM unit tests (`../../entry` → `../entry`)
- Update assertions for `structuredOutput` field added in #1000
- Add WASM unit test step to CI test workflow