### PR TITLE
feat: refine sliding window coversation manager logic

### DIFF
--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { SlidingWindowConversationManager } from '../sliding-window-conversation-manager.js'
 import {
   ContextWindowOverflowError,
+  ImageBlock,
   Message,
   TextBlock,
   ToolUseBlock,
@@ -65,7 +66,7 @@ describe('SlidingWindowConversationManager', () => {
             new ToolResultBlock({
               toolUseId: 'tool-1',
               status: 'success',
-              content: [new TextBlock('Large tool result content')],
+              content: [new TextBlock('x'.repeat(500))],
             }),
           ],
         }),
@@ -160,8 +161,10 @@ describe('SlidingWindowConversationManager', () => {
   })
 
   describe('reduceContext - tool result truncation', () => {
-    it('truncates tool results when shouldTruncateResults is true', async () => {
+    it('partially truncates large tool results preserving first and last 200 chars', async () => {
       const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const middle = 'MIDDLE_CONTENT_TO_REMOVE'.repeat(10) // 240 chars, safely above MIN_TRUNCATION_GAIN
+      const original = 'A'.repeat(200) + middle + 'B'.repeat(200)
       const messages = [
         new Message({
           role: 'user',
@@ -169,7 +172,7 @@ describe('SlidingWindowConversationManager', () => {
             new ToolResultBlock({
               toolUseId: 'tool-1',
               status: 'success',
-              content: [new TextBlock('Large tool result content')],
+              content: [new TextBlock(original)],
             }),
           ],
         }),
@@ -179,12 +182,38 @@ describe('SlidingWindowConversationManager', () => {
       await triggerContextOverflow(manager, mockAgent, new ContextWindowOverflowError('Context overflow'))
 
       const toolResult = messages[0]!.content[0]! as ToolResultBlock
-      expect(toolResult.status).toBe('error')
-      expect(toolResult.content[0]).toEqual({ type: 'textBlock', text: 'The tool result was too large!' })
+      // Status is preserved
+      expect(toolResult.status).toBe('success')
+      const first = toolResult.content[0]!
+      expect(first.type).toBe('textBlock')
+      const text = (first as TextBlock).text
+      const expected = `${'A'.repeat(200)}\n<truncated chars="${middle.length}"/>\n${'B'.repeat(200)}`
+      expect(text).toBe(expected)
+    })
+
+    it('leaves small tool results unchanged', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new TextBlock('Small result')],
+            }),
+          ],
+        }),
+      ]
+
+      const result = (manager as any)._truncateToolResults(messages, 0)
+      expect(result).toBe(false)
     })
 
     it('finds last message with tool results', async () => {
       const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const firstOriginal = 'F'.repeat(500)
+      const secondOriginal = 'S'.repeat(500)
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({
@@ -193,7 +222,7 @@ describe('SlidingWindowConversationManager', () => {
             new ToolResultBlock({
               toolUseId: 'tool-1',
               status: 'success',
-              content: [new TextBlock('First result')],
+              content: [new TextBlock(firstOriginal)],
             }),
           ],
         }),
@@ -204,7 +233,7 @@ describe('SlidingWindowConversationManager', () => {
             new ToolResultBlock({
               toolUseId: 'tool-2',
               status: 'success',
-              content: [new TextBlock('Second result')],
+              content: [new TextBlock(secondOriginal)],
             }),
           ],
         }),
@@ -215,13 +244,13 @@ describe('SlidingWindowConversationManager', () => {
 
       // Should truncate the last message with tool results (index 3)
       const lastToolResult = messages[3]!.content[0]! as ToolResultBlock
-      expect(lastToolResult.status).toBe('error')
-      expect(lastToolResult.content[0]).toEqual({ type: 'textBlock', text: 'The tool result was too large!' })
+      expect(lastToolResult.status).toBe('success')
+      expect((lastToolResult.content[0] as TextBlock).text).toContain('<truncated chars="100"/>')
 
       // Earlier tool result should remain unchanged
       const firstToolResult = messages[1]!.content[0]! as ToolResultBlock
       expect(firstToolResult.status).toBe('success')
-      expect(firstToolResult.content[0]).toEqual({ type: 'textBlock', text: 'First result' })
+      expect(firstToolResult.content[0]).toEqual({ type: 'textBlock', text: firstOriginal })
     })
 
     it('returns after successful truncation without trimming messages', async () => {
@@ -235,7 +264,7 @@ describe('SlidingWindowConversationManager', () => {
             new ToolResultBlock({
               toolUseId: 'tool-1',
               status: 'success',
-              content: [new TextBlock('Large result')],
+              content: [new TextBlock('L'.repeat(500))],
             }),
           ],
         }),
@@ -264,7 +293,7 @@ describe('SlidingWindowConversationManager', () => {
             new ToolResultBlock({
               toolUseId: 'tool-1',
               status: 'success',
-              content: [new TextBlock('Large result')],
+              content: [new TextBlock('L'.repeat(500))],
             }),
           ],
         }),
@@ -280,24 +309,28 @@ describe('SlidingWindowConversationManager', () => {
       // Tool result should not be truncated
       const toolResult = mockAgent.messages[2]!.content[0]! as ToolResultBlock
       expect(toolResult.status).toBe('success')
+      expect((toolResult.content[0] as TextBlock).text).toBe('L'.repeat(500))
     })
 
-    it('does not truncate already-truncated results', async () => {
+    it('does not re-truncate already-truncated results', async () => {
       const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      // Produced by an earlier run: 200 chars + marker + 200 chars = well under the 450-char
+      // threshold below which truncation is not worth running.
+      const alreadyTruncated = 'A'.repeat(200) + '\n<truncated chars="1000"/>\n' + 'B'.repeat(200)
       const messages = [
         new Message({
           role: 'user',
           content: [
             new ToolResultBlock({
               toolUseId: 'tool-1',
-              status: 'error',
-              content: [new TextBlock('The tool result was too large!')],
+              status: 'success',
+              content: [new TextBlock(alreadyTruncated)],
             }),
           ],
         }),
       ]
 
-      // First call should return false (already truncated)
+      // First call should return false (too short to gain anything from re-truncating)
       const result = (manager as any)._truncateToolResults(messages, 0)
       expect(result).toBe(false)
 
@@ -308,8 +341,8 @@ describe('SlidingWindowConversationManager', () => {
           content: [
             new ToolResultBlock({
               toolUseId: 'tool-1',
-              status: 'error',
-              content: [new TextBlock('The tool result was too large!')],
+              status: 'success',
+              content: [new TextBlock(alreadyTruncated)],
             }),
           ],
         }),
@@ -322,6 +355,85 @@ describe('SlidingWindowConversationManager', () => {
 
       // Should have trimmed messages since truncation was skipped
       expect(mockAgent.messages.length).toBeLessThan(3)
+    })
+
+    it('replaces image blocks nested in tool results with descriptive placeholders', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const bytes = new Uint8Array(1234)
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new ImageBlock({ format: 'png', source: { bytes } }), new TextBlock('tail')],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+
+      const toolResult = messages[0]!.content[0] as ToolResultBlock
+      expect(toolResult.status).toBe('success')
+      expect(toolResult.content).toHaveLength(2)
+      expect(toolResult.content[0]).toEqual({
+        type: 'textBlock',
+        text: '[image: png, source: bytes, 1234 bytes]',
+      })
+      expect(toolResult.content[1]).toEqual({ type: 'textBlock', text: 'tail' })
+    })
+
+    it('preserves the error field on truncated tool results', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const originalError = new Error('tool blew up')
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'error',
+              content: [new TextBlock('x'.repeat(500))],
+              error: originalError,
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+
+      const toolResult = messages[0]!.content[0] as ToolResultBlock
+      expect(toolResult.status).toBe('error')
+      expect(toolResult.error).toBe(originalError)
+    })
+
+    it('image placeholder reflects non-bytes source kinds honestly', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [
+                new ImageBlock({ format: 'jpeg', source: { url: 'https://example.com/x.jpg' } }),
+                new ImageBlock({ format: 'png', source: { location: { type: 's3', uri: 's3://bucket/key' } } }),
+              ],
+            }),
+          ],
+        }),
+      ]
+
+      ;(manager as any)._truncateToolResults(messages, 0)
+
+      const toolResult = messages[0]!.content[0] as ToolResultBlock
+      expect(toolResult.content[0]).toEqual({ type: 'textBlock', text: '[image: jpeg, source: url]' })
+      expect(toolResult.content[1]).toEqual({ type: 'textBlock', text: '[image: png, source: s3]' })
     })
 
     it('does not call truncateToolResults unless an error is passed in', async () => {
@@ -723,7 +835,7 @@ describe('SlidingWindowConversationManager', () => {
               new ToolResultBlock({
                 toolUseId: 'id-1',
                 status: 'success',
-                content: [new TextBlock('Large result')],
+                content: [new TextBlock('x'.repeat(500))],
               }),
             ],
           }),
@@ -735,14 +847,15 @@ describe('SlidingWindowConversationManager', () => {
 
       it('returns false when already truncated', () => {
         const manager = new SlidingWindowConversationManager()
+        const alreadyTruncated = 'A'.repeat(200) + '\n<truncated chars="1000"/>\n' + 'B'.repeat(200)
         const messages = [
           new Message({
             role: 'user',
             content: [
               new ToolResultBlock({
                 toolUseId: 'id-1',
-                status: 'error',
-                content: [new TextBlock('The tool result was too large!')],
+                status: 'success',
+                content: [new TextBlock(alreadyTruncated)],
               }),
             ],
           }),

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -213,7 +213,7 @@ describe('SlidingWindowConversationManager', () => {
       expect(result).toBe(false)
     })
 
-    it('finds last message with tool results', async () => {
+    it('finds oldest message with tool results', async () => {
       const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
       const firstOriginal = 'F'.repeat(500)
       const secondOriginal = 'S'.repeat(500)
@@ -245,20 +245,20 @@ describe('SlidingWindowConversationManager', () => {
 
       await triggerContextOverflow(manager, mockAgent, new ContextWindowOverflowError('Context overflow'))
 
-      // Last tool-result message is truncated; earlier one is untouched.
-      const expectedTruncated = `${'S'.repeat(200)}\n<truncated chars="100"/>\n${'S'.repeat(200)}`
-      expect(messages[3]!.content[0]).toEqual(
-        new ToolResultBlock({
-          toolUseId: 'tool-2',
-          status: 'success',
-          content: [new TextBlock(expectedTruncated)],
-        })
-      )
+      // Oldest tool-result message is truncated; newer one is untouched.
+      const expectedTruncated = `${'F'.repeat(200)}\n<truncated chars="100"/>\n${'F'.repeat(200)}`
       expect(messages[1]!.content[0]).toEqual(
         new ToolResultBlock({
           toolUseId: 'tool-1',
           status: 'success',
-          content: [new TextBlock(firstOriginal)],
+          content: [new TextBlock(expectedTruncated)],
+        })
+      )
+      expect(messages[3]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-2',
+          status: 'success',
+          content: [new TextBlock(secondOriginal)],
         })
       )
     })
@@ -363,7 +363,7 @@ describe('SlidingWindowConversationManager', () => {
         new Message({ role: 'assistant', content: [new TextBlock('Response')] }),
         new Message({ role: 'user', content: [new TextBlock('Message')] }),
       ]
-      const mockAgent = { messages: messages2 } as unknown as Agent
+      const mockAgent = createMockAgent({ messages: messages2 })
 
       await triggerContextOverflow(manager, mockAgent, new ContextWindowOverflowError('Context overflow'))
 
@@ -1041,7 +1041,7 @@ describe('SlidingWindowConversationManager', () => {
   })
 
   describe('helper methods', () => {
-    describe('findLastMessageWithToolResults', () => {
+    describe('findOldestMessageWithToolResults', () => {
       it('returns correct index when tool results exist', () => {
         const manager = new SlidingWindowConversationManager()
         const messages = [
@@ -1059,7 +1059,7 @@ describe('SlidingWindowConversationManager', () => {
           new Message({ role: 'assistant', content: [new TextBlock('Response')] }),
         ]
 
-        const index = (manager as any)._findLastMessageWithToolResults(messages)
+        const index = (manager as any)._findOldestMessageWithToolResults(messages)
         expect(index).toBe(1)
       })
 
@@ -1070,11 +1070,11 @@ describe('SlidingWindowConversationManager', () => {
           new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
         ]
 
-        const index = (manager as any)._findLastMessageWithToolResults(messages)
+        const index = (manager as any)._findOldestMessageWithToolResults(messages)
         expect(index).toBeUndefined()
       })
 
-      it('iterates backwards from end', () => {
+      it('iterates forward from start', () => {
         const manager = new SlidingWindowConversationManager()
         const messages = [
           new Message({
@@ -1100,9 +1100,9 @@ describe('SlidingWindowConversationManager', () => {
           }),
         ]
 
-        const index = (manager as any)._findLastMessageWithToolResults(messages)
-        // Should find the last one (index 2), not the first one (index 0)
-        expect(index).toBe(2)
+        const index = (manager as any)._findOldestMessageWithToolResults(messages)
+        // Should find the first one (index 0), not the last (index 2)
+        expect(index).toBe(0)
       })
     })
 

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi } from 'vitest'
 import { SlidingWindowConversationManager } from '../sliding-window-conversation-manager.js'
 import {
   ContextWindowOverflowError,
+  DocumentBlock,
   ImageBlock,
+  JsonBlock,
   Message,
   TextBlock,
   ToolUseBlock,
   ToolResultBlock,
+  VideoBlock,
   type Model,
 } from '../../index.js'
 import { AfterInvocationEvent, AfterModelCallEvent } from '../../hooks/events.js'
@@ -181,14 +184,14 @@ describe('SlidingWindowConversationManager', () => {
 
       await triggerContextOverflow(manager, mockAgent, new ContextWindowOverflowError('Context overflow'))
 
-      const toolResult = messages[0]!.content[0]! as ToolResultBlock
-      // Status is preserved
-      expect(toolResult.status).toBe('success')
-      const first = toolResult.content[0]!
-      expect(first.type).toBe('textBlock')
-      const text = (first as TextBlock).text
-      const expected = `${'A'.repeat(200)}\n<truncated chars="${middle.length}"/>\n${'B'.repeat(200)}`
-      expect(text).toBe(expected)
+      const expectedText = `${'A'.repeat(200)}\n<truncated chars="${middle.length}"/>\n${'B'.repeat(200)}`
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock(expectedText)],
+        })
+      )
     })
 
     it('leaves small tool results unchanged', () => {
@@ -242,15 +245,22 @@ describe('SlidingWindowConversationManager', () => {
 
       await triggerContextOverflow(manager, mockAgent, new ContextWindowOverflowError('Context overflow'))
 
-      // Should truncate the last message with tool results (index 3)
-      const lastToolResult = messages[3]!.content[0]! as ToolResultBlock
-      expect(lastToolResult.status).toBe('success')
-      expect((lastToolResult.content[0] as TextBlock).text).toContain('<truncated chars="100"/>')
-
-      // Earlier tool result should remain unchanged
-      const firstToolResult = messages[1]!.content[0]! as ToolResultBlock
-      expect(firstToolResult.status).toBe('success')
-      expect(firstToolResult.content[0]).toEqual({ type: 'textBlock', text: firstOriginal })
+      // Last tool-result message is truncated; earlier one is untouched.
+      const expectedTruncated = `${'S'.repeat(200)}\n<truncated chars="100"/>\n${'S'.repeat(200)}`
+      expect(messages[3]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-2',
+          status: 'success',
+          content: [new TextBlock(expectedTruncated)],
+        })
+      )
+      expect(messages[1]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock(firstOriginal)],
+        })
+      )
     })
 
     it('returns after successful truncation without trimming messages', async () => {
@@ -307,9 +317,13 @@ describe('SlidingWindowConversationManager', () => {
       expect(mockAgent.messages[0]!.role).toBe('user')
 
       // Tool result should not be truncated
-      const toolResult = mockAgent.messages[2]!.content[0]! as ToolResultBlock
-      expect(toolResult.status).toBe('success')
-      expect((toolResult.content[0] as TextBlock).text).toBe('L'.repeat(500))
+      expect(mockAgent.messages[2]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('L'.repeat(500))],
+        })
+      )
     })
 
     it('does not re-truncate already-truncated results', async () => {
@@ -376,14 +390,13 @@ describe('SlidingWindowConversationManager', () => {
       const changed = (manager as any)._truncateToolResults(messages, 0)
       expect(changed).toBe(true)
 
-      const toolResult = messages[0]!.content[0] as ToolResultBlock
-      expect(toolResult.status).toBe('success')
-      expect(toolResult.content).toHaveLength(2)
-      expect(toolResult.content[0]).toEqual({
-        type: 'textBlock',
-        text: '[image: png, source: bytes, 1234 bytes]',
-      })
-      expect(toolResult.content[1]).toEqual({ type: 'textBlock', text: 'tail' })
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('[image: png, source: bytes, 1234 bytes]'), new TextBlock('tail')],
+        })
+      )
     })
 
     it('preserves the error field on truncated tool results', () => {
@@ -406,9 +419,15 @@ describe('SlidingWindowConversationManager', () => {
       const changed = (manager as any)._truncateToolResults(messages, 0)
       expect(changed).toBe(true)
 
-      const toolResult = messages[0]!.content[0] as ToolResultBlock
-      expect(toolResult.status).toBe('error')
-      expect(toolResult.error).toBe(originalError)
+      const expectedText = `${'x'.repeat(200)}\n<truncated chars="100"/>\n${'x'.repeat(200)}`
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'error',
+          content: [new TextBlock(expectedText)],
+          error: originalError,
+        })
+      )
     })
 
     it('image placeholder reflects non-bytes source kinds honestly', () => {
@@ -431,9 +450,271 @@ describe('SlidingWindowConversationManager', () => {
 
       ;(manager as any)._truncateToolResults(messages, 0)
 
-      const toolResult = messages[0]!.content[0] as ToolResultBlock
-      expect(toolResult.content[0]).toEqual({ type: 'textBlock', text: '[image: jpeg, source: url]' })
-      expect(toolResult.content[1]).toEqual({ type: 'textBlock', text: '[image: png, source: s3]' })
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('[image: jpeg, source: url]'), new TextBlock('[image: png, source: s3]')],
+        })
+      )
+    })
+
+    it('replaces video bytes blocks with a descriptive placeholder', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new VideoBlock({ format: 'mp4', source: { bytes: new Uint8Array(4096) } })],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('[video: mp4, source: bytes, 4096 bytes]')],
+        })
+      )
+    })
+
+    it('replaces video s3 blocks with a descriptive placeholder', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [
+                new VideoBlock({
+                  format: 'mp4',
+                  source: { location: { type: 's3', uri: 's3://bucket/key' } },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('[video: mp4, source: s3]')],
+        })
+      )
+    })
+
+    it('replaces document bytes blocks with a descriptive placeholder', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [
+                new DocumentBlock({
+                  name: 'report',
+                  format: 'pdf',
+                  source: { bytes: new Uint8Array(8192) },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('[document: report, pdf, source: bytes, 8192 bytes]')],
+        })
+      )
+    })
+
+    it('replaces document s3 blocks with a descriptive placeholder', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [
+                new DocumentBlock({
+                  name: 'spec',
+                  format: 'pdf',
+                  source: { location: { type: 's3', uri: 's3://b/k' } },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock('[document: spec, pdf, source: s3]')],
+        })
+      )
+    })
+
+    it('partially truncates large text inside a document text source', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const middle = 'M'.repeat(240)
+      const originalText = 'A'.repeat(200) + middle + 'B'.repeat(200)
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new DocumentBlock({ name: 'report', format: 'txt', source: { text: originalText } })],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+
+      const expectedText = `${'A'.repeat(200)}\n<truncated chars="${middle.length}"/>\n${'B'.repeat(200)}`
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new DocumentBlock({ name: 'report', format: 'txt', source: { text: expectedText } })],
+        })
+      )
+    })
+
+    it('leaves small text inside a document text source unchanged', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new DocumentBlock({ name: 'short', format: 'txt', source: { text: 'hello' } })],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(false)
+    })
+
+    it('truncates long nested text blocks inside a document content source', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const longText = 'A'.repeat(200) + 'M'.repeat(240) + 'B'.repeat(200)
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [
+                new DocumentBlock({
+                  name: 'pages',
+                  format: 'txt',
+                  source: { content: [new TextBlock(longText), new TextBlock('short')] },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+
+      const expectedText = `${'A'.repeat(200)}\n<truncated chars="240"/>\n${'B'.repeat(200)}`
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [
+            new DocumentBlock({
+              name: 'pages',
+              format: 'txt',
+              source: { content: [new TextBlock(expectedText), new TextBlock('short')] },
+            }),
+          ],
+        })
+      )
+    })
+
+    it('replaces large json blocks with a size placeholder', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const big = { payload: 'x'.repeat(1000) }
+      const size = JSON.stringify(big).length
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new JsonBlock({ json: big })],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock(`[json: ${size} chars]`)],
+        })
+      )
+    })
+
+    it('leaves small json blocks unchanged', () => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new JsonBlock({ json: { ok: true } })],
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(false)
     })
 
     it('does not call truncateToolResults unless an error is passed in', async () => {

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -5,11 +5,39 @@
  * that preserves tool usage pairs and avoids invalid window states.
  */
 
-import { Message, TextBlock, ToolResultBlock } from '../types/messages.js'
+import { Message, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
+import { ImageBlock } from '../types/media.js'
 import type { LocalAgent } from '../types/agent.js'
 import { AfterInvocationEvent } from '../hooks/events.js'
 import { ConversationManager, type ConversationManagerReduceOptions } from './conversation-manager.js'
 import { logger } from '../logging/logger.js'
+
+const PRESERVE_CHARS = 200
+// Max plausible marker length, including newlines. Used as the minimum reduction
+// a re-truncation would need to produce in order to be worth running.
+const MIN_TRUNCATION_GAIN = 50
+
+/**
+ * Build a short textual stand-in for an image block, used when truncating tool
+ * results. The placeholder identifies the image format and its source kind
+ * (bytes/url/s3) so the model can reason about what was dropped. For inline
+ * bytes the size is included; URL and S3 sources only report the kind since
+ * their byte count isn't known locally.
+ */
+function imagePlaceholder(image: ImageBlock): string {
+  const format = image.format ?? 'unknown'
+  const source = image.source
+  if (source.type === 'imageSourceBytes') {
+    return `[image: ${format}, source: bytes, ${source.bytes.byteLength} bytes]`
+  }
+  if (source.type === 'imageSourceUrl') {
+    return `[image: ${format}, source: url]`
+  }
+  if (source.type === 'imageSourceS3Location') {
+    return `[image: ${format}, source: s3]`
+  }
+  return `[image: ${format}]`
+}
 
 /**
  * Configuration for the sliding window conversation manager.
@@ -187,10 +215,15 @@ export class SlidingWindowConversationManager extends ConversationManager {
   }
 
   /**
-   * Truncate tool results in a message to reduce context size.
+   * Truncate tool results and replace image blocks in a message to reduce context size.
    *
-   * When a message contains tool results that are too large for the model's context window,
-   * this function replaces the content of those tool results with a simple error message.
+   * For text blocks inside tool results, content longer than 2 * {@link PRESERVE_CHARS}
+   * is partially truncated, keeping the first and last {@link PRESERVE_CHARS} characters
+   * and replacing the middle with a marker indicating how many characters were removed.
+   * Already-truncated text is skipped. The tool result status is preserved.
+   *
+   * Image blocks nested inside tool result content are replaced with a short descriptive
+   * placeholder.
    *
    * @param messages - The conversation message history.
    * @param msgIdx - Index of the message containing tool results to truncate.
@@ -206,46 +239,55 @@ export class SlidingWindowConversationManager extends ConversationManager {
       return false
     }
 
-    const toolResultTooLargeMessage = 'The tool result was too large!'
-    let foundToolResultToTruncate = false
+    let changesMade = false
+    const newContent = message.content.map((block) => {
+      if (block.type !== 'toolResultBlock') {
+        return block
+      }
 
-    // First, check if there's a tool result that needs truncation
-    for (const block of message.content) {
-      if (block.type === 'toolResultBlock') {
-        const toolResultBlock = block as ToolResultBlock
+      const toolResultBlock = block as ToolResultBlock
+      const newItems: ToolResultContent[] = []
+      let itemChanged = false
 
-        // Check if already truncated
-        const firstContent = toolResultBlock.content[0]
-        const contentText = firstContent && firstContent.type === 'textBlock' ? firstContent.text : ''
-
-        if (toolResultBlock.status === 'error' && contentText === toolResultTooLargeMessage) {
-          return false
+      for (const item of toolResultBlock.content) {
+        if (item.type === 'imageBlock') {
+          newItems.push(new TextBlock(imagePlaceholder(item)))
+          itemChanged = true
+          continue
         }
 
-        foundToolResultToTruncate = true
-        break
-      }
-    }
+        if (item.type === 'textBlock') {
+          const text = item.text
+          if (text.length > 2 * PRESERVE_CHARS + MIN_TRUNCATION_GAIN) {
+            const prefix = text.slice(0, PRESERVE_CHARS)
+            const suffix = text.slice(-PRESERVE_CHARS)
+            const removed = text.length - 2 * PRESERVE_CHARS
+            newItems.push(new TextBlock(`${prefix}\n<truncated chars="${removed}"/>\n${suffix}`))
+            itemChanged = true
+            continue
+          }
+        }
 
-    if (!foundToolResultToTruncate) {
+        newItems.push(item)
+      }
+
+      if (!itemChanged) {
+        return block
+      }
+
+      changesMade = true
+      return new ToolResultBlock({
+        toolUseId: toolResultBlock.toolUseId,
+        status: toolResultBlock.status,
+        content: newItems,
+        ...(toolResultBlock.error !== undefined ? { error: toolResultBlock.error } : {}),
+      })
+    })
+
+    if (!changesMade) {
       return false
     }
 
-    // Create new content array with truncated tool results
-    const newContent = message.content.map((block) => {
-      if (block.type === 'toolResultBlock') {
-        const toolResultBlock = block as ToolResultBlock
-        // Create new ToolResultBlock with truncated content
-        return new ToolResultBlock({
-          toolUseId: toolResultBlock.toolUseId,
-          status: 'error',
-          content: [new TextBlock(toolResultTooLargeMessage)],
-        })
-      }
-      return block
-    })
-
-    // Replace the message in the array with a new message containing the modified content
     messages[msgIdx] = new Message({
       role: message.role,
       content: newContent,

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -5,8 +5,8 @@
  * that preserves tool usage pairs and avoids invalid window states.
  */
 
-import { Message, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
-import { ImageBlock } from '../types/media.js'
+import { JsonBlock, Message, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
 import type { LocalAgent } from '../types/agent.js'
 import { AfterInvocationEvent } from '../hooks/events.js'
 import { ConversationManager, type ConversationManagerReduceOptions } from './conversation-manager.js'
@@ -16,6 +16,11 @@ const PRESERVE_CHARS = 200
 // Max plausible marker length, including newlines. Used as the minimum reduction
 // a re-truncation would need to produce in order to be worth running.
 const MIN_TRUNCATION_GAIN = 50
+// Text payloads at or below this length aren't worth truncating: the savings
+// would be smaller than the marker itself, and already-truncated output (which
+// lands just above `2 * PRESERVE_CHARS`) falls under this threshold so a
+// second pass is a natural no-op.
+const TRUNCATION_THRESHOLD = 2 * PRESERVE_CHARS + MIN_TRUNCATION_GAIN
 
 /**
  * Build a short textual stand-in for an image block, used when truncating tool
@@ -25,18 +30,50 @@ const MIN_TRUNCATION_GAIN = 50
  * their byte count isn't known locally.
  */
 function imagePlaceholder(image: ImageBlock): string {
-  const format = image.format ?? 'unknown'
   const source = image.source
   if (source.type === 'imageSourceBytes') {
-    return `[image: ${format}, source: bytes, ${source.bytes.byteLength} bytes]`
+    return `[image: ${image.format}, source: bytes, ${source.bytes.byteLength} bytes]`
   }
   if (source.type === 'imageSourceUrl') {
-    return `[image: ${format}, source: url]`
+    return `[image: ${image.format}, source: url]`
   }
-  if (source.type === 'imageSourceS3Location') {
-    return `[image: ${format}, source: s3]`
+  return `[image: ${image.format}, source: s3]`
+}
+
+/**
+ * Build a short textual stand-in for a video block. Binary payloads can't be
+ * partially inspected, so videos are replaced wholesale. The placeholder
+ * reports format and source kind; byte count is included for inline bytes.
+ */
+function videoPlaceholder(video: VideoBlock): string {
+  const source = video.source
+  if (source.type === 'videoSourceBytes') {
+    return `[video: ${video.format}, source: bytes, ${source.bytes.byteLength} bytes]`
   }
-  return `[image: ${format}]`
+  return `[video: ${video.format}, source: s3]`
+}
+
+/**
+ * Build a short textual stand-in for a document block with a binary or remote
+ * source. Text-based document sources (text / content) are truncated in place
+ * instead of replaced, so this is only called for bytes / s3.
+ */
+function documentPlaceholder(doc: DocumentBlock): string {
+  const source = doc.source
+  if (source.type === 'documentSourceBytes') {
+    return `[document: ${doc.name}, ${doc.format}, source: bytes, ${source.bytes.byteLength} bytes]`
+  }
+  return `[document: ${doc.name}, ${doc.format}, source: s3]`
+}
+
+/**
+ * Build a short textual stand-in for a JSON block. The serialized length is
+ * reported so the model knows how much was dropped; truncating JSON
+ * mid-structure would produce invalid output, so the whole block is replaced.
+ */
+function jsonPlaceholder(json: JsonBlock): string {
+  const size = JSON.stringify(json.json).length
+  return `[json: ${size} chars]`
 }
 
 /**
@@ -215,15 +252,37 @@ export class SlidingWindowConversationManager extends ConversationManager {
   }
 
   /**
-   * Truncate tool results and replace image blocks in a message to reduce context size.
+   * Apply head/tail truncation to a string if it exceeds the size threshold.
    *
-   * For text blocks inside tool results, content longer than 2 * {@link PRESERVE_CHARS}
-   * is partially truncated, keeping the first and last {@link PRESERVE_CHARS} characters
-   * and replacing the middle with a marker indicating how many characters were removed.
-   * Already-truncated text is skipped. The tool result status is preserved.
+   * Returns the truncated form (first {@link PRESERVE_CHARS} + marker + last
+   * {@link PRESERVE_CHARS}) when the input exceeds {@link TRUNCATION_THRESHOLD},
+   * otherwise `undefined`.
+   */
+  private _truncateLongText(text: string): string | undefined {
+    if (text.length <= TRUNCATION_THRESHOLD) {
+      return undefined
+    }
+    const prefix = text.slice(0, PRESERVE_CHARS)
+    const suffix = text.slice(-PRESERVE_CHARS)
+    const removed = text.length - 2 * PRESERVE_CHARS
+    return `${prefix}\n<truncated chars="${removed}"/>\n${suffix}`
+  }
+
+  /**
+   * Truncate tool result content in a message to reduce context size.
    *
-   * Image blocks nested inside tool result content are replaced with a short descriptive
-   * placeholder.
+   * Rule: preserve head/tail when the payload is plain-text-shaped; replace
+   * wholesale when it's binary or remote. Specifically:
+   * - Text blocks: partial head/tail truncation if over threshold.
+   * - Image, Video blocks: wholesale replacement with a textual placeholder.
+   * - Document blocks with bytes/s3 source: wholesale replacement.
+   * - Document blocks with text source: partial truncation of the inner text.
+   * - Document blocks with content source (TextBlock[]): partial truncation of
+   *   each nested block.
+   * - JSON blocks: wholesale replacement if serialized length is over threshold;
+   *   mid-structure truncation would produce invalid JSON.
+   *
+   * The tool result `status` and `error` fields are preserved.
    *
    * @param messages - The conversation message history.
    * @param msgIdx - Index of the message containing tool results to truncate.
@@ -256,13 +315,78 @@ export class SlidingWindowConversationManager extends ConversationManager {
           continue
         }
 
+        if (item.type === 'videoBlock') {
+          newItems.push(new TextBlock(videoPlaceholder(item)))
+          itemChanged = true
+          continue
+        }
+
+        if (item.type === 'documentBlock') {
+          const source = item.source
+          if (source.type === 'documentSourceBytes' || source.type === 'documentSourceS3Location') {
+            newItems.push(new TextBlock(documentPlaceholder(item)))
+            itemChanged = true
+            continue
+          }
+          if (source.type === 'documentSourceText') {
+            const truncated = this._truncateLongText(source.text)
+            if (truncated !== undefined) {
+              newItems.push(
+                new DocumentBlock({
+                  name: item.name,
+                  format: item.format,
+                  source: { text: truncated },
+                  ...(item.citations !== undefined ? { citations: item.citations } : {}),
+                  ...(item.context !== undefined ? { context: item.context } : {}),
+                })
+              )
+              itemChanged = true
+              continue
+            }
+          }
+          if (source.type === 'documentSourceContentBlock') {
+            let nestedChanged = false
+            const newContentBlocks = source.content.map((nested) => {
+              const truncated = this._truncateLongText(nested.text)
+              if (truncated !== undefined) {
+                nestedChanged = true
+                return new TextBlock(truncated)
+              }
+              return nested
+            })
+            if (nestedChanged) {
+              newItems.push(
+                new DocumentBlock({
+                  name: item.name,
+                  format: item.format,
+                  source: { content: newContentBlocks },
+                  ...(item.citations !== undefined ? { citations: item.citations } : {}),
+                  ...(item.context !== undefined ? { context: item.context } : {}),
+                })
+              )
+              itemChanged = true
+              continue
+            }
+          }
+          newItems.push(item)
+          continue
+        }
+
+        if (item.type === 'jsonBlock') {
+          const serializedLength = JSON.stringify(item.json).length
+          if (serializedLength > TRUNCATION_THRESHOLD) {
+            newItems.push(new TextBlock(jsonPlaceholder(item)))
+            itemChanged = true
+            continue
+          }
+          newItems.push(item)
+          continue
+        }
+
         if (item.type === 'textBlock') {
-          const text = item.text
-          if (text.length > 2 * PRESERVE_CHARS + MIN_TRUNCATION_GAIN) {
-            const prefix = text.slice(0, PRESERVE_CHARS)
-            const suffix = text.slice(-PRESERVE_CHARS)
-            const removed = text.length - 2 * PRESERVE_CHARS
-            newItems.push(new TextBlock(`${prefix}\n<truncated chars="${removed}"/>\n${suffix}`))
+          const truncated = this._truncateLongText(item.text)
+          if (truncated !== undefined) {
+            newItems.push(new TextBlock(truncated))
             itemChanged = true
             continue
           }

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -5,7 +5,7 @@
  * that preserves tool usage pairs and avoids invalid window states.
  */
 
-import { JsonBlock, Message, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
+import { Message, TextBlock, ToolResultBlock, type ToolResultContent } from '../types/messages.js'
 import { DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
 import type { LocalAgent } from '../types/agent.js'
 import { AfterInvocationEvent } from '../hooks/events.js'
@@ -71,9 +71,8 @@ function documentPlaceholder(doc: DocumentBlock): string {
  * reported so the model knows how much was dropped; truncating JSON
  * mid-structure would produce invalid output, so the whole block is replaced.
  */
-function jsonPlaceholder(json: JsonBlock): string {
-  const size = JSON.stringify(json.json).length
-  return `[json: ${size} chars]`
+function jsonPlaceholder(serializedLength: number): string {
+  return `[json: ${serializedLength} chars]`
 }
 
 /**
@@ -375,7 +374,7 @@ export class SlidingWindowConversationManager extends ConversationManager {
         if (item.type === 'jsonBlock') {
           const serializedLength = JSON.stringify(item.json).length
           if (serializedLength > TRUNCATION_THRESHOLD) {
-            newItems.push(new TextBlock(jsonPlaceholder(item)))
+            newItems.push(new TextBlock(jsonPlaceholder(serializedLength)))
             itemChanged = true
             continue
           }

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -186,9 +186,9 @@ export class SlidingWindowConversationManager extends ConversationManager {
    */
   private _reduceContext(messages: Message[], _error?: Error): boolean {
     // Only truncate tool results when handling a context overflow error, not for window size enforcement
-    const lastMessageIdxWithToolResults = this._findLastMessageWithToolResults(messages)
-    if (_error && lastMessageIdxWithToolResults !== undefined && this._shouldTruncateResults) {
-      const resultsTruncated = this._truncateToolResults(messages, lastMessageIdxWithToolResults)
+    const oldestMessageIdxWithToolResults = this._findOldestMessageWithToolResults(messages)
+    if (_error && oldestMessageIdxWithToolResults !== undefined && this._shouldTruncateResults) {
+      const resultsTruncated = this._truncateToolResults(messages, oldestMessageIdxWithToolResults)
       if (resultsTruncated) {
         return true
       }
@@ -420,16 +420,16 @@ export class SlidingWindowConversationManager extends ConversationManager {
   }
 
   /**
-   * Find the index of the last message containing tool results.
+   * Find the index of the oldest message containing tool results.
    *
-   * This is useful for identifying messages that might need to be truncated to reduce context size.
+   * Truncation targets the least-recent tool result first so the most relevant
+   * recent context is preserved as long as possible.
    *
    * @param messages - The conversation message history.
-   * @returns Index of the last message with tool results, or undefined if no such message exists.
+   * @returns Index of the oldest message with tool results, or undefined if no such message exists.
    */
-  private _findLastMessageWithToolResults(messages: Message[]): number | undefined {
-    // Iterate backwards through all messages (from newest to oldest)
-    for (let idx = messages.length - 1; idx >= 0; idx--) {
+  private _findOldestMessageWithToolResults(messages: Message[]): number | undefined {
+    for (let idx = 0; idx < messages.length; idx++) {
       const currentMessage = messages[idx]!
 
       const hasToolResult = currentMessage.content.some((block) => block.type === 'toolResultBlock')


### PR DESCRIPTION
## Description

Improves how `SlidingWindowConversationManager` handles context overflow by truncating oversized tool-result content instead of destroying it.

Previously, overflow recovery replaced any tool-result block with a fixed error message and forced its status to `error`. This misreported successful tool calls to the model on retry and threw away every byte of the result, including the small head/tail that's often the useful part.

This change aligns closer towards the python implementation.

The new behavior:

- Large text items in tool results keep their first and last 200 characters, with a `<truncated chars="N"/>` marker in the middle.
- Image, video, and binary/remote document blocks nested in tool results become textual placeholders that identify format and source (e.g. `bytes`, `url`, `s3`), with byte count for inline bytes.
- Document blocks with `text` or `content` (TextBlock[]) sources have their inner text partially truncated in place.
- Large JSON blocks are replaced with a size placeholder; mid-structure truncation would produce invalid JSON.
- Truncation targets the oldest tool result first so the most relevant recent context is preserved as long as possible.
- Original `status` and `error` fields on the tool-result block are preserved.
- Re-running truncation on already-truncated content is a no-op, enforced by the length threshold rather than a sentinel string — no coupling to the marker format.

When a tool-result is already small enough that truncation wouldn't help, the manager falls through to its existing message-trimming path, so context still shrinks.


### Python Comparison

Same core idea as Python: partial head/tail truncation (200 chars each side) with a middle marker, oldest-first targeting, image/video/document blocks replaced by text placeholders, tool-result `status` preserved. Differences: TS enforces idempotency via a length threshold (450 chars); Python does it via a sentinel string (`"... [truncated:"`).

TS image placeholders distinguish `bytes`/`url`/`s3` sources honestly; Python's only reports bytes and renders URL/S3 images as `0 bytes`. TS also covers `VideoBlock`, `DocumentBlock` (all four source kinds, including partial truncation for text/content sources), and `JsonBlock`, which the Python pass-through skips. Python has features TS still lacks: a `per_turn` proactive management mode for screenshot-heavy loops, and a fallback trim boundary at `assistant(toolUse) + user(toolResult)` pairs when no plain-user boundary exists — both are reasonable follow-ups but out of scope for this diff.

## Related Issues

## Documentation PR

follow up

## Type of Change

Bug fix/Feature Update

## Testing

How have you tested the change?

- [x] I ran `npm run check`

Unit tests in `strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts` cover:
- Partial truncation preserves head/tail and emits the expected marker
- Small results pass through unchanged
- Oldest tool-result message is the one truncated
- Already-truncated results are not re-truncated
- `status` and `error` fields survive truncation
- Placeholders for image / video / document (bytes, s3) sources
- Partial truncation for document text and content sources
- JSON blocks: size placeholder when large, pass-through when small

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
