### PR TITLE
fix(test): allow browser env in OpenAI responses integ fixture

### DIFF
--- a/strands-ts/test/integ/__fixtures__/model-providers.ts
+++ b/strands-ts/test/integ/__fixtures__/model-providers.ts
@@ -128,6 +128,7 @@ export const openaiResponses = {
       ...config,
       api: 'responses',
       apiKey,
+      clientConfig: { ...(config.clientConfig ?? {}), dangerouslyAllowBrowser: true },
     })
   },
 }


### PR DESCRIPTION
## Description

Integ tests are failing currently with below error. **This is same configuration we use with Anthropic and OpenAI already.**

```
 FAIL   integ-browser (chromium)  test/integ/models/openai/responses.test.ts > OpenAIModel (api: 'responses') Integration Tests > Error Handling > handles invalid model ID gracefully
 FAIL   integ-browser (chromium)  test/integ/models/openai/responses.test.ts > OpenAIModel (api: 'responses') Integration Tests > Error Handling > handles invalid model ID gracefully
Error: It looks like you're running in a browser-like environment.

This is disabled by default, as it risks exposing your secret API credentials to attackers.
If you understand the risks and have appropriate mitigations in place,
you can set the `dangerouslyAllowBrowser` option to `true`, e.g.,

new OpenAI({ apiKey, dangerouslyAllowBrowser: true });

https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety

 ❯ new OpenAI node_modules/.vite/vitest/0a199b3b68ed20e692e14bd2f976d8c041e29b72/deps/openai.js?v=f279f0b2:6728:12
 ❯ new OpenAIModel src/models/openai/model.ts:105:21
    103|         )
    104|       }
    105|       this._client = new OpenAI({
       |                     ^
    106|         ...(apiKey ? { apiKey } : {}),
    107|         ...clientConfig,
 ❯ Object.createModel test/integ/__fixtures__/model-providers.ts:127:11
 ❯ test/integ/models/openai/responses.test.ts:317:39

```

## Related Issues

n/a

## Documentation PR

n/a

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
