### PR TITLE
chore: serialized interrupts and structuredOutput as JSON and citationsBlock

### DIFF
--- a/strands-ts/src/types/__tests__/agent.test.ts
+++ b/strands-ts/src/types/__tests__/agent.test.ts
@@ -4,6 +4,8 @@ import { AgentMetrics } from '../../telemetry/meter.js'
 import { AgentTrace } from '../../telemetry/tracer.js'
 import { Message } from '../messages.js'
 import { TextBlock, ReasoningBlock, ToolUseBlock, ToolResultBlock, CachePointBlock } from '../messages.js'
+import { CitationsBlock } from '../citations.js'
+import { Interrupt } from '../../interrupt.js'
 
 describe('AgentResult', () => {
   describe('toString', () => {
@@ -168,6 +170,119 @@ describe('AgentResult', () => {
         })
 
         expect(result.toString()).toBe('Before tool\n💭 Reasoning:\n   Thinking...\nAfter tool')
+      })
+    })
+
+    describe('when interrupts are present', () => {
+      it('returns JSON-stringified interrupts, taking priority over text content', () => {
+        const message = new Message({
+          role: 'assistant',
+          content: [new TextBlock('ignored')],
+        })
+
+        const interrupt = new Interrupt({ id: 'i-1', name: 'confirm', reason: 'ok?' })
+
+        const result = new AgentResult({
+          stopReason: 'interrupt',
+          lastMessage: message,
+          metrics: new AgentMetrics(),
+          invocationState: {},
+          interrupts: [interrupt],
+        })
+
+        expect(result.toString()).toBe(JSON.stringify([interrupt]))
+      })
+
+      it('falls through when interrupts array is empty', () => {
+        const message = new Message({
+          role: 'assistant',
+          content: [new TextBlock('Hello')],
+        })
+
+        const result = new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: message,
+          metrics: new AgentMetrics(),
+          invocationState: {},
+          interrupts: [],
+        })
+
+        expect(result.toString()).toBe('Hello')
+      })
+    })
+
+    describe('when structuredOutput is present', () => {
+      it('returns JSON-stringified structured output, taking priority over text content', () => {
+        const message = new Message({
+          role: 'assistant',
+          content: [new TextBlock('ignored')],
+        })
+
+        const structuredOutput = { answer: 42, note: 'hello' }
+
+        const result = new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: message,
+          metrics: new AgentMetrics(),
+          invocationState: {},
+          structuredOutput,
+        })
+
+        expect(result.toString()).toBe(JSON.stringify(structuredOutput))
+      })
+    })
+
+    describe('when interrupts and structuredOutput are both present', () => {
+      it('returns interrupts, taking priority over structuredOutput', () => {
+        const message = new Message({
+          role: 'assistant',
+          content: [new TextBlock('ignored')],
+        })
+
+        const interrupt = new Interrupt({ id: 'i-1', name: 'confirm' })
+        const structuredOutput = { answer: 42 }
+
+        const result = new AgentResult({
+          stopReason: 'interrupt',
+          lastMessage: message,
+          metrics: new AgentMetrics(),
+          invocationState: {},
+          interrupts: [interrupt],
+          structuredOutput,
+        })
+
+        expect(result.toString()).toBe(JSON.stringify([interrupt]))
+      })
+    })
+
+    describe('when content has CitationsBlock', () => {
+      it('concatenates generated content text from citations', () => {
+        const message = new Message({
+          role: 'assistant',
+          content: [
+            new TextBlock('Here is a citation:'),
+            new CitationsBlock({
+              citations: [
+                {
+                  location: { type: 'documentChar', documentIndex: 0, start: 0, end: 5 },
+                  source: 'doc',
+                  sourceContent: [{ text: 'source text' }],
+                  title: 'Doc',
+                },
+              ],
+              content: [{ text: 'cited fragment' }],
+            }),
+          ],
+        })
+
+        const result = new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: message,
+          metrics: new AgentMetrics(),
+          invocationState: {},
+        })
+
+        expect(result.toString()).toBe('Here is a citation:\ncited fragment')
       })
     })
 

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -381,12 +381,24 @@ export class AgentResult {
   }
 
   /**
-   * Extracts and concatenates all text content from the last message.
-   * Includes text from TextBlock and ReasoningBlock content blocks.
+   * Extracts a string representation of the result.
    *
-   * @returns The agent's last message as a string, with multiple blocks joined by newlines.
+   * Priority order:
+   * 1. `interrupts` serialized as JSON, if any are present
+   * 2. `structuredOutput` serialized as JSON
+   * 3. Text from `textBlock`, `reasoningBlock`, and `citationsBlock` content blocks
+   *
+   * @returns String representation of the result: JSON for interrupts/structuredOutput, or text content joined by newlines.
    */
   public toString(): string {
+    if (this.interrupts && this.interrupts.length > 0) {
+      return JSON.stringify(this.interrupts)
+    }
+
+    if (this.structuredOutput !== undefined) {
+      return JSON.stringify(this.structuredOutput)
+    }
+
     const textParts: string[] = []
 
     for (const block of this.lastMessage.content) {
@@ -399,6 +411,13 @@ export class AgentResult {
             // Add indentation to reasoning content
             const indentedText = block.text.replace(/\n/g, '\n   ')
             textParts.push(`💭 Reasoning:\n   ${indentedText}`)
+          }
+          break
+        case 'citationsBlock':
+          for (const c of block.content) {
+            if ('text' in c) {
+              textParts.push(c.text)
+            }
           }
           break
         default:


### PR DESCRIPTION
## Description

Aligns `AgentResult.toString()` with the Python SDK's `__str__` priority order so parent agents and direct callers see interrupt and structured output content instead of falling back to (often empty) last-message text.

New priority order:
1. `interrupts` → `JSON.stringify(this.interrupts)` when any are present
2. `structuredOutput` → `JSON.stringify(this.structuredOutput)` when defined
3. Text walk over `lastMessage.content`, now including `citationsBlock` alongside `textBlock` and `reasoningBlock`

## Notes:
- `citationsBlock` uses `'text' in c` guard so the code stays safe if `CitationGeneratedContent` gains non-text variants.
- `reasoningBlock` with the `💭` prefix is preserved (TS-only enrichment, not in Python).
- Non-breaking on the common path: plain text results produce the same string as before.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

## Testing

Added unit tests in `src/types/__tests__/agent.test.ts` covering:
- Interrupts present → JSON output, takes priority over text
- Empty interrupts array → falls through to text
- `structuredOutput` present → JSON output, takes priority over text
- `citationsBlock` content → text appended to output

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.