### PR TITLE
feat: add timeouts to graph/swarm; bedrock request timeout

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,6 +20,7 @@ All test fixtures are located in `src/__fixtures__/`. Use these helpers to reduc
 | `createMockContext()`  | `tool-helpers.ts`       | Create mock `ToolContext` for testing tool implementations directly                  | [Tool Fixtures](#tool-fixtures-tool-helpersts)                              |
 | `createMockAgent()`    | `agent-helpers.ts`      | Create minimal mock Agent with messages and state                                    | [Agent Fixtures](#agent-fixtures-agent-helpersts)                           |
 | `expectAgentResult()`  | `agent-helpers.ts`      | Assert on `AgentResult` with expected stop reason, message text, cycle count, and traces | [Agent Fixtures](#agent-fixtures-agent-helpersts)                           |
+| `createCancellableAgent()` | `agent-helpers.ts`  | Create a minimal `InvokableAgent` that sleeps for a configurable delay and aborts early when its `cancelSignal` fires — used for timeout/cancellation tests | [Agent Fixtures](#agent-fixtures-agent-helpersts)                           |
 | `isNode` / `isBrowser` | `environment.ts`        | Environment detection for conditional test execution                                 | [Environment Fixtures](#environment-fixtures-environmentts)                 |
 | `MockSpan`             | `mock-span.ts`          | Mock OTEL Span that records all setAttribute/addEvent/end calls for assertion            | [Telemetry Fixtures](#telemetry-fixtures-mock-spants-mock-meterts)          |
 | `eventAttr()`          | `mock-span.ts`          | Extract a string attribute from a mock span event                                        | [Telemetry Fixtures](#telemetry-fixtures-mock-spants-mock-meterts)          |
@@ -538,6 +539,18 @@ expect(result).toEqual(
 - `traceCount` (optional) - Expected exact number of traces. When omitted, validates at least one trace exists
 - `toolNames` (optional) - Expected tool names that were invoked
 - `usage` (optional) - Expected token usage. When omitted, validates shape with `expect.any(Number)`
+
+- **`createCancellableAgent(id, delayMs, structuredOutput?)`** - Creates a minimal `InvokableAgent` that sleeps for `delayMs` before resolving, aborting the sleep early when the invocation's `cancelSignal` fires. Use for exercising timeout and cancellation behavior in multi-agent orchestrators (swarm, graph) without standing up a full Agent.
+
+```typescript
+import { createCancellableAgent } from '../__fixtures__/agent-helpers'
+
+// Plain slow agent for a nodeTimeout test
+const slow = createCancellableAgent('slow', 100)
+
+// With a swarm handoff as structured output
+const handoffAgent = createCancellableAgent('a', 30, { agentId: 'b', message: 'to b' })
+```
 
 ### Environment Fixtures (`environment.ts`)
 

--- a/strands-ts/eslint.config.js
+++ b/strands-ts/eslint.config.js
@@ -53,6 +53,8 @@ function sdkRules(options) {
       globals: {
         console: 'readonly',
         process: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
       },
     },
     plugins: {
@@ -86,6 +88,8 @@ function unitTestRules(options) {
         window: 'readonly',
         document: 'readonly',
         navigator: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
       },
     },
     plugins: {

--- a/strands-ts/src/__fixtures__/agent-helpers.ts
+++ b/strands-ts/src/__fixtures__/agent-helpers.ts
@@ -191,16 +191,17 @@ export function expectAgentResult(options: AgentResultMatcher): AgentResult {
 }
 
 /**
- * Creates a minimal InvokableAgent that sleeps for `delayMs` before resolving.
- * Respects `cancelSignal` by aborting the sleep early. Used to exercise timeout
- * behavior deterministically without spinning up a full Agent.
+ * Creates a minimal InvokableAgent that sleeps for `delayMs` before resolving,
+ * aborting the sleep early when the invocation's `cancelSignal` fires. Used to
+ * exercise timeout and cancellation behavior deterministically without spinning
+ * up a full Agent.
  *
  * @param id - The agent id
  * @param delayMs - How long the agent should sleep before returning
  * @param structuredOutput - Optional structured output (e.g. a swarm handoff). When present,
  *   its `message` field is used as the assistant text.
  */
-export function createSlowAgent(
+export function createCancellableAgent(
   id: string,
   delayMs: number,
   structuredOutput: { agentId?: string; message: string } = { message: 'done' }

--- a/strands-ts/src/__fixtures__/agent-helpers.ts
+++ b/strands-ts/src/__fixtures__/agent-helpers.ts
@@ -5,14 +5,14 @@
 
 import { expect } from 'vitest'
 import type { Agent } from '../agent/agent.js'
-import type { AgentResult } from '../types/agent.js'
+import type { AgentResult, InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
 import type { StopReason } from '../types/messages.js'
 import { Message, TextBlock } from '../types/messages.js'
 import type { Role } from '../types/messages.js'
 import { StateStore } from '../state-store.js'
 import type { JSONValue } from '../types/json.js'
 import { ToolRegistry } from '../registry/tool-registry.js'
-import type { HookableEvent } from '../hooks/events.js'
+import type { HookableEvent, StreamEvent } from '../hooks/events.js'
 import type { HookableEventConstructor, HookCallback } from '../hooks/types.js'
 import { expectLoopMetrics, type LoopMetricsMatcher } from './metrics-helpers.js'
 
@@ -188,4 +188,50 @@ export function expectAgentResult(options: AgentResultMatcher): AgentResult {
     traces: expectedTraces,
     invocationState: invocationState ?? expect.any(Object),
   }) as AgentResult
+}
+
+/**
+ * Creates a minimal InvokableAgent that sleeps for `delayMs` before resolving.
+ * Respects `cancelSignal` by aborting the sleep early. Used to exercise timeout
+ * behavior deterministically without spinning up a full Agent.
+ *
+ * @param id - The agent id
+ * @param delayMs - How long the agent should sleep before returning
+ * @param structuredOutput - Optional structured output (e.g. a swarm handoff). When present,
+ *   its `message` field is used as the assistant text.
+ */
+export function createSlowAgent(
+  id: string,
+  delayMs: number,
+  structuredOutput: { agentId?: string; message: string } = { message: 'done' }
+): InvokableAgent {
+  const sleep = (signal?: AbortSignal): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, delayMs)
+      if (signal) {
+        const onAbort = (): void => {
+          clearTimeout(timer)
+          reject(new Error('cancelled'))
+        }
+        if (signal.aborted) onAbort()
+        else signal.addEventListener('abort', onAbort, { once: true })
+      }
+    })
+
+  return {
+    id,
+    description: `Agent ${id}`,
+    async invoke(_args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+      await sleep(options?.cancelSignal)
+      return {
+        stopReason: 'endTurn',
+        lastMessage: { role: 'assistant', content: [new TextBlock(structuredOutput.message)] },
+        structuredOutput,
+      } as AgentResult
+    },
+    // eslint-disable-next-line require-yield
+    async *stream(args: InvokeArgs, options?: InvokeOptions): AsyncGenerator<StreamEvent, AgentResult, undefined> {
+      return await this.invoke(args, options)
+    },
+  }
 }

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -218,6 +218,7 @@ describe('BedrockModel', () => {
       expect(BedrockRuntimeClient).toHaveBeenCalledWith({
         region: customRegion,
         customUserAgent: 'strands-agents-ts-sdk',
+        requestHandler: { requestTimeout: 120_000 },
       })
     })
 
@@ -227,6 +228,7 @@ describe('BedrockModel', () => {
       expect(BedrockRuntimeClient).toHaveBeenCalledWith({
         region: 'us-west-2',
         customUserAgent: 'my-app/1.0 strands-agents-ts-sdk',
+        requestHandler: { requestTimeout: 120_000 },
       })
     })
 
@@ -238,6 +240,7 @@ describe('BedrockModel', () => {
         region,
         endpoint,
         customUserAgent: 'strands-agents-ts-sdk',
+        requestHandler: { requestTimeout: 120_000 },
       })
     })
 
@@ -252,7 +255,35 @@ describe('BedrockModel', () => {
         region,
         credentials,
         customUserAgent: 'strands-agents-ts-sdk',
+        requestHandler: { requestTimeout: 120_000 },
       })
+    })
+
+    it('applies a default 120s request timeout', () => {
+      new BedrockModel({ region: 'us-west-2' })
+      expect(BedrockRuntimeClient).toHaveBeenCalledWith(
+        expect.objectContaining({ requestHandler: { requestTimeout: 120_000 } })
+      )
+    })
+
+    it('lets the caller override requestTimeout', () => {
+      new BedrockModel({ region: 'us-west-2', clientConfig: { requestHandler: { requestTimeout: 5_000 } } })
+      expect(BedrockRuntimeClient).toHaveBeenCalledWith(
+        expect.objectContaining({ requestHandler: { requestTimeout: 5_000 } })
+      )
+    })
+
+    it('merges the default timeout with other requestHandler options', () => {
+      new BedrockModel({ region: 'us-west-2', clientConfig: { requestHandler: { connectionTimeout: 1_000 } } })
+      expect(BedrockRuntimeClient).toHaveBeenCalledWith(
+        expect.objectContaining({ requestHandler: { requestTimeout: 120_000, connectionTimeout: 1_000 } })
+      )
+    })
+
+    it('passes a user-provided handler instance through untouched', () => {
+      const handler = { handle: vi.fn(), updateHttpClientConfig: vi.fn(), httpHandlerConfigs: vi.fn() }
+      new BedrockModel({ region: 'us-west-2', clientConfig: { requestHandler: handler } })
+      expect(BedrockRuntimeClient).toHaveBeenCalledWith(expect.objectContaining({ requestHandler: handler }))
     })
 
     it('adds api key middleware when apiKey is provided', () => {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -1660,7 +1660,9 @@ function withDefaultRequestTimeout(
     return handler
   }
   const options = (handler ?? {}) as { requestTimeout?: number; [key: string]: unknown }
-  return { requestTimeout: DEFAULT_REQUEST_TIMEOUT_MS, ...options }
+  // Use `??` rather than spread order so an explicit `requestTimeout: undefined` still gets
+  // the default (spread would otherwise overwrite the default with `undefined`, disabling it).
+  return { ...options, requestTimeout: options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS }
 }
 
 /**

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -65,6 +65,13 @@ import { MODEL_DEFAULTS, defaultModelWarningMessage } from './defaults.js'
 const DEFAULT_BEDROCK_REGION_SUPPORTS_FIP = false
 
 /**
+ * Default request timeout in milliseconds. The AWS SDK defaults to 0 (disabled), which lets
+ * a stuck connection hang indefinitely — we pick 120s to bound that. Callers can override
+ * via `clientConfig.requestHandler.requestTimeout`.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000
+
+/**
  * Models that require the status field in tool results.
  * According to AWS Bedrock API documentation, the status field is only supported by Anthropic Claude models.
  * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
@@ -376,9 +383,9 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       ? `${clientConfig.customUserAgent} strands-agents-ts-sdk`
       : 'strands-agents-ts-sdk'
 
-    // Initialize Bedrock Runtime client with custom user agent
     this._client = new BedrockRuntimeClient({
       ...(clientConfig ?? {}),
+      requestHandler: withDefaultRequestTimeout(clientConfig?.requestHandler),
       // region takes precedence over clientConfig
       ...(region ? { region: region } : {}),
       customUserAgent,
@@ -1633,6 +1640,27 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
     return events
   }
+}
+
+/**
+ * Merges a default request timeout into the caller's requestHandler options.
+ *
+ * The SDK's `requestHandler` slot accepts either a constructed handler instance
+ * or an options bag that the SDK uses to build its default handler. We only
+ * inject a default in the options-bag case: a handler instance has its timeouts
+ * baked in at construction time, so we pass it through untouched.
+ *
+ * The handler-vs-options discriminator mirrors the SDK's own check — see
+ * `NodeHttp2Handler.create` in `@smithy/node-http-handler`.
+ */
+function withDefaultRequestTimeout(
+  handler: BedrockRuntimeClientConfig['requestHandler']
+): NonNullable<BedrockRuntimeClientConfig['requestHandler']> {
+  if (handler && typeof (handler as { handle?: unknown }).handle === 'function') {
+    return handler
+  }
+  const options = (handler ?? {}) as { requestTimeout?: number; [key: string]: unknown }
+  return { requestTimeout: DEFAULT_REQUEST_TIMEOUT_MS, ...options }
 }
 
 /**

--- a/strands-ts/src/multiagent/__tests__/graph.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.test.ts
@@ -9,10 +9,46 @@ import { Status, MultiAgentState } from '../state.js'
 import { AgentNode, MultiAgentNode } from '../nodes.js'
 import { Graph } from '../graph.js'
 import { SessionManager } from '../../session/session-manager.js'
+import type { AgentResult, InvokableAgent, InvokeArgs, InvokeOptions } from '../../types/agent.js'
+import type { StreamEvent } from '../../hooks/events.js'
 
 function makeAgent(id: string, text = 'reply'): Agent {
   const model = new MockMessageModel().addTurn(new TextBlock(text))
   return new Agent({ model, printer: false, id })
+}
+
+/**
+ * InvokableAgent that sleeps for `delayMs` and respects `cancelSignal` — used to
+ * exercise timeout behavior deterministically.
+ */
+function makeSlowAgent(id: string, delayMs: number, text: string = 'done'): InvokableAgent {
+  const sleep = (signal?: AbortSignal): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, delayMs)
+      if (signal) {
+        const onAbort = (): void => {
+          clearTimeout(timer)
+          reject(new Error('cancelled'))
+        }
+        if (signal.aborted) onAbort()
+        else signal.addEventListener('abort', onAbort, { once: true })
+      }
+    })
+  return {
+    id,
+    description: `Agent ${id}`,
+    async invoke(_args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+      await sleep(options?.cancelSignal)
+      return {
+        stopReason: 'endTurn',
+        lastMessage: { role: 'assistant', content: [new TextBlock(text)] },
+      } as AgentResult
+    },
+    // eslint-disable-next-line require-yield
+    async *stream(args: InvokeArgs, options?: InvokeOptions): AsyncGenerator<StreamEvent, AgentResult, undefined> {
+      return await this.invoke(args, options)
+    },
+  }
 }
 
 describe('Graph', () => {
@@ -168,6 +204,39 @@ describe('Graph', () => {
             maxConcurrency: 0,
           })
       ).toThrow('max_concurrency=<0> | must be at least 1')
+    })
+
+    it('defaults maxConcurrency, maxSteps, timeout, and nodeTimeout to Infinity', () => {
+      const graph = new Graph({
+        nodes: [makeAgent('a')],
+        edges: [],
+      })
+      expect(graph.config.maxConcurrency).toBe(Infinity)
+      expect(graph.config.maxSteps).toBe(Infinity)
+      expect(graph.config.timeout).toBe(Infinity)
+      expect(graph.config.nodeTimeout).toBe(Infinity)
+    })
+
+    it('throws when timeout < 1', () => {
+      expect(
+        () =>
+          new Graph({
+            nodes: [makeAgent('a')],
+            edges: [],
+            timeout: 0,
+          })
+      ).toThrow('timeout=<0> | must be at least 1')
+    })
+
+    it('throws when nodeTimeout < 1', () => {
+      expect(
+        () =>
+          new Graph({
+            nodes: [makeAgent('a')],
+            edges: [],
+            nodeTimeout: 0,
+          })
+      ).toThrow('node_timeout=<0> | must be at least 1')
     })
   })
 
@@ -409,6 +478,60 @@ describe('Graph', () => {
       })
 
       await expect(graph.invoke('go')).rejects.toThrow('max steps reached')
+    })
+
+    it('throws when a node exceeds nodeTimeout', async () => {
+      const graph = new Graph({
+        nodes: [{ agent: makeSlowAgent('slow', 100) }],
+        edges: [],
+        nodeTimeout: 20,
+      })
+
+      await expect(graph.invoke('go')).rejects.toThrow(/node_timeout=<20>, node_id=<slow>/)
+    })
+
+    it('applies per-node timeout over nodeTimeout', async () => {
+      const graph = new Graph({
+        nodes: [{ agent: makeSlowAgent('slow', 100), timeout: 15 }],
+        edges: [],
+        nodeTimeout: 10_000,
+      })
+
+      await expect(graph.invoke('go')).rejects.toThrow(/node_timeout=<15>, node_id=<slow>/)
+    })
+
+    it('does not throw when nodeTimeout is Infinity', async () => {
+      const graph = new Graph({
+        nodes: [{ agent: makeSlowAgent('a', 20) }],
+        edges: [],
+        nodeTimeout: Infinity,
+      })
+
+      const result = await graph.invoke('go')
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]?.status).toBe(Status.COMPLETED)
+    })
+
+    it('per-node timeout of Infinity disables a finite nodeTimeout', async () => {
+      const graph = new Graph({
+        nodes: [{ agent: makeSlowAgent('slow', 30), timeout: Infinity }],
+        edges: [],
+        nodeTimeout: 10,
+      })
+
+      const result = await graph.invoke('go')
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]?.status).toBe(Status.COMPLETED)
+    })
+
+    it('throws when timeout is exceeded', async () => {
+      const graph = new Graph({
+        nodes: [{ agent: makeSlowAgent('a', 30) }, { agent: makeSlowAgent('b', 30) }],
+        edges: [['a', 'b']],
+        timeout: 20,
+      })
+
+      await expect(graph.invoke('go')).rejects.toThrow(/timeout=<20>/)
     })
 
     it('calls initialize only once across invocations', async () => {

--- a/strands-ts/src/multiagent/__tests__/graph.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.test.ts
@@ -3,7 +3,7 @@ import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { MockSnapshotStorage } from '../../__fixtures__/mock-storage-provider.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
-import { createSlowAgent } from '../../__fixtures__/agent-helpers.js'
+import { createCancellableAgent } from '../../__fixtures__/agent-helpers.js'
 import { AfterNodeCallEvent, BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import { TextBlock, type ContentBlockData } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
@@ -447,7 +447,7 @@ describe('Graph', () => {
 
     it('throws when a node exceeds nodeTimeout', async () => {
       const graph = new Graph({
-        nodes: [{ agent: createSlowAgent('slow', 100) }],
+        nodes: [{ agent: createCancellableAgent('slow', 100) }],
         edges: [],
         nodeTimeout: 20,
       })
@@ -457,7 +457,7 @@ describe('Graph', () => {
 
     it('applies per-node timeout over nodeTimeout', async () => {
       const graph = new Graph({
-        nodes: [{ agent: createSlowAgent('slow', 100), timeout: 15 }],
+        nodes: [{ agent: createCancellableAgent('slow', 100), timeout: 15 }],
         edges: [],
         nodeTimeout: 10_000,
       })
@@ -467,7 +467,7 @@ describe('Graph', () => {
 
     it('does not throw when nodeTimeout is Infinity', async () => {
       const graph = new Graph({
-        nodes: [{ agent: createSlowAgent('a', 20) }],
+        nodes: [{ agent: createCancellableAgent('a', 20) }],
         edges: [],
         nodeTimeout: Infinity,
       })
@@ -479,7 +479,7 @@ describe('Graph', () => {
 
     it('per-node timeout of Infinity disables a finite nodeTimeout', async () => {
       const graph = new Graph({
-        nodes: [{ agent: createSlowAgent('slow', 30), timeout: Infinity }],
+        nodes: [{ agent: createCancellableAgent('slow', 30), timeout: Infinity }],
         edges: [],
         nodeTimeout: 10,
       })
@@ -491,7 +491,7 @@ describe('Graph', () => {
 
     it('throws when timeout is exceeded', async () => {
       const graph = new Graph({
-        nodes: [{ agent: createSlowAgent('a', 30) }, { agent: createSlowAgent('b', 30) }],
+        nodes: [{ agent: createCancellableAgent('a', 30) }, { agent: createCancellableAgent('b', 30) }],
         edges: [['a', 'b']],
         timeout: 20,
       })

--- a/strands-ts/src/multiagent/__tests__/graph.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.test.ts
@@ -3,52 +3,17 @@ import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { MockSnapshotStorage } from '../../__fixtures__/mock-storage-provider.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import { createSlowAgent } from '../../__fixtures__/agent-helpers.js'
 import { AfterNodeCallEvent, BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import { TextBlock, type ContentBlockData } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
 import { AgentNode, MultiAgentNode } from '../nodes.js'
 import { Graph } from '../graph.js'
 import { SessionManager } from '../../session/session-manager.js'
-import type { AgentResult, InvokableAgent, InvokeArgs, InvokeOptions } from '../../types/agent.js'
-import type { StreamEvent } from '../../hooks/events.js'
 
 function makeAgent(id: string, text = 'reply'): Agent {
   const model = new MockMessageModel().addTurn(new TextBlock(text))
   return new Agent({ model, printer: false, id })
-}
-
-/**
- * InvokableAgent that sleeps for `delayMs` and respects `cancelSignal` — used to
- * exercise timeout behavior deterministically.
- */
-function makeSlowAgent(id: string, delayMs: number, text: string = 'done'): InvokableAgent {
-  const sleep = (signal?: AbortSignal): Promise<void> =>
-    new Promise((resolve, reject) => {
-      const timer = setTimeout(resolve, delayMs)
-      if (signal) {
-        const onAbort = (): void => {
-          clearTimeout(timer)
-          reject(new Error('cancelled'))
-        }
-        if (signal.aborted) onAbort()
-        else signal.addEventListener('abort', onAbort, { once: true })
-      }
-    })
-  return {
-    id,
-    description: `Agent ${id}`,
-    async invoke(_args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
-      await sleep(options?.cancelSignal)
-      return {
-        stopReason: 'endTurn',
-        lastMessage: { role: 'assistant', content: [new TextBlock(text)] },
-      } as AgentResult
-    },
-    // eslint-disable-next-line require-yield
-    async *stream(args: InvokeArgs, options?: InvokeOptions): AsyncGenerator<StreamEvent, AgentResult, undefined> {
-      return await this.invoke(args, options)
-    },
-  }
 }
 
 describe('Graph', () => {
@@ -482,7 +447,7 @@ describe('Graph', () => {
 
     it('throws when a node exceeds nodeTimeout', async () => {
       const graph = new Graph({
-        nodes: [{ agent: makeSlowAgent('slow', 100) }],
+        nodes: [{ agent: createSlowAgent('slow', 100) }],
         edges: [],
         nodeTimeout: 20,
       })
@@ -492,7 +457,7 @@ describe('Graph', () => {
 
     it('applies per-node timeout over nodeTimeout', async () => {
       const graph = new Graph({
-        nodes: [{ agent: makeSlowAgent('slow', 100), timeout: 15 }],
+        nodes: [{ agent: createSlowAgent('slow', 100), timeout: 15 }],
         edges: [],
         nodeTimeout: 10_000,
       })
@@ -502,7 +467,7 @@ describe('Graph', () => {
 
     it('does not throw when nodeTimeout is Infinity', async () => {
       const graph = new Graph({
-        nodes: [{ agent: makeSlowAgent('a', 20) }],
+        nodes: [{ agent: createSlowAgent('a', 20) }],
         edges: [],
         nodeTimeout: Infinity,
       })
@@ -514,7 +479,7 @@ describe('Graph', () => {
 
     it('per-node timeout of Infinity disables a finite nodeTimeout', async () => {
       const graph = new Graph({
-        nodes: [{ agent: makeSlowAgent('slow', 30), timeout: Infinity }],
+        nodes: [{ agent: createSlowAgent('slow', 30), timeout: Infinity }],
         edges: [],
         nodeTimeout: 10,
       })
@@ -526,7 +491,7 @@ describe('Graph', () => {
 
     it('throws when timeout is exceeded', async () => {
       const graph = new Graph({
-        nodes: [{ agent: makeSlowAgent('a', 30) }, { agent: makeSlowAgent('b', 30) }],
+        nodes: [{ agent: createSlowAgent('a', 30) }, { agent: createSlowAgent('b', 30) }],
         edges: [['a', 'b']],
         timeout: 20,
       })

--- a/strands-ts/src/multiagent/__tests__/nodes.test.ts
+++ b/strands-ts/src/multiagent/__tests__/nodes.test.ts
@@ -118,6 +118,22 @@ describe('AgentNode', () => {
     state = new MultiAgentState({ nodeIds: ['agent-1'] })
   })
 
+  describe('constructor', () => {
+    it('throws when timeout < 1', () => {
+      expect(() => new AgentNode({ agent, timeout: 0 })).toThrow('timeout=<0>, node_id=<agent-1> | must be at least 1')
+    })
+
+    it('accepts a positive timeout', () => {
+      const timedNode = new AgentNode({ agent, timeout: 5_000 })
+      expect(timedNode.timeout).toBe(5_000)
+    })
+
+    it('accepts Infinity as an explicit opt-out', () => {
+      const timedNode = new AgentNode({ agent, timeout: Infinity })
+      expect(timedNode.timeout).toBe(Infinity)
+    })
+  })
+
   describe('handle', () => {
     it('wraps agent events and returns content', async () => {
       const { items, result } = await collectGenerator(node.stream([new TextBlock('prompt')], state))

--- a/strands-ts/src/multiagent/__tests__/swarm.test.ts
+++ b/strands-ts/src/multiagent/__tests__/swarm.test.ts
@@ -4,6 +4,8 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import type { JSONValue } from '../../types/json.js'
+import type { AgentResult, InvokableAgent, InvokeArgs, InvokeOptions } from '../../types/agent.js'
+import type { StreamEvent } from '../../hooks/events.js'
 import { TextBlock } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
 import { AgentNode } from '../nodes.js'
@@ -34,6 +36,46 @@ function createHandoffAgent(
  */
 function createFinalAgent(agentId: string, message: string, description: string = `Agent ${agentId}`): Agent {
   return createHandoffAgent(agentId, { message }, description)
+}
+
+/**
+ * Custom InvokableAgent that sleeps for `delayMs` before resolving. Respects `cancelSignal`
+ * by aborting the sleep early. Used to exercise timeout behavior deterministically.
+ */
+function createSlowAgent(
+  agentId: string,
+  delayMs: number,
+  handoff: { agentId?: string; message: string } = { message: 'done' }
+): InvokableAgent {
+  const sleep = (signal?: AbortSignal): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, delayMs)
+      if (signal) {
+        const onAbort = (): void => {
+          clearTimeout(timer)
+          reject(new Error('cancelled'))
+        }
+        if (signal.aborted) onAbort()
+        else signal.addEventListener('abort', onAbort, { once: true })
+      }
+    })
+
+  return {
+    id: agentId,
+    description: `Agent ${agentId}`,
+    async invoke(_args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+      await sleep(options?.cancelSignal)
+      return {
+        stopReason: 'endTurn',
+        lastMessage: { role: 'assistant', content: [new TextBlock(handoff.message)] },
+        structuredOutput: handoff,
+      } as AgentResult
+    },
+    // eslint-disable-next-line require-yield
+    async *stream(args: InvokeArgs, options?: InvokeOptions): AsyncGenerator<StreamEvent, AgentResult, undefined> {
+      return await this.invoke(args, options)
+    },
+  }
 }
 
 describe('Swarm', () => {
@@ -105,6 +147,38 @@ describe('Swarm', () => {
             maxSteps: 0,
           })
       ).toThrow('max_steps=<0> | must be at least 1')
+    })
+
+    it('defaults maxSteps, timeout, and nodeTimeout to Infinity', () => {
+      const swarm = new Swarm({
+        nodes: [createFinalAgent('a', 'hi')],
+        start: 'a',
+      })
+      expect(swarm.config.maxSteps).toBe(Infinity)
+      expect(swarm.config.timeout).toBe(Infinity)
+      expect(swarm.config.nodeTimeout).toBe(Infinity)
+    })
+
+    it('throws when timeout < 1', () => {
+      expect(
+        () =>
+          new Swarm({
+            nodes: [createFinalAgent('a', 'hi')],
+            start: 'a',
+            timeout: 0,
+          })
+      ).toThrow('timeout=<0> | must be at least 1')
+    })
+
+    it('throws when nodeTimeout < 1', () => {
+      expect(
+        () =>
+          new Swarm({
+            nodes: [createFinalAgent('a', 'hi')],
+            start: 'a',
+            nodeTimeout: 0,
+          })
+      ).toThrow('node_timeout=<0> | must be at least 1')
     })
   })
 
@@ -223,6 +297,61 @@ describe('Swarm', () => {
 
       expect(result.status).toBe(Status.COMPLETED)
       expect(result.results.map((r) => r.nodeId)).toStrictEqual(['a', 'b'])
+    })
+
+    it('throws when a node exceeds nodeTimeout', async () => {
+      const swarm = new Swarm({
+        nodes: [{ agent: createSlowAgent('slow', 100) }],
+        start: 'slow',
+        nodeTimeout: 20,
+      })
+
+      await expect(swarm.invoke('go')).rejects.toThrow(/node_timeout=<20>, node_id=<slow>/)
+    })
+
+    it('applies per-node timeout over nodeTimeout', async () => {
+      const swarm = new Swarm({
+        nodes: [{ agent: createSlowAgent('slow', 100), timeout: 15 }],
+        start: 'slow',
+        nodeTimeout: 10_000,
+      })
+
+      await expect(swarm.invoke('go')).rejects.toThrow(/node_timeout=<15>, node_id=<slow>/)
+    })
+
+    it('does not throw when nodeTimeout is Infinity', async () => {
+      const swarm = new Swarm({
+        nodes: [{ agent: createSlowAgent('a', 20) }],
+        start: 'a',
+        nodeTimeout: Infinity,
+      })
+
+      const result = await swarm.invoke('go')
+      expect(result.status).toBe(Status.COMPLETED)
+    })
+
+    it('per-node timeout of Infinity disables a finite nodeTimeout', async () => {
+      const swarm = new Swarm({
+        nodes: [{ agent: createSlowAgent('slow', 30), timeout: Infinity }],
+        start: 'slow',
+        nodeTimeout: 10,
+      })
+
+      const result = await swarm.invoke('go')
+      expect(result.status).toBe(Status.COMPLETED)
+    })
+
+    it('throws when timeout is exceeded between steps', async () => {
+      const swarm = new Swarm({
+        nodes: [
+          { agent: createSlowAgent('a', 30, { agentId: 'b', message: 'to b' }) },
+          { agent: createSlowAgent('b', 30) },
+        ],
+        start: 'a',
+        timeout: 20,
+      })
+
+      await expect(swarm.invoke('go')).rejects.toThrow(/timeout=<20>/)
     })
 
     it('returns cancelled result with custom message when cancel is a string', async () => {

--- a/strands-ts/src/multiagent/__tests__/swarm.test.ts
+++ b/strands-ts/src/multiagent/__tests__/swarm.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+import { createSlowAgent } from '../../__fixtures__/agent-helpers.js'
 import { BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import type { JSONValue } from '../../types/json.js'
-import type { AgentResult, InvokableAgent, InvokeArgs, InvokeOptions } from '../../types/agent.js'
-import type { StreamEvent } from '../../hooks/events.js'
 import { TextBlock } from '../../types/messages.js'
 import { Status, MultiAgentState } from '../state.js'
 import { AgentNode } from '../nodes.js'
@@ -36,46 +35,6 @@ function createHandoffAgent(
  */
 function createFinalAgent(agentId: string, message: string, description: string = `Agent ${agentId}`): Agent {
   return createHandoffAgent(agentId, { message }, description)
-}
-
-/**
- * Custom InvokableAgent that sleeps for `delayMs` before resolving. Respects `cancelSignal`
- * by aborting the sleep early. Used to exercise timeout behavior deterministically.
- */
-function createSlowAgent(
-  agentId: string,
-  delayMs: number,
-  handoff: { agentId?: string; message: string } = { message: 'done' }
-): InvokableAgent {
-  const sleep = (signal?: AbortSignal): Promise<void> =>
-    new Promise((resolve, reject) => {
-      const timer = setTimeout(resolve, delayMs)
-      if (signal) {
-        const onAbort = (): void => {
-          clearTimeout(timer)
-          reject(new Error('cancelled'))
-        }
-        if (signal.aborted) onAbort()
-        else signal.addEventListener('abort', onAbort, { once: true })
-      }
-    })
-
-  return {
-    id: agentId,
-    description: `Agent ${agentId}`,
-    async invoke(_args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
-      await sleep(options?.cancelSignal)
-      return {
-        stopReason: 'endTurn',
-        lastMessage: { role: 'assistant', content: [new TextBlock(handoff.message)] },
-        structuredOutput: handoff,
-      } as AgentResult
-    },
-    // eslint-disable-next-line require-yield
-    async *stream(args: InvokeArgs, options?: InvokeOptions): AsyncGenerator<StreamEvent, AgentResult, undefined> {
-      return await this.invoke(args, options)
-    },
-  }
 }
 
 describe('Swarm', () => {
@@ -348,6 +307,16 @@ describe('Swarm', () => {
           { agent: createSlowAgent('b', 30) },
         ],
         start: 'a',
+        timeout: 20,
+      })
+
+      await expect(swarm.invoke('go')).rejects.toThrow(/timeout=<20>/)
+    })
+
+    it('aborts an in-flight node when the swarm timeout expires mid-step', async () => {
+      const swarm = new Swarm({
+        nodes: [{ agent: createSlowAgent('slow', 200) }],
+        start: 'slow',
         timeout: 20,
       })
 

--- a/strands-ts/src/multiagent/__tests__/swarm.test.ts
+++ b/strands-ts/src/multiagent/__tests__/swarm.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
-import { createSlowAgent } from '../../__fixtures__/agent-helpers.js'
+import { createCancellableAgent } from '../../__fixtures__/agent-helpers.js'
 import { BeforeNodeCallEvent, MultiAgentInitializedEvent } from '../events.js'
 import type { JSONValue } from '../../types/json.js'
 import { TextBlock } from '../../types/messages.js'
@@ -260,7 +260,7 @@ describe('Swarm', () => {
 
     it('throws when a node exceeds nodeTimeout', async () => {
       const swarm = new Swarm({
-        nodes: [{ agent: createSlowAgent('slow', 100) }],
+        nodes: [{ agent: createCancellableAgent('slow', 100) }],
         start: 'slow',
         nodeTimeout: 20,
       })
@@ -270,7 +270,7 @@ describe('Swarm', () => {
 
     it('applies per-node timeout over nodeTimeout', async () => {
       const swarm = new Swarm({
-        nodes: [{ agent: createSlowAgent('slow', 100), timeout: 15 }],
+        nodes: [{ agent: createCancellableAgent('slow', 100), timeout: 15 }],
         start: 'slow',
         nodeTimeout: 10_000,
       })
@@ -280,7 +280,7 @@ describe('Swarm', () => {
 
     it('does not throw when nodeTimeout is Infinity', async () => {
       const swarm = new Swarm({
-        nodes: [{ agent: createSlowAgent('a', 20) }],
+        nodes: [{ agent: createCancellableAgent('a', 20) }],
         start: 'a',
         nodeTimeout: Infinity,
       })
@@ -291,7 +291,7 @@ describe('Swarm', () => {
 
     it('per-node timeout of Infinity disables a finite nodeTimeout', async () => {
       const swarm = new Swarm({
-        nodes: [{ agent: createSlowAgent('slow', 30), timeout: Infinity }],
+        nodes: [{ agent: createCancellableAgent('slow', 30), timeout: Infinity }],
         start: 'slow',
         nodeTimeout: 10,
       })
@@ -303,8 +303,8 @@ describe('Swarm', () => {
     it('throws when timeout is exceeded between steps', async () => {
       const swarm = new Swarm({
         nodes: [
-          { agent: createSlowAgent('a', 30, { agentId: 'b', message: 'to b' }) },
-          { agent: createSlowAgent('b', 30) },
+          { agent: createCancellableAgent('a', 30, { agentId: 'b', message: 'to b' }) },
+          { agent: createCancellableAgent('b', 30) },
         ],
         start: 'a',
         timeout: 20,
@@ -315,7 +315,7 @@ describe('Swarm', () => {
 
     it('aborts an in-flight node when the swarm timeout expires mid-step', async () => {
       const swarm = new Swarm({
-        nodes: [{ agent: createSlowAgent('slow', 200) }],
+        nodes: [{ agent: createCancellableAgent('slow', 200) }],
         start: 'slow',
         timeout: 20,
       })

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -4,6 +4,7 @@ import type { MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
 import type { ContentBlock } from '../types/messages.js'
 import { TextBlock, contentBlockFromData } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
+import { warnOnce } from '../logging/warn-once.js'
 import { HookableEvent } from '../hooks/events.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
@@ -37,10 +38,20 @@ import { normalizeError } from '../errors.js'
  * Runtime configuration for graph execution.
  */
 export interface GraphConfig {
-  /** Max nodes executing in parallel. */
+  /** Max nodes executing in parallel. Defaults to `Infinity` (no limit). */
   maxConcurrency?: number
-  /** Max total steps (prevents infinite loops in cyclic graphs). */
+  /** Max total steps (prevents infinite loops in cyclic graphs). Defaults to `Infinity` (no limit). */
   maxSteps?: number
+  /** Wall-clock ceiling for the entire graph invocation, in milliseconds. Defaults to `Infinity` (no limit). */
+  timeout?: number
+  /**
+   * Fallback per-node wall-clock ceiling in milliseconds. Applied to any `AgentNode` that
+   * doesn't set its own `timeout`. Defaults to `Infinity` (no limit).
+   *
+   * Enforced via `AbortSignal` — cancellation is cooperative, so a tool that neither polls
+   * its cancel signal nor forwards it to a cancellable API can run past this deadline.
+   */
+  nodeTimeout?: number
 }
 
 /**
@@ -117,8 +128,14 @@ export class Graph implements MultiAgent {
     this.config = {
       maxConcurrency: config.maxConcurrency ?? Infinity,
       maxSteps: config.maxSteps ?? Infinity,
+      timeout: config.timeout ?? Infinity,
+      nodeTimeout: config.nodeTimeout ?? Infinity,
     }
     this._validateConfig()
+
+    if (this.config.maxSteps === Infinity && this.config.timeout === Infinity) {
+      warnOnce(logger, 'graph has no maxSteps or timeout set; execution is unbounded')
+    }
 
     this.nodes = this._resolveNodes(nodes)
     this.edges = this._resolveEdges(edges)
@@ -233,17 +250,29 @@ export class Graph implements MultiAgent {
     // Resume: if state was restored, find nodes that are ready but haven't completed otherwise start from source nodes
     const targets = (await this._findResumeTargets(state)) ?? [...this._sources]
 
+    // Execution timeout: when fired, cancels all in-flight node invocations via their
+    // composed cancel signal. In-flight nodes return `stopReason: 'cancelled'`; the queue
+    // drains and the outer loop throws below when it sees the signal aborted.
+    const execController = Number.isFinite(this.config.timeout) ? new AbortController() : undefined
+    const execTimeoutHandle = execController ? setTimeout(() => execController.abort(), this.config.timeout) : undefined
+
     let caughtError: Error | undefined
     let result: MultiAgentResult | undefined
     try {
       while (targets.length > 0 || streams.size > 0) {
+        if (execController?.signal.aborted) {
+          throw new Error(`timeout=<${this.config.timeout}> | graph exceeded wall-clock budget`)
+        }
         while (targets.length > 0 && streams.size < this.config.maxConcurrency) {
           const node = targets.shift()!
 
           this._checkSteps(state)
           state.steps++
 
-          streams.set(node.id, this._streamNode(node, input, state, queue, multiAgentSpan, invocationState))
+          streams.set(
+            node.id,
+            this._streamNode(node, input, state, queue, multiAgentSpan, invocationState, execController?.signal)
+          )
         }
 
         await queue.wait()
@@ -290,6 +319,7 @@ export class Graph implements MultiAgent {
       caughtError = normalizeError(error)
       throw caughtError
     } finally {
+      if (execTimeoutHandle !== undefined) clearTimeout(execTimeoutHandle)
       queue.dispose()
       await Promise.allSettled(streams.values())
 
@@ -315,7 +345,8 @@ export class Graph implements MultiAgent {
     state: MultiAgentState,
     queue: Queue,
     multiAgentSpan: Span | null,
-    invocationState: InvocationState
+    invocationState: InvocationState,
+    executionSignal?: AbortSignal
   ): Promise<void> {
     const nodeState = state.node(node.id)!
 
@@ -347,15 +378,33 @@ export class Graph implements MultiAgent {
       return
     }
 
+    // Per-node timeout applies only to AgentNode. MultiAgentNode wraps a nested Swarm/Graph
+    // that has its own timeout config; cancelSignal isn't yet plumbed into nested orchestrators
+    // so bounding belongs on the child.
+    const nodeTimeout = node instanceof AgentNode ? (node.timeout ?? this.config.nodeTimeout) : Infinity
+    const nodeTimeoutController = Number.isFinite(nodeTimeout) ? new AbortController() : undefined
+    const nodeTimeoutHandle = nodeTimeoutController
+      ? setTimeout(() => nodeTimeoutController.abort(), nodeTimeout)
+      : undefined
+    const signals = [executionSignal, nodeTimeoutController?.signal].filter((s): s is AbortSignal => s !== undefined)
+    const cancelSignal = signals.length > 0 ? AbortSignal.any(signals) : undefined
+
     try {
       const nodeInput = this._resolveNodeInput(node, input, state)
 
-      const gen = this._tracer.withSpanContext(nodeSpan, () => node.stream(nodeInput, state, { invocationState }))
+      const gen = this._tracer.withSpanContext(nodeSpan, () =>
+        node.stream(nodeInput, state, { invocationState, ...(cancelSignal && { cancelSignal }) })
+      )
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       while (!next.done) {
         await queue.send({ type: 'event', node, event: next.value })
         next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       }
+
+      if (nodeTimeoutController?.signal.aborted) {
+        throw new Error(`node_timeout=<${nodeTimeout}>, node_id=<${node.id}> | node exceeded wall-clock budget`)
+      }
+
       const result = next.value
       this._tracer.endNodeSpan(nodeSpan, { status: result.status, duration: result.duration, usage: result.usage })
       queue.push({ type: 'result', node, result })
@@ -385,6 +434,8 @@ export class Graph implements MultiAgent {
         node,
         error: nodeError,
       })
+    } finally {
+      if (nodeTimeoutHandle !== undefined) clearTimeout(nodeTimeoutHandle)
     }
   }
 
@@ -394,6 +445,12 @@ export class Graph implements MultiAgent {
     }
     if (this.config.maxSteps < 1) {
       throw new Error(`max_steps=<${this.config.maxSteps}> | must be at least 1`)
+    }
+    if (this.config.timeout < 1) {
+      throw new Error(`timeout=<${this.config.timeout}> | must be at least 1`)
+    }
+    if (this.config.nodeTimeout < 1) {
+      throw new Error(`node_timeout=<${this.config.nodeTimeout}> | must be at least 1`)
     }
   }
 

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -42,11 +42,21 @@ export interface GraphConfig {
   maxConcurrency?: number
   /** Max total steps (prevents infinite loops in cyclic graphs). Defaults to `Infinity` (no limit). */
   maxSteps?: number
-  /** Wall-clock ceiling for the entire graph invocation, in milliseconds. Defaults to `Infinity` (no limit). */
+  /**
+   * Wall-clock ceiling for the entire graph invocation, in milliseconds. Defaults to `Infinity`
+   * (no limit).
+   *
+   * Does not propagate into nested orchestrators wrapped via `MultiAgentNode` — a nested
+   * `Swarm`/`Graph` runs to completion under its own timeout config; the parent graph's
+   * timeout only fires once the nested node returns.
+   */
   timeout?: number
   /**
    * Fallback per-node wall-clock ceiling in milliseconds. Applied to any `AgentNode` that
    * doesn't set its own `timeout`. Defaults to `Infinity` (no limit).
+   *
+   * Does not apply to `MultiAgentNode`. Set `timeout`/`nodeTimeout` on the nested
+   * orchestrator to bound it.
    *
    * Enforced via `AbortSignal` — cancellation is cooperative, so a tool that neither polls
    * its cancel signal nor forwards it to a cancellable API can run past this deadline.
@@ -261,7 +271,7 @@ export class Graph implements MultiAgent {
     try {
       while (targets.length > 0 || streams.size > 0) {
         if (execController?.signal.aborted) {
-          throw new Error(`timeout=<${this.config.timeout}> | graph exceeded wall-clock budget`)
+          throw new Error(`timeout=<${this.config.timeout}>, graph_id=<${this.id}> | graph exceeded wall-clock budget`)
         }
         while (targets.length > 0 && streams.size < this.config.maxConcurrency) {
           const node = targets.shift()!
@@ -402,7 +412,9 @@ export class Graph implements MultiAgent {
       }
 
       if (nodeTimeoutController?.signal.aborted) {
-        throw new Error(`node_timeout=<${nodeTimeout}>, node_id=<${node.id}> | node exceeded wall-clock budget`)
+        throw new Error(
+          `node_timeout=<${nodeTimeout}>, node_id=<${node.id}>, graph_id=<${this.id}> | node exceeded wall-clock budget`
+        )
       }
 
       const result = next.value

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -41,6 +41,12 @@ export interface NodeInputOptions {
    * hooks/tools can read state written by a previous node.
    */
   invocationState?: InvocationState
+
+  /**
+   * Cancellation signal forwarded to the node's underlying agent. Used by
+   * orchestrators to enforce per-node timeouts or propagate external cancellation.
+   */
+  cancelSignal?: AbortSignal
 }
 
 /**
@@ -143,6 +149,13 @@ export abstract class Node {
 export interface AgentNodeOptions {
   /** The agent to wrap as a node. */
   agent: InvokableAgent
+  /**
+   * Per-node wall-clock ceiling in milliseconds. Overrides the orchestrator's
+   * default node timeout. Cancellation is cooperative — a tool that neither
+   * polls its cancel signal nor forwards it to a cancellable API can run past
+   * this deadline.
+   */
+  timeout?: number
 }
 
 /**
@@ -154,9 +167,10 @@ export interface AgentNodeOptions {
 export class AgentNode extends Node {
   readonly type = 'agentNode' as const
   private readonly _agent: InvokableAgent
+  readonly timeout?: number
 
   constructor(options: AgentNodeOptions) {
-    const { agent, ...config } = options
+    const { agent, timeout, ...config } = options
 
     super(agent.id, {
       ...config,
@@ -164,6 +178,9 @@ export class AgentNode extends Node {
     })
 
     this._agent = agent
+    if (timeout !== undefined) {
+      this.timeout = timeout
+    }
   }
 
   get agent(): InvokableAgent {
@@ -196,6 +213,7 @@ export class AgentNode extends Node {
     try {
       const invokeOptions: InvokeOptions = {
         ...(options?.structuredOutputSchema && { structuredOutputSchema: options.structuredOutputSchema }),
+        ...(options?.cancelSignal && { cancelSignal: options.cancelSignal }),
         invocationState,
       }
 

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -167,6 +167,11 @@ export interface AgentNodeOptions {
 export class AgentNode extends Node {
   readonly type = 'agentNode' as const
   private readonly _agent: InvokableAgent
+  /**
+   * Per-node wall-clock ceiling in milliseconds. When set, overrides the orchestrator's
+   * `nodeTimeout` for this node. Undefined means "fall back to the orchestrator's setting."
+   * See {@link AgentNodeOptions.timeout}.
+   */
   readonly timeout?: number
 
   constructor(options: AgentNodeOptions) {

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -184,6 +184,9 @@ export class AgentNode extends Node {
 
     this._agent = agent
     if (timeout !== undefined) {
+      if (timeout < 1) {
+        throw new Error(`timeout=<${timeout}>, node_id=<${agent.id}> | must be at least 1`)
+      }
       this.timeout = timeout
     }
   }

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logging/logger.js'
+import { warnOnce } from '../logging/warn-once.js'
 import type { AttributeValue, Span } from '@opentelemetry/api'
 import type { InvocationState, InvokableAgent } from '../types/agent.js'
 import type { MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
@@ -33,8 +34,22 @@ import { normalizeError } from '../errors.js'
  * Runtime configuration for swarm execution.
  */
 export interface SwarmConfig {
-  /** Max total agent executions (including start). Defaults to Infinity. */
+  /** Max total agent executions (including start). Defaults to `Infinity` (no limit). */
   maxSteps?: number
+  /**
+   * Wall-clock ceiling for the entire swarm invocation, in milliseconds. Defaults to `Infinity`
+   * (no limit). Checked between steps — a long-running node may exceed this bound by up to its
+   * own `nodeTimeout` before the swarm throws.
+   */
+  timeout?: number
+  /**
+   * Fallback per-node wall-clock ceiling in milliseconds. Applied to any node that doesn't
+   * set its own `timeout`. Defaults to `Infinity` (no limit).
+   *
+   * Enforced via `AbortSignal` — cancellation is cooperative, so a tool that neither polls
+   * its cancel signal nor forwards it to a cancellable API can run past this deadline.
+   */
+  nodeTimeout?: number
 }
 
 /**
@@ -119,8 +134,14 @@ export class Swarm implements MultiAgent {
 
     this.config = {
       maxSteps: config.maxSteps ?? Infinity,
+      timeout: config.timeout ?? Infinity,
+      nodeTimeout: config.nodeTimeout ?? Infinity,
     }
     this._validateConfig()
+
+    if (this.config.maxSteps === Infinity && this.config.timeout === Infinity) {
+      warnOnce(logger, 'swarm has no maxSteps or timeout set; execution is unbounded')
+    }
 
     this.nodes = this._resolveNodes(nodes)
     this.start = this._resolveStart(start)
@@ -234,6 +255,10 @@ export class Swarm implements MultiAgent {
 
     try {
       while (state.steps < this.config.maxSteps) {
+        const elapsed = Date.now() - state.startTime
+        if (elapsed >= this.config.timeout) {
+          throw new Error(`timeout=<${this.config.timeout}> | swarm exceeded wall-clock budget`)
+        }
         state.steps++
 
         // Execute current node
@@ -307,14 +332,26 @@ export class Swarm implements MultiAgent {
 
     const nodeInput = this._resolveNodeInput(input, handoff)
 
+    const nodeTimeout = node.timeout ?? this.config.nodeTimeout
+    const timeoutController = Number.isFinite(nodeTimeout) ? new AbortController() : undefined
+    const timeoutHandle = timeoutController ? setTimeout(() => timeoutController.abort(), nodeTimeout) : undefined
+
     try {
       const gen = this._tracer.withSpanContext(nodeSpan, () =>
-        node.stream(nodeInput, state, { structuredOutputSchema: handoffSchema, invocationState })
+        node.stream(nodeInput, state, {
+          structuredOutputSchema: handoffSchema,
+          invocationState,
+          ...(timeoutController && { cancelSignal: timeoutController.signal }),
+        })
       )
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       while (!next.done) {
         yield next.value
         next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
+      }
+
+      if (timeoutController?.signal.aborted) {
+        throw new Error(`node_timeout=<${nodeTimeout}>, node_id=<${node.id}> | node exceeded wall-clock budget`)
       }
 
       const result = next.value
@@ -335,12 +372,20 @@ export class Swarm implements MultiAgent {
         error: nodeError,
       })
       throw nodeError
+    } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
     }
   }
 
   private _validateConfig(): void {
     if (this.config.maxSteps < 1) {
       throw new Error(`max_steps=<${this.config.maxSteps}> | must be at least 1`)
+    }
+    if (this.config.timeout < 1) {
+      throw new Error(`timeout=<${this.config.timeout}> | must be at least 1`)
+    }
+    if (this.config.nodeTimeout < 1) {
+      throw new Error(`node_timeout=<${this.config.nodeTimeout}> | must be at least 1`)
     }
   }
 

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -38,8 +38,8 @@ export interface SwarmConfig {
   maxSteps?: number
   /**
    * Wall-clock ceiling for the entire swarm invocation, in milliseconds. Defaults to `Infinity`
-   * (no limit). Checked between steps — a long-running node may exceed this bound by up to its
-   * own `nodeTimeout` before the swarm throws.
+   * (no limit). Composed with each node's cancel signal, so a node that exceeds this bound
+   * mid-execution will be aborted (cooperatively).
    */
   timeout?: number
   /**
@@ -253,17 +253,36 @@ export class Swarm implements MultiAgent {
     let caughtError: Error | undefined
     let result: MultiAgentResult | undefined
 
+    // Swarm-level timeout: when fired, composes with each node's per-node signal so a node
+    // that hangs and ignores its own signal still gets an abort when the overall budget expires.
+    // The between-steps elapsed check below handles the case where the current node returned
+    // cleanly but we've run out of budget.
+    const execController = Number.isFinite(this.config.timeout) ? new AbortController() : undefined
+    const execTimeoutHandle = execController ? setTimeout(() => execController.abort(), this.config.timeout) : undefined
+
     try {
       while (state.steps < this.config.maxSteps) {
         const elapsed = Date.now() - state.startTime
         if (elapsed >= this.config.timeout) {
-          throw new Error(`timeout=<${this.config.timeout}> | swarm exceeded wall-clock budget`)
+          throw new Error(`timeout=<${this.config.timeout}>, swarm_id=<${this.id}> | swarm exceeded wall-clock budget`)
         }
         state.steps++
 
         // Execute current node
-        const nodeResult = yield* this._streamNode(node, input, state, handoff, multiAgentSpan, invocationState)
+        const nodeResult = yield* this._streamNode(
+          node,
+          input,
+          state,
+          handoff,
+          multiAgentSpan,
+          invocationState,
+          execController?.signal
+        )
         handoff = nodeResult.structuredOutput as HandoffResult | undefined
+
+        if (execController?.signal.aborted) {
+          throw new Error(`timeout=<${this.config.timeout}>, swarm_id=<${this.id}> | swarm exceeded wall-clock budget`)
+        }
 
         // Check for terminal conditions
         if (nodeResult.status === Status.FAILED || !handoff?.agentId) {
@@ -288,6 +307,7 @@ export class Swarm implements MultiAgent {
       caughtError = normalizeError(error)
       throw caughtError
     } finally {
+      if (execTimeoutHandle !== undefined) clearTimeout(execTimeoutHandle)
       this._tracer.endMultiAgentSpan(multiAgentSpan, {
         duration: Date.now() - state.startTime,
         ...(result && { usage: result.usage }),
@@ -307,7 +327,8 @@ export class Swarm implements MultiAgent {
     state: MultiAgentState,
     handoff: HandoffResult | undefined,
     multiAgentSpan: Span | null,
-    invocationState: InvocationState
+    invocationState: InvocationState,
+    executionSignal?: AbortSignal
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResult, undefined> {
     const nodeState = state.node(node.id)!
     const handoffSchema = this._buildHandoffSchema(node.id)
@@ -335,13 +356,15 @@ export class Swarm implements MultiAgent {
     const nodeTimeout = node.timeout ?? this.config.nodeTimeout
     const timeoutController = Number.isFinite(nodeTimeout) ? new AbortController() : undefined
     const timeoutHandle = timeoutController ? setTimeout(() => timeoutController.abort(), nodeTimeout) : undefined
+    const signals = [executionSignal, timeoutController?.signal].filter((s): s is AbortSignal => s !== undefined)
+    const cancelSignal = signals.length > 0 ? AbortSignal.any(signals) : undefined
 
     try {
       const gen = this._tracer.withSpanContext(nodeSpan, () =>
         node.stream(nodeInput, state, {
           structuredOutputSchema: handoffSchema,
           invocationState,
-          ...(timeoutController && { cancelSignal: timeoutController.signal }),
+          ...(cancelSignal && { cancelSignal }),
         })
       )
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
@@ -351,7 +374,9 @@ export class Swarm implements MultiAgent {
       }
 
       if (timeoutController?.signal.aborted) {
-        throw new Error(`node_timeout=<${nodeTimeout}>, node_id=<${node.id}> | node exceeded wall-clock budget`)
+        throw new Error(
+          `node_timeout=<${nodeTimeout}>, node_id=<${node.id}>, swarm_id=<${this.id}> | node exceeded wall-clock budget`
+        )
       }
 
       const result = next.value

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -281,7 +281,9 @@ export class Swarm implements MultiAgent {
         handoff = nodeResult.structuredOutput as HandoffResult | undefined
 
         if (execController?.signal.aborted) {
-          throw new Error(`timeout=<${this.config.timeout}>, swarm_id=<${this.id}> | swarm exceeded wall-clock budget`)
+          throw new Error(
+            `timeout=<${this.config.timeout}>, swarm_id=<${this.id}>, node_id=<${node.id}> | swarm exceeded wall-clock budget during node execution`
+          )
         }
 
         // Check for terminal conditions

--- a/strands-ts/src/vended-tools/bash/bash.ts
+++ b/strands-ts/src/vended-tools/bash/bash.ts
@@ -88,7 +88,6 @@ class BashSession {
     const effectiveTimeout = timeout ?? this._timeout
     let stdoutData = ''
     let stderrData = ''
-    // eslint-disable-next-line no-undef
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null
     let isTimedOut = false
 
@@ -138,7 +137,6 @@ class BashSession {
       // Does NOT stop the process, preserving session state between calls.
       const cleanup = (): void => {
         if (timeoutHandle !== null) {
-          // eslint-disable-next-line no-undef
           clearTimeout(timeoutHandle)
           timeoutHandle = null
         }
@@ -152,7 +150,6 @@ class BashSession {
       }
 
       // Set up timeout
-      // eslint-disable-next-line no-undef
       timeoutHandle = setTimeout(() => {
         isTimedOut = true
         cleanup()

--- a/strands-ts/test/integ/models/bedrock.test.ts
+++ b/strands-ts/test/integ/models/bedrock.test.ts
@@ -346,7 +346,6 @@ describe.skipIf(bedrock.skip)('BedrockModel Integration Tests', () => {
         }
 
         console.log(`Waiting for guardrail to become active. Current status: ${status}`)
-        // eslint-disable-next-line no-undef
         await new Promise((resolve) => setTimeout(resolve, delayMs))
       }
 


### PR DESCRIPTION
## Description

Two independent reliability improvements:

**Bedrock**: the AWS SDK's `requestTimeout` defaults to `0` (disabled), so a stuck Bedrock connection can hang a process indefinitely. We now inject a 120s default into the `BedrockRuntimeClient`'s `requestHandler`. Callers can override via `clientConfig.requestHandler.requestTimeout`. A user-supplied handler *instance* is left untouched because its timeouts are baked in at construction.

**Swarm / Graph**: add a `timeout` (wall-clock ceiling for the whole invocation) and `nodeTimeout` (fallback per-node ceiling) on `SwarmConfig` / `GraphConfig`, plus a per-node `timeout` override on `AgentNodeOptions`. Per-node enforcement composes via `AbortSignal`, forwarded into the agent's existing `cancelSignal` channel — cancellation is cooperative, so tools that don't check the signal can still run past the deadline (documented). All new fields default to `Infinity` (no behavior change); a one-shot `warnOnce` fires when both `maxSteps` and `timeout` are unbounded.

## Related Issues

#897  #893 

## Documentation PR

follow up

## Type of Change

New feature

## Public API Changes

**Bedrock** — `BedrockModelOptions.clientConfig.requestHandler.requestTimeout` now defaults to 120s:

```typescript
// Before: no default — stuck connections could hang indefinitely
new BedrockModel({ region: 'us-west-2' })

// After: 120s default applied automatically; override as needed
new BedrockModel({
  region: 'us-west-2',
  clientConfig: { requestHandler: { requestTimeout: 300_000 } },
})
```

Backward compatible for any request that completes in under 120s. Requests that legitimately take longer (rare, and usually streaming — which doesn't go through this path) will need to raise the limit.

**Swarm / Graph** — new `timeout` and `nodeTimeout` on orchestrator config; new per-node `timeout` on `AgentNodeOptions`:

```typescript
// Bound a swarm's total wall-clock and each node's execution
const swarm = new Swarm({
  nodes: [researcher, writer],
  timeout: 60_000,      // entire swarm must finish in 60s
  nodeTimeout: 20_000,  // any single node has 20s
})

// Per-node override for a known-slow agent
const graph = new Graph({
  nodes: [
    { agent: fastClassifier },                        // uses nodeTimeout
    { agent: slowResearcher, timeout: 120_000 },      // overrides
  ],
  edges: [['fastClassifier', 'slowResearcher']],
  nodeTimeout: 30_000,
})
```

All three default to `Infinity` (no limit). Set `nodeTimeout: Infinity` or a per-node `timeout: Infinity` to opt out while still using other defaults. Enforcement is via `AbortSignal` — cancellation is cooperative, so a tool that neither polls its cancel signal nor forwards it to a cancellable API (e.g. `fetch(url, { signal })`) can run past the deadline.

## Use Cases

- **Bound runaway swarms** — an LLM caught in a handoff loop no longer holds the process open forever; `timeout` throws, `nodeTimeout` interrupts a stuck agent.
- **Mix fast and slow agents in one graph** — per-node `timeout` override lets a known-slow research agent use 2 minutes while the rest of the graph stays tight at 20s.
- **Bedrock clients behind flaky networks** — the default 120s timeout surfaces a hung connection as an error instead of waiting indefinitely, matching what most users expect out of the box.

## Breaking Changes

None intended. The Bedrock 120s default is technically new behavior — a previously-working non-streaming Bedrock request that takes longer than 120s will now fail. In practice, any such request was either streaming (routed through the event-stream handler, unaffected) or already hung. Callers who need a longer ceiling can raise it via `clientConfig.requestHandler.requestTimeout`.

Swarm / Graph timeouts default to `Infinity`, so no behavior change for existing callers beyond an informational `warnOnce` when both `maxSteps` and `timeout` are unbounded.
