### PR TITLE
feat(mcp): add Symbol.asyncDispose to McpClient to enable await-using cleanup

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -375,6 +375,12 @@ describe('MCP Integration', () => {
       expect(mockTransport.close).toHaveBeenCalled()
     })
 
+    it('supports Symbol.asyncDispose for await using pattern', async () => {
+      await client[Symbol.asyncDispose]()
+      expect(sdkClientMock.close).toHaveBeenCalled()
+      expect(mockTransport.close).toHaveBeenCalled()
+    })
+
     it('registers elicitation handler before connecting when callback is provided', async () => {
       const resultsLengthBefore = vi.mocked(Client).mock.results.length
       const callback: ElicitationCallback = vi.fn()

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -198,6 +198,14 @@ export class McpClient {
   }
 
   /**
+   * Enables the `await using` pattern for automatic resource cleanup.
+   * Delegates to {@link McpClient.disconnect}.
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.disconnect()
+  }
+
+  /**
    * Lists the tools available on the server and returns them as executable McpTool instances.
    *
    * @returns A promise that resolves with an array of McpTool instances.


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Currently, users must call `await mcpClient.disconnect()` manually to close the underlying MCP SDK client and transport channel.

Adding `Symbol.asyncDispose` enables the `await using` pattern:

```ts
await using client = new McpClient({ transport })
await client.connect()

// automatically disconnects when scope exits
```

No risk – it's safe to combine with manual `disconnect()` calls since calling `close()` multiple times on the same connection is a no-op.

## Related Issues

<!-- Link to related issues using #issue-number format -->

Closes #250 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
