### PR TITLE
feat(mcp): surface server logs, enable failOpen, metadata getters

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -16,6 +16,8 @@ import type { ToolContext } from '../tools/tool.js'
 import type { ElicitationCallback } from '../types/elicitation.js'
 import { context, propagation, trace, TraceFlags } from '@opentelemetry/api'
 import type { SpanContext } from '@opentelemetry/api'
+import { logger } from '../logging/index.js'
+import type { LoggingMessageNotificationParams } from '@modelcontextprotocol/sdk/types.js'
 
 /**
  * Helper to create a mock async generator that yields a result message.
@@ -35,6 +37,10 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
       listTools: vi.fn(),
       callTool: vi.fn(),
       setRequestHandler: vi.fn(),
+      setNotificationHandler: vi.fn(),
+      getServerCapabilities: vi.fn(),
+      getServerVersion: vi.fn(),
+      getInstructions: vi.fn(),
       experimental: {
         tasks: {
           callToolStream: vi.fn(),
@@ -127,6 +133,10 @@ describe('MCP Integration', () => {
       listTools: ReturnType<typeof vi.fn>
       callTool: ReturnType<typeof vi.fn>
       setRequestHandler: ReturnType<typeof vi.fn>
+      setNotificationHandler: ReturnType<typeof vi.fn>
+      getServerCapabilities: ReturnType<typeof vi.fn>
+      getServerVersion: ReturnType<typeof vi.fn>
+      getInstructions: ReturnType<typeof vi.fn>
       experimental: { tasks: { callToolStream: ReturnType<typeof vi.fn> } }
     }
 
@@ -772,5 +782,261 @@ describe('MCP Integration', () => {
       expect(result.status).toBe('error')
       expect((result.content[0] as TextBlock).text).toBe('MCP error -32600: Bad request')
     })
+  })
+})
+
+describe('server metadata getters', () => {
+  let client: McpClient
+  let sdkClientMock: {
+    connect: ReturnType<typeof vi.fn>
+    getServerCapabilities: ReturnType<typeof vi.fn>
+    getServerVersion: ReturnType<typeof vi.fn>
+    getInstructions: ReturnType<typeof vi.fn>
+    setNotificationHandler: ReturnType<typeof vi.fn>
+    setRequestHandler: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    client = new McpClient({ applicationName: 'TestApp', transport: mockTransport })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns undefined for all getters before connect', () => {
+    sdkClientMock.getServerCapabilities.mockReturnValue(undefined)
+    sdkClientMock.getServerVersion.mockReturnValue(undefined)
+    sdkClientMock.getInstructions.mockReturnValue(undefined)
+
+    expect(client.serverCapabilities).toBeUndefined()
+    expect(client.serverVersion).toBeUndefined()
+    expect(client.serverInstructions).toBeUndefined()
+  })
+
+  it('returns serverCapabilities after connect', async () => {
+    const caps = { tools: {} }
+    sdkClientMock.getServerCapabilities.mockReturnValue(caps)
+
+    await client.connect()
+
+    expect(client.serverCapabilities).toBe(caps)
+  })
+
+  it('returns serverVersion after connect', async () => {
+    const version = { name: 'my-server', version: '1.2.3' }
+    sdkClientMock.getServerVersion.mockReturnValue(version)
+
+    await client.connect()
+
+    expect(client.serverVersion).toBe(version)
+  })
+
+  it('returns serverInstructions after connect', async () => {
+    sdkClientMock.getInstructions.mockReturnValue('Use this server for X.')
+
+    await client.connect()
+
+    expect(client.serverInstructions).toBe('Use this server for X.')
+  })
+
+  it('connectionState is disconnected before connect', () => {
+    expect(client.connectionState).toBe('disconnected')
+  })
+
+  it('connectionState is connected after successful connect', async () => {
+    await client.connect()
+    expect(client.connectionState).toBe('connected')
+  })
+})
+
+describe('failOpen', () => {
+  let sdkClientMock: {
+    connect: ReturnType<typeof vi.fn>
+    listTools: ReturnType<typeof vi.fn>
+    callTool: ReturnType<typeof vi.fn>
+    setNotificationHandler: ReturnType<typeof vi.fn>
+    setRequestHandler: ReturnType<typeof vi.fn>
+    getServerCapabilities: ReturnType<typeof vi.fn>
+    getServerVersion: ReturnType<typeof vi.fn>
+    getInstructions: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws on connection failure by default', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
+
+    await expect(client.connect()).rejects.toThrow('connection refused')
+  })
+
+  it('swallows connection failure when failOpen is true', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
+
+    await expect(client.connect()).resolves.toBeUndefined()
+  })
+
+  it('logs a warning when failOpen swallows a connection failure', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
+
+    await client.connect()
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('MCP server failed to connect'))
+  })
+
+  it('listTools returns empty array when failOpen and connection failed', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
+
+    const tools = await client.listTools()
+
+    expect(tools).toEqual([])
+  })
+
+  it('callTool throws when failOpen and connection failed', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
+    const tool = new McpTool({ name: 'my_tool', description: '', inputSchema: {}, client })
+
+    await expect(client.callTool(tool, {})).rejects.toThrow(
+      'MCP server failed to connect. Call connect(true) to retry.'
+    )
+  })
+
+  it('does not retry connection on subsequent calls after failOpen failure', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
+
+    await client.listTools()
+    await client.listTools()
+
+    expect(sdkClientMock.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers after explicit connect(true) when server comes back', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    sdkClientMock.connect.mockRejectedValueOnce(new Error('connection refused'))
+    sdkClientMock.listTools.mockResolvedValue({ tools: [] })
+
+    const firstTools = await client.listTools()
+    expect(firstTools).toEqual([])
+    expect(client.connectionState).toBe('failed')
+
+    await client.connect(true)
+    const secondTools = await client.listTools()
+
+    expect(secondTools).toEqual([])
+    expect(client.connectionState).toBe('connected')
+    expect(sdkClientMock.connect).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('log routing', () => {
+  let notificationHandler: (notification: { params: LoggingMessageNotificationParams }) => void
+  let sdkClientMock: {
+    connect: ReturnType<typeof vi.fn>
+    setNotificationHandler: ReturnType<typeof vi.fn>
+    setRequestHandler: ReturnType<typeof vi.fn>
+    getServerCapabilities: ReturnType<typeof vi.fn>
+    getServerVersion: ReturnType<typeof vi.fn>
+    getInstructions: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    new McpClient({ applicationName: 'TestApp', transport: mockTransport })
+    sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+    // Handler is registered in the constructor — read it from the first setNotificationHandler call
+    notificationHandler = sdkClientMock.setNotificationHandler.mock.calls[0]![1]
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('routes debug level to logger.debug', () => {
+    const spy = vi.spyOn(logger, 'debug').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'debug', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes info level to logger.info', () => {
+    const spy = vi.spyOn(logger, 'info').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'info', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes notice level to logger.info', () => {
+    const spy = vi.spyOn(logger, 'info').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'notice', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes warning level to logger.warn', () => {
+    const spy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'warning', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes error level to logger.error', () => {
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'error', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes critical level to logger.error', () => {
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'critical', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes alert level to logger.error', () => {
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'alert', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('routes emergency level to logger.error', () => {
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'emergency', data: 'hello' } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('hello'))
+  })
+
+  it('includes logger name and data in the message', () => {
+    const spy = vi.spyOn(logger, 'info').mockImplementation(() => {})
+    notificationHandler({ params: { level: 'info', logger: 'my-server', data: { key: 'val' } } })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('my-server'))
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('key'))
+  })
+
+  it('calls custom logHandler when provided', () => {
+    const customHandler = vi.fn()
+    new McpClient({ applicationName: 'TestApp', transport: mockTransport, logHandler: customHandler })
+    const customSdkMock = vi.mocked(Client).mock.results.at(-1)!.value
+    const capturedHandler = customSdkMock.setNotificationHandler.mock.calls[0]![1]
+
+    const params: LoggingMessageNotificationParams = { level: 'info', data: 'test' }
+    capturedHandler({ params })
+
+    expect(customHandler).toHaveBeenCalledWith(params)
   })
 })

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -236,7 +236,7 @@ export { configureLogging } from './logging/logger.js'
 export type { Logger } from './logging/types.js'
 
 // MCP Client types and implementations
-export { type McpClientConfig, type McpTransport, type TasksConfig, McpClient } from './mcp.js'
+export { type McpClientConfig, type McpTransport, type TasksConfig, type McpConnectionState, McpClient } from './mcp.js'
 export type { ElicitationCallback, ElicitationContext } from './types/elicitation.js'
 
 // Session management

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -1,7 +1,13 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { takeResult } from '@modelcontextprotocol/sdk/shared/responseMessage.js'
-import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import {
+  ElicitRequestSchema,
+  LoggingMessageNotificationSchema,
+  type ServerCapabilities,
+  type Implementation,
+  type LoggingMessageNotificationParams,
+} from '@modelcontextprotocol/sdk/types.js'
 import { context, propagation, trace } from '@opentelemetry/api'
 import type { JSONSchema, JSONValue } from './types/json.js'
 import type { ElicitationCallback } from './types/elicitation.js'
@@ -48,6 +54,9 @@ export interface TasksConfig {
   pollTimeout?: number
 }
 
+/** Connection state of an MCP client. */
+export type McpConnectionState = 'disconnected' | 'connected' | 'failed'
+
 /** Arguments for configuring an MCP Client. */
 export type McpClientConfig = RuntimeConfig & {
   transport: McpTransport
@@ -68,6 +77,12 @@ export type McpClientConfig = RuntimeConfig & {
    * and routes incoming elicitation requests to this callback.
    */
   elicitationCallback?: ElicitationCallback
+
+  /** When true, connection failures are logged as warnings instead of throwing. */
+  failOpen?: boolean
+
+  /** Called when the server emits a log message. Defaults to routing through the Strands logger. */
+  logHandler?: (params: LoggingMessageNotificationParams) => void
 }
 
 /** MCP Client for interacting with Model Context Protocol servers. */
@@ -81,8 +96,10 @@ export class McpClient {
   private _clientName: string
   private _clientVersion: string
   private _transport: Transport
-  private _connected: boolean
+  private _state: McpConnectionState
   private _client: Client
+  private _failOpen: boolean
+  private _logHandler: (params: LoggingMessageNotificationParams) => void
   private _disableMcpInstrumentation: boolean
   private _tasksConfig: TasksConfig | undefined
   private _elicitationCallback: ElicitationCallback | undefined
@@ -91,7 +108,9 @@ export class McpClient {
     this._clientName = args.applicationName || 'strands-agents-ts-sdk'
     this._clientVersion = args.applicationVersion || '0.0.1'
     this._transport = args.transport as Transport
-    this._connected = false
+    this._state = 'disconnected'
+    this._failOpen = args.failOpen ?? false
+    this._logHandler = args.logHandler ?? defaultLogHandler
     this._tasksConfig = args.tasksConfig
     this._elicitationCallback = args.elicitationCallback
     this._client = new Client(
@@ -102,6 +121,10 @@ export class McpClient {
       this._elicitationCallback ? { capabilities: { elicitation: { form: {}, url: {} } } } : undefined
     )
 
+    this._client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      this._logHandler(notification.params)
+    })
+
     this._disableMcpInstrumentation = args.disableMcpInstrumentation ?? false
   }
 
@@ -109,21 +132,38 @@ export class McpClient {
     return this._client
   }
 
+  get serverCapabilities(): ServerCapabilities | undefined {
+    return this._client.getServerCapabilities()
+  }
+
+  get serverVersion(): Implementation | undefined {
+    return this._client.getServerVersion()
+  }
+
+  get serverInstructions(): string | undefined {
+    return this._client.getInstructions()
+  }
+
+  get connectionState(): McpConnectionState {
+    return this._state
+  }
+
   /**
    * Connects the MCP client to the server.
    *
-   * This function is exposed to allow consumers to connect manually, but will be called lazily before any operations that require a connection.
+   * Called lazily before any operation that requires a connection. When `failOpen` is true,
+   * connection failures are swallowed and the client enters a `'failed'` state — subsequent
+   * calls are no-ops until `connect(true)` is called explicitly to retry.
    *
+   * @param reconnect - When true, forces a reconnect even if already connected or failed.
    * @returns A promise that resolves when the connection is established.
    */
   public async connect(reconnect: boolean = false): Promise<void> {
-    if (this._connected && !reconnect) {
-      return
-    }
+    if (this._state !== 'disconnected' && !reconnect) return
 
-    if (this._connected && reconnect) {
+    if (this._state === 'connected' && reconnect) {
       await this._client.close()
-      this._connected = false
+      this._state = 'disconnected'
     }
 
     if (this._elicitationCallback) {
@@ -133,8 +173,16 @@ export class McpClient {
       })
     }
 
-    await this._client.connect(this._transport)
-    this._connected = true
+    try {
+      await this._client.connect(this._transport)
+      this._state = 'connected'
+    } catch (error) {
+      if (!this._failOpen) throw error
+      this._state = 'failed'
+      logger.warn(
+        `client=<${this._clientName}>, error=<${error}> | MCP server failed to connect, continuing with failOpen`
+      )
+    }
   }
 
   /**
@@ -146,7 +194,7 @@ export class McpClient {
     // Must be done sequentially
     await this._client.close()
     await this._transport.close()
-    this._connected = false
+    this._state = 'disconnected'
   }
 
   /**
@@ -156,6 +204,7 @@ export class McpClient {
    */
   public async listTools(): Promise<McpTool[]> {
     await this.connect()
+    if (this._state === 'failed') return []
 
     const tools: McpTool[] = []
     let cursor: string | undefined
@@ -194,6 +243,7 @@ export class McpClient {
    */
   public async callTool(tool: McpTool, args: JSONValue): Promise<JSONValue> {
     await this.connect()
+    if (this._state === 'failed') throw new Error('MCP server failed to connect. Call connect(true) to retry.')
 
     if (args === null || args === undefined) {
       return await this.callTool(tool, {})
@@ -228,6 +278,20 @@ export class McpClient {
 
     const result = await takeResult(stream)
     return result as JSONValue
+  }
+}
+
+function defaultLogHandler(params: LoggingMessageNotificationParams): void {
+  const { level, logger: serverLogger, data } = params
+  const message = `logger=<${serverLogger ?? 'mcp'}>, data=<${JSON.stringify(data)}> | MCP server log`
+  if (level === 'debug') {
+    logger.debug(message)
+  } else if (level === 'info' || level === 'notice') {
+    logger.info(message)
+  } else if (level === 'warning') {
+    logger.warn(message)
+  } else {
+    logger.error(message)
   }
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

**Server metadata getters** — `serverCapabilities`, `serverVersion`, and `serverInstructions` proxy through to the MCP SDK Client after `connect()`. Gives consumers access to server capabilities and instructions without reaching into the underlying client directly. 

**`connectionState` getter** — exposes the client's connection state ('disconnected' | 'connected' | 'failed') so consumers can inspect which servers connected successfully after Agent.initialize().

**`failOpen`** — when true, connection failures are logged as warnings instead of throwing. The client enters a 'failed' state: listTools() returns [] and callTool() throws a descriptive error. No retries until client.connect(true) is called explicitly. Defaults to false — no behavior change for existing users.

**`logHandler`** — registers a `notifications/message` handler so server logs are no longer silently dropped. Routes through the Strands logger by default with level mapping (`debug`→debug, `info`/`notice`→info, `warning`→warn, `error`/`critical`/`alert`/`emergency`→error). Overridable with a custom callback.

## Related Issues

<!-- Link to related issues using #issue-number format -->

#850 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix / enhancements

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
