### PR TITLE
feat: add optional preserveContext property to AgentNode

### DIFF
--- a/strands-ts/src/multiagent/__tests__/nodes.test.ts
+++ b/strands-ts/src/multiagent/__tests__/nodes.test.ts
@@ -132,6 +132,15 @@ describe('AgentNode', () => {
       const timedNode = new AgentNode({ agent, timeout: Infinity })
       expect(timedNode.timeout).toBe(Infinity)
     })
+
+    it('defaults stateful to false', () => {
+      expect(node.stateful).toBe(false)
+    })
+
+    it('stores the stateful flag when provided', () => {
+      const statefulNode = new AgentNode({ agent, stateful: true })
+      expect(statefulNode.stateful).toBe(true)
+    })
   })
 
   describe('handle', () => {
@@ -169,6 +178,21 @@ describe('AgentNode', () => {
 
       expect(agent.messages).toStrictEqual(messagesBefore)
       expect(agent.appState.getAll()).toStrictEqual(stateBefore)
+    })
+
+    it('retains agent messages across executions when stateful', async () => {
+      const model = new MockMessageModel().addTurn(new TextBlock('reply-1')).addTurn(new TextBlock('reply-2'))
+      const statefulAgent = new Agent({ model, printer: false, id: 'stateful-agent' })
+      const statefulNode = new AgentNode({ agent: statefulAgent, stateful: true })
+      const statefulState = new MultiAgentState({ nodeIds: ['stateful-agent'] })
+
+      await collectGenerator(statefulNode.stream([new TextBlock('first')], statefulState))
+      const messagesAfterFirst = statefulAgent.messages.length
+      expect(messagesAfterFirst).toBeGreaterThan(0)
+
+      await collectGenerator(statefulNode.stream([new TextBlock('second')], statefulState))
+
+      expect(statefulAgent.messages.length).toBeGreaterThan(messagesAfterFirst)
     })
 
     it('passes structuredOutputSchema from options to the agent', async () => {

--- a/strands-ts/src/multiagent/__tests__/nodes.test.ts
+++ b/strands-ts/src/multiagent/__tests__/nodes.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { Agent } from '../../agent/agent.js'
+import { BeforeInvocationEvent } from '../../hooks/events.js'
 import type { MultiAgentInput } from '../multiagent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
@@ -193,6 +194,41 @@ describe('AgentNode', () => {
       await collectGenerator(statefulNode.stream([new TextBlock('second')], statefulState))
 
       expect(statefulAgent.messages.length).toBeGreaterThan(messagesAfterFirst)
+    })
+
+    it('retains appState mutations across executions when stateful', async () => {
+      const model = new MockMessageModel().addTurn(new TextBlock('reply-1')).addTurn(new TextBlock('reply-2'))
+      const statefulAgent = new Agent({ model, printer: false, id: 'stateful-agent' })
+      // Hook bumps a counter on appState every time the agent is invoked.
+      statefulAgent.addHook(BeforeInvocationEvent, (event) => {
+        const count = event.agent.appState.get<{ count: number }>('count') ?? 0
+        event.agent.appState.set('count', count + 1)
+      })
+      const statefulNode = new AgentNode({ agent: statefulAgent, stateful: true })
+      const statefulState = new MultiAgentState({ nodeIds: ['stateful-agent'] })
+
+      await collectGenerator(statefulNode.stream([new TextBlock('first')], statefulState))
+      expect(statefulAgent.appState.get<{ count: number }>('count')).toBe(1)
+
+      await collectGenerator(statefulNode.stream([new TextBlock('second')], statefulState))
+      expect(statefulAgent.appState.get<{ count: number }>('count')).toBe(2)
+    })
+
+    it('throws when stateful is set with a non-Agent InvokableAgent', () => {
+      const customAgent = {
+        id: 'custom',
+        async invoke() {
+          throw new Error('not used')
+        },
+        // eslint-disable-next-line require-yield
+        async *stream() {
+          throw new Error('not used')
+        },
+        addHook() {
+          return () => {}
+        },
+      }
+      expect(() => new AgentNode({ agent: customAgent, stateful: true })).toThrow(/stateful=true requires an Agent/)
     })
 
     it('passes structuredOutputSchema from options to the agent', async () => {

--- a/strands-ts/src/multiagent/__tests__/nodes.test.ts
+++ b/strands-ts/src/multiagent/__tests__/nodes.test.ts
@@ -142,6 +142,23 @@ describe('AgentNode', () => {
       const statefulNode = new AgentNode({ agent, stateful: true })
       expect(statefulNode.stateful).toBe(true)
     })
+
+    it('throws when stateful is set with a non-Agent InvokableAgent', () => {
+      const customAgent = {
+        id: 'custom',
+        async invoke() {
+          throw new Error('not used')
+        },
+        // eslint-disable-next-line require-yield
+        async *stream() {
+          throw new Error('not used')
+        },
+        addHook() {
+          return () => {}
+        },
+      }
+      expect(() => new AgentNode({ agent: customAgent, stateful: true })).toThrow(/stateful=true requires an Agent/)
+    })
   })
 
   describe('handle', () => {
@@ -212,23 +229,6 @@ describe('AgentNode', () => {
 
       await collectGenerator(statefulNode.stream([new TextBlock('second')], statefulState))
       expect(statefulAgent.appState.get<{ count: number }>('count')).toBe(2)
-    })
-
-    it('throws when stateful is set with a non-Agent InvokableAgent', () => {
-      const customAgent = {
-        id: 'custom',
-        async invoke() {
-          throw new Error('not used')
-        },
-        // eslint-disable-next-line require-yield
-        async *stream() {
-          throw new Error('not used')
-        },
-        addHook() {
-          return () => {}
-        },
-      }
-      expect(() => new AgentNode({ agent: customAgent, stateful: true })).toThrow(/stateful=true requires an Agent/)
     })
 
     it('passes structuredOutputSchema from options to the agent', async () => {

--- a/strands-ts/src/multiagent/__tests__/nodes.test.ts
+++ b/strands-ts/src/multiagent/__tests__/nodes.test.ts
@@ -134,16 +134,16 @@ describe('AgentNode', () => {
       expect(timedNode.timeout).toBe(Infinity)
     })
 
-    it('defaults stateful to false', () => {
-      expect(node.stateful).toBe(false)
+    it('defaults preserveContext to false', () => {
+      expect(node.preserveContext).toBe(false)
     })
 
-    it('stores the stateful flag when provided', () => {
-      const statefulNode = new AgentNode({ agent, stateful: true })
-      expect(statefulNode.stateful).toBe(true)
+    it('stores the preserveContext flag when provided', () => {
+      const preserveContextNode = new AgentNode({ agent, preserveContext: true })
+      expect(preserveContextNode.preserveContext).toBe(true)
     })
 
-    it('throws when stateful is set with a non-Agent InvokableAgent', () => {
+    it('throws when preserveContext is set with a non-Agent InvokableAgent', () => {
       const customAgent = {
         id: 'custom',
         async invoke() {
@@ -157,7 +157,9 @@ describe('AgentNode', () => {
           return () => {}
         },
       }
-      expect(() => new AgentNode({ agent: customAgent, stateful: true })).toThrow(/stateful=true requires an Agent/)
+      expect(() => new AgentNode({ agent: customAgent, preserveContext: true })).toThrow(
+        /preserveContext=true requires an Agent/
+      )
     })
   })
 
@@ -198,37 +200,37 @@ describe('AgentNode', () => {
       expect(agent.appState.getAll()).toStrictEqual(stateBefore)
     })
 
-    it('retains agent messages across executions when stateful', async () => {
+    it('retains agent messages across executions when preserveContext is true', async () => {
       const model = new MockMessageModel().addTurn(new TextBlock('reply-1')).addTurn(new TextBlock('reply-2'))
-      const statefulAgent = new Agent({ model, printer: false, id: 'stateful-agent' })
-      const statefulNode = new AgentNode({ agent: statefulAgent, stateful: true })
-      const statefulState = new MultiAgentState({ nodeIds: ['stateful-agent'] })
+      const preserveContextAgent = new Agent({ model, printer: false, id: 'preserve-context-agent' })
+      const preserveContextNode = new AgentNode({ agent: preserveContextAgent, preserveContext: true })
+      const preserveContextState = new MultiAgentState({ nodeIds: ['preserve-context-agent'] })
 
-      await collectGenerator(statefulNode.stream([new TextBlock('first')], statefulState))
-      const messagesAfterFirst = statefulAgent.messages.length
+      await collectGenerator(preserveContextNode.stream([new TextBlock('first')], preserveContextState))
+      const messagesAfterFirst = preserveContextAgent.messages.length
       expect(messagesAfterFirst).toBeGreaterThan(0)
 
-      await collectGenerator(statefulNode.stream([new TextBlock('second')], statefulState))
+      await collectGenerator(preserveContextNode.stream([new TextBlock('second')], preserveContextState))
 
-      expect(statefulAgent.messages.length).toBeGreaterThan(messagesAfterFirst)
+      expect(preserveContextAgent.messages.length).toBeGreaterThan(messagesAfterFirst)
     })
 
-    it('retains appState mutations across executions when stateful', async () => {
+    it('retains appState mutations across executions when preserveContext is true', async () => {
       const model = new MockMessageModel().addTurn(new TextBlock('reply-1')).addTurn(new TextBlock('reply-2'))
-      const statefulAgent = new Agent({ model, printer: false, id: 'stateful-agent' })
+      const preserveContextAgent = new Agent({ model, printer: false, id: 'preserve-context-agent' })
       // Hook bumps a counter on appState every time the agent is invoked.
-      statefulAgent.addHook(BeforeInvocationEvent, (event) => {
+      preserveContextAgent.addHook(BeforeInvocationEvent, (event) => {
         const count = event.agent.appState.get<{ count: number }>('count') ?? 0
         event.agent.appState.set('count', count + 1)
       })
-      const statefulNode = new AgentNode({ agent: statefulAgent, stateful: true })
-      const statefulState = new MultiAgentState({ nodeIds: ['stateful-agent'] })
+      const preserveContextNode = new AgentNode({ agent: preserveContextAgent, preserveContext: true })
+      const preserveContextState = new MultiAgentState({ nodeIds: ['preserve-context-agent'] })
 
-      await collectGenerator(statefulNode.stream([new TextBlock('first')], statefulState))
-      expect(statefulAgent.appState.get<{ count: number }>('count')).toBe(1)
+      await collectGenerator(preserveContextNode.stream([new TextBlock('first')], preserveContextState))
+      expect(preserveContextAgent.appState.get<{ count: number }>('count')).toBe(1)
 
-      await collectGenerator(statefulNode.stream([new TextBlock('second')], statefulState))
-      expect(statefulAgent.appState.get<{ count: number }>('count')).toBe(2)
+      await collectGenerator(preserveContextNode.stream([new TextBlock('second')], preserveContextState))
+      expect(preserveContextAgent.appState.get<{ count: number }>('count')).toBe(2)
     })
 
     it('passes structuredOutputSchema from options to the agent', async () => {

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -173,13 +173,30 @@ export interface AgentNodeOptions {
    * this deadline.
    */
   timeout?: number
+  /**
+   * When `true`, the wrapped agent accumulates state (messages, appState,
+   * modelState) across node executions. Useful for graph patterns where a
+   * node is revisited and should build on its previous work (e.g., an
+   * analyst that accumulates findings, or iterative refinement).
+   *
+   * When `false` (default), the agent's state is snapshotted before each
+   * execution and restored in `finally`, so the node is stateless across
+   * visits.
+   *
+   * Only applies when the wrapped agent is an {@link Agent} instance;
+   * non-`Agent` `InvokableAgent`s are never snapshotted regardless of this
+   * flag.
+   */
+  stateful?: boolean
 }
 
 /**
  * Node that wraps an {@link InvokableAgent} instance for multi-agent orchestration.
  *
- * Each execution is isolated. When the wrapped agent is an {@link Agent} instance,
- * its internal state is snapshot/restored so it remains unchanged after the node completes.
+ * By default, when the wrapped agent is an {@link Agent} instance, its internal
+ * state is snapshot/restored around each execution so it remains unchanged
+ * after the node completes. Pass `stateful: true` to opt out and let the
+ * wrapped agent accumulate state across node executions.
  */
 export class AgentNode extends Node {
   readonly type = 'agentNode' as const
@@ -190,9 +207,14 @@ export class AgentNode extends Node {
    * See {@link AgentNodeOptions.timeout}.
    */
   readonly timeout?: number
+  /**
+   * Whether the wrapped agent retains state across node executions.
+   * See {@link AgentNodeOptions.stateful}.
+   */
+  readonly stateful: boolean
 
   constructor(options: AgentNodeOptions) {
-    const { agent, timeout, ...config } = options
+    const { agent, timeout, stateful, ...config } = options
 
     super(agent.id, {
       ...config,
@@ -206,6 +228,7 @@ export class AgentNode extends Node {
       }
       this.timeout = timeout
     }
+    this.stateful = stateful ?? false
   }
 
   get agent(): InvokableAgent {
@@ -231,10 +254,13 @@ export class AgentNode extends Node {
     const invocationState: InvocationState = options?.invocationState ?? {}
 
     // Only Agent instances support snapshot/restore for state isolation.
+    // When `stateful` is set, skip the snapshot/restore cycle so the agent
+    // accumulates state across node executions.
     const isAgent = this._agent instanceof Agent
-    const preRunSnapshot = isAgent ? this._agent.takeSnapshot({ preset: 'session' }) : undefined
+    const preRunSnapshot = !this.stateful && isAgent ? this._agent.takeSnapshot({ preset: 'session' }) : undefined
 
     // Rehydrate agent state from a prior INTERRUPTED run (messages + interrupt state).
+    // Independent of `stateful`: a paused run always resumes from where it left off.
     const nodeState = state.node(this.id)
     if (isAgent && nodeState?.interruptedSnapshot) {
       this._agent.loadSnapshot(nodeState.interruptedSnapshot)

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -228,6 +228,11 @@ export class AgentNode extends Node {
       }
       this.timeout = timeout
     }
+    if (stateful && !(agent instanceof Agent)) {
+      throw new Error(
+        `node_id=<${agent.id}> | stateful=true requires an Agent instance; non-Agent InvokableAgents cannot be snapshotted`
+      )
+    }
     this.stateful = stateful ?? false
   }
 

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -183,9 +183,8 @@ export interface AgentNodeOptions {
    * execution and restored in `finally`, so the node is stateless across
    * visits.
    *
-   * Only applies when the wrapped agent is an {@link Agent} instance;
-   * non-`Agent` `InvokableAgent`s are never snapshotted regardless of this
-   * flag.
+   * Throws at construction time when set to `true` with a non-`Agent`
+   * `InvokableAgent`, since snapshot/restore only applies to `Agent` instances.
    */
   stateful?: boolean
 }

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -186,7 +186,7 @@ export interface AgentNodeOptions {
    * Throws at construction time when set to `true` with a non-`Agent`
    * `InvokableAgent`, since snapshot/restore only applies to `Agent` instances.
    */
-  stateful?: boolean
+  preserveContext?: boolean
 }
 
 /**
@@ -194,7 +194,7 @@ export interface AgentNodeOptions {
  *
  * By default, when the wrapped agent is an {@link Agent} instance, its internal
  * state is snapshot/restored around each execution so it remains unchanged
- * after the node completes. Pass `stateful: true` to opt out and let the
+ * after the node completes. Pass `preserveContext: true` to opt out and let the
  * wrapped agent accumulate state across node executions.
  */
 export class AgentNode extends Node {
@@ -208,12 +208,12 @@ export class AgentNode extends Node {
   readonly timeout?: number
   /**
    * Whether the wrapped agent retains state across node executions.
-   * See {@link AgentNodeOptions.stateful}.
+   * See {@link AgentNodeOptions.preserveContext}.
    */
-  readonly stateful: boolean
+  readonly preserveContext: boolean
 
   constructor(options: AgentNodeOptions) {
-    const { agent, timeout, stateful, ...config } = options
+    const { agent, timeout, preserveContext, ...config } = options
 
     super(agent.id, {
       ...config,
@@ -227,12 +227,12 @@ export class AgentNode extends Node {
       }
       this.timeout = timeout
     }
-    if (stateful && !(agent instanceof Agent)) {
+    if (preserveContext && !(agent instanceof Agent)) {
       throw new Error(
-        `node_id=<${agent.id}> | stateful=true requires an Agent instance; non-Agent InvokableAgents cannot be snapshotted`
+        `node_id=<${agent.id}> | preserveContext=true requires an Agent instance; non-Agent InvokableAgents cannot be snapshotted`
       )
     }
-    this.stateful = stateful ?? false
+    this.preserveContext = preserveContext ?? false
   }
 
   get agent(): InvokableAgent {
@@ -258,13 +258,14 @@ export class AgentNode extends Node {
     const invocationState: InvocationState = options?.invocationState ?? {}
 
     // Only Agent instances support snapshot/restore for state isolation.
-    // When `stateful` is set, skip the snapshot/restore cycle so the agent
+    // When `preserveContext` is set, skip the snapshot/restore cycle so the agent
     // accumulates state across node executions.
     const isAgent = this._agent instanceof Agent
-    const preRunSnapshot = !this.stateful && isAgent ? this._agent.takeSnapshot({ preset: 'session' }) : undefined
+    const preRunSnapshot =
+      !this.preserveContext && isAgent ? this._agent.takeSnapshot({ preset: 'session' }) : undefined
 
     // Rehydrate agent state from a prior INTERRUPTED run (messages + interrupt state).
-    // Independent of `stateful`: a paused run always resumes from where it left off.
+    // Independent of `preserveContext`: a paused run always resumes from where it left off.
     const nodeState = state.node(this.id)
     if (isAgent && nodeState?.interruptedSnapshot) {
       this._agent.loadSnapshot(nodeState.interruptedSnapshot)


### PR DESCRIPTION
## Description

`AgentNode` always snapshots the wrapped agent's messages/appState/modelState before each execution and restores them in `finally`, so the node is stateless across visits. This blocks a useful class of graph workflows where a node is revisited and should build on its previous work.

Add an opt-in `preserveContext` flag on `AgentNode` that skips the snapshot/restore cycle. Default is `false` to preserve today's isolation semantics. The flag lives on the node (not the graph) because the snapshot logic is already self-contained in `AgentNode.handle` and the choice is a per-node design decision — one graph can mix accumulator nodes with stateless ones without any orchestrator plumbing. This also makes it work for Swarm for free.

```typescript
// Default: stateless across visits (unchanged)
new AgentNode({ agent })

// Opt in: agent accumulates state across executions
new AgentNode({ agent, preserveContext: true })
```

The flag only applies when the wrapped agent is an `Agent` instance; non-`Agent` `InvokableAgent`s were never snapshotted and aren't affected.

## Related Issues

Resolves #905

## Documentation PR

Follow up

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
