### PR TITLE
refactor: rename hook order to SDK first/last

### DIFF
--- a/strands-ts/src/hooks/types.ts
+++ b/strands-ts/src/hooks/types.ts
@@ -34,16 +34,19 @@ export interface HookCallbackOptions {
 export type HookCleanup = () => void
 
 /**
- * Named constants for hook execution order.
- * Lower values run first.
+ * Presets for hook execution order. Lower values run first.
+ * Any number is a valid order — these presets are not bounds, just convenient
+ * reference points. SDK_FIRST/SDK_LAST mark where the SDK's own hooks run,
+ * so you can position yours relative to them.
  *
  * @example
  * ```typescript
- * agent.addHook(BeforeToolCallEvent, callback, { order: HookOrder.FIRST })
+ * agent.addHook(BeforeToolCallEvent, callback, { order: HookOrder.SDK_FIRST }) // run with the SDK's earliest hooks
+ * agent.addHook(BeforeToolCallEvent, callback, { order: HookOrder.SDK_FIRST - 1 }) // run before the SDK's earliest hooks
  * ```
  */
 export const HookOrder = {
-  FIRST: -100,
+  SDK_FIRST: -100,
   DEFAULT: 0,
-  LAST: 100,
+  SDK_LAST: 100,
 } as const


### PR DESCRIPTION

## Description

Renames `HookOrder.FIRST`/`HookOrder.LAST` to `HookOrder.SDK_FIRST`/`HookOrder.SDK_LAST` to clarify that these are reference points for where the SDK's internal hooks run, not enforced bounds. Users can pass any number (including values beyond these) to position their hooks relative to the SDK's.

Updates the JSDoc to make it clear these are convenience presets, not absolute limits.

## Related Issues

#1005

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.