### PR TITLE
feat(mcp): handle toolsChanged notifications

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -149,7 +149,14 @@ describe('MCP Integration', () => {
     })
 
     it('initializes SDK client with correct configuration', () => {
-      expect(Client).toHaveBeenCalledWith({ name: 'TestApp', version: '0.0.1' }, undefined)
+      expect(Client).toHaveBeenCalledWith(
+        { name: 'TestApp', version: '0.0.1' },
+        expect.objectContaining({
+          listChanged: expect.objectContaining({
+            tools: expect.objectContaining({ autoRefresh: false, debounceMs: 300 }),
+          }),
+        })
+      )
     })
 
     it('injects trace context into tool arguments when active span exists', async () => {
@@ -414,7 +421,7 @@ describe('MCP Integration', () => {
       })
 
       const lastCall = vi.mocked(Client).mock.calls.at(-1)!
-      expect(lastCall[1]).toEqual({ capabilities: { elicitation: { form: {}, url: {} } } })
+      expect(lastCall[1]).toEqual(expect.objectContaining({ capabilities: { elicitation: { form: {}, url: {} } } }))
     })
 
     it('elicitation handler returns accepted result with content', async () => {
@@ -482,6 +489,136 @@ describe('MCP Integration', () => {
       const extra = { signal: new AbortController().signal }
 
       await expect(handler(request, extra)).rejects.toThrow('User cancelled')
+    })
+  })
+
+  describe('tools list changed', () => {
+    let client: McpClient
+    let sdkClientMock: {
+      connect: ReturnType<typeof vi.fn>
+      close: ReturnType<typeof vi.fn>
+      listTools: ReturnType<typeof vi.fn>
+      callTool: ReturnType<typeof vi.fn>
+      setRequestHandler: ReturnType<typeof vi.fn>
+      setNotificationHandler: ReturnType<typeof vi.fn>
+      getServerCapabilities: ReturnType<typeof vi.fn>
+      getServerVersion: ReturnType<typeof vi.fn>
+      getInstructions: ReturnType<typeof vi.fn>
+      experimental: { tasks: { callToolStream: ReturnType<typeof vi.fn> } }
+    }
+
+    beforeEach(() => {
+      client = new McpClient({ applicationName: 'TestApp', transport: mockTransport })
+      sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
+      sdkClientMock.connect.mockResolvedValue(undefined)
+    })
+
+    function triggerToolsChanged(): void {
+      const ctorCall = vi.mocked(Client).mock.calls.at(-1)!
+      ctorCall[1]!.listChanged!.tools!.onChanged(null, null)
+    }
+
+    it('calls onToolsChanged with old names and new tools when list changes', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'tool_a', description: 'A', inputSchema: {} }],
+      })
+      await client.listTools()
+
+      const onToolsChanged = vi.fn()
+      client.onToolsChanged = onToolsChanged
+
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [
+          { name: 'tool_a', description: 'A', inputSchema: {} },
+          { name: 'tool_b', description: 'B', inputSchema: {} },
+        ],
+      })
+
+      triggerToolsChanged()
+      await vi.waitFor(() => expect(onToolsChanged).toHaveBeenCalled())
+
+      expect(onToolsChanged).toHaveBeenCalledWith(['tool_a'], expect.any(Array))
+      const newTools = onToolsChanged.mock.calls[0]![1] as McpTool[]
+      expect(newTools.map((t) => t.name)).toEqual(['tool_a', 'tool_b'])
+    })
+
+    it('updates registered tool names after each listTools call', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [
+          { name: 'x', description: 'X', inputSchema: {} },
+          { name: 'y', description: 'Y', inputSchema: {} },
+        ],
+      })
+      await client.listTools()
+
+      const onToolsChanged = vi.fn()
+      client.onToolsChanged = onToolsChanged
+
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'z', description: 'Z', inputSchema: {} }],
+      })
+
+      triggerToolsChanged()
+      await vi.waitFor(() => expect(onToolsChanged).toHaveBeenCalled())
+
+      expect(onToolsChanged).toHaveBeenCalledWith(['x', 'y'], expect.any(Array))
+      const newTools = onToolsChanged.mock.calls[0]![1] as McpTool[]
+      expect(newTools.map((t) => t.name)).toEqual(['z'])
+    })
+
+    it('does not throw when onToolsChanged is not set', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'tool_a', description: 'A', inputSchema: {} }],
+      })
+      await client.listTools()
+
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'tool_b', description: 'B', inputSchema: {} }],
+      })
+
+      triggerToolsChanged()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    it('logs warning and preserves registry when listTools fails during refresh', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'tool_a', description: 'A', inputSchema: {} }],
+      })
+      await client.listTools()
+
+      const onToolsChanged = vi.fn()
+      client.onToolsChanged = onToolsChanged
+
+      sdkClientMock.listTools.mockRejectedValue(new Error('server disconnected'))
+      const warnSpy = vi.spyOn(logger, 'warn')
+
+      triggerToolsChanged()
+      await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled())
+
+      expect(onToolsChanged).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to refresh tools'))
+    })
+
+    it('coalesces notifications received during an in-flight refresh into one extra refresh', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'tool_a', description: 'A', inputSchema: {} }],
+      })
+      await client.listTools()
+
+      const onToolsChanged = vi.fn()
+      client.onToolsChanged = onToolsChanged
+
+      let resolveListTools: (value: unknown) => void
+      sdkClientMock.listTools.mockReturnValue(new Promise((r) => (resolveListTools = r)))
+
+      triggerToolsChanged()
+      triggerToolsChanged()
+      triggerToolsChanged()
+
+      resolveListTools!({ tools: [{ name: 'tool_b', description: 'B', inputSchema: {} }] })
+      await vi.waitFor(() => expect(onToolsChanged).toHaveBeenCalledTimes(2))
+
+      expect(sdkClientMock.listTools).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { Agent, type ToolList } from '../agent.js'
+import { McpClient } from '../../mcp.js'
+import { McpTool } from '../../tools/mcp-tool.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockTool, createRandomTool } from '../../__fixtures__/tool-helpers.js'
@@ -1854,5 +1856,43 @@ describe('normalizeToolUseNames', () => {
       .find((m) => m.role === 'assistant')!
       .content.find((b) => b.type === 'toolUseBlock') as ToolUseBlock
     expect(sentToolUse).toStrictEqual(new ToolUseBlock({ name: 'good_tool-1', toolUseId: 'tu-1', input: {} }))
+  })
+
+  describe('MCP toolsChanged integration', () => {
+    it('removes old tools and adds new tools when onToolsChanged fires', async () => {
+      const mcpClient = new McpClient({
+        transport: { start: vi.fn(), send: vi.fn(), close: vi.fn() } as never,
+      })
+
+      const initialTools = [
+        new McpTool({ name: 'tool_a', description: 'A', inputSchema: {}, client: mcpClient }),
+        new McpTool({ name: 'tool_b', description: 'B', inputSchema: {}, client: mcpClient }),
+      ]
+      vi.spyOn(mcpClient, 'listTools').mockResolvedValue(initialTools)
+
+      let capturedCallback: ((oldTools: string[], newTools: McpTool[]) => void) | undefined
+      const setterSpy = vi.spyOn(McpClient.prototype, 'onToolsChanged', 'set').mockImplementation((cb) => {
+        capturedCallback = cb
+      })
+
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'done' })
+      const agent = new Agent({ model, tools: [mcpClient] })
+      await agent.initialize()
+
+      expect(agent.tools.map((t) => t.name)).toEqual(['tool_a', 'tool_b'])
+      expect(capturedCallback).toBeDefined()
+
+      const newTools = [
+        new McpTool({ name: 'tool_b', description: 'B-updated', inputSchema: {}, client: mcpClient }),
+        new McpTool({ name: 'tool_c', description: 'C', inputSchema: {}, client: mcpClient }),
+      ]
+
+      capturedCallback!(['tool_a', 'tool_b'], newTools)
+
+      expect(agent.tools.map((t) => t.name)).toEqual(['tool_b', 'tool_c'])
+      expect(agent.tools.find((t) => t.name === 'tool_b')!.description).toBe('B-updated')
+
+      setterSpy.mockRestore()
+    })
   })
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -426,6 +426,10 @@ export class Agent implements LocalAgent, InvokableAgent {
       this._mcpClients.map(async (client) => {
         const tools = await client.listTools()
         this._toolRegistry.add(tools)
+        client.onToolsChanged = (oldTools, newTools): void => {
+          oldTools.forEach((name) => this._toolRegistry.remove(name))
+          this._toolRegistry.addOrReplace(newTools)
+        }
       })
     )
 

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -103,6 +103,10 @@ export class McpClient {
   private _disableMcpInstrumentation: boolean
   private _tasksConfig: TasksConfig | undefined
   private _elicitationCallback: ElicitationCallback | undefined
+  private _registeredToolNames = new Set<string>()
+  private _onToolsChanged: ((oldTools: string[], newTools: McpTool[]) => void) | undefined
+  private _refreshingTools = false
+  private _pendingRefresh = false
 
   constructor(args: McpClientConfig) {
     this._clientName = args.applicationName || 'strands-agents-ts-sdk'
@@ -118,7 +122,18 @@ export class McpClient {
         name: this._clientName,
         version: this._clientVersion,
       },
-      this._elicitationCallback ? { capabilities: { elicitation: { form: {}, url: {} } } } : undefined
+      {
+        ...(this._elicitationCallback ? { capabilities: { elicitation: { form: {}, url: {} } } } : undefined),
+        listChanged: {
+          tools: {
+            autoRefresh: false,
+            debounceMs: 300,
+            onChanged: (): void => {
+              this._handleToolsChanged()
+            },
+          },
+        },
+      }
     )
 
     this._client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
@@ -235,7 +250,41 @@ export class McpClient {
       cursor = result.nextCursor
     } while (cursor)
 
+    this._registeredToolNames = new Set(tools.map((t) => t.name))
+
     return tools
+  }
+
+  /**
+   * Sets a callback invoked when the MCP server's tool list changes at runtime.
+   *
+   * @param callback - Handler receiving the previous tool names and the refreshed tool instances,
+   *                   or undefined to remove the callback.
+   */
+  set onToolsChanged(callback: ((oldTools: string[], newTools: McpTool[]) => void) | undefined) {
+    this._onToolsChanged = callback
+  }
+
+  private async _handleToolsChanged(): Promise<void> {
+    if (this._refreshingTools) {
+      this._pendingRefresh = true
+      return
+    }
+    this._refreshingTools = true
+    try {
+      do {
+        this._pendingRefresh = false
+        const oldTools = [...this._registeredToolNames]
+        const newTools = await this.listTools()
+        this._onToolsChanged?.(oldTools, newTools)
+      } while (this._pendingRefresh)
+    } catch (err) {
+      logger.warn(
+        `client=<${this._clientName}>, error=<${err}> | failed to refresh tools after toolsChanged notification`
+      )
+    } finally {
+      this._refreshingTools = false
+    }
   }
 
   /**

--- a/strands-ts/src/registry/__tests__/tool-registry.test.ts
+++ b/strands-ts/src/registry/__tests__/tool-registry.test.ts
@@ -110,6 +110,26 @@ describe('ToolRegistry', () => {
     })
   })
 
+  describe('addOrReplace', () => {
+    it('registers tools', () => {
+      const tool = createMockTool({ name: 'tool-1' })
+      registry.addOrReplace([tool])
+      expect(registry.get('tool-1')).toBe(tool)
+    })
+
+    it('replaces an existing tool with the same name', () => {
+      const original = createMockTool({ name: 'tool-1', description: 'original' })
+      const replacement = createMockTool({ name: 'tool-1', description: 'replacement' })
+      registry.add(original)
+      registry.addOrReplace([replacement])
+      expect(registry.get('tool-1')).toBe(replacement)
+    })
+
+    it('validates tool properties', () => {
+      expect(() => registry.addOrReplace([createMockTool({ name: 'invalid name!' })])).toThrow(ToolValidationError)
+    })
+  })
+
   describe('get', () => {
     it('retrieves a tool by name', () => {
       const tool = createMockTool({ name: 'find-me' })

--- a/strands-ts/src/registry/tool-registry.ts
+++ b/strands-ts/src/registry/tool-registry.ts
@@ -27,8 +27,24 @@ export class ToolRegistry {
   add(tool: Tool | Tool[]): void {
     const tools = Array.isArray(tool) ? tool : [tool]
     for (const t of tools) {
-      this._validate(t)
+      this._validateProperties(t)
+      if (this._tools.has(t.name)) {
+        throw new ToolValidationError(`Tool with name '${t.name}' already registered`)
+      }
       this._tools.set(t.name, t)
+    }
+  }
+
+  /**
+   * Registers one or more tools, replacing any existing tools with the same name.
+   *
+   * @param tools - Array of tools to register
+   * @throws ToolValidationError If a tool's properties are invalid
+   */
+  addOrReplace(newTools: Tool[]): void {
+    for (const tool of newTools) {
+      this._validateProperties(tool)
+      this._tools.set(tool.name, tool)
     }
   }
 
@@ -67,13 +83,7 @@ export class ToolRegistry {
     return Array.from(this._tools.values())
   }
 
-  /**
-   * Validates a tool before registration.
-   *
-   * @param tool - The tool to validate
-   * @throws ToolValidationError If the tool's properties are invalid or its name is already registered
-   */
-  private _validate(tool: Tool): void {
+  private _validateProperties(tool: Tool): void {
     if (typeof tool.name !== 'string') {
       throw new ToolValidationError('Tool name must be a string')
     }
@@ -91,10 +101,6 @@ export class ToolRegistry {
       if (typeof tool.description !== 'string' || tool.description.length < 1) {
         throw new ToolValidationError('Tool description must be a non-empty string')
       }
-    }
-
-    if (this._tools.has(tool.name)) {
-      throw new ToolValidationError(`Tool with name '${tool.name}' already registered`)
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

When an MCP server adds, removes, or changes its tools at runtime, the agent's tool registry now stays in sync automatically.

MCP servers emit notifications/tools/list_changed when their tool list changes. The MCP SDK already handles subscribing to this — it debounces (300ms) and calls a hook you provide at client construction time.

## Changes

- mcp.ts — Pass listChanged.tools.onChanged to the MCP SDK Client constructor; track registered tool names; expose onToolsChanged setter; implement _handleToolsChanged with re-entrance guard and error handling
- agent.ts — In initialize(), register an onToolsChanged callback on each McpClient that removes old tools from the registry and adds the new ones
- mcp.test.ts — Tests for: callback with correct old/new tools, error path (listTools rejects), re-entrance skip

## Related Issues

<!-- Link to related issues using #issue-number format -->

#850 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
