### PR TITLE
feat: normalize invalid tool names

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1718,3 +1718,79 @@ describe('_estimateInputTokens', () => {
     expect(await tokenPromise).toBe(265)
   })
 })
+
+describe('normalizeToolUseNames', () => {
+  it('replaces invalid tool-use names with INVALID_TOOL_NAME before calling model', async () => {
+    const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' })
+    const streamSpy = vi.spyOn(model, 'stream')
+
+    const agent = new Agent({
+      model,
+      printer: false,
+      messages: [
+        new Message({ role: 'user', content: [new TextBlock('do thing')] }),
+        new Message({
+          role: 'assistant',
+          content: [new ToolUseBlock({ name: 'bad name!', toolUseId: 'tu-1', input: {} })],
+        }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tu-1',
+              status: 'success',
+              content: [new TextBlock('result')],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    await agent.invoke('continue')
+
+    const sentMessages = streamSpy.mock.calls[0]?.[0] as Message[]
+    const assistantMessage = sentMessages.find((m) => m.role === 'assistant')!
+    const toolUse = assistantMessage.content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(toolUse.name).toBe('INVALID_TOOL_NAME')
+    expect(toolUse.toolUseId).toBe('tu-1')
+
+    // Agent's stored history is not mutated.
+    const storedAssistant = agent.messages.find((m) => m.role === 'assistant')!
+    const storedToolUse = storedAssistant.content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(storedToolUse.name).toBe('bad name!')
+  })
+
+  it('leaves valid names untouched', async () => {
+    const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' })
+    const streamSpy = vi.spyOn(model, 'stream')
+
+    const agent = new Agent({
+      model,
+      printer: false,
+      messages: [
+        new Message({ role: 'user', content: [new TextBlock('do thing')] }),
+        new Message({
+          role: 'assistant',
+          content: [new ToolUseBlock({ name: 'good_tool-1', toolUseId: 'tu-1', input: {} })],
+        }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tu-1',
+              status: 'success',
+              content: [new TextBlock('result')],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    await agent.invoke('continue')
+
+    const sentMessages = streamSpy.mock.calls[0]?.[0] as Message[]
+    const assistantMessage = sentMessages.find((m) => m.role === 'assistant')!
+    const toolUse = assistantMessage.content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(toolUse.name).toBe('good_tool-1')
+  })
+})

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1749,15 +1749,52 @@ describe('normalizeToolUseNames', () => {
     await agent.invoke('continue')
 
     const sentMessages = streamSpy.mock.calls[0]?.[0] as Message[]
-    const assistantMessage = sentMessages.find((m) => m.role === 'assistant')!
-    const toolUse = assistantMessage.content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
-    expect(toolUse.name).toBe('INVALID_TOOL_NAME')
-    expect(toolUse.toolUseId).toBe('tu-1')
+    const sentToolUse = sentMessages
+      .find((m) => m.role === 'assistant')!
+      .content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(sentToolUse).toStrictEqual(new ToolUseBlock({ name: 'INVALID_TOOL_NAME', toolUseId: 'tu-1', input: {} }))
 
     // Agent's stored history is not mutated.
-    const storedAssistant = agent.messages.find((m) => m.role === 'assistant')!
-    const storedToolUse = storedAssistant.content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
-    expect(storedToolUse.name).toBe('bad name!')
+    const storedToolUse = agent.messages
+      .find((m) => m.role === 'assistant')!
+      .content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(storedToolUse).toStrictEqual(new ToolUseBlock({ name: 'bad name!', toolUseId: 'tu-1', input: {} }))
+  })
+
+  it('preserves reasoningSignature on replaced tool-use blocks', async () => {
+    const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' })
+    const streamSpy = vi.spyOn(model, 'stream')
+
+    const agent = new Agent({
+      model,
+      printer: false,
+      messages: [
+        new Message({ role: 'user', content: [new TextBlock('do thing')] }),
+        new Message({
+          role: 'assistant',
+          content: [new ToolUseBlock({ name: 'bad!', toolUseId: 'tu-1', input: {}, reasoningSignature: 'sig-abc' })],
+        }),
+        new Message({
+          role: 'user',
+          content: [new ToolResultBlock({ toolUseId: 'tu-1', status: 'success', content: [new TextBlock('ok')] })],
+        }),
+      ],
+    })
+
+    await agent.invoke('continue')
+
+    const sentMessages = streamSpy.mock.calls[0]?.[0] as Message[]
+    const sentToolUse = sentMessages
+      .find((m) => m.role === 'assistant')!
+      .content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(sentToolUse).toStrictEqual(
+      new ToolUseBlock({
+        name: 'INVALID_TOOL_NAME',
+        toolUseId: 'tu-1',
+        input: {},
+        reasoningSignature: 'sig-abc',
+      })
+    )
   })
 
   it('leaves valid names untouched', async () => {
@@ -1789,8 +1826,9 @@ describe('normalizeToolUseNames', () => {
     await agent.invoke('continue')
 
     const sentMessages = streamSpy.mock.calls[0]?.[0] as Message[]
-    const assistantMessage = sentMessages.find((m) => m.role === 'assistant')!
-    const toolUse = assistantMessage.content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
-    expect(toolUse.name).toBe('good_tool-1')
+    const sentToolUse = sentMessages
+      .find((m) => m.role === 'assistant')!
+      .content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
+    expect(sentToolUse).toStrictEqual(new ToolUseBlock({ name: 'good_tool-1', toolUseId: 'tu-1', input: {} }))
   })
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -24,7 +24,7 @@ import {
 } from '../types/messages.js'
 import type { JSONValue } from '../types/json.js'
 import { McpClient } from '../mcp.js'
-import { type Tool, type ToolContext } from '../tools/tool.js'
+import { isValidToolName, type Tool, type ToolContext } from '../tools/tool.js'
 import type { ToolChoice } from '../tools/types.js'
 import { systemPromptFromData } from '../types/messages.js'
 import { normalizeError, ConcurrentInvocationError, StructuredOutputError } from '../errors.js'
@@ -1267,6 +1267,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     streamOptions: StreamOptions,
     invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
+    messages = normalizeToolUseNames(messages)
     const streamGenerator = this.model.streamAggregated(messages, streamOptions)
     let result = await streamGenerator.next()
 
@@ -1897,6 +1898,44 @@ export class Agent implements LocalAgent, InvokableAgent {
     this.messages.push(message)
     return new MessageAddedEvent({ agent: this, message, invocationState })
   }
+}
+
+const INVALID_TOOL_NAME_PLACEHOLDER = 'INVALID_TOOL_NAME'
+
+/**
+ * Replaces invalid tool-use names on assistant messages with `INVALID_TOOL_NAME`
+ * so providers that reject malformed names don't fail the whole request.
+ * Returns the input unchanged (same reference) when nothing needs replacing.
+ */
+function normalizeToolUseNames(messages: Message[]): Message[] {
+  let replaced = false
+  const next = messages.map((message) => {
+    if (!message || message.role !== 'assistant') return message
+
+    let messageReplaced = false
+    const content = message.content.map((block) => {
+      if (block.type !== 'toolUseBlock') return block
+      if (isValidToolName(block.name)) return block
+      messageReplaced = true
+      logger.debug(`tool_name=<${block.name}> | replacing invalid tool name with ${INVALID_TOOL_NAME_PLACEHOLDER}`)
+      return new ToolUseBlock({
+        name: INVALID_TOOL_NAME_PLACEHOLDER,
+        toolUseId: block.toolUseId,
+        input: block.input,
+        ...(block.reasoningSignature !== undefined && { reasoningSignature: block.reasoningSignature }),
+      })
+    })
+
+    if (!messageReplaced) return message
+    replaced = true
+    return new Message({
+      role: message.role,
+      content,
+      ...(message.metadata !== undefined && { metadata: message.metadata }),
+    })
+  })
+
+  return replaced ? next : messages
 }
 
 /**

--- a/strands-ts/src/tools/__tests__/tool.test.ts
+++ b/strands-ts/src/tools/__tests__/tool.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import { FunctionTool } from '../function-tool.js'
-import { Tool, ToolStreamEvent } from '../tool.js'
+import { Tool, ToolStreamEvent, isValidToolName } from '../tool.js'
 import type { ToolContext } from '../tool.js'
 import type { JSONValue } from '../../types/json.js'
 import { createMockContext } from '../../__fixtures__/tool-helpers.js'
 
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
+
+describe('isValidToolName', () => {
+  it.each([
+    ['simple', true],
+    ['with_underscore', true],
+    ['with-hyphen', true],
+    ['Mixed-Case_123', true],
+    ['a', true],
+    ['a'.repeat(64), true],
+  ])('accepts %s', (name, expected) => {
+    expect(isValidToolName(name)).toBe(expected)
+  })
+
+  it.each([
+    ['', 'empty string'],
+    ['a'.repeat(65), 'over 64 chars'],
+    ['has space', 'space'],
+    ['has.dot', 'dot'],
+    ['has/slash', 'slash'],
+    ['has:colon', 'colon'],
+    ['emoji🚀', 'non-ascii'],
+  ])('rejects %s (%s)', (name) => {
+    expect(isValidToolName(name)).toBe(false)
+  })
+})
 
 describe('FunctionTool', () => {
   describe('properties', () => {

--- a/strands-ts/src/tools/tool.ts
+++ b/strands-ts/src/tools/tool.ts
@@ -202,3 +202,14 @@ export function createErrorResult(error: unknown, toolUseId: string): ToolResult
     error: errorObject,
   })
 }
+
+const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
+const TOOL_NAME_MAX_LENGTH = 64
+
+/**
+ * Returns `true` when `name` satisfies the provider-accepted tool name format:
+ * non-empty, 1–64 characters, and only letters, digits, underscores, or hyphens.
+ */
+export function isValidToolName(name: string): boolean {
+  return name.length > 0 && name.length <= TOOL_NAME_MAX_LENGTH && TOOL_NAME_PATTERN.test(name)
+}

--- a/strands-ts/src/tools/tool.ts
+++ b/strands-ts/src/tools/tool.ts
@@ -209,6 +209,9 @@ const TOOL_NAME_MAX_LENGTH = 64
 /**
  * Returns `true` when `name` satisfies the provider-accepted tool name format:
  * non-empty, 1–64 characters, and only letters, digits, underscores, or hyphens.
+ *
+ * @param name - The tool name to validate
+ * @returns `true` if the name is valid, `false` otherwise
  */
 export function isValidToolName(name: string): boolean {
   return name.length > 0 && name.length <= TOOL_NAME_MAX_LENGTH && TOOL_NAME_PATTERN.test(name)


### PR DESCRIPTION
## Description

Normalizes invalid tool-use names on assistant messages to `INVALID_TOOL_NAME` before dispatching to the model provider. Matches the Python SDK's behavior so that a hallucinated or malformed tool name in conversation history doesn't blow up the next model call with a provider-side validation error.

Validation rule: non-empty, 1–64 characters, `^[a-zA-Z0-9_-]+$` — the tightest common denominator across Bedrock Converse, Anthropic, OpenAI, and Gemini. The replacement happens on messages sent to the model; the agent's stored history is left untouched.

Scope is intentionally limited to the invalid-name branch. The companion Python normalizations (blank-text handling, `recover_message_on_max_tokens`) are out:

## Related Issues

Resolves #900

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Unit tests for `isValidToolName` cover the boundary, whitespace, punctuation, and non-ASCII cases.
- Agent-level tests spy on `model.stream`, confirm the in-flight message carries `INVALID_TOOL_NAME` while `agent.messages` retains the original name, and confirm valid names pass through unchanged.
- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
