### PR TITLE
feat: add useNativeTokenCount flag to skip token counting API calls

### DIFF
--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -818,5 +818,16 @@ describe('AnthropicModel', () => {
       expect(typeof result).toBe('number')
       expect(result).toBeGreaterThanOrEqual(0)
     })
+
+    it('should skip native API and use heuristic when useNativeTokenCount is false', async () => {
+      const mockCountTokens = vi.fn()
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: false })
+
+      const result = await model.countTokens(messages)
+
+      expect(mockCountTokens).not.toHaveBeenCalled()
+      expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
+    })
   })
 })

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -4308,5 +4308,16 @@ describe('BedrockModel', () => {
       await model.countTokens(messages)
       expect(mockSend).toHaveBeenCalledTimes(2)
     })
+
+    it('should skip native API and use heuristic when useNativeTokenCount is false', async () => {
+      const mockSend = vi.fn()
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel({ useNativeTokenCount: false })
+
+      const result = await model.countTokens(messages)
+
+      expect(mockSend).not.toHaveBeenCalled()
+      expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
+    })
   })
 })

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -1325,5 +1325,16 @@ describe('GoogleModel', () => {
       expect(typeof result).toBe('number')
       expect(result).toBeGreaterThanOrEqual(0)
     })
+
+    it('should skip native API and use heuristic when useNativeTokenCount is false', async () => {
+      const mockCountTokens = vi.fn()
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: false })
+
+      const result = await model.countTokens(messages)
+
+      expect(mockCountTokens).not.toHaveBeenCalled()
+      expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
+    })
   })
 })

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -29,6 +29,15 @@ export interface AnthropicModelConfig extends BaseModelConfig {
   maxTokens?: number
   stopSequences?: string[]
   params?: Record<string, unknown>
+
+  /**
+   * Whether to use the native Anthropic countTokens API.
+   *
+   * When `true` (default), `countTokens()` calls the Anthropic token counting API for
+   * accurate counts. When `false`, skips the API call and uses the character-based
+   * heuristic estimator.
+   */
+  useNativeTokenCount?: boolean
 }
 
 export interface AnthropicModelOptions extends AnthropicModelConfig {
@@ -101,6 +110,8 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    if (this._config.useNativeTokenCount === false) return super.countTokens(messages, options)
+
     try {
       const request = this._formatRequest(messages, options)
       const params: Anthropic.MessageCountTokensParams = {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -281,6 +281,15 @@ export interface BedrockModelConfig extends BaseModelConfig {
    * @see https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
    */
   guardrailConfig?: BedrockGuardrailConfig
+
+  /**
+   * Whether to use the native Bedrock CountTokens API.
+   *
+   * When `true` (default), `countTokens()` calls the Bedrock CountTokens API for
+   * accurate counts. When `false`, skips the API call and uses the character-based
+   * heuristic estimator.
+   */
+  useNativeTokenCount?: boolean
 }
 
 /**
@@ -501,6 +510,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    if (this._config.useNativeTokenCount === false) return super.countTokens(messages, options)
+
     const modelId = this._config.modelId ?? MODEL_DEFAULTS.bedrock.modelId
 
     if (UNSUPPORTED_COUNT_TOKENS_MODELS.has(modelId)) {

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -160,6 +160,8 @@ export class GoogleModel extends Model<GoogleModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
+    if (this._config.useNativeTokenCount === false) return super.countTokens(messages, options)
+
     try {
       const params = this._formatRequest(messages, options)
       const modelId = params.model

--- a/strands-ts/src/models/google/types.ts
+++ b/strands-ts/src/models/google/types.ts
@@ -41,6 +41,15 @@ export interface GoogleModelConfig extends BaseModelConfig {
    * @see https://ai.google.dev/gemini-api/docs/function-calling
    */
   builtInTools?: Tool[]
+
+  /**
+   * Whether to use the native Gemini countTokens API.
+   *
+   * When `true` (default), `countTokens()` calls the Gemini token counting API for
+   * accurate counts. When `false`, skips the API call and uses the character-based
+   * heuristic estimator.
+   */
+  useNativeTokenCount?: boolean
 }
 
 /**


### PR DESCRIPTION
## Description

Model providers with native token counting APIs (Bedrock, Anthropic, Google) make an additional API call on every `countTokens()` invocation. In scenarios where latency or cost of these calls is undesirable such as high-frequency proactive compression checks, users need a way to opt out and fall back to the heuristic estimator.

Each provider with native token overriding gains a new optional `useNativeTokenCount` property in the config:
  
  ```typescript
  // Before: native API always called (with heuristic fallback on error)
  const model = new BedrockModel({ modelId: '\''anthropic.claude-sonnet-4-20250514'\'' })
  
  // After: skip native API, always use heuristic
  const model = new BedrockModel({
    modelId: '\''anthropic.claude-sonnet-4-20250514'\'',
    useNativeTokenCount: false,
  })
  ```

Defaults to true (current behavior). Available on BedrockModelConfig, AnthropicModelConfig, and GoogleModelConfig (the three providers that override countTokens() with native API calls). The base Model class is unaffected since it only has the heuristic implementation.'

## Related Issues

NA

## Documentation PR

Will include this in the proactive compression docs

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
