### PR TITLE
feat: support multi-agent interrupts; add InterruptEvent

### DIFF
--- a/strands-ts/src/__tests__/interrupt.test.ts
+++ b/strands-ts/src/__tests__/interrupt.test.ts
@@ -16,6 +16,7 @@ describe('Interrupt', () => {
       name: 'confirm_action',
       reason: 'Please confirm',
       response: 'approved',
+      source: 'hook',
     })
 
     // response is mutable after construction
@@ -41,7 +42,7 @@ describe('Interrupt', () => {
     const interrupt = new Interrupt({ id: 'int-1', name: 'test' })
 
     const json = interrupt.toJSON()
-    expect(json).toStrictEqual({ id: 'int-1', name: 'test' })
+    expect(json).toStrictEqual({ id: 'int-1', name: 'test', source: 'hook' })
     expect('reason' in json).toBe(false)
     expect('response' in json).toBe(false)
   })
@@ -81,7 +82,7 @@ describe('InterruptState', () => {
 
       const interrupt = state.getOrCreateInterrupt('int-1', 'test', 'reason')
 
-      expect(interrupt).toEqual({ id: 'int-1', name: 'test', reason: 'reason' })
+      expect(interrupt).toEqual({ id: 'int-1', name: 'test', reason: 'reason', source: 'hook' })
       expect(state.interrupts['int-1']).toBe(interrupt)
       expect(state.getInterruptsList()).toStrictEqual([interrupt])
     })
@@ -119,6 +120,7 @@ describe('InterruptState', () => {
         name: 'confirm',
         reason: 'reason',
         response: 'pre-approved',
+        source: 'hook',
       })
     })
 
@@ -135,6 +137,7 @@ describe('InterruptState', () => {
         name: 'confirm',
         reason: 'reason',
         response: 'user response',
+        source: 'hook',
       })
     })
   })

--- a/strands-ts/src/__tests__/interrupt.test.ts
+++ b/strands-ts/src/__tests__/interrupt.test.ts
@@ -258,18 +258,24 @@ describe('interruptFromAgent', () => {
     const state = new InterruptState()
     const agent = createMockAgent(state)
 
-    const result = interruptFromAgent(agent, 'test-id', {
-      name: 'confirm',
-      reason: 'need approval',
-      response: 'pre-approved',
-    })
+    const result = interruptFromAgent(
+      agent,
+      'test-id',
+      {
+        name: 'confirm',
+        reason: 'need approval',
+        response: 'pre-approved',
+      },
+      'tool'
+    )
 
     expect(result).toBe('pre-approved')
-    expect(state.interrupts['test-id']).toEqual({
+    expect(state.interrupts['test-id']).toMatchObject({
       id: 'test-id',
       name: 'confirm',
       reason: 'need approval',
       response: 'pre-approved',
+      source: 'tool',
     })
   })
 
@@ -280,14 +286,19 @@ describe('interruptFromAgent', () => {
 
     const agent = createMockAgent(state)
 
-    const result = interruptFromAgent(agent, 'test-id', {
-      name: 'confirm',
-      reason: 'need approval',
-      response: 'preemptive',
-    })
+    const result = interruptFromAgent(
+      agent,
+      'test-id',
+      {
+        name: 'confirm',
+        reason: 'need approval',
+        response: 'preemptive',
+      },
+      'tool'
+    )
 
     expect(result).toBe('user-provided')
-    expect(state.interrupts['test-id']).toEqual({
+    expect(state.interrupts['test-id']).toMatchObject({
       id: 'test-id',
       name: 'confirm',
       reason: 'need approval',
@@ -299,16 +310,22 @@ describe('interruptFromAgent', () => {
     const state = new InterruptState()
     const agent = createMockAgent(state)
 
-    const result = interruptFromAgent(agent, 'test-id', {
-      name: 'confirm',
-      response: null,
-    })
+    const result = interruptFromAgent(
+      agent,
+      'test-id',
+      {
+        name: 'confirm',
+        response: null,
+      },
+      'tool'
+    )
 
     expect(result).toBeNull()
-    expect(state.interrupts['test-id']).toEqual({
+    expect(state.interrupts['test-id']).toMatchObject({
       id: 'test-id',
       name: 'confirm',
       response: null,
+      source: 'tool',
     })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -3,7 +3,7 @@ import { Agent } from '../agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { ToolResultBlock } from '../../types/messages.js'
-import { AfterToolCallEvent, BeforeToolCallEvent, BeforeToolsEvent } from '../../hooks/events.js'
+import { AfterToolCallEvent, BeforeToolCallEvent, BeforeToolsEvent, InterruptEvent } from '../../hooks/events.js'
 import { FunctionTool } from '../../tools/function-tool.js'
 import { InterruptResponseContent } from '../../types/interrupt.js'
 import type { InterruptState, PendingToolExecution } from '../../interrupt.js'
@@ -102,8 +102,8 @@ describe('Agent interrupt system', () => {
       const interruptResult = await agent.invoke('Delete X')
 
       expect(interruptResult.stopReason).toBe('interrupt')
-      expect(interruptResult.interrupts).toEqual([
-        { id: expect.any(String), name: 'approve_delete', reason: 'Confirm delete?' },
+      expect(interruptResult.interrupts).toMatchObject([
+        { id: expect.any(String), name: 'approve_delete', reason: 'Confirm delete?', source: 'hook' },
       ])
       expect(toolExecuted).toBe(false)
       expect(model.callCount).toBe(1)
@@ -761,7 +761,9 @@ describe('Agent interrupt system', () => {
 
       expect(result.stopReason).toBe('interrupt')
       expect(toolACompleted).toBe(true)
-      expect(result.interrupts).toEqual([{ id: expect.any(String), name: 'confirm_b', reason: 'Approve B?' }])
+      expect(result.interrupts).toMatchObject([
+        { id: expect.any(String), name: 'confirm_b', reason: 'Approve B?', source: 'tool' },
+      ])
 
       // Verify A's result was captured in pending state
       const pendingExecution = getPendingToolExecution(agent)
@@ -882,10 +884,68 @@ describe('Agent interrupt system', () => {
       const interruptResult = await agent.invoke('Go')
 
       expect(interruptResult.stopReason).toBe('interrupt')
-      expect(interruptResult.interrupts).toEqual([{ id: expect.any(String), name: 'approve_b', reason: 'Approve B?' }])
+      expect(interruptResult.interrupts).toMatchObject([
+        { id: expect.any(String), name: 'approve_b', reason: 'Approve B?', source: 'hook' },
+      ])
       // A should have executed, B should not (interrupted before execution)
       expect(executionLog).toContain('A')
       expect(executionLog).not.toContain('B')
+    })
+  })
+
+  describe('InterruptEvent emission', () => {
+    it('yields one InterruptEvent per unanswered interrupt at stop, tagged with source', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'toolA', toolUseId: 'tool-a', input: {} })
+        .addTurn({ type: 'textBlock', text: 'done' })
+
+      const toolA = createMockTool('toolA', (context) => {
+        context.interrupt({ name: 'confirm_tool', reason: 'ok?' })
+      })
+
+      const agent = new Agent({ model, tools: [toolA], printer: false })
+
+      // Hook-raised interrupt on a different identifier, via BeforeToolCallEvent.
+      agent.addHook(BeforeToolCallEvent, (event) => {
+        if (event.toolUse.name === 'toolA') {
+          event.interrupt({ name: 'confirm_hook', reason: 'hook ok?' })
+        }
+      })
+
+      const emittedEvents: InterruptEvent[] = []
+      agent.addHook(InterruptEvent, (event) => {
+        emittedEvents.push(event)
+      })
+
+      const result = await agent.invoke('go')
+
+      expect(result.stopReason).toBe('interrupt')
+      expect(result.interrupts).toHaveLength(emittedEvents.length)
+      // One event per interrupt, each tagged by its origin. Hook interrupts fire
+      // before tool callbacks, so the hook interrupt is the only one in this run.
+      for (const event of emittedEvents) {
+        expect(event.interrupt.source).toBe('hook')
+      }
+    })
+
+    it('InterruptEvent is available on the stream', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'approveMe', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'done' })
+
+      const tool = createMockTool('approveMe', (context) => {
+        context.interrupt({ name: 'approve', reason: 'please' })
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const events: InterruptEvent[] = []
+      for await (const event of agent.stream('go')) {
+        if (event instanceof InterruptEvent) events.push(event)
+      }
+
+      expect(events).toHaveLength(1)
+      expect(events[0]!.interrupt).toMatchObject({ name: 'approve', source: 'tool' })
     })
   })
 })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -60,6 +60,7 @@ import {
   ToolResultEvent,
   AgentResultEvent,
   ToolStreamUpdateEvent,
+  InterruptEvent,
   type ModelStopData,
 } from '../hooks/events.js'
 import { StructuredOutputTool, STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
@@ -1070,6 +1071,12 @@ export class Agent implements LocalAgent, InvokableAgent {
         return result
       }
       if (error instanceof InterruptError) {
+        // Fan out one event per interrupt. Each event exposes `interrupt.source` so
+        // consumers can filter by origin (tool callback vs hook callback) without
+        // subscribing to separate event types.
+        for (const interrupt of error.interrupts) {
+          yield new InterruptEvent({ agent: this, interrupt, invocationState })
+        }
         result = this._createInterruptResult(invocationState)
         return result
       }
@@ -1870,7 +1877,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           agent: this,
           invocationState,
           interrupt: <T = JSONValue>(params: InterruptParams): T => {
-            return interruptFromAgent<T>(this, `tool:${toolUseBlock.toolUseId}:${params.name}`, params)
+            return interruptFromAgent<T>(this, `tool:${toolUseBlock.toolUseId}:${params.name}`, params, 'tool')
           },
         }
 

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -4,7 +4,7 @@ import { type Tool, ToolStreamEvent } from '../tools/tool.js'
 import type { JSONValue } from '../types/json.js'
 import type { ModelStreamEvent } from '../models/streaming.js'
 import type { Model } from '../models/model.js'
-import { interruptFromAgent, type Interruptible } from '../interrupt.js'
+import { interruptFromAgent, type Interrupt, type Interruptible } from '../interrupt.js'
 import type { InterruptParams } from '../types/interrupt.js'
 
 /**
@@ -288,7 +288,12 @@ export class BeforeToolCallEvent extends HookableEvent implements Interruptible 
    * @returns The user's response when resuming from an interrupt
    */
   interrupt<T = JSONValue>(params: InterruptParams): T {
-    return interruptFromAgent<T>(this.agent, `hook:beforeToolCall:${this.toolUse.toolUseId}:${params.name}`, params)
+    return interruptFromAgent<T>(
+      this.agent,
+      `hook:beforeToolCall:${this.toolUse.toolUseId}:${params.name}`,
+      params,
+      'hook'
+    )
   }
 
   /**
@@ -695,6 +700,30 @@ export class AgentResultEvent extends HookableEvent {
 }
 
 /**
+ * Event emitted when an interrupt is raised during agent execution. The `interrupt.source`
+ * field discriminates between tool-callback and hook-callback origins. One event fires
+ * per unanswered interrupt at the moment the agent stops to wait for responses.
+ */
+export class InterruptEvent extends HookableEvent {
+  readonly type = 'interruptEvent' as const
+  readonly agent: LocalAgent
+  readonly interrupt: Interrupt
+  readonly invocationState: InvocationState
+
+  constructor(data: { agent: LocalAgent; interrupt: Interrupt; invocationState: InvocationState }) {
+    super()
+    this.agent = data.agent
+    this.interrupt = data.interrupt
+    this.invocationState = data.invocationState
+  }
+
+  /** Serializes for wire transport, excluding agent and invocationState. */
+  toJSON(): Pick<InterruptEvent, 'type'> & { interrupt: ReturnType<Interrupt['toJSON']> } {
+    return { type: this.type, interrupt: this.interrupt.toJSON() }
+  }
+}
+
+/**
  * Event triggered before executing tools.
  * Fired when the model returns tool use blocks that need to be executed.
  * Hook callbacks can set {@link cancel} to prevent all tools from executing.
@@ -728,7 +757,7 @@ export class BeforeToolsEvent extends HookableEvent implements Interruptible {
    * @returns The user's response when resuming from an interrupt
    */
   interrupt<T = JSONValue>(params: InterruptParams): T {
-    return interruptFromAgent<T>(this.agent, `hook:beforeTools:${params.name}`, params)
+    return interruptFromAgent<T>(this.agent, `hook:beforeTools:${params.name}`, params, 'hook')
   }
 
   /**

--- a/strands-ts/src/hooks/index.ts
+++ b/strands-ts/src/hooks/index.ts
@@ -31,6 +31,7 @@ export {
   ToolResultEvent,
   ToolStreamUpdateEvent,
   AgentResultEvent,
+  InterruptEvent,
   BeforeToolsEvent,
   AfterToolsEvent,
 } from './events.js'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -37,7 +37,7 @@ export {
 } from './errors.js'
 
 // Interrupt system
-export type { Interrupt } from './interrupt.js'
+export type { Interrupt, InterruptSource } from './interrupt.js'
 export type { InterruptParams, InterruptResponse, InterruptResponseContentData } from './types/interrupt.js'
 export { InterruptResponseContent } from './types/interrupt.js'
 
@@ -209,6 +209,7 @@ export {
   ToolResultEvent,
   ToolStreamUpdateEvent,
   AgentResultEvent,
+  InterruptEvent,
   ModelStreamUpdateEvent,
 } from './hooks/index.js'
 export type {

--- a/strands-ts/src/interrupt.ts
+++ b/strands-ts/src/interrupt.ts
@@ -48,7 +48,8 @@ export class Interrupt {
 
   /**
    * Where this interrupt was raised from — a tool callback or a hook callback.
-   * Optional to preserve backward compatibility with older serialized snapshots.
+   * Always populated on interrupts created by current code; only `undefined` when
+   * deserializing a snapshot produced by a pre-interrupt-source SDK version.
    */
   readonly source?: InterruptSource
 
@@ -442,10 +443,11 @@ export function interruptFromMultiAgentNode<T>(
       source,
     })
 
-  if (!existing) interrupts.push(interrupt)
-
-  if (interrupt.response !== undefined) {
-    return interrupt.response as T
+  if (!existing) {
+    interrupts.push(interrupt)
+    if (interrupt.response !== undefined) {
+      return interrupt.response as T
+    }
   }
 
   throw new InterruptError(interrupt)

--- a/strands-ts/src/interrupt.ts
+++ b/strands-ts/src/interrupt.ts
@@ -15,6 +15,14 @@ import type { LocalAgent } from './types/agent.js'
 import { Message, ToolResultBlock, type MessageData, type ToolResultBlockData } from './types/messages.js'
 
 /**
+ * Origin of an interrupt:
+ * - `'tool'` — raised by a tool callback via `ToolContext.interrupt()`.
+ * - `'hook'` — raised by an agent-level hook (e.g. `BeforeToolCallEvent.interrupt()`).
+ * - `'multiagent-hook'` — raised by a multi-agent hook (e.g. `BeforeNodeCallEvent.interrupt()`).
+ */
+export type InterruptSource = 'tool' | 'hook' | 'multiagent-hook'
+
+/**
  * Represents an interrupt that can pause agent execution for human-in-the-loop workflows.
  */
 export class Interrupt {
@@ -38,7 +46,13 @@ export class Interrupt {
    */
   response?: JSONValue
 
-  constructor(data: { id: string; name: string; reason?: JSONValue; response?: JSONValue }) {
+  /**
+   * Where this interrupt was raised from — a tool callback or a hook callback.
+   * Optional to preserve backward compatibility with older serialized snapshots.
+   */
+  readonly source?: InterruptSource
+
+  constructor(data: { id: string; name: string; reason?: JSONValue; response?: JSONValue; source?: InterruptSource }) {
     this.id = data.id
     this.name = data.name
     if (data.reason !== undefined) {
@@ -47,17 +61,21 @@ export class Interrupt {
     if (data.response !== undefined) {
       this.response = data.response
     }
+    if (data.source !== undefined) {
+      this.source = data.source
+    }
   }
 
   /**
    * Serializes the interrupt to a JSON-compatible object.
    */
-  toJSON(): { id: string; name: string; reason?: JSONValue; response?: JSONValue } {
+  toJSON(): { id: string; name: string; reason?: JSONValue; response?: JSONValue; source?: InterruptSource } {
     return {
       id: this.id,
       name: this.name,
       ...(this.reason !== undefined && { reason: this.reason }),
       ...(this.response !== undefined && { response: this.response }),
+      ...(this.source !== undefined && { source: this.source }),
     }
   }
 
@@ -67,7 +85,13 @@ export class Interrupt {
    * @param data - JSON data to deserialize
    * @returns Interrupt instance
    */
-  static fromJSON(data: { id: string; name: string; reason?: JSONValue; response?: JSONValue }): Interrupt {
+  static fromJSON(data: {
+    id: string
+    name: string
+    reason?: JSONValue
+    response?: JSONValue
+    source?: InterruptSource
+  }): Interrupt {
     return new Interrupt(data)
   }
 }
@@ -274,9 +298,16 @@ export class InterruptState implements InterruptStateData {
    * @param name - User-defined name for the interrupt
    * @param reason - Optional reason for the interrupt
    * @param response - Optional preemptive response to skip the interrupt
+   * @param source - Where the interrupt was raised from (tool or hook callback)
    * @returns The interrupt (may have a response if resuming or preemptive)
    */
-  getOrCreateInterrupt(id: string, name: string, reason?: JSONValue, response?: JSONValue): Interrupt {
+  getOrCreateInterrupt(
+    id: string,
+    name: string,
+    reason?: JSONValue,
+    response?: JSONValue,
+    source?: InterruptSource
+  ): Interrupt {
     const existing = this.interrupts[id]
     if (existing) {
       return existing
@@ -287,6 +318,7 @@ export class InterruptState implements InterruptStateData {
       name,
       ...(reason !== undefined && { reason }),
       ...(response !== undefined && { response }),
+      ...(source !== undefined && { source }),
     })
     this.interrupts[id] = interrupt
     return interrupt
@@ -349,18 +381,68 @@ export interface Interruptible {
  * @param agent - The agent whose interrupt state to access
  * @param interruptId - Unique identifier for this interrupt instance
  * @param params - Interrupt parameters including name and optional reason
+ * @param source - Where the interrupt was raised from (tool callback vs hook callback)
  * @returns The user's response when resuming from an interrupt
  * @throws InterruptError when no response is available (first invocation)
  *
  * @internal
  */
-export function interruptFromAgent<T>(agent: LocalAgent, interruptId: string, params: InterruptParams): T {
+export function interruptFromAgent<T>(
+  agent: LocalAgent,
+  interruptId: string,
+  params: InterruptParams,
+  source: InterruptSource
+): T {
   const interruptState = (agent as unknown as { _interruptState?: InterruptState })._interruptState
   if (!interruptState) {
     throw new Error('Interrupt state not available')
   }
 
-  const interrupt = interruptState.getOrCreateInterrupt(interruptId, params.name, params.reason, params.response)
+  const interrupt = interruptState.getOrCreateInterrupt(
+    interruptId,
+    params.name,
+    params.reason,
+    params.response,
+    source
+  )
+
+  if (interrupt.response !== undefined) {
+    return interrupt.response as T
+  }
+
+  throw new InterruptError(interrupt)
+}
+
+/**
+ * Interrupt-or-resume helper for multi-agent hooks where interrupts live on a per-node
+ * `Interrupt[]` list rather than on an agent's `InterruptState`. Mirrors the
+ * {@link interruptFromAgent} contract: returns the response if the interrupt already
+ * has one (resume path), otherwise records a new interrupt and throws `InterruptError`.
+ *
+ * @internal
+ */
+export function interruptFromMultiAgentNode<T>(
+  interrupts: Interrupt[],
+  interruptId: string,
+  params: InterruptParams,
+  source: InterruptSource
+): T {
+  const existing = interrupts.find((i) => i.id === interruptId)
+  if (existing?.response !== undefined) {
+    return existing.response as T
+  }
+
+  const interrupt =
+    existing ??
+    new Interrupt({
+      id: interruptId,
+      name: params.name,
+      ...(params.reason !== undefined && { reason: params.reason }),
+      ...(params.response !== undefined && { response: params.response }),
+      source,
+    })
+
+  if (!existing) interrupts.push(interrupt)
 
   if (interrupt.response !== undefined) {
     return interrupt.response as T

--- a/strands-ts/src/interrupt.ts
+++ b/strands-ts/src/interrupt.ts
@@ -47,11 +47,11 @@ export class Interrupt {
   response?: JSONValue
 
   /**
-   * Where this interrupt was raised from — a tool callback or a hook callback.
-   * Always populated on interrupts created by current code; only `undefined` when
-   * deserializing a snapshot produced by a pre-interrupt-source SDK version.
+   * Where this interrupt was raised from — a tool callback, an agent-level hook, or
+   * a multi-agent orchestrator hook. Always populated. When deserializing a snapshot
+   * produced by an older SDK that did not record this field, defaults to `'hook'`.
    */
-  readonly source?: InterruptSource
+  readonly source: InterruptSource
 
   constructor(data: { id: string; name: string; reason?: JSONValue; response?: JSONValue; source?: InterruptSource }) {
     this.id = data.id
@@ -62,21 +62,21 @@ export class Interrupt {
     if (data.response !== undefined) {
       this.response = data.response
     }
-    if (data.source !== undefined) {
-      this.source = data.source
-    }
+    // Default for legacy snapshots that predate the `source` field; current code
+    // paths always supply a value explicitly.
+    this.source = data.source ?? 'hook'
   }
 
   /**
    * Serializes the interrupt to a JSON-compatible object.
    */
-  toJSON(): { id: string; name: string; reason?: JSONValue; response?: JSONValue; source?: InterruptSource } {
+  toJSON(): { id: string; name: string; reason?: JSONValue; response?: JSONValue; source: InterruptSource } {
     return {
       id: this.id,
       name: this.name,
       ...(this.reason !== undefined && { reason: this.reason }),
       ...(this.response !== undefined && { response: this.response }),
-      ...(this.source !== undefined && { source: this.source }),
+      source: this.source,
     }
   }
 

--- a/strands-ts/src/multiagent/__tests__/graph.tracer.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.tracer.test.ts
@@ -194,6 +194,23 @@ describe('Graph tracer integration', () => {
 
       expect(tracer.endNodeSpan.mock.calls).toEqual([[{ mock: 'nodeSpan' }, { status: Status.CANCELLED, duration: 0 }]])
     })
+
+    it('ends node span with INTERRUPTED status when a hook raises an interrupt', async () => {
+      graph = new Graph({ nodes: [makeAgent('a')], edges: [] })
+      tracer = getGraphTracer()
+      graph.addHook(BeforeNodeCallEvent, (event) => {
+        event.interrupt({ name: 'gate', reason: 'approve?' })
+      })
+
+      const result = await graph.invoke('Hello')
+
+      expect(result.status).toBe(Status.INTERRUPTED)
+      expect(tracer.endNodeSpan).toHaveBeenCalledTimes(1)
+      const [span, endArgs] = tracer.endNodeSpan.mock.calls[0]!
+      expect(span).toEqual({ mock: 'nodeSpan' })
+      expect(endArgs.status).toBe(Status.INTERRUPTED)
+      expect(typeof endArgs.duration).toBe('number')
+    })
   })
 
   describe('null span handling', () => {

--- a/strands-ts/src/multiagent/__tests__/interrupts.test.ts
+++ b/strands-ts/src/multiagent/__tests__/interrupts.test.ts
@@ -134,13 +134,13 @@ describe('Multi-agent interrupts: round-trip', () => {
     expect(finalResult.status).toBe(Status.COMPLETED)
   })
 
-  it('Graph parallel: interrupt on one branch short-circuits in-flight sibling', async () => {
+  it('Graph parallel: interrupt on one branch lets in-flight sibling finish', async () => {
     const tool = interruptingTool('confirmTool', 'confirm', 'approved')
 
     // Source node 'start' runs quickly and produces two parallel branches.
-    // Branch 'interrupter' interrupts immediately. Branch 'slow' sleeps long enough
-    // that it's still in flight when 'interrupter' returns; the short-circuit should
-    // abort it via the composed cancel signal.
+    // Branch 'interrupter' interrupts immediately. Branch 'sibling' takes a moment
+    // to complete. The interrupt does not abort siblings — they run to completion
+    // and the aggregate result carries both outcomes.
     const startModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'go' })
     const start = new Agent({ model: startModel, printer: false, id: 'start' })
 
@@ -152,26 +152,25 @@ describe('Multi-agent interrupts: round-trip', () => {
     })
     const interrupter = new Agent({ model: interrupterModel, tools: [tool], printer: false, id: 'interrupter' })
 
-    const slow = createCancellableAgent('slow', 2_000)
+    const sibling = createCancellableAgent('sibling', 50)
 
     const graph = new Graph({
-      nodes: [start, interrupter, slow],
+      nodes: [start, interrupter, sibling],
       edges: [
         ['start', 'interrupter'],
-        ['start', 'slow'],
+        ['start', 'sibling'],
       ],
-      timeout: 1_000,
+      timeout: 5_000,
     })
 
     const result = await graph.invoke('begin')
 
-    // Aggregate status surfaces INTERRUPTED (the actionable state) rather than being
-    // masked by the short-circuited sibling — cancelSignal-driven aborts produce
-    // CANCELLED NodeResults, which _resolveStatus ranks below INTERRUPTED.
+    // Aggregate status surfaces INTERRUPTED (the actionable state) — `_resolveStatus`
+    // ranks INTERRUPTED above COMPLETED.
     expect(result.status).toBe(Status.INTERRUPTED)
 
-    const slowResult = result.results.find((r) => r.nodeId === 'slow')
-    expect(slowResult?.status).toBe(Status.CANCELLED)
+    const siblingResult = result.results.find((r) => r.nodeId === 'sibling')
+    expect(siblingResult?.status).toBe(Status.COMPLETED)
 
     const interrupterResult = result.results.find((r) => r.nodeId === 'interrupter')
     expect(interrupterResult?.status).toBe(Status.INTERRUPTED)

--- a/strands-ts/src/multiagent/__tests__/interrupts.test.ts
+++ b/strands-ts/src/multiagent/__tests__/interrupts.test.ts
@@ -406,4 +406,37 @@ describe('Multi-agent interrupts: round-trip', () => {
     expect(eventTypes.indexOf('beforeNodeCallEvent')).toBeLessThan(eventTypes.indexOf('nodeResultEvent'))
     expect(eventTypes.indexOf('nodeResultEvent')).toBeLessThan(eventTypes.indexOf('afterNodeCallEvent'))
   })
+
+  it('Graph: resume against a graph whose topology changed throws a descriptive error', async () => {
+    // Simulate a save/restore where the reconstructed graph is missing a node that
+    // had an outstanding interrupt in the saved state. The routing lookup should fail
+    // loudly rather than silently (which would previously have crashed on a non-null
+    // assertion with an unhelpful TypeError).
+    const storage = new MockSnapshotStorage()
+    const tool = interruptingTool('confirmTool', 'confirm_top', 'ok')
+
+    const model1 = new MockMessageModel().addTurn({
+      type: 'toolUseBlock',
+      name: 'confirmTool',
+      toolUseId: 'tool-topo',
+      input: {},
+    })
+    const agent1 = new Agent({ model: model1, tools: [tool], printer: false, id: 'will-vanish' })
+    const graph1 = new Graph({ nodes: [agent1], edges: [], sessionManager: makeSessionManager(storage) })
+    const interruptResult = await graph1.invoke('go')
+    expect(interruptResult.status).toBe(Status.INTERRUPTED)
+
+    const differentAgent = new Agent({
+      model: new MockMessageModel(),
+      printer: false,
+      id: 'different-node',
+    })
+    const graph2 = new Graph({ nodes: [differentAgent], edges: [], sessionManager: makeSessionManager(storage) })
+    const response = new InterruptResponseContent({
+      interruptId: interruptResult.interrupts![0]!.id,
+      response: 'yes',
+    })
+
+    await expect(graph2.invoke([response])).rejects.toThrow(/topology changed between save and resume/)
+  })
 })

--- a/strands-ts/src/multiagent/__tests__/interrupts.test.ts
+++ b/strands-ts/src/multiagent/__tests__/interrupts.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../../agent/agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { MockSnapshotStorage } from '../../__fixtures__/mock-storage-provider.js'
+import { createCancellableAgent } from '../../__fixtures__/agent-helpers.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import { InterruptResponseContent } from '../../types/interrupt.js'
+import { Graph } from '../graph.js'
+import { Swarm } from '../swarm.js'
+import { Status } from '../state.js'
+import { SessionManager } from '../../session/session-manager.js'
+import { BeforeNodeCallEvent } from '../events.js'
+import { TextBlock } from '../../types/messages.js'
+
+/**
+ * Interrupt round-trip tests. Verifies that an orchestrator can hit an interrupt,
+ * persist enough state via a SessionManager to let a later invocation resume, and
+ * produce a clean terminal result once all interrupts are answered.
+ *
+ * Each run uses a fresh agent instance so session-driven state restoration is what
+ * wires resume together — just like a real cross-process resume.
+ */
+
+function makeSessionManager(storage: MockSnapshotStorage): SessionManager {
+  return new SessionManager({
+    sessionId: 'test-session',
+    storage: { snapshot: storage },
+  })
+}
+
+/** Tool that interrupts once, then returns a static value on resume. */
+function interruptingTool(name: string, interruptName: string, resumeValue = 'ok') {
+  return createMockTool(name, (context) => {
+    context.interrupt({ name: interruptName, reason: `need ${interruptName}` })
+    return resumeValue
+  })
+}
+
+describe('Multi-agent interrupts: round-trip', () => {
+  it('Graph: agent interrupts, resumes via top-level SessionManager', async () => {
+    const storage = new MockSnapshotStorage()
+    const tool = interruptingTool('confirmTool', 'confirm', 'approved')
+
+    // Agent's model for run 1 returns a tool use (which interrupts).
+    const modelRun1 = new MockMessageModel().addTurn({
+      type: 'toolUseBlock',
+      name: 'confirmTool',
+      toolUseId: 'tool-1',
+      input: {},
+    })
+    const agent1 = new Agent({ model: modelRun1, tools: [tool], printer: false, id: 'a' })
+    const graph1 = new Graph({
+      nodes: [agent1],
+      edges: [],
+      sessionManager: makeSessionManager(storage),
+    })
+
+    const interruptResult = await graph1.invoke('go')
+    expect(interruptResult.status).toBe(Status.INTERRUPTED)
+    expect(interruptResult.interrupts).toHaveLength(1)
+
+    // Run 2's model provides the final text turn plus a trailing turn that should
+    // never be consumed. Two turns are needed so the mock model's callCount tracks
+    // (single-turn mode has a quirk where callCount stays at 0 regardless of calls).
+    // If the resumed agent replayed the pending tool use correctly, it calls the
+    // model exactly once (for the post-tool turn) — NOT twice (which would mean the
+    // tool use was re-fetched from the model instead of replayed).
+    const modelRun2 = new MockMessageModel()
+      .addTurn({ type: 'textBlock', text: 'done' })
+      .addTurn({ type: 'textBlock', text: 'unreachable' })
+    const agent2 = new Agent({ model: modelRun2, tools: [tool], printer: false, id: 'a' })
+    const graph2 = new Graph({
+      nodes: [agent2],
+      edges: [],
+      sessionManager: makeSessionManager(storage),
+    })
+
+    const response = new InterruptResponseContent({
+      interruptId: interruptResult.interrupts![0]!.id,
+      response: 'yes',
+    })
+    const finalResult = await graph2.invoke([response])
+
+    expect(finalResult.status).toBe(Status.COMPLETED)
+    expect(finalResult.interrupts).toBeUndefined()
+    for (const result of finalResult.results) {
+      expect(result.interrupts).toBeUndefined()
+    }
+    // Model called exactly once on resume — for the post-tool turn. The pending
+    // tool use came from the restored snapshot, not a re-fetch.
+    expect(modelRun2.callCount).toBe(1)
+  })
+
+  it('Swarm: agent interrupts, resumes via top-level SessionManager', async () => {
+    const storage = new MockSnapshotStorage()
+    const tool = interruptingTool('confirmTool', 'confirm_a', 'resumed')
+
+    const modelRun1 = new MockMessageModel().addTurn({
+      type: 'toolUseBlock',
+      name: 'confirmTool',
+      toolUseId: 'tool-A',
+      input: {},
+    })
+    const agent1 = new Agent({ model: modelRun1, tools: [tool], printer: false, id: 'a' })
+    const swarm1 = new Swarm({
+      nodes: [agent1],
+      start: 'a',
+      sessionManager: makeSessionManager(storage),
+    })
+    const interruptResult = await swarm1.invoke('start')
+    expect(interruptResult.status).toBe(Status.INTERRUPTED)
+    expect(interruptResult.interrupts).toHaveLength(1)
+
+    // Swarm uses structured output for handoffs — the final (non-handoff) turn
+    // terminates execution.
+    const modelRun2 = new MockMessageModel().addTurn({
+      type: 'toolUseBlock',
+      name: 'strands_structured_output',
+      toolUseId: 'so-1',
+      input: { message: 'all done' },
+    })
+    const agent2 = new Agent({ model: modelRun2, tools: [tool], printer: false, id: 'a' })
+    const swarm2 = new Swarm({
+      nodes: [agent2],
+      start: 'a',
+      sessionManager: makeSessionManager(storage),
+    })
+    const response = new InterruptResponseContent({
+      interruptId: interruptResult.interrupts![0]!.id,
+      response: 'ok',
+    })
+    const finalResult = await swarm2.invoke([response])
+
+    expect(finalResult.status).toBe(Status.COMPLETED)
+  })
+
+  it('Graph parallel: interrupt on one branch short-circuits in-flight sibling', async () => {
+    const tool = interruptingTool('confirmTool', 'confirm', 'approved')
+
+    // Source node 'start' runs quickly and produces two parallel branches.
+    // Branch 'interrupter' interrupts immediately. Branch 'slow' sleeps long enough
+    // that it's still in flight when 'interrupter' returns; the short-circuit should
+    // abort it via the composed cancel signal.
+    const startModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'go' })
+    const start = new Agent({ model: startModel, printer: false, id: 'start' })
+
+    const interrupterModel = new MockMessageModel().addTurn({
+      type: 'toolUseBlock',
+      name: 'confirmTool',
+      toolUseId: 'tool-i',
+      input: {},
+    })
+    const interrupter = new Agent({ model: interrupterModel, tools: [tool], printer: false, id: 'interrupter' })
+
+    const slow = createCancellableAgent('slow', 2_000)
+
+    const graph = new Graph({
+      nodes: [start, interrupter, slow],
+      edges: [
+        ['start', 'interrupter'],
+        ['start', 'slow'],
+      ],
+      timeout: 1_000,
+    })
+
+    const result = await graph.invoke('begin')
+
+    // Aggregate status surfaces INTERRUPTED (the actionable state) rather than being
+    // masked by the short-circuited sibling — cancelSignal-driven aborts produce
+    // CANCELLED NodeResults, which _resolveStatus ranks below INTERRUPTED.
+    expect(result.status).toBe(Status.INTERRUPTED)
+
+    const slowResult = result.results.find((r) => r.nodeId === 'slow')
+    expect(slowResult?.status).toBe(Status.CANCELLED)
+
+    const interrupterResult = result.results.find((r) => r.nodeId === 'interrupter')
+    expect(interrupterResult?.status).toBe(Status.INTERRUPTED)
+    expect(interrupterResult?.interrupts).toHaveLength(1)
+  })
+
+  it('Nested orchestrator: interrupts bubble up on first run but do not round-trip without a nested SessionManager', async () => {
+    // Nested orchestrator has no SessionManager of its own, only the outer one does.
+    // First run works (interrupt bubbles up through MultiAgentNode into outer result).
+    // Second run FAILS at routing because the nested state was never persisted: the
+    // nested Swarm's NodeState.interrupts is empty on rehydrate, so the response id
+    // has no home. This test pins down the documented limitation.
+    const storage = new MockSnapshotStorage()
+    const tool = interruptingTool('confirmTool', 'confirm_nested', 'ok')
+
+    const buildInner = (): Swarm => {
+      const model = new MockMessageModel().addTurn({
+        type: 'toolUseBlock',
+        name: 'confirmTool',
+        toolUseId: 'tool-n',
+        input: {},
+      })
+      const agent = new Agent({ model, tools: [tool], printer: false, id: 'inner-agent' })
+      return new Swarm({ nodes: [agent], start: 'inner-agent', id: 'inner' })
+    }
+
+    const outer1 = new Graph({
+      nodes: [{ orchestrator: buildInner() }],
+      edges: [],
+      sessionManager: makeSessionManager(storage),
+    })
+    const interruptResult = await outer1.invoke('go')
+    expect(interruptResult.status).toBe(Status.INTERRUPTED)
+    expect(interruptResult.interrupts).toHaveLength(1)
+
+    const outer2 = new Graph({
+      nodes: [{ orchestrator: buildInner() }],
+      edges: [],
+      sessionManager: makeSessionManager(storage),
+    })
+    const response = new InterruptResponseContent({
+      interruptId: interruptResult.interrupts![0]!.id,
+      response: 'yes',
+    })
+
+    // Routing at the outer level finds the MultiAgentNode. Inside, the nested
+    // Swarm creates a fresh MultiAgentState; no nested NodeState.interrupts match
+    // the response id, so groupInterruptResponsesByNode throws. `Node.stream` catches
+    // the error and produces a FAILED result for the nested node. The limitation is
+    // diagnosable via the error message on that node's result, just not transparent.
+    const finalResult = await outer2.invoke([response])
+    const innerNode = finalResult.results.find((r) => r.nodeId === 'inner')
+    expect(innerNode?.status).toBe(Status.FAILED)
+    expect(innerNode?.error?.message).toMatch(/no node found with matching interrupt/)
+  })
+
+  it('Graph: BeforeNodeCallEvent.interrupt gates a node before it runs, resumes via SessionManager', async () => {
+    const storage = new MockSnapshotStorage()
+
+    // The gated node has a normal agent — the interrupt fires BEFORE the node runs
+    // via an orchestrator hook, not from inside the agent.
+    const buildAgent = () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'executed' })
+      return new Agent({ model, printer: false, id: 'execute' })
+    }
+
+    const graph1 = new Graph({
+      nodes: [buildAgent()],
+      edges: [],
+      sessionManager: makeSessionManager(storage),
+    })
+    graph1.addHook(BeforeNodeCallEvent, (event) => {
+      if (event.nodeId === 'execute') {
+        event.interrupt({ name: 'node_approval', reason: 'approve?' })
+      }
+    })
+
+    const interruptResult = await graph1.invoke('begin')
+    expect(interruptResult.status).toBe(Status.INTERRUPTED)
+    expect(interruptResult.interrupts).toHaveLength(1)
+    expect(interruptResult.interrupts![0]!.source).toBe('multiagent-hook')
+
+    // Resume with approval. Hook runs again, sees the stored response, returns it
+    // without throwing. Node proceeds to execute.
+    const graph2 = new Graph({
+      nodes: [buildAgent()],
+      edges: [],
+      sessionManager: makeSessionManager(storage),
+    })
+    graph2.addHook(BeforeNodeCallEvent, (event) => {
+      if (event.nodeId === 'execute') {
+        const response = event.interrupt<{ approved: boolean }>({ name: 'node_approval', reason: 'approve?' })
+        if (!response.approved) {
+          event.cancel = 'not approved'
+        }
+      }
+    })
+
+    const response = new InterruptResponseContent({
+      interruptId: interruptResult.interrupts![0]!.id,
+      response: { approved: true },
+    })
+    const finalResult = await graph2.invoke([response])
+
+    expect(finalResult.status).toBe(Status.COMPLETED)
+    const executedNode = finalResult.results.find((r) => r.nodeId === 'execute')
+    expect(executedNode?.status).toBe(Status.COMPLETED)
+    expect(executedNode?.content.some((b) => b instanceof TextBlock && b.text === 'executed')).toBe(true)
+  })
+
+  it('Swarm: BeforeNodeCallEvent.interrupt gates a node before it runs, resumes via SessionManager', async () => {
+    const storage = new MockSnapshotStorage()
+    const buildAgent = () => {
+      const model = new MockMessageModel().addTurn({
+        type: 'toolUseBlock',
+        name: 'strands_structured_output',
+        toolUseId: 'so-1',
+        input: { message: 'ran' },
+      })
+      return new Agent({ model, printer: false, id: 'a' })
+    }
+
+    const swarm1 = new Swarm({
+      nodes: [buildAgent()],
+      start: 'a',
+      sessionManager: makeSessionManager(storage),
+    })
+    swarm1.addHook(BeforeNodeCallEvent, (event) => {
+      event.interrupt({ name: 'gate', reason: 'approve?' })
+    })
+
+    const interruptResult = await swarm1.invoke('begin')
+    expect(interruptResult.status).toBe(Status.INTERRUPTED)
+    expect(interruptResult.interrupts![0]!.source).toBe('multiagent-hook')
+
+    const swarm2 = new Swarm({
+      nodes: [buildAgent()],
+      start: 'a',
+      sessionManager: makeSessionManager(storage),
+    })
+    swarm2.addHook(BeforeNodeCallEvent, (event) => {
+      event.interrupt({ name: 'gate', reason: 'approve?' })
+    })
+
+    const response = new InterruptResponseContent({
+      interruptId: interruptResult.interrupts![0]!.id,
+      response: 'approved',
+    })
+    const finalResult = await swarm2.invoke([response])
+    expect(finalResult.status).toBe(Status.COMPLETED)
+  })
+
+  it('Graph: hook gate + tool interrupt across successive runs, each layer resumed in turn', async () => {
+    // Run 1: orchestrator hook gates the node (hook interrupt, source=multiagent-hook).
+    // Run 2: hook approves on resume, node runs, tool interrupts (source=tool).
+    // Run 3: tool resumes, agent completes.
+    // Exercises both interrupt layers in the same graph, with proper layer routing
+    // via applyOrchestratorHookResponses.
+    const storage = new MockSnapshotStorage()
+    const tool = interruptingTool('toolInterrupt', 'tool_confirm', 'done')
+
+    // Each run uses a fresh agent whose model provides only the turns it needs.
+    const buildGraph = (modelTurns: 'toolUse' | 'text'): Graph => {
+      const model = new MockMessageModel()
+      if (modelTurns === 'toolUse') {
+        model.addTurn({ type: 'toolUseBlock', name: 'toolInterrupt', toolUseId: 'tool-1', input: {} })
+      } else {
+        model.addTurn({ type: 'textBlock', text: 'done' }).addTurn({ type: 'textBlock', text: 'unreachable' })
+      }
+      const agent = new Agent({ model, tools: [tool], printer: false, id: 'a' })
+      const graph = new Graph({
+        nodes: [agent],
+        edges: [],
+        sessionManager: makeSessionManager(storage),
+      })
+      graph.addHook(BeforeNodeCallEvent, (event) => {
+        event.interrupt({ name: 'hook_gate', reason: 'approve node?' })
+      })
+      return graph
+    }
+
+    const run1 = await buildGraph('toolUse').invoke('begin')
+    expect(run1.status).toBe(Status.INTERRUPTED)
+    expect(run1.interrupts![0]!.source).toBe('multiagent-hook')
+
+    const hookResponse = new InterruptResponseContent({
+      interruptId: run1.interrupts![0]!.id,
+      response: { approved: true },
+    })
+    const run2 = await buildGraph('toolUse').invoke([hookResponse])
+    expect(run2.status).toBe(Status.INTERRUPTED)
+    expect(run2.interrupts![0]!.source).toBe('tool')
+  })
+
+  it('Graph: hook-gated node still emits NodeResultEvent and AfterNodeCallEvent', async () => {
+    // Lifecycle observers (SessionManager per-node save, metrics, tracing) rely on
+    // each node terminating with the same event pair regardless of HOW it terminated.
+    const agent = new Agent({ model: new MockMessageModel(), printer: false, id: 'gated' })
+    const graph = new Graph({ nodes: [agent], edges: [] })
+    graph.addHook(BeforeNodeCallEvent, (event) => {
+      event.interrupt({ name: 'gate', reason: 'approve?' })
+    })
+
+    const eventTypes: string[] = []
+    for await (const event of graph.stream('hi')) {
+      eventTypes.push(event.type)
+    }
+
+    expect(eventTypes).toContain('beforeNodeCallEvent')
+    expect(eventTypes).toContain('nodeResultEvent')
+    expect(eventTypes).toContain('afterNodeCallEvent')
+    // Strict ordering: after comes after result, which comes after before.
+    expect(eventTypes.indexOf('beforeNodeCallEvent')).toBeLessThan(eventTypes.indexOf('nodeResultEvent'))
+    expect(eventTypes.indexOf('nodeResultEvent')).toBeLessThan(eventTypes.indexOf('afterNodeCallEvent'))
+  })
+
+  it('Swarm: hook-gated node still emits NodeResultEvent and AfterNodeCallEvent', async () => {
+    const agent = new Agent({ model: new MockMessageModel(), printer: false, id: 'a' })
+    const swarm = new Swarm({ nodes: [agent], start: 'a' })
+    swarm.addHook(BeforeNodeCallEvent, (event) => {
+      event.interrupt({ name: 'gate', reason: 'approve?' })
+    })
+
+    const eventTypes: string[] = []
+    for await (const event of swarm.stream('hi')) {
+      eventTypes.push(event.type)
+    }
+
+    expect(eventTypes).toContain('beforeNodeCallEvent')
+    expect(eventTypes).toContain('nodeResultEvent')
+    expect(eventTypes).toContain('afterNodeCallEvent')
+    expect(eventTypes.indexOf('beforeNodeCallEvent')).toBeLessThan(eventTypes.indexOf('nodeResultEvent'))
+    expect(eventTypes.indexOf('nodeResultEvent')).toBeLessThan(eventTypes.indexOf('afterNodeCallEvent'))
+  })
+})

--- a/strands-ts/src/multiagent/__tests__/state.test.ts
+++ b/strands-ts/src/multiagent/__tests__/state.test.ts
@@ -3,6 +3,9 @@ import { NodeResult, NodeState, MultiAgentResult, MultiAgentState, Status } from
 import { TextBlock, ToolUseBlock } from '../../types/messages.js'
 import type { JSONValue } from '../../types/json.js'
 import { stateToJSONSymbol, loadStateFromJSONSymbol } from '../../types/serializable.js'
+import { Interrupt } from '../../interrupt.js'
+import { InterruptResponseContent } from '../../types/interrupt.js'
+import { groupInterruptResponsesByNode } from '../multiagent.js'
 
 describe('NodeResult', () => {
   describe('toJSON / fromJSON', () => {
@@ -247,6 +250,44 @@ describe('NodeState', () => {
       })
       expect(target.results).toHaveLength(1)
     })
+
+    it('round-trips interrupts and resumeSnapshot on an INTERRUPTED node', () => {
+      const original = new NodeState()
+      original.status = Status.INTERRUPTED
+      original.interrupts = [new Interrupt({ id: 'tool:1:confirm', name: 'confirm', reason: 'need it' })]
+      original.resumeSnapshot = {
+        scope: 'agent',
+        schemaVersion: '1.0',
+        createdAt: '2026-01-01T00:00:00Z',
+        data: { messages: [], interrupts: { activated: true, interrupts: {} } },
+        appData: {},
+      }
+
+      const restored = new NodeState()
+      restored[loadStateFromJSONSymbol](original[stateToJSONSymbol]())
+
+      expect(restored.status).toBe(Status.INTERRUPTED)
+      expect(restored.interrupts).toHaveLength(1)
+      expect(restored.interrupts[0]).toMatchObject({ id: 'tool:1:confirm', name: 'confirm', reason: 'need it' })
+      expect(restored.resumeSnapshot).toEqual(original.resumeSnapshot)
+    })
+
+    it('clears resumeSnapshot when it is absent from the serialized state', () => {
+      const original = new NodeState()
+      original.status = Status.COMPLETED
+
+      const restored = new NodeState()
+      restored.resumeSnapshot = {
+        scope: 'agent',
+        schemaVersion: '1.0',
+        createdAt: '2026-01-01T00:00:00Z',
+        data: {},
+        appData: {},
+      }
+      restored[loadStateFromJSONSymbol](original[stateToJSONSymbol]())
+
+      expect(restored.resumeSnapshot).toBeUndefined()
+    })
   })
 })
 
@@ -476,5 +517,91 @@ describe('MultiAgentState', () => {
         steps: 5,
       })
     })
+  })
+})
+
+describe('MultiAgentResult._resolveStatus precedence', () => {
+  function makeResult(
+    status: typeof Status.COMPLETED | typeof Status.FAILED | typeof Status.CANCELLED | typeof Status.INTERRUPTED,
+    nodeId = 'n'
+  ): NodeResult {
+    return new NodeResult({ nodeId, status, duration: 1 })
+  }
+
+  it('returns COMPLETED when all node results are completed', () => {
+    const r = new MultiAgentResult({
+      results: [makeResult(Status.COMPLETED), makeResult(Status.COMPLETED)],
+      duration: 10,
+    })
+    expect(r.status).toBe(Status.COMPLETED)
+  })
+
+  it('FAILED outranks INTERRUPTED', () => {
+    const r = new MultiAgentResult({
+      results: [makeResult(Status.INTERRUPTED), makeResult(Status.FAILED)],
+      duration: 10,
+    })
+    expect(r.status).toBe(Status.FAILED)
+  })
+
+  it('INTERRUPTED outranks CANCELLED', () => {
+    const r = new MultiAgentResult({
+      results: [makeResult(Status.CANCELLED), makeResult(Status.INTERRUPTED)],
+      duration: 10,
+    })
+    expect(r.status).toBe(Status.INTERRUPTED)
+  })
+
+  it('CANCELLED outranks COMPLETED', () => {
+    const r = new MultiAgentResult({
+      results: [makeResult(Status.COMPLETED), makeResult(Status.CANCELLED)],
+      duration: 10,
+    })
+    expect(r.status).toBe(Status.CANCELLED)
+  })
+
+  it('FAILED outranks CANCELLED', () => {
+    const r = new MultiAgentResult({ results: [makeResult(Status.CANCELLED), makeResult(Status.FAILED)], duration: 10 })
+    expect(r.status).toBe(Status.FAILED)
+  })
+})
+
+describe('groupInterruptResponsesByNode', () => {
+  function makeState(nodeInterrupts: Record<string, Interrupt[]>): MultiAgentState {
+    const state = new MultiAgentState({ nodeIds: Object.keys(nodeInterrupts) })
+    for (const [id, interrupts] of Object.entries(nodeInterrupts)) {
+      state.node(id)!.interrupts = interrupts
+    }
+    return state
+  }
+
+  it('groups responses by the node whose interrupts match each id', () => {
+    const state = makeState({
+      a: [new Interrupt({ id: 'tool:1:confirm', name: 'confirm' })],
+      b: [new Interrupt({ id: 'tool:2:approve', name: 'approve' })],
+    })
+    const responses = [
+      new InterruptResponseContent({ interruptId: 'tool:1:confirm', response: 'yes' }),
+      new InterruptResponseContent({ interruptId: 'tool:2:approve', response: 'ok' }),
+    ]
+
+    const grouped = groupInterruptResponsesByNode(responses, state)
+
+    expect(grouped.get('a')).toHaveLength(1)
+    expect(grouped.get('b')).toHaveLength(1)
+    expect(grouped.get('a')?.[0]?.interruptResponse.interruptId).toBe('tool:1:confirm')
+  })
+
+  it('throws when a response id does not match any node interrupt', () => {
+    const state = makeState({ a: [new Interrupt({ id: 'tool:1:confirm', name: 'confirm' })] })
+    const responses = [new InterruptResponseContent({ interruptId: 'tool:missing:xyz', response: 'yes' })]
+
+    expect(() => groupInterruptResponsesByNode(responses, state)).toThrow(/tool:missing:xyz/)
+  })
+
+  it('returns an empty map for empty responses', () => {
+    const state = makeState({ a: [new Interrupt({ id: 'tool:1:confirm', name: 'confirm' })] })
+    const grouped = groupInterruptResponsesByNode([], state)
+    expect(grouped.size).toBe(0)
   })
 })

--- a/strands-ts/src/multiagent/__tests__/state.test.ts
+++ b/strands-ts/src/multiagent/__tests__/state.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, it } from 'vitest'
 import { NodeResult, NodeState, MultiAgentResult, MultiAgentState, Status } from '../state.js'
 import { TextBlock, ToolUseBlock } from '../../types/messages.js'
 import type { JSONValue } from '../../types/json.js'
-import { stateToJSONSymbol, loadStateFromJSONSymbol } from '../../types/serializable.js'
+import {
+  stateToJSONSymbol,
+  loadStateFromJSONSymbol,
+  serializeStateSerializable,
+  loadStateSerializable,
+} from '../../types/serializable.js'
 import { Interrupt } from '../../interrupt.js'
 import { InterruptResponseContent } from '../../types/interrupt.js'
-import { groupInterruptResponsesByNode } from '../multiagent.js'
+import { extractResumeResponses, groupInterruptResponsesByNode } from '../multiagent.js'
 
 describe('NodeResult', () => {
   describe('toJSON / fromJSON', () => {
@@ -251,11 +256,11 @@ describe('NodeState', () => {
       expect(target.results).toHaveLength(1)
     })
 
-    it('round-trips interrupts and resumeSnapshot on an INTERRUPTED node', () => {
+    it('round-trips interrupts and interruptedSnapshot on an INTERRUPTED node', () => {
       const original = new NodeState()
       original.status = Status.INTERRUPTED
       original.interrupts = [new Interrupt({ id: 'tool:1:confirm', name: 'confirm', reason: 'need it' })]
-      original.resumeSnapshot = {
+      original.interruptedSnapshot = {
         scope: 'agent',
         schemaVersion: '1.0',
         createdAt: '2026-01-01T00:00:00Z',
@@ -264,29 +269,26 @@ describe('NodeState', () => {
       }
 
       const restored = new NodeState()
-      restored[loadStateFromJSONSymbol](original[stateToJSONSymbol]())
+      loadStateSerializable(restored, serializeStateSerializable(original))
 
-      expect(restored.status).toBe(Status.INTERRUPTED)
-      expect(restored.interrupts).toHaveLength(1)
-      expect(restored.interrupts[0]).toEqual(original.interrupts[0])
-      expect(restored.resumeSnapshot).toEqual(original.resumeSnapshot)
+      expect(restored).toEqual(original)
     })
 
-    it('clears resumeSnapshot when it is absent from the serialized state', () => {
+    it('clears interruptedSnapshot when it is absent from the serialized state', () => {
       const original = new NodeState()
       original.status = Status.COMPLETED
 
       const restored = new NodeState()
-      restored.resumeSnapshot = {
+      restored.interruptedSnapshot = {
         scope: 'agent',
         schemaVersion: '1.0',
         createdAt: '2026-01-01T00:00:00Z',
         data: {},
         appData: {},
       }
-      restored[loadStateFromJSONSymbol](original[stateToJSONSymbol]())
+      loadStateSerializable(restored, serializeStateSerializable(original))
 
-      expect(restored.resumeSnapshot).toBeUndefined()
+      expect(restored).toEqual(original)
     })
   })
 })
@@ -522,7 +524,7 @@ describe('MultiAgentState', () => {
       const original = new MultiAgentState()
       original._pendingInput = 'hello'
       const restored = new MultiAgentState()
-      restored[loadStateFromJSONSymbol](JSON.parse(JSON.stringify(original[stateToJSONSymbol]())) as JSONValue)
+      loadStateSerializable(restored, JSON.parse(JSON.stringify(serializeStateSerializable(original))) as JSONValue)
       expect(restored._pendingInput).toBe('hello')
     })
 
@@ -533,15 +535,12 @@ describe('MultiAgentState', () => {
       // some downstream code paths.
       const original = new MultiAgentState()
       original._pendingInput = [new TextBlock('question')]
-      const serialized = JSON.parse(JSON.stringify(original[stateToJSONSymbol]())) as JSONValue
+      const serialized = JSON.parse(JSON.stringify(serializeStateSerializable(original))) as JSONValue
       const restored = new MultiAgentState()
-      restored[loadStateFromJSONSymbol](serialized)
+      loadStateSerializable(restored, serialized)
 
-      expect(Array.isArray(restored._pendingInput)).toBe(true)
-      const blocks = restored._pendingInput as TextBlock[]
-      expect(blocks).toHaveLength(1)
-      expect(blocks[0]).toBeInstanceOf(TextBlock)
-      expect(blocks[0]!.text).toBe('question')
+      expect(restored._pendingInput).toEqual([new TextBlock('question')])
+      expect((restored._pendingInput as TextBlock[])[0]).toBeInstanceOf(TextBlock)
     })
   })
 })
@@ -629,5 +628,23 @@ describe('groupInterruptResponsesByNode', () => {
     const state = makeState({ a: [new Interrupt({ id: 'tool:1:confirm', name: 'confirm' })] })
     const grouped = groupInterruptResponsesByNode([], state)
     expect(grouped.size).toBe(0)
+  })
+})
+
+describe('extractResumeResponses', () => {
+  it('throws when interrupt responses are mixed with other content', () => {
+    // Cast through `unknown` since the public type rejects mixed arrays at compile-time;
+    // this test pins the runtime guard for callers that bypass typing.
+    const mixed = [
+      new InterruptResponseContent({ interruptId: 'tool:1:confirm', response: 'ok' }),
+      new TextBlock('stray content'),
+    ] as unknown as InterruptResponseContent[]
+    expect(() => extractResumeResponses(mixed)).toThrow(TypeError)
+  })
+
+  it('returns undefined for empty input or non-response arrays', () => {
+    expect(extractResumeResponses([])).toBeUndefined()
+    expect(extractResumeResponses('hello')).toBeUndefined()
+    expect(extractResumeResponses([new TextBlock('hi')])).toBeUndefined()
   })
 })

--- a/strands-ts/src/multiagent/__tests__/state.test.ts
+++ b/strands-ts/src/multiagent/__tests__/state.test.ts
@@ -268,7 +268,7 @@ describe('NodeState', () => {
 
       expect(restored.status).toBe(Status.INTERRUPTED)
       expect(restored.interrupts).toHaveLength(1)
-      expect(restored.interrupts[0]).toMatchObject({ id: 'tool:1:confirm', name: 'confirm', reason: 'need it' })
+      expect(restored.interrupts[0]).toEqual(original.interrupts[0])
       expect(restored.resumeSnapshot).toEqual(original.resumeSnapshot)
     })
 
@@ -516,6 +516,32 @@ describe('MultiAgentState', () => {
         startTime: 1234567890,
         steps: 5,
       })
+    })
+
+    it('round-trips _pendingInput as a string', () => {
+      const original = new MultiAgentState()
+      original._pendingInput = 'hello'
+      const restored = new MultiAgentState()
+      restored[loadStateFromJSONSymbol](JSON.parse(JSON.stringify(original[stateToJSONSymbol]())) as JSONValue)
+      expect(restored._pendingInput).toBe('hello')
+    })
+
+    it('rehydrates _pendingInput ContentBlock[] to ContentBlock instances', () => {
+      // Round-trips through JSON.stringify/parse to simulate FileStorage persistence,
+      // then asserts the restored entries are real ContentBlock instances rather than
+      // raw data objects — agent message construction depends on instance shape for
+      // some downstream code paths.
+      const original = new MultiAgentState()
+      original._pendingInput = [new TextBlock('question')]
+      const serialized = JSON.parse(JSON.stringify(original[stateToJSONSymbol]())) as JSONValue
+      const restored = new MultiAgentState()
+      restored[loadStateFromJSONSymbol](serialized)
+
+      expect(Array.isArray(restored._pendingInput)).toBe(true)
+      const blocks = restored._pendingInput as TextBlock[]
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0]).toBeInstanceOf(TextBlock)
+      expect(blocks[0]!.text).toBe('question')
     })
   })
 })

--- a/strands-ts/src/multiagent/events.ts
+++ b/strands-ts/src/multiagent/events.ts
@@ -3,6 +3,10 @@ import type { AgentStreamEvent, InvocationState } from '../types/agent.js'
 import type { MultiAgentResult, MultiAgentState, NodeResult } from './state.js'
 import type { MultiAgent } from './multiagent.js'
 import type { NodeType } from './nodes.js'
+import type { Interruptible } from '../interrupt.js'
+import { interruptFromMultiAgentNode } from '../interrupt.js'
+import type { InterruptParams } from '../types/interrupt.js'
+import type { JSONValue } from '../types/json.js'
 
 /**
  * Event triggered when a multi-agent orchestrator has finished initialization.
@@ -71,7 +75,7 @@ export class AfterMultiAgentInvocationEvent extends HookableEvent {
  * Event triggered before a node begins execution.
  * Hook callbacks can set {@link cancel} to prevent the node from executing.
  */
-export class BeforeNodeCallEvent extends HookableEvent {
+export class BeforeNodeCallEvent extends HookableEvent implements Interruptible {
   readonly type = 'beforeNodeCallEvent' as const
   readonly orchestrator: MultiAgent
   readonly state: MultiAgentState
@@ -96,6 +100,29 @@ export class BeforeNodeCallEvent extends HookableEvent {
     this.state = data.state
     this.nodeId = data.nodeId
     this.invocationState = data.invocationState
+  }
+
+  /**
+   * Raises an orchestrator-level interrupt that pauses the run before this node
+   * executes. If a prior resume has answered the interrupt, returns the response;
+   * otherwise throws an `InterruptError` and the orchestrator produces an
+   * INTERRUPTED result with the pending interrupt.
+   *
+   * The interrupt is stored on the target node's `NodeState.interrupts`, so resume
+   * via `InterruptResponseContent[]` routes through the same machinery as child-
+   * agent interrupts.
+   */
+  interrupt<T = JSONValue>(params: InterruptParams): T {
+    const nodeState = this.state.node(this.nodeId)
+    if (!nodeState) {
+      throw new Error(`node_id=<${this.nodeId}> | node state not found`)
+    }
+    return interruptFromMultiAgentNode<T>(
+      nodeState.interrupts,
+      `multiagent-hook:beforeNodeCall:${this.nodeId}:${params.name}`,
+      params,
+      'multiagent-hook'
+    )
   }
 
   toJSON(): Pick<BeforeNodeCallEvent, 'type' | 'nodeId'> {

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -301,14 +301,9 @@ export class Graph implements MultiAgent {
         })
       : ((await this._findResumeTargets(state)) ?? [...this._sources])
 
-    // execController has two abort sources that the loop must distinguish:
-    //   1. The `setTimeout` below fires when `config.timeout` elapses → real timeout.
-    //   2. The interrupt short-circuit (`execController.abort()` below the queue drain)
-    //      fires to stop in-flight siblings when any node returns INTERRUPTED.
-    // The loop's timeout check gates on `!interrupted` so an interrupt-driven abort
-    // doesn't get misreported as a timeout. External cancellation stays on its own
-    // signal for the same reason — we need to know whose abort it was. Keep that
-    // `!interrupted` discriminator intact when editing this loop.
+    // Wall-clock timeout for the whole graph invocation. External cancellation is kept
+    // on its own signal so the loop's abort checks below can distinguish the two causes
+    // and produce the right error message.
     const execController = new AbortController()
     const execTimeoutHandle = Number.isFinite(this.config.timeout)
       ? setTimeout(() => execController.abort(), this.config.timeout)
@@ -323,7 +318,7 @@ export class Graph implements MultiAgent {
     let result: MultiAgentResult | undefined
     try {
       while (targets.length > 0 || streams.size > 0) {
-        if (execTimeoutHandle !== undefined && execController.signal.aborted && !interrupted) {
+        if (execTimeoutHandle !== undefined && execController.signal.aborted) {
           throw new Error(`timeout=<${this.config.timeout}>, graph_id=<${this.id}> | graph exceeded wall-clock budget`)
         }
         if (externalCancelSignal?.aborted) {
@@ -385,11 +380,10 @@ export class Graph implements MultiAgent {
 
           if (interrupted) continue
 
-          // Short-circuit: first node to interrupt aborts in-flight siblings so they
-          // don't keep burning work past the point we're going to pause.
+          // Stop scheduling new nodes once any node has interrupted; in-flight siblings
+          // run to completion on their own.
           if (nodeResult.status === Status.INTERRUPTED) {
             interrupted = true
-            execController.abort()
             continue
           }
 

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -290,11 +290,25 @@ export class Graph implements MultiAgent {
     }
 
     const targets = interruptResponsesByNode
-      ? [...interruptResponsesByNode.keys()].map((id) => this.nodes.get(id)!)
+      ? [...interruptResponsesByNode.keys()].map((id) => {
+          const node = this.nodes.get(id)
+          if (!node) {
+            throw new Error(
+              `node_id=<${id}>, graph_id=<${this.id}> | resume response targets a node missing from the graph; topology changed between save and resume?`
+            )
+          }
+          return node
+        })
       : ((await this._findResumeTargets(state)) ?? [...this._sources])
 
-    // execController fires on both timeout and interrupt short-circuit; external
-    // cancellation stays on its own signal so the loop can distinguish the two causes.
+    // execController has two abort sources that the loop must distinguish:
+    //   1. The `setTimeout` below fires when `config.timeout` elapses → real timeout.
+    //   2. The interrupt short-circuit (`execController.abort()` below the queue drain)
+    //      fires to stop in-flight siblings when any node returns INTERRUPTED.
+    // The loop's timeout check gates on `!interrupted` so an interrupt-driven abort
+    // doesn't get misreported as a timeout. External cancellation stays on its own
+    // signal for the same reason — we need to know whose abort it was. Keep that
+    // `!interrupted` discriminator intact when editing this loop.
     const execController = new AbortController()
     const execTimeoutHandle = Number.isFinite(this.config.timeout)
       ? setTimeout(() => execController.abort(), this.config.timeout)
@@ -699,7 +713,13 @@ export class Graph implements MultiAgent {
     state: MultiAgentState
   ): MultiAgentInput {
     if (routed) {
-      const forwarded = applyOrchestratorHookResponses(state.node(node.id)!, routed)
+      const nodeState = state.node(node.id)
+      if (!nodeState) {
+        throw new Error(
+          `node_id=<${node.id}>, graph_id=<${this.id}> | routed interrupt response targets a node missing from state; topology changed between save and resume?`
+        )
+      }
+      const forwarded = applyOrchestratorHookResponses(nodeState, routed)
       if (forwarded.length > 0) return forwarded
     }
     if (contentInput === undefined) {

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -1,8 +1,17 @@
 import type { AttributeValue } from '@opentelemetry/api'
 import type { InvocationState, InvokableAgent } from '../types/agent.js'
-import type { MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
+import type { MultiAgentContentInput, MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
+import {
+  applyOrchestratorHookResponses,
+  dropStaleInterruptedResult,
+  extractResumeResponses,
+  groupInterruptResponsesByNode,
+  recordHookInterrupt,
+} from './multiagent.js'
 import type { ContentBlock } from '../types/messages.js'
 import { TextBlock, contentBlockFromData } from '../types/messages.js'
+import type { InterruptResponseContent } from '../types/interrupt.js'
+import { InterruptError } from '../interrupt.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
 import { HookableEvent } from '../hooks/events.js'
@@ -26,6 +35,7 @@ import {
   MultiAgentInitializedEvent,
   MultiAgentResultEvent,
   NodeCancelEvent,
+  NodeResultEvent,
 } from './events.js'
 import type { EdgeDefinition } from './edge.js'
 import { Edge } from './edge.js'
@@ -129,6 +139,13 @@ export class Graph implements MultiAgent {
   private readonly _tracer: Tracer
   readonly sessionManager?: SessionManager | undefined
   private _initialized: boolean
+  /**
+   * State retained across invocations when a run ends INTERRUPTED. Lets
+   * `graph.invoke(responses)` resume on the same instance without requiring a
+   * SessionManager, mirroring single-agent ergonomics. Cleared when a run
+   * terminates in any non-INTERRUPTED state.
+   */
+  private _pendingInterruptState?: MultiAgentState
 
   constructor(options: GraphOptions) {
     const { id, nodes, edges, sources, sessionManager, plugins, traceAttributes, ...config } = options
@@ -223,13 +240,12 @@ export class Graph implements MultiAgent {
     // child agent so mutations in one node are visible in the next.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
-    const gen = this._stream(input, invocationState)
+    // Hook invocation lives in `_stream` so hook-raised `InterruptError`s land in the
+    // same frame as the execution loop.
+    const gen = this._stream(input, invocationState, options?.cancelSignal)
     try {
       let next = await gen.next()
       while (!next.done) {
-        if (next.value instanceof HookableEvent) {
-          await this._hookRegistry.invokeCallbacks(next.value)
-        }
         yield next.value
         next = await gen.next()
       }
@@ -241,9 +257,13 @@ export class Graph implements MultiAgent {
 
   private async *_stream(
     input: MultiAgentInput,
-    invocationState: InvocationState
+    invocationState: InvocationState,
+    externalCancelSignal?: AbortSignal
   ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
-    const state = new MultiAgentState({ nodeIds: [...this.nodes.keys()] })
+    // Reuse state from a prior INTERRUPTED run so `graph.invoke(responses)` can
+    // resume on the same instance without a SessionManager.
+    const state = this._pendingInterruptState ?? new MultiAgentState({ nodeIds: [...this.nodes.keys()] })
+    delete this._pendingInterruptState
 
     const queue = new Queue()
     const streams = new Map<string, Promise<void>>()
@@ -255,34 +275,75 @@ export class Graph implements MultiAgent {
     })
 
     // SessionManager (or plugins) may restore state.results here via the hook
-    yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
+    yield* this._emit(new BeforeMultiAgentInvocationEvent({ orchestrator: this, state, invocationState }))
 
-    // Resume: if state was restored, find nodes that are ready but haven't completed otherwise start from source nodes
-    const targets = (await this._findResumeTargets(state)) ?? [...this._sources]
+    // Resume input bypasses dependency resolution (routed by interrupt id). On fresh
+    // runs, stash the input so resume can replay it to hook-gated nodes that never ran.
+    const resumeResponses = extractResumeResponses(input)
+    const interruptResponsesByNode = resumeResponses ? groupInterruptResponsesByNode(resumeResponses, state) : undefined
+    let contentInput: MultiAgentContentInput | undefined
+    if (resumeResponses) {
+      contentInput = state._pendingInput as MultiAgentContentInput | undefined
+    } else {
+      contentInput = input as MultiAgentContentInput
+      state._pendingInput = contentInput
+    }
 
-    // Execution timeout: when fired, cancels all in-flight node invocations via their
-    // composed cancel signal. In-flight nodes return `stopReason: 'cancelled'`; the queue
-    // drains and the outer loop throws below when it sees the signal aborted.
-    const execController = Number.isFinite(this.config.timeout) ? new AbortController() : undefined
-    const execTimeoutHandle = execController ? setTimeout(() => execController.abort(), this.config.timeout) : undefined
+    const targets = interruptResponsesByNode
+      ? [...interruptResponsesByNode.keys()].map((id) => this.nodes.get(id)!)
+      : ((await this._findResumeTargets(state)) ?? [...this._sources])
 
+    // execController fires on both timeout and interrupt short-circuit; external
+    // cancellation stays on its own signal so the loop can distinguish the two causes.
+    const execController = new AbortController()
+    const execTimeoutHandle = Number.isFinite(this.config.timeout)
+      ? setTimeout(() => execController.abort(), this.config.timeout)
+      : undefined
+
+    const cancelSignal = externalCancelSignal
+      ? AbortSignal.any([execController.signal, externalCancelSignal])
+      : execController.signal
+
+    let interrupted = false
     let caughtError: Error | undefined
     let result: MultiAgentResult | undefined
     try {
       while (targets.length > 0 || streams.size > 0) {
-        if (execController?.signal.aborted) {
+        if (execTimeoutHandle !== undefined && execController.signal.aborted && !interrupted) {
           throw new Error(`timeout=<${this.config.timeout}>, graph_id=<${this.id}> | graph exceeded wall-clock budget`)
         }
-        while (targets.length > 0 && streams.size < this.config.maxConcurrency) {
+        if (externalCancelSignal?.aborted) {
+          throw new Error(`graph_id=<${this.id}> | graph cancelled by external signal`)
+        }
+        while (!interrupted && targets.length > 0 && streams.size < this.config.maxConcurrency) {
           const node = targets.shift()!
 
           this._checkSteps(state)
           state.steps++
 
-          streams.set(
-            node.id,
-            this._streamNode(node, input, state, queue, multiAgentSpan, invocationState, execController?.signal)
+          // Resolve input first so `applyOrchestratorHookResponses` has populated the
+          // stored `Interrupt.response` entries before the BeforeNodeCall hook reads them.
+          const nodeInput = this._resolveInputForScheduling(
+            node,
+            interruptResponsesByNode?.get(node.id),
+            contentInput,
+            state
           )
+
+          const nodeSpan = this._tracer.withSpanContext(multiAgentSpan, () =>
+            this._tracer.startNodeSpan({ nodeId: node.id, nodeType: node.type })
+          )
+
+          const preResult = yield* this._runBeforeNodeCall(node, nodeSpan, state, invocationState)
+          if (preResult !== undefined) {
+            // Hook gated the node before it could run; surface the synthetic result
+            // through the queue so the main loop handles short-circuit and downstream
+            // scheduling uniformly with normal node results.
+            queue.push({ type: 'result', node, result: preResult })
+            continue
+          }
+
+          streams.set(node.id, this._streamNode(node, nodeInput, state, queue, nodeSpan, invocationState, cancelSignal))
         }
 
         await queue.wait()
@@ -290,6 +351,7 @@ export class Graph implements MultiAgent {
           const { data, ack } = queue.shift()!
 
           if (data.type === 'event') {
+            await this._hookRegistry.invokeCallbacks(data.event)
             yield data.event
             ack()
             continue
@@ -307,14 +369,26 @@ export class Graph implements MultiAgent {
 
           state.results.push(nodeResult)
 
+          if (interrupted) continue
+
+          // Short-circuit: first node to interrupt aborts in-flight siblings so they
+          // don't keep burning work past the point we're going to pause.
+          if (nodeResult.status === Status.INTERRUPTED) {
+            interrupted = true
+            execController.abort()
+            continue
+          }
+
           const ready = await this._findReady(node, state, streams, targets)
           if (ready.length > 0) {
-            yield new MultiAgentHandoffEvent({
-              source: node.id,
-              targets: ready.map((n) => n.id),
-              state,
-              invocationState,
-            })
+            yield* this._emit(
+              new MultiAgentHandoffEvent({
+                source: node.id,
+                targets: ready.map((n) => n.id),
+                state,
+                invocationState,
+              })
+            )
             targets.push(...ready)
           }
         }
@@ -325,6 +399,13 @@ export class Graph implements MultiAgent {
         content: this._resolveContent(state),
         duration: Date.now() - state.startTime,
       })
+      // Stash on interrupt so same-instance resume has state; otherwise start fresh.
+      if (result.status === Status.INTERRUPTED) {
+        this._pendingInterruptState = state
+      } else {
+        delete this._pendingInterruptState
+        delete state._pendingInput
+      }
     } catch (error) {
       caughtError = normalizeError(error)
       throw caughtError
@@ -339,58 +420,86 @@ export class Graph implements MultiAgent {
         ...(caughtError && { error: caughtError }),
       })
 
-      yield new AfterMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
+      yield* this._emit(new AfterMultiAgentInvocationEvent({ orchestrator: this, state, invocationState }))
     }
 
-    yield new MultiAgentResultEvent({ result, invocationState })
+    yield* this._emit(new MultiAgentResultEvent({ result, invocationState }))
     return result
   }
 
   /**
-   * Executes a single node, pushing streaming events to the shared queue in real-time.
+   * Invokes hook callbacks on an event, then yields it.
+   */
+  private async *_emit<T extends HookableEvent>(event: T): AsyncGenerator<T, void, undefined> {
+    await this._hookRegistry.invokeCallbacks(event)
+    yield event
+  }
+
+  /**
+   * Fires `BeforeNodeCallEvent` and handles hook-raised interrupts or cancels inline.
+   * Returns a synthetic NodeResult (INTERRUPTED or CANCELLED) when a hook gates the
+   * node, in which case the caller skips `_streamNode` and surfaces the result directly.
+   * Returns `undefined` when no hook gated the node and execution should proceed.
+   *
+   * Owns the `nodeSpan` on gated paths — `_streamNode` owns it on the ungated path.
+   * Yields the `NodeResultEvent` + `AfterNodeCallEvent` lifecycle pair on gated paths
+   * so observers see the same event sequence regardless of how the node terminated.
+   */
+  private async *_runBeforeNodeCall(
+    node: Node,
+    nodeSpan: Span | null,
+    state: MultiAgentState,
+    invocationState: InvocationState
+  ): AsyncGenerator<MultiAgentStreamEvent, NodeResult | undefined, undefined> {
+    const nodeState = state.node(node.id)!
+    const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
+    try {
+      await this._hookRegistry.invokeCallbacks(beforeEvent)
+    } catch (error) {
+      if (error instanceof InterruptError) {
+        const result = recordHookInterrupt(node.id, nodeState)
+        yield beforeEvent
+        yield* this._emit(new NodeResultEvent({ nodeId: node.id, nodeType: node.type, state, result, invocationState }))
+        yield* this._emit(new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }))
+        this._tracer.endNodeSpan(nodeSpan, { status: Status.INTERRUPTED, duration: result.duration })
+        return result
+      }
+      throw error
+    }
+    yield beforeEvent
+
+    if (beforeEvent.cancel) {
+      const message = typeof beforeEvent.cancel === 'string' ? beforeEvent.cancel : 'node cancelled by hook'
+      // Cancel path doesn't go through Node.stream, so do its INTERRUPTED cleanup here.
+      dropStaleInterruptedResult(node.id, nodeState, state)
+      const result = new NodeResult({ nodeId: node.id, status: Status.CANCELLED, duration: 0 })
+      nodeState.status = Status.CANCELLED
+      nodeState.results.push(result)
+      yield* this._emit(new NodeCancelEvent({ nodeId: node.id, state, message, invocationState }))
+      yield* this._emit(new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }))
+      this._tracer.endNodeSpan(nodeSpan, { status: Status.CANCELLED, duration: 0 })
+      return result
+    }
+
+    return undefined
+  }
+
+  /**
+   * Runs a node whose `BeforeNodeCallEvent` already fired without a hook gating it
+   * (interrupt or cancel are handled by `_runBeforeNodeCall` before this coroutine
+   * is spawned). Takes ownership of the already-started `nodeSpan` and ends it.
    */
   private async _streamNode(
     node: Node,
     input: MultiAgentInput,
     state: MultiAgentState,
     queue: Queue,
-    multiAgentSpan: Span | null,
+    nodeSpan: Span | null,
     invocationState: InvocationState,
     executionSignal?: AbortSignal
   ): Promise<void> {
-    const nodeState = state.node(node.id)!
-
-    const nodeSpan = this._tracer.withSpanContext(multiAgentSpan, () =>
-      this._tracer.startNodeSpan({ nodeId: node.id, nodeType: node.type })
-    )
-
-    const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
-    await queue.send({ type: 'event', node, event: beforeEvent })
-
-    if (beforeEvent.cancel) {
-      const message = typeof beforeEvent.cancel === 'string' ? beforeEvent.cancel : 'node cancelled by hook'
-      const result = new NodeResult({ nodeId: node.id, status: Status.CANCELLED, duration: 0 })
-      nodeState.status = Status.CANCELLED
-      nodeState.results.push(result)
-
-      await queue.send({
-        type: 'event',
-        node,
-        event: new NodeCancelEvent({ nodeId: node.id, state, message, invocationState }),
-      })
-      await queue.send({
-        type: 'event',
-        node,
-        event: new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }),
-      })
-      this._tracer.endNodeSpan(nodeSpan, { status: Status.CANCELLED, duration: 0 })
-      queue.push({ type: 'result', node, result })
-      return
-    }
-
-    // Per-node timeout applies only to AgentNode. MultiAgentNode wraps a nested Swarm/Graph
-    // that has its own timeout config; cancelSignal isn't yet plumbed into nested orchestrators
-    // so bounding belongs on the child.
+    // Per-node timeout only applies to AgentNode; a nested MultiAgentNode manages
+    // its own node-level timeouts.
     const nodeTimeout = node instanceof AgentNode ? (node.timeout ?? this.config.nodeTimeout) : Infinity
     const nodeTimeoutController = Number.isFinite(nodeTimeout) ? new AbortController() : undefined
     const nodeTimeoutHandle = nodeTimeoutController
@@ -400,10 +509,8 @@ export class Graph implements MultiAgent {
     const cancelSignal = signals.length > 0 ? AbortSignal.any(signals) : undefined
 
     try {
-      const nodeInput = this._resolveNodeInput(node, input, state)
-
       const gen = this._tracer.withSpanContext(nodeSpan, () =>
-        node.stream(nodeInput, state, { invocationState, ...(cancelSignal && { cancelSignal }) })
+        node.stream(input, state, { invocationState, ...(cancelSignal && { cancelSignal }) })
       )
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       while (!next.done) {
@@ -579,9 +686,37 @@ export class Graph implements MultiAgent {
   }
 
   /**
-   * Builds the input for a node by combining the original task with dependency outputs.
+   * Chooses the input for a node about to be scheduled, handling the three resume cases:
+   * routed orchestrator-hook responses (forward leftovers to the agent), routed responses
+   * fully consumed by the hook (replay the original invocation input), and fresh runs
+   * (dependency-merged). Falls back to an empty input with a warning if a custom
+   * SessionManager dropped `_pendingInput`.
    */
-  private _resolveNodeInput(node: Node, input: MultiAgentInput, state: MultiAgentState): MultiAgentInput {
+  private _resolveInputForScheduling(
+    node: Node,
+    routed: InterruptResponseContent[] | undefined,
+    contentInput: MultiAgentContentInput | undefined,
+    state: MultiAgentState
+  ): MultiAgentInput {
+    if (routed) {
+      const forwarded = applyOrchestratorHookResponses(state.node(node.id)!, routed)
+      if (forwarded.length > 0) return forwarded
+    }
+    if (contentInput === undefined) {
+      logger.warn(`node_id=<${node.id}>, graph_id=<${this.id}> | no pending input on resume; using empty`)
+      return this._resolveNodeInput(node, '', state)
+    }
+    return this._resolveNodeInput(node, contentInput, state)
+  }
+
+  /**
+   * Builds the input for a node by combining the original task with dependency outputs.
+   *
+   * Only called for non-resume executions: the caller routes resume responses directly
+   * to interrupted nodes without going through dependency resolution, so this helper
+   * never sees `InterruptResponseContent[]`.
+   */
+  private _resolveNodeInput(node: Node, input: MultiAgentContentInput, state: MultiAgentState): MultiAgentInput {
     const deps: ContentBlock[] = []
     for (const edge of this.edges.filter((e) => e.target.id === node.id)) {
       const ns = state.node(edge.source.id)!

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -279,6 +279,13 @@ export class Graph implements MultiAgent {
 
     // Resume input bypasses dependency resolution (routed by interrupt id). On fresh
     // runs, stash the input so resume can replay it to hook-gated nodes that never ran.
+    //
+    // Example: Source node A has a `BeforeNodeCallEvent` hook that interrupts. The user
+    // calls `graph.invoke('original task')`, the hook fires before A executes, the run
+    // pauses with status INTERRUPTED. On resume, `graph.invoke([response])` only carries
+    // the response — A still needs `'original task'` as its input because A never ran
+    // and has no snapshot or upstream results to fall back on. `state._pendingInput`
+    // carries `'original task'` across the pause so resume can replay it.
     const resumeResponses = extractResumeResponses(input)
     const interruptResponsesByNode = resumeResponses ? groupInterruptResponsesByNode(resumeResponses, state) : undefined
     let contentInput: MultiAgentContentInput | undefined

--- a/strands-ts/src/multiagent/multiagent.ts
+++ b/strands-ts/src/multiagent/multiagent.ts
@@ -24,6 +24,8 @@ export type MultiAgentInput = Exclude<InvokeArgs, Message[] | MessageData[]>
  * The non-resume subset of {@link MultiAgentInput}. Internal orchestrator helpers that
  * participate in dependency resolution / handoff routing accept this narrower type so
  * they don't need to re-check for {@link InterruptResponseContent} entries at each call.
+ *
+ * @internal
  */
 export type MultiAgentContentInput = Exclude<
   MultiAgentInput,

--- a/strands-ts/src/multiagent/multiagent.ts
+++ b/strands-ts/src/multiagent/multiagent.ts
@@ -104,9 +104,18 @@ export interface MultiAgent {
 export function extractResumeResponses(input: MultiAgentInput): InterruptResponseContent[] | undefined {
   if (!Array.isArray(input) || input.length === 0) return undefined
   if (!isInterruptResponseContent(input[0])) return undefined
-  return (input as readonly (InterruptResponseContent | InterruptResponseContentData)[]).map((entry) =>
-    entry instanceof InterruptResponseContent ? entry : InterruptResponseContent.fromJSON(entry)
-  )
+
+  const responses: InterruptResponseContent[] = []
+  for (const entry of input) {
+    if (entry instanceof InterruptResponseContent) {
+      responses.push(entry)
+    } else if (isInterruptResponseContent(entry)) {
+      responses.push(InterruptResponseContent.fromJSON(entry as InterruptResponseContentData))
+    } else {
+      throw new TypeError('Must resume from interrupt with a list of interruptResponse content blocks only')
+    }
+  }
+  return responses
 }
 
 /**

--- a/strands-ts/src/multiagent/multiagent.ts
+++ b/strands-ts/src/multiagent/multiagent.ts
@@ -2,19 +2,32 @@ import type { InvocationState, InvokeArgs } from '../types/agent.js'
 import type { Message, MessageData } from '../types/messages.js'
 import type { HookableEvent } from '../hooks/events.js'
 import type { HookCallback, HookableEventConstructor, HookCleanup } from '../hooks/types.js'
+import type { InterruptResponseContentData } from '../types/interrupt.js'
+import { InterruptResponseContent, isInterruptResponseContent } from '../types/interrupt.js'
 import type { MultiAgentStreamEvent } from './events.js'
-import type { MultiAgentResult } from './state.js'
-
-import type { InterruptResponseContent, InterruptResponseContentData } from '../types/interrupt.js'
+import { NodeResult, Status } from './state.js'
+import type { MultiAgentResult, MultiAgentState, NodeState } from './state.js'
 
 /**
- * Input type for multi-agent orchestrators. Excludes `Message[]`, `MessageData[]`,
- * and `InterruptResponseContent[]` from {@link InvokeArgs} since orchestrators route
- * content blocks between nodes. Graph interrupts will be handled separately.
+ * Input type for multi-agent orchestrators. Excludes `Message[]` / `MessageData[]`
+ * since orchestrators route content blocks between nodes rather than replaying raw
+ * conversation history.
+ *
+ * Accepts `InterruptResponseContent[]` / `InterruptResponseContentData[]` for resuming
+ * from an interrupted run — orchestrators detect resume input at the entry point and
+ * route responses to the interrupted nodes rather than flowing through dependency
+ * resolution.
  */
-export type MultiAgentInput = Exclude<
-  InvokeArgs,
-  Message[] | MessageData[] | InterruptResponseContent[] | InterruptResponseContentData[]
+export type MultiAgentInput = Exclude<InvokeArgs, Message[] | MessageData[]>
+
+/**
+ * The non-resume subset of {@link MultiAgentInput}. Internal orchestrator helpers that
+ * participate in dependency resolution / handoff routing accept this narrower type so
+ * they don't need to re-check for {@link InterruptResponseContent} entries at each call.
+ */
+export type MultiAgentContentInput = Exclude<
+  MultiAgentInput,
+  InterruptResponseContent[] | InterruptResponseContentData[]
 >
 
 /**
@@ -27,6 +40,19 @@ export interface MultiAgentInvokeOptions {
    * {@link InvocationState} for details. Defaults to `{}` when omitted.
    */
   invocationState?: InvocationState
+
+  /**
+   * Cancellation signal forwarded to every node (and into any nested orchestrators
+   * via `MultiAgentNode`). Composed with the orchestrator's own timeout and
+   * short-circuit signals, matching {@link InvokeOptions.cancelSignal} on the
+   * single-agent path. Cooperative — honored by nodes that forward it to their
+   * underlying agents/tools.
+   *
+   * When this signal aborts, the orchestrator throws rather than returning a clean
+   * result. This matches single-agent behavior: external cancellation is treated as
+   * an exceptional exit, not a normal terminal state.
+   */
+  cancelSignal?: AbortSignal
 }
 
 /**
@@ -65,4 +91,115 @@ export interface MultiAgent {
    * @returns Cleanup function that removes the callback when invoked
    */
   addHook<T extends HookableEvent>(eventType: HookableEventConstructor<T>, callback: HookCallback<T>): HookCleanup
+}
+
+/**
+ * Detects whether a {@link MultiAgentInput} is a resume from an interrupted run and
+ * normalizes its entries to {@link InterruptResponseContent} instances.
+ *
+ * Returns `undefined` for fresh input (string / content blocks / empty array).
+ */
+export function extractResumeResponses(input: MultiAgentInput): InterruptResponseContent[] | undefined {
+  if (!Array.isArray(input) || input.length === 0) return undefined
+  if (!isInterruptResponseContent(input[0])) return undefined
+  return (input as readonly (InterruptResponseContent | InterruptResponseContentData)[]).map((entry) =>
+    entry instanceof InterruptResponseContent ? entry : InterruptResponseContent.fromJSON(entry)
+  )
+}
+
+/**
+ * Groups a flat list of interrupt responses by the node that raised each interrupt.
+ *
+ * For each response, finds the node whose `NodeState.interrupts` contains an entry
+ * with a matching id. Ids are globally unique (derived from model-assigned
+ * `toolUseId`s) so each response maps to exactly one node. Nested orchestrators
+ * carry their subtree's interrupts on the wrapping `MultiAgentNode`'s state, so a
+ * matching response is forwarded as-is to the nested orchestrator, which does its
+ * own grouping recursively.
+ *
+ * @throws Error if any response's interrupt id does not match any tracked node
+ */
+export function groupInterruptResponsesByNode(
+  responses: InterruptResponseContent[],
+  state: MultiAgentState
+): Map<string, InterruptResponseContent[]> {
+  const grouped = new Map<string, InterruptResponseContent[]>()
+  for (const response of responses) {
+    const id = response.interruptResponse.interruptId
+    let target: string | undefined
+    for (const [nodeId, nodeState] of state.nodes) {
+      if (nodeState.interrupts.some((i) => i.id === id)) {
+        target = nodeId
+        break
+      }
+    }
+    if (!target) {
+      throw new Error(`interrupt_id=<${id}> | no node found with matching interrupt`)
+    }
+    const bucket = grouped.get(target) ?? []
+    bucket.push(response)
+    grouped.set(target, bucket)
+  }
+  return grouped
+}
+
+/**
+ * Removes a stale INTERRUPTED result for the given node from both per-node history
+ * and the orchestrator-level aggregate so a fresh result (from resume or cancel)
+ * replaces it cleanly. No-op if the node isn't in an INTERRUPTED state.
+ */
+export function dropStaleInterruptedResult(nodeId: string, nodeState: NodeState, state: MultiAgentState): void {
+  if (nodeState.status !== Status.INTERRUPTED) return
+  if (nodeState.results[nodeState.results.length - 1]?.status === Status.INTERRUPTED) {
+    nodeState.results.pop()
+  }
+  const idx = state.results.findIndex((r) => r.nodeId === nodeId && r.status === Status.INTERRUPTED)
+  if (idx >= 0) state.results.splice(idx, 1)
+}
+
+/**
+ * Records a hook-raised interrupt on a node that hadn't started executing: builds
+ * the INTERRUPTED {@link NodeResult}, transitions `nodeState.status`, and appends
+ * the result to `nodeState.results`. Returns the result so callers can route it
+ * into their own queue/lifecycle machinery.
+ *
+ * Shared between Graph and Swarm so their hook-interrupt branches don't drift.
+ */
+export function recordHookInterrupt(nodeId: string, nodeState: NodeState): NodeResult {
+  const result = new NodeResult({
+    nodeId,
+    status: Status.INTERRUPTED,
+    duration: Date.now() - nodeState.startTime,
+    interrupts: nodeState.interrupts,
+  })
+  nodeState.status = Status.INTERRUPTED
+  nodeState.results.push(result)
+  return result
+}
+
+/**
+ * Applies interrupt responses to a node's own orchestrator-level interrupts and
+ * returns the remaining responses — those bound for the child agent's interrupts.
+ *
+ * Orchestrator hooks (source `'multiagent-hook'`) store their interrupts on
+ * `NodeState.interrupts` directly; the hook re-runs on resume and reads the stored
+ * response. Agent-level interrupts aren't answerable here — they flow to the child
+ * agent as resume input and are applied by the agent's own interrupt machinery.
+ */
+export function applyOrchestratorHookResponses(
+  nodeState: NodeState,
+  responses: InterruptResponseContent[]
+): InterruptResponseContent[] {
+  const forwarded: InterruptResponseContent[] = []
+  for (const response of responses) {
+    const local = nodeState.interrupts.find(
+      (i) => i.id === response.interruptResponse.interruptId && i.source === 'multiagent-hook'
+    )
+    if (local) {
+      local.response = response.interruptResponse.response
+    } else {
+      forwarded.push(response)
+    }
+  }
+  return forwarded
 }

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -1,6 +1,7 @@
 import { Agent } from '../agent/agent.js'
 import type { InvocationState, InvokeOptions, InvokableAgent, AgentStreamEvent } from '../types/agent.js'
 import type { MultiAgentInput } from './multiagent.js'
+import { dropStaleInterruptedResult } from './multiagent.js'
 import type { MultiAgentStreamEvent } from './events.js'
 import { NodeStreamUpdateEvent, NodeResultEvent } from './events.js'
 import { NodeResult, Status } from './state.js'
@@ -86,6 +87,10 @@ export abstract class Node {
     options?: NodeInputOptions
   ): AsyncGenerator<MultiAgentStreamEvent, NodeResult, undefined> {
     const nodeState = state.node(this.id)!
+
+    // Resuming from INTERRUPTED: drop the stale result so the fresh one replaces it.
+    dropStaleInterruptedResult(this.id, nodeState, state)
+
     nodeState.status = Status.EXECUTING
     nodeState.startTime = Date.now()
 
@@ -97,24 +102,36 @@ export abstract class Node {
     let result: NodeResult
     try {
       const update = yield* this.handle(input, state, resolvedOptions)
+      const defaultStatus = update.interrupts && update.interrupts.length > 0 ? Status.INTERRUPTED : Status.COMPLETED
       result = new NodeResult({
         nodeId: this.id,
-        status: Status.COMPLETED,
+        status: defaultStatus,
         duration: Date.now() - nodeState.startTime,
         content: [],
         ...update,
       })
     } catch (error) {
+      // Orchestrator cancellation (short-circuit or external) maps thrown errors to
+      // CANCELLED — node was stopped, not broken.
+      const status = options?.cancelSignal?.aborted ? Status.CANCELLED : Status.FAILED
       result = new NodeResult({
         nodeId: this.id,
-        status: Status.FAILED,
+        status,
         duration: Date.now() - nodeState.startTime,
         error: normalizeError(error),
       })
-      logger.warn(`node_id=<${this.id}>, error=<${result.error?.message}> | node execution failed`)
+      if (status === Status.FAILED) {
+        logger.warn(`node_id=<${this.id}>, error=<${result.error?.message}> | node execution failed`)
+      }
     } finally {
       nodeState.status = result!.status
       nodeState.results.push(result!)
+      nodeState.interrupts = result!.interrupts ?? []
+      // Clear the stored snapshot on non-INTERRUPTED terminal states; `handle()`
+      // repopulates it above if this run itself interrupted.
+      if (result!.status !== Status.INTERRUPTED) {
+        delete nodeState.resumeSnapshot
+      }
     }
 
     yield new NodeResultEvent({
@@ -212,11 +229,16 @@ export class AgentNode extends Node {
     // handle() is public API, so direct callers get per-call state.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
-    // Only Agent instances support snapshot/restore for state isolation
-    const snapshot =
-      this._agent instanceof Agent
-        ? this._agent.takeSnapshot({ include: ['messages', 'state', 'modelState'] })
-        : undefined
+    // Only Agent instances support snapshot/restore for state isolation.
+    const isAgent = this._agent instanceof Agent
+    const preRunSnapshot = isAgent ? this._agent.takeSnapshot({ preset: 'session' }) : undefined
+
+    // Rehydrate agent state from a prior INTERRUPTED run (messages + interrupt state).
+    const nodeState = state.node(this.id)
+    if (isAgent && nodeState?.resumeSnapshot) {
+      this._agent.loadSnapshot(nodeState.resumeSnapshot)
+    }
+
     try {
       const invokeOptions: InvokeOptions = {
         ...(options?.structuredOutputSchema && { structuredOutputSchema: options.structuredOutputSchema }),
@@ -231,23 +253,34 @@ export class AgentNode extends Node {
           nodeId: this.id,
           nodeType: this.type,
           state,
-          inner:
-            this._agent instanceof Agent
-              ? { source: 'agent', event: next.value as AgentStreamEvent }
-              : { source: 'custom', event: next.value },
+          inner: isAgent
+            ? { source: 'agent', event: next.value as AgentStreamEvent }
+            : { source: 'custom', event: next.value },
           invocationState,
         })
         next = await gen.next()
       }
 
+      const agentResult = next.value
+      const interrupted =
+        agentResult.stopReason === 'interrupt' && agentResult.interrupts && agentResult.interrupts.length > 0
+
+      // Capture post-interrupt state for the next resume cycle. Only Agent instances
+      // are snapshottable.
+      if (interrupted && isAgent && nodeState) {
+        nodeState.resumeSnapshot = this._agent.takeSnapshot({ preset: 'session' })
+      }
+
       return {
-        content: next.value.lastMessage.content,
-        ...('structuredOutput' in next.value && { structuredOutput: next.value.structuredOutput }),
-        ...(next.value.metrics?.accumulatedUsage && { usage: next.value.metrics.accumulatedUsage }),
+        content: agentResult.lastMessage.content,
+        ...('structuredOutput' in agentResult && { structuredOutput: agentResult.structuredOutput }),
+        ...(agentResult.metrics?.accumulatedUsage && { usage: agentResult.metrics.accumulatedUsage }),
+        ...(interrupted && { interrupts: agentResult.interrupts }),
       }
     } finally {
-      if (snapshot) {
-        ;(this._agent as Agent).loadSnapshot(snapshot)
+      // Restore pre-run state — keeps the agent observably unchanged across runs.
+      if (preRunSnapshot) {
+        ;(this._agent as Agent).loadSnapshot(preRunSnapshot)
       }
     }
   }
@@ -302,7 +335,10 @@ export class MultiAgentNode extends Node {
     // handle() is public API, so direct callers get per-call state.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
-    const gen = this._orchestrator.stream(input, { invocationState })
+    const gen = this._orchestrator.stream(input, {
+      invocationState,
+      ...(options?.cancelSignal && { cancelSignal: options.cancelSignal }),
+    })
     let next = await gen.next()
     while (!next.done) {
       const event = next.value
@@ -320,11 +356,14 @@ export class MultiAgentNode extends Node {
       next = await gen.next()
     }
     const innerResult = next.value
+    const interrupted = innerResult.interrupts && innerResult.interrupts.length > 0
+
     return {
       content: innerResult.content,
       usage: innerResult.usage,
       ...(innerResult.status !== Status.COMPLETED && { status: innerResult.status }),
       ...(innerResult.error && { error: innerResult.error }),
+      ...(interrupted && { interrupts: innerResult.interrupts }),
     }
   }
 }

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -10,6 +10,7 @@ import type { MultiAgent } from './multiagent.js'
 import { logger } from '../logging/logger.js'
 import type { z } from 'zod'
 import { normalizeError } from '../errors.js'
+import { omitUndefined } from '../types/json.js'
 
 /**
  * Known node type identifiers with extensibility for custom nodes.
@@ -130,7 +131,7 @@ export abstract class Node {
       // Clear the stored snapshot on non-INTERRUPTED terminal states; `handle()`
       // repopulates it above if this run itself interrupted.
       if (result!.status !== Status.INTERRUPTED) {
-        delete nodeState.resumeSnapshot
+        delete nodeState.interruptedSnapshot
       }
     }
 
@@ -235,8 +236,8 @@ export class AgentNode extends Node {
 
     // Rehydrate agent state from a prior INTERRUPTED run (messages + interrupt state).
     const nodeState = state.node(this.id)
-    if (isAgent && nodeState?.resumeSnapshot) {
-      this._agent.loadSnapshot(nodeState.resumeSnapshot)
+    if (isAgent && nodeState?.interruptedSnapshot) {
+      this._agent.loadSnapshot(nodeState.interruptedSnapshot)
     }
 
     try {
@@ -268,15 +269,15 @@ export class AgentNode extends Node {
       // Capture post-interrupt state for the next resume cycle. Only Agent instances
       // are snapshottable.
       if (interrupted && isAgent && nodeState) {
-        nodeState.resumeSnapshot = this._agent.takeSnapshot({ preset: 'session' })
+        nodeState.interruptedSnapshot = this._agent.takeSnapshot({ preset: 'session' })
       }
 
-      return {
+      return omitUndefined({
         content: agentResult.lastMessage.content,
-        ...('structuredOutput' in agentResult && { structuredOutput: agentResult.structuredOutput }),
-        ...(agentResult.metrics?.accumulatedUsage && { usage: agentResult.metrics.accumulatedUsage }),
-        ...(interrupted && { interrupts: agentResult.interrupts }),
-      }
+        structuredOutput: 'structuredOutput' in agentResult ? agentResult.structuredOutput : undefined,
+        usage: agentResult.metrics?.accumulatedUsage,
+        interrupts: interrupted ? agentResult.interrupts : undefined,
+      })
     } finally {
       // Restore pre-run state — keeps the agent observably unchanged across runs.
       if (preRunSnapshot) {
@@ -358,13 +359,13 @@ export class MultiAgentNode extends Node {
     const innerResult = next.value
     const interrupted = innerResult.interrupts && innerResult.interrupts.length > 0
 
-    return {
+    return omitUndefined({
       content: innerResult.content,
       usage: innerResult.usage,
-      ...(innerResult.status !== Status.COMPLETED && { status: innerResult.status }),
-      ...(innerResult.error && { error: innerResult.error }),
-      ...(interrupted && { interrupts: innerResult.interrupts }),
-    }
+      status: innerResult.status !== Status.COMPLETED ? innerResult.status : undefined,
+      error: innerResult.error,
+      interrupts: interrupted ? innerResult.interrupts : undefined,
+    })
   }
 }
 

--- a/strands-ts/src/multiagent/state.ts
+++ b/strands-ts/src/multiagent/state.ts
@@ -5,6 +5,9 @@ import { accumulateUsage, createEmptyUsage } from '../models/streaming.js'
 import type { z } from 'zod'
 import type { JSONValue } from '../types/json.js'
 import { normalizeError, serializeError } from '../errors.js'
+import { Interrupt } from '../interrupt.js'
+import type { MultiAgentInput } from './multiagent.js'
+import type { Snapshot } from '../types/snapshot.js'
 import {
   loadStateFromJSONSymbol,
   stateToJSONSymbol,
@@ -27,6 +30,8 @@ export const Status = {
   FAILED: 'FAILED',
   /** Execution was cancelled before or during processing. */
   CANCELLED: 'CANCELLED',
+  /** Execution paused awaiting an interrupt response; can be resumed. */
+  INTERRUPTED: 'INTERRUPTED',
 } as const
 
 /**
@@ -35,9 +40,13 @@ export const Status = {
 export type Status = (typeof Status)[keyof typeof Status]
 
 /**
- * Subset of {@link Status} representing terminal outcomes.
+ * Subset of {@link Status} valid for a {@link NodeResult}.
  */
-export type ResultStatus = typeof Status.COMPLETED | typeof Status.FAILED | typeof Status.CANCELLED
+export type ResultStatus =
+  | typeof Status.COMPLETED
+  | typeof Status.FAILED
+  | typeof Status.CANCELLED
+  | typeof Status.INTERRUPTED
 
 /**
  * Result of executing a single node.
@@ -54,6 +63,8 @@ export class NodeResult {
   readonly structuredOutput?: z.output<z.ZodType>
   /** Token usage from the node execution. */
   readonly usage?: Usage
+  /** Interrupts raised by the underlying agent/orchestrator. Present iff `status === 'INTERRUPTED'`. */
+  readonly interrupts?: Interrupt[]
 
   constructor(data: {
     nodeId: string
@@ -63,6 +74,7 @@ export class NodeResult {
     error?: Error
     structuredOutput?: z.output<z.ZodType>
     usage?: Usage
+    interrupts?: Interrupt[]
   }) {
     this.nodeId = data.nodeId
     this.status = data.status
@@ -71,6 +83,7 @@ export class NodeResult {
     if ('error' in data) this.error = data.error
     if ('structuredOutput' in data) this.structuredOutput = data.structuredOutput
     if ('usage' in data) this.usage = data.usage
+    if (data.interrupts && data.interrupts.length > 0) this.interrupts = data.interrupts
   }
 
   /** Serializes this result to a JSON-compatible value. */
@@ -84,6 +97,7 @@ export class NodeResult {
       ...(this.error && { error: serializeError(this.error) }),
       ...(this.structuredOutput !== undefined && { structuredOutput: this.structuredOutput as JSONValue }),
       ...(this.usage && { usage: { ...this.usage } }),
+      ...(this.interrupts && { interrupts: this.interrupts.map((i) => i.toJSON()) }),
     } as JSONValue
   }
 
@@ -98,6 +112,9 @@ export class NodeResult {
       ...(json.error && { error: normalizeError(json.error) }),
       ...(json.structuredOutput !== undefined && { structuredOutput: json.structuredOutput }),
       ...(json.usage && { usage: json.usage as unknown as Usage }),
+      ...(json.interrupts && {
+        interrupts: (json.interrupts as JSONValue[]).map((i) => Interrupt.fromJSON(i as never)),
+      }),
     })
   }
 }
@@ -122,12 +139,22 @@ export class NodeState implements StateSerializable {
   /** Node execution start time in milliseconds since epoch. */
   startTime: number
   readonly results: NodeResult[]
+  /** Unanswered interrupts raised during this node's most recent run. Populated when `status === 'INTERRUPTED'`. */
+  interrupts: Interrupt[]
+  /**
+   * Snapshot of the node's underlying runnable (Agent or nested orchestrator) captured
+   * when the node returned INTERRUPTED. Loaded back into the runnable on resume so it
+   * can pick up mid-execution without losing its interrupt bookkeeping. Cleared when
+   * the node completes.
+   */
+  resumeSnapshot?: Snapshot
 
   constructor() {
     this.status = Status.PENDING
     this.terminus = false
     this.startTime = Date.now()
     this.results = []
+    this.interrupts = []
   }
 
   /** Content from the most recent result, or empty array if none. */
@@ -143,6 +170,8 @@ export class NodeState implements StateSerializable {
       terminus: this.terminus,
       startTime: this.startTime,
       results: this.results.map((res) => res.toJSON()),
+      interrupts: this.interrupts.map((i) => i.toJSON()),
+      ...(this.resumeSnapshot && { resumeSnapshot: { ...this.resumeSnapshot } }),
     } as JSONValue
   }
 
@@ -155,6 +184,12 @@ export class NodeState implements StateSerializable {
     this.results.length = 0
     for (const entry of data.results as JSONValue[]) {
       this.results.push(NodeResult.fromJSON(entry))
+    }
+    this.interrupts = ((data.interrupts as JSONValue[] | undefined) ?? []).map((i) => Interrupt.fromJSON(i as never))
+    if (data.resumeSnapshot) {
+      this.resumeSnapshot = data.resumeSnapshot as unknown as Snapshot
+    } else {
+      delete this.resumeSnapshot
     }
   }
 }
@@ -172,6 +207,8 @@ export class MultiAgentResult {
   readonly error?: Error
   /** Aggregated token usage across all node results. */
   readonly usage: Usage
+  /** Interrupts aggregated across all node results. Present when any node ended INTERRUPTED. */
+  readonly interrupts?: Interrupt[]
 
   constructor(data: {
     status?: ResultStatus
@@ -179,6 +216,7 @@ export class MultiAgentResult {
     content?: ContentBlock[]
     duration: number
     error?: Error
+    interrupts?: Interrupt[]
   }) {
     this.status = data.status ?? this._resolveStatus(data.results)
     this.results = data.results
@@ -186,6 +224,8 @@ export class MultiAgentResult {
     this.duration = data.duration
     if ('error' in data) this.error = data.error
     this.usage = this._aggregateNodeUsage(data.results)
+    const interrupts = data.interrupts ?? data.results.flatMap((r) => r.interrupts ?? [])
+    if (interrupts.length > 0) this.interrupts = interrupts
   }
 
   /** Serializes this result to a JSON-compatible value. */
@@ -198,6 +238,7 @@ export class MultiAgentResult {
       duration: this.duration,
       usage: { ...this.usage },
       ...(this.error && { error: serializeError(this.error) }),
+      ...(this.interrupts && { interrupts: this.interrupts.map((i) => i.toJSON()) }),
     } as JSONValue
   }
 
@@ -210,12 +251,23 @@ export class MultiAgentResult {
       content: (json.content as JSONValue[]).map((c) => contentBlockFromData(c as never)),
       duration: json.duration as number,
       ...(json.error && { error: normalizeError(json.error) }),
+      ...(json.interrupts && {
+        interrupts: (json.interrupts as JSONValue[]).map((i) => Interrupt.fromJSON(i as never)),
+      }),
     })
   }
 
-  /** Derives the aggregate status from individual node results. */
+  /**
+   * Derives the aggregate status from individual node results.
+   *
+   * Precedence: FAILED \> INTERRUPTED \> CANCELLED \> COMPLETED. INTERRUPTED outranks
+   * CANCELLED because parallel-graph short-circuit aborts siblings as CANCELLED when
+   * one node interrupts — the actionable "resume me" signal should surface over the
+   * collateral cancellations.
+   */
   private _resolveStatus(results: NodeResult[]): ResultStatus {
     if (results.some((result) => result.status === Status.FAILED)) return Status.FAILED
+    if (results.some((result) => result.status === Status.INTERRUPTED)) return Status.INTERRUPTED
     if (results.some((result) => result.status === Status.CANCELLED)) return Status.CANCELLED
     return Status.COMPLETED
   }
@@ -243,6 +295,15 @@ export class MultiAgentState implements StateSerializable {
   readonly results: NodeResult[]
   /** App-level key-value state accessible from hooks, edge handlers, and custom nodes. */
   readonly app: StateStore
+  /**
+   * The invocation's input, carried through an interrupt pause so that resuming a
+   * run (on the same instance, or via a SessionManager) can re-enter nodes that
+   * never ran (hook-gated source/start nodes) with the original content. Cleared
+   * when the invocation terminates in any non-INTERRUPTED state.
+   *
+   * @internal — not part of the public state shape; orchestrator-owned.
+   */
+  _pendingInput?: MultiAgentInput
   private readonly _nodes: Map<string, NodeState>
 
   constructor(data?: { nodeIds?: string[] }) {
@@ -285,6 +346,7 @@ export class MultiAgentState implements StateSerializable {
       results: this.results.map((result) => result.toJSON()),
       app: serializeStateSerializable(this.app),
       nodes,
+      ...(this._pendingInput !== undefined && { _pendingInput: this._pendingInput as unknown as JSONValue }),
     } as JSONValue
   }
 
@@ -306,6 +368,11 @@ export class MultiAgentState implements StateSerializable {
         loadStateSerializable(nodeState, nodeData)
         this._nodes.set(id, nodeState)
       }
+    }
+    if (data._pendingInput !== undefined) {
+      this._pendingInput = data._pendingInput as unknown as MultiAgentInput
+    } else {
+      delete this._pendingInput
     }
   }
 }

--- a/strands-ts/src/multiagent/state.ts
+++ b/strands-ts/src/multiagent/state.ts
@@ -147,7 +147,7 @@ export class NodeState implements StateSerializable {
    * can pick up mid-execution without losing its interrupt bookkeeping. Cleared when
    * the node completes.
    */
-  resumeSnapshot?: Snapshot
+  interruptedSnapshot?: Snapshot
 
   constructor() {
     this.status = Status.PENDING
@@ -171,7 +171,7 @@ export class NodeState implements StateSerializable {
       startTime: this.startTime,
       results: this.results.map((res) => res.toJSON()),
       interrupts: this.interrupts.map((i) => i.toJSON()),
-      ...(this.resumeSnapshot && { resumeSnapshot: { ...this.resumeSnapshot } }),
+      ...(this.interruptedSnapshot && { interruptedSnapshot: { ...this.interruptedSnapshot } }),
     } as JSONValue
   }
 
@@ -186,10 +186,10 @@ export class NodeState implements StateSerializable {
       this.results.push(NodeResult.fromJSON(entry))
     }
     this.interrupts = ((data.interrupts as JSONValue[] | undefined) ?? []).map((i) => Interrupt.fromJSON(i as never))
-    if (data.resumeSnapshot) {
-      this.resumeSnapshot = data.resumeSnapshot as unknown as Snapshot
+    if (data.interruptedSnapshot) {
+      this.interruptedSnapshot = data.interruptedSnapshot as unknown as Snapshot
     } else {
-      delete this.resumeSnapshot
+      delete this.interruptedSnapshot
     }
   }
 }

--- a/strands-ts/src/multiagent/state.ts
+++ b/strands-ts/src/multiagent/state.ts
@@ -284,6 +284,21 @@ export class MultiAgentResult {
 }
 
 /**
+ * Rehydrates a serialized `_pendingInput` back to its runtime shape. `string` round-trips
+ * as-is; array inputs (which serialize as `ContentBlockData[]` via each block's `toJSON`)
+ * are mapped through `contentBlockFromData` so downstream callers see `ContentBlock[]`
+ * instead of raw data objects.
+ */
+function rehydratePendingInput(value: JSONValue): MultiAgentInput {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return (value as JSONValue[]).map((entry) => contentBlockFromData(entry as never)) as ContentBlock[]
+  }
+  // Unexpected shape — pass through so callers see the exact value and can diagnose.
+  return value as unknown as MultiAgentInput
+}
+
+/**
  * Per-execution state for multi-agent orchestration, created fresh each invocation.
  */
 export class MultiAgentState implements StateSerializable {
@@ -370,7 +385,7 @@ export class MultiAgentState implements StateSerializable {
       }
     }
     if (data._pendingInput !== undefined) {
-      this._pendingInput = data._pendingInput as unknown as MultiAgentInput
+      this._pendingInput = rehydratePendingInput(data._pendingInput)
     } else {
       delete this._pendingInput
     }

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -3,6 +3,14 @@ import { warnOnce } from '../logging/warn-once.js'
 import type { AttributeValue, Span } from '@opentelemetry/api'
 import type { InvocationState, InvokableAgent } from '../types/agent.js'
 import type { MultiAgentInput, MultiAgentInvokeOptions } from './multiagent.js'
+import {
+  applyOrchestratorHookResponses,
+  dropStaleInterruptedResult,
+  extractResumeResponses,
+  groupInterruptResponsesByNode,
+  recordHookInterrupt,
+} from './multiagent.js'
+import { InterruptError } from '../interrupt.js'
 import { z } from 'zod'
 import { HookableEvent } from '../hooks/events.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
@@ -26,6 +34,7 @@ import {
   MultiAgentInitializedEvent,
   MultiAgentResultEvent,
   NodeCancelEvent,
+  NodeResultEvent,
 } from './events.js'
 import { Tracer } from '../telemetry/tracer.js'
 import { normalizeError } from '../errors.js'
@@ -126,6 +135,13 @@ export class Swarm implements MultiAgent {
   readonly start: AgentNode
   readonly sessionManager?: SessionManager | undefined
   private _initialized: boolean
+  /**
+   * State retained across invocations when a run ends INTERRUPTED. Lets
+   * `swarm.invoke(responses)` resume on the same instance without requiring a
+   * SessionManager, mirroring single-agent ergonomics. Cleared when a run
+   * terminates in any non-INTERRUPTED state.
+   */
+  private _pendingInterruptState?: MultiAgentState
 
   constructor(options: SwarmOptions) {
     const { id, nodes, start, sessionManager, plugins, traceAttributes, ...config } = options
@@ -217,12 +233,11 @@ export class Swarm implements MultiAgent {
     // are visible to the next.
     const invocationState: InvocationState = options?.invocationState ?? {}
 
-    const gen = this._stream(input, invocationState)
+    // Hook invocation lives in `_stream` so hook-raised `InterruptError`s land in the
+    // same frame as the execution loop.
+    const gen = this._stream(input, invocationState, options?.cancelSignal)
     let next = await gen.next()
     while (!next.done) {
-      if (next.value instanceof HookableEvent) {
-        await this._hookRegistry.invokeCallbacks(next.value)
-      }
       yield next.value
       next = await gen.next()
     }
@@ -231,11 +246,17 @@ export class Swarm implements MultiAgent {
 
   private async *_stream(
     input: MultiAgentInput,
-    invocationState: InvocationState
+    invocationState: InvocationState,
+    externalCancelSignal?: AbortSignal
   ): AsyncGenerator<MultiAgentStreamEvent, MultiAgentResult, undefined> {
-    const state = new MultiAgentState({
-      nodeIds: [...this.nodes.keys()],
-    })
+    // Reuse state from a prior INTERRUPTED run so `swarm.invoke(responses)` can
+    // resume on the same instance without a SessionManager.
+    const state =
+      this._pendingInterruptState ??
+      new MultiAgentState({
+        nodeIds: [...this.nodes.keys()],
+      })
+    delete this._pendingInterruptState
 
     const multiAgentSpan = this._tracer.startMultiAgentSpan({
       orchestratorId: this.id,
@@ -244,40 +265,73 @@ export class Swarm implements MultiAgent {
     })
 
     // SessionManager (or plugins) may restore state.results here via the hook
-    yield new BeforeMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
+    yield* this._emit(new BeforeMultiAgentInvocationEvent({ orchestrator: this, state, invocationState }))
 
-    // Resume: if state was restored from a snapshot, derive the next node from the last handoff
-    const resumeNode = this._findResumeNode(state)
-    let node = resumeNode?.node ?? this.start
-    let handoff: HandoffResult | undefined = resumeNode?.lastHandoff
+    // Resume input bypasses handoff-derived resume (goes straight to the interrupted
+    // node). On fresh runs, stash the input for replay if a hook-gate pauses before
+    // the node runs.
+    const resumeResponses = extractResumeResponses(input)
+    const interruptResponsesByNode = resumeResponses ? groupInterruptResponsesByNode(resumeResponses, state) : undefined
+    if (!resumeResponses) {
+      state._pendingInput = input
+    }
+
+    let node: AgentNode
+    let handoff: HandoffResult | undefined
+    let nextInput: MultiAgentInput = input
+    if (interruptResponsesByNode) {
+      // Swarm is sequential, so at most one node is INTERRUPTED per run.
+      const entry = interruptResponsesByNode.entries().next().value
+      if (!entry) throw new Error(`swarm_id=<${this.id}> | no interrupt responses to route`)
+      const [nodeId, responses] = entry
+      node = this.nodes.get(nodeId)!
+
+      // Orchestrator hooks consume matching responses; leftovers go to the child
+      // agent. If the hook consumed everything, replay the original invocation input.
+      const forwarded = applyOrchestratorHookResponses(state.node(nodeId)!, responses)
+      nextInput = forwarded.length > 0 ? forwarded : (state._pendingInput ?? '')
+    } else {
+      const resumeNode = this._findResumeNode(state)
+      node = resumeNode?.node ?? this.start
+      handoff = resumeNode?.lastHandoff
+    }
+
     let caughtError: Error | undefined
     let result: MultiAgentResult | undefined
 
-    // Swarm-level timeout: when fired, composes with each node's per-node signal so a node
-    // that hangs and ignores its own signal still gets an abort when the overall budget expires.
-    // The between-steps elapsed check below handles the case where the current node returned
-    // cleanly but we've run out of budget.
+    // Swarm-level timeout composes with each node's signal so a hung node still gets
+    // aborted. Timer starts fresh per invocation; human response time between resumes
+    // is not deducted.
     const execController = Number.isFinite(this.config.timeout) ? new AbortController() : undefined
     const execTimeoutHandle = execController ? setTimeout(() => execController.abort(), this.config.timeout) : undefined
 
+    const nodeCancelSignal =
+      execController && externalCancelSignal
+        ? AbortSignal.any([execController.signal, externalCancelSignal])
+        : (execController?.signal ?? externalCancelSignal)
+
     try {
       while (state.steps < this.config.maxSteps) {
-        const elapsed = Date.now() - state.startTime
-        if (elapsed >= this.config.timeout) {
+        if (execController?.signal.aborted) {
           throw new Error(`timeout=<${this.config.timeout}>, swarm_id=<${this.id}> | swarm exceeded wall-clock budget`)
+        }
+        if (externalCancelSignal?.aborted) {
+          throw new Error(`swarm_id=<${this.id}> | swarm cancelled by external signal`)
         }
         state.steps++
 
-        // Execute current node
+        // After the first step (which may use routed resume responses), revert to the
+        // original input so post-handoff nodes see fresh content.
         const nodeResult = yield* this._streamNode(
           node,
-          input,
+          nextInput,
           state,
           handoff,
           multiAgentSpan,
           invocationState,
-          execController?.signal
+          nodeCancelSignal
         )
+        nextInput = input
         handoff = nodeResult.structuredOutput as HandoffResult | undefined
 
         if (execController?.signal.aborted) {
@@ -287,13 +341,13 @@ export class Swarm implements MultiAgent {
         }
 
         // Check for terminal conditions
-        if (nodeResult.status === Status.FAILED || !handoff?.agentId) {
+        if (nodeResult.status === Status.FAILED || nodeResult.status === Status.INTERRUPTED || !handoff?.agentId) {
           break
         }
 
         // Hand off to next agent
         const target = this.nodes.get(handoff.agentId)!
-        yield new MultiAgentHandoffEvent({ source: node.id, targets: [target.id], state, invocationState })
+        yield* this._emit(new MultiAgentHandoffEvent({ source: node.id, targets: [target.id], state, invocationState }))
         logger.debug(`source=<${node.id}>, target=<${target.id}> | swarm handoff`)
         node = target
       }
@@ -305,6 +359,13 @@ export class Swarm implements MultiAgent {
         content: this._resolveContent(state),
         duration: Date.now() - state.startTime,
       })
+      // Stash on interrupt so same-instance resume has state; otherwise start fresh.
+      if (result.status === Status.INTERRUPTED) {
+        this._pendingInterruptState = state
+      } else {
+        delete this._pendingInterruptState
+        delete state._pendingInput
+      }
     } catch (error) {
       caughtError = normalizeError(error)
       throw caughtError
@@ -316,11 +377,17 @@ export class Swarm implements MultiAgent {
         ...(caughtError && { error: caughtError }),
       })
 
-      yield new AfterMultiAgentInvocationEvent({ orchestrator: this, state, invocationState })
+      yield* this._emit(new AfterMultiAgentInvocationEvent({ orchestrator: this, state, invocationState }))
     }
 
-    yield new MultiAgentResultEvent({ result, invocationState })
+    yield* this._emit(new MultiAgentResultEvent({ result, invocationState }))
     return result
+  }
+
+  /** Invokes hook callbacks on an event, then yields it. */
+  private async *_emit<T extends HookableEvent>(event: T): AsyncGenerator<T, void, undefined> {
+    await this._hookRegistry.invokeCallbacks(event)
+    yield event
   }
 
   private async *_streamNode(
@@ -339,16 +406,32 @@ export class Swarm implements MultiAgent {
     )
 
     const beforeEvent = new BeforeNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
+    try {
+      await this._hookRegistry.invokeCallbacks(beforeEvent)
+    } catch (error) {
+      if (error instanceof InterruptError) {
+        const result = recordHookInterrupt(node.id, nodeState)
+        state.results.push(result)
+        yield beforeEvent
+        yield* this._emit(new NodeResultEvent({ nodeId: node.id, nodeType: node.type, state, result, invocationState }))
+        yield* this._emit(new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }))
+        this._tracer.endNodeSpan(nodeSpan, { status: Status.INTERRUPTED, duration: result.duration })
+        return result
+      }
+      throw error
+    }
     yield beforeEvent
 
     if (beforeEvent.cancel) {
       const message = typeof beforeEvent.cancel === 'string' ? beforeEvent.cancel : 'node cancelled by hook'
+      // Cancel path doesn't go through Node.stream, so do its INTERRUPTED cleanup here.
+      dropStaleInterruptedResult(node.id, nodeState, state)
       const result = new NodeResult({ nodeId: node.id, status: Status.CANCELLED, duration: 0 })
       nodeState.status = Status.CANCELLED
       nodeState.results.push(result)
       state.results.push(result)
-      yield new NodeCancelEvent({ nodeId: node.id, state, message, invocationState })
-      yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
+      yield* this._emit(new NodeCancelEvent({ nodeId: node.id, state, message, invocationState }))
+      yield* this._emit(new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }))
       this._tracer.endNodeSpan(nodeSpan, { status: Status.CANCELLED, duration: 0 })
       return result
     }
@@ -371,7 +454,11 @@ export class Swarm implements MultiAgent {
       )
       let next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       while (!next.done) {
-        yield next.value
+        if (next.value instanceof HookableEvent) {
+          yield* this._emit(next.value)
+        } else {
+          yield next.value
+        }
         next = await this._tracer.withSpanContext(nodeSpan, () => gen.next())
       }
 
@@ -385,19 +472,15 @@ export class Swarm implements MultiAgent {
       this._tracer.endNodeSpan(nodeSpan, { status: result.status, duration: result.duration, usage: result.usage })
       state.results.push(result)
 
-      yield new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState })
+      yield* this._emit(new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }))
       return result
     } catch (error) {
       const nodeError = normalizeError(error)
       this._tracer.endNodeSpan(nodeSpan, { error: nodeError })
 
-      yield new AfterNodeCallEvent({
-        orchestrator: this,
-        state,
-        nodeId: node.id,
-        invocationState,
-        error: nodeError,
-      })
+      yield* this._emit(
+        new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState, error: nodeError })
+      )
       throw nodeError
     } finally {
       if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
@@ -456,6 +539,12 @@ export class Swarm implements MultiAgent {
     return [...last.content]
   }
 
+  /**
+   * Builds the input for the next node after a handoff, or returns the input as-is
+   * when there is no handoff (initial or resume invocation). The caller passes the
+   * original `MultiAgentInput` through; resume responses flow through here untouched
+   * so the underlying agent sees them directly.
+   */
   private _resolveNodeInput(input: MultiAgentInput, handoff?: HandoffResult): MultiAgentInput {
     if (!handoff) return input
 

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -280,15 +280,34 @@ export class Swarm implements MultiAgent {
     let handoff: HandoffResult | undefined
     let nextInput: MultiAgentInput = input
     if (interruptResponsesByNode) {
-      // Swarm is sequential, so at most one node is INTERRUPTED per run.
+      // Swarm runs sequentially, so at most one node can be INTERRUPTED per run.
+      // Assert the invariant so a future change that accidentally produces multiple
+      // interrupted nodes surfaces loudly rather than silently taking the first.
+      if (interruptResponsesByNode.size > 1) {
+        throw new Error(
+          `swarm_id=<${this.id}>, interrupted_nodes=<${[...interruptResponsesByNode.keys()].join(',')}> | swarm cannot have multiple interrupted nodes simultaneously`
+        )
+      }
       const entry = interruptResponsesByNode.entries().next().value
       if (!entry) throw new Error(`swarm_id=<${this.id}> | no interrupt responses to route`)
       const [nodeId, responses] = entry
-      node = this.nodes.get(nodeId)!
+      const resolvedNode = this.nodes.get(nodeId)
+      if (!resolvedNode) {
+        throw new Error(
+          `node_id=<${nodeId}>, swarm_id=<${this.id}> | resume response targets a node missing from the swarm; topology changed between save and resume?`
+        )
+      }
+      node = resolvedNode
+      const resolvedNodeState = state.node(nodeId)
+      if (!resolvedNodeState) {
+        throw new Error(
+          `node_id=<${nodeId}>, swarm_id=<${this.id}> | routed interrupt response targets a node missing from state; topology changed between save and resume?`
+        )
+      }
 
       // Orchestrator hooks consume matching responses; leftovers go to the child
       // agent. If the hook consumed everything, replay the original invocation input.
-      const forwarded = applyOrchestratorHookResponses(state.node(nodeId)!, responses)
+      const forwarded = applyOrchestratorHookResponses(resolvedNodeState, responses)
       nextInput = forwarded.length > 0 ? forwarded : (state._pendingInput ?? '')
     } else {
       const resumeNode = this._findResumeNode(state)

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -21,6 +21,7 @@ import type {
   ToolResultEvent,
   ToolStreamUpdateEvent,
   AgentResultEvent,
+  InterruptEvent,
   HookableEvent,
   StreamEvent,
 } from '../hooks/events.js'
@@ -476,4 +477,5 @@ export type AgentStreamEvent =
   | BeforeToolCallEvent
   | AfterToolCallEvent
   | MessageAddedEvent
+  | InterruptEvent
   | AgentResultEvent

--- a/strands-ts/test/integ/multiagent/_interrupt-helpers.ts
+++ b/strands-ts/test/integ/multiagent/_interrupt-helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers for multi-agent interrupt integration tests.
+ *
+ * Leading-underscore filename keeps it out of vitest's auto-discovery.
+ */
+import type { InterruptResponseContentData, JSONValue } from '@strands-agents/sdk'
+import { Status } from '$/sdk/multiagent/index.js'
+import type { MultiAgentResult } from '$/sdk/multiagent/index.js'
+import { SessionManager } from '$/sdk/session/session-manager.js'
+import { FileStorage } from '$/sdk/session/file-storage.js'
+
+export function makeSessionManager(sessionId: string, storageDir: string): SessionManager {
+  return new SessionManager({ sessionId, storage: { snapshot: new FileStorage(storageDir) } })
+}
+
+/**
+ * Resumes an interrupted orchestrator by answering all pending interrupts, looping
+ * until the run terminates or we hit the max iteration limit. Used for both Graph
+ * and Swarm.
+ */
+export async function resumeUntilDone(
+  invoke: (responses: InterruptResponseContentData[]) => Promise<MultiAgentResult>,
+  initial: MultiAgentResult,
+  respond: (interrupt: { id: string; name: string; reason?: unknown }) => JSONValue,
+  maxRounds = 5
+): Promise<MultiAgentResult> {
+  let current = initial
+  for (let i = 0; i < maxRounds && current.status === Status.INTERRUPTED; i++) {
+    const responses: InterruptResponseContentData[] = current.interrupts!.map((interrupt) => ({
+      interruptResponse: { interruptId: interrupt.id, response: respond(interrupt) },
+    }))
+    current = await invoke(responses)
+  }
+  return current
+}

--- a/strands-ts/test/integ/multiagent/interrupt-hook.test.node.ts
+++ b/strands-ts/test/integ/multiagent/interrupt-hook.test.node.ts
@@ -1,0 +1,106 @@
+/**
+ * Integration tests for orchestrator-hook interrupts — interrupts raised from
+ * `BeforeNodeCallEvent.interrupt()` to gate a node before it runs.
+ */
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { Agent, tool } from '@strands-agents/sdk'
+import { Graph, Swarm, Status, BeforeNodeCallEvent } from '$/sdk/multiagent/index.js'
+import { bedrock } from '../__fixtures__/model-providers.js'
+import { resumeUntilDone } from './_interrupt-helpers.js'
+
+const weatherTool = tool({
+  name: 'weather_tool',
+  description: 'Returns the current weather.',
+  inputSchema: z.object({}),
+  callback: async () => 'sunny',
+})
+
+describe.skipIf(bedrock.skip)('Multi-agent orchestrator-hook interrupts', () => {
+  const createModel = (maxTokens = 1024) => bedrock.createModel({ maxTokens })
+
+  it('Graph: hook gates a node before it runs, resume approves', async () => {
+    const agent = new Agent({
+      model: createModel(),
+      printer: false,
+      id: 'execute',
+      tools: [weatherTool],
+      systemPrompt: 'Use the tool and briefly answer.',
+    })
+
+    const graph = new Graph({ nodes: [agent], edges: [] })
+    graph.addHook(BeforeNodeCallEvent, (event) => {
+      if (event.nodeId !== 'execute') return
+      const response = event.interrupt<string>({ name: 'execute_approval', reason: 'approve?' })
+      if (response !== 'APPROVE') event.cancel = 'rejected'
+    })
+
+    const result = await graph.invoke('What is the weather?')
+    expect(result.status).toBe(Status.INTERRUPTED)
+    expect(result.interrupts![0]!.source).toBe('multiagent-hook')
+    expect(result.interrupts![0]!.name).toBe('execute_approval')
+
+    const finalResult = await resumeUntilDone(
+      (responses) => graph.invoke(responses),
+      result,
+      () => 'APPROVE'
+    )
+    expect(finalResult.status).toBe(Status.COMPLETED)
+  })
+
+  it('Graph: hook rejection cancels the node', async () => {
+    const agent = new Agent({
+      model: createModel(),
+      printer: false,
+      id: 'execute',
+      tools: [weatherTool],
+    })
+
+    const graph = new Graph({ nodes: [agent], edges: [] })
+    graph.addHook(BeforeNodeCallEvent, (event) => {
+      if (event.nodeId !== 'execute') return
+      const response = event.interrupt<string>({ name: 'execute_approval', reason: 'approve?' })
+      if (response !== 'APPROVE') event.cancel = 'rejected'
+    })
+
+    const result = await graph.invoke('anything')
+    expect(result.status).toBe(Status.INTERRUPTED)
+
+    const finalResult = await resumeUntilDone(
+      (responses) => graph.invoke(responses),
+      result,
+      () => 'REJECT'
+    )
+    const executeResult = finalResult.results.find((r) => r.nodeId === 'execute')
+    expect(executeResult?.status).toBe(Status.CANCELLED)
+  })
+
+  it('Swarm: hook gates the start node, resume approves', async () => {
+    const agent = new Agent({
+      model: createModel(),
+      printer: false,
+      id: 'assistant',
+      description: 'Answers questions briefly.',
+      systemPrompt: 'Answer in one word only.',
+    })
+
+    const swarm = new Swarm({ nodes: [agent], start: 'assistant' })
+    swarm.addHook(BeforeNodeCallEvent, (event) => {
+      event.interrupt({ name: 'approval', reason: 'approve?' })
+    })
+
+    const result = await swarm.invoke('What is the capital of France?')
+    expect(result.status).toBe(Status.INTERRUPTED)
+    expect(result.interrupts![0]!.source).toBe('multiagent-hook')
+
+    const finalResult = await resumeUntilDone(
+      (responses) => swarm.invoke(responses),
+      result,
+      () => 'APPROVE'
+    )
+    expect(finalResult.status).toBe(Status.COMPLETED)
+
+    const text = finalResult.content.find((b) => b.type === 'textBlock')
+    expect(text?.text).toMatch(/Paris/i)
+  })
+})

--- a/strands-ts/test/integ/multiagent/interrupt-node.test.node.ts
+++ b/strands-ts/test/integ/multiagent/interrupt-node.test.node.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration tests for interrupts raised by tool callbacks inside a node's child
+ * agent. Exercises Graph and Swarm routing the interrupt up through the orchestrator
+ * result, then resuming with a response.
+ */
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { Agent, tool } from '@strands-agents/sdk'
+import { Graph, Swarm, Status } from '$/sdk/multiagent/index.js'
+import { bedrock } from '../__fixtures__/model-providers.js'
+import { resumeUntilDone } from './_interrupt-helpers.js'
+
+const interruptingWeatherTool = tool({
+  name: 'weather_tool',
+  description: 'Returns the current weather.',
+  inputSchema: z.object({}),
+  callback: async (_input, context) =>
+    context!.interrupt({ name: 'weather_interrupt', reason: 'need weather' }) as string,
+})
+
+describe.skipIf(bedrock.skip)('Multi-agent tool-callback interrupts', () => {
+  const createModel = (maxTokens = 1024) => bedrock.createModel({ maxTokens })
+
+  it('Graph: tool inside a node interrupts, resumes', async () => {
+    const weatherAgent = new Agent({
+      model: createModel(),
+      printer: false,
+      id: 'weather',
+      tools: [interruptingWeatherTool],
+      systemPrompt: 'Use the weather tool to answer the user.',
+    })
+
+    const graph = new Graph({ nodes: [weatherAgent], edges: [] })
+
+    const result = await graph.invoke('What is the weather?')
+    expect(result.status).toBe(Status.INTERRUPTED)
+    expect(result.interrupts).toBeDefined()
+    expect(result.interrupts![0]!.name).toBe('weather_interrupt')
+    expect(result.interrupts![0]!.source).toBe('tool')
+
+    const finalResult = await resumeUntilDone(
+      (responses) => graph.invoke(responses),
+      result,
+      () => 'cloudy'
+    )
+    expect(finalResult.status).toBe(Status.COMPLETED)
+
+    const text = finalResult.content
+      .filter((b) => b.type === 'textBlock')
+      .map((b) => b.text)
+      .join(' ')
+      .toLowerCase()
+    expect(text).toMatch(/cloudy/)
+  })
+
+  it('Swarm: tool inside the start agent interrupts, resumes', async () => {
+    const weatherAgent = new Agent({
+      model: createModel(),
+      printer: false,
+      id: 'weather',
+      tools: [interruptingWeatherTool],
+      description: 'Fetches weather data.',
+      systemPrompt: 'Use the weather tool, then produce a final response with no handoff.',
+    })
+
+    const swarm = new Swarm({ nodes: [weatherAgent], start: 'weather' })
+
+    const result = await swarm.invoke('What is the weather?')
+    expect(result.status).toBe(Status.INTERRUPTED)
+    expect(result.interrupts![0]!.source).toBe('tool')
+
+    const finalResult = await resumeUntilDone(
+      (responses) => swarm.invoke(responses),
+      result,
+      () => 'cloudy'
+    )
+    expect(finalResult.status).toBe(Status.COMPLETED)
+  })
+})

--- a/strands-ts/test/integ/multiagent/interrupt-session.test.node.ts
+++ b/strands-ts/test/integ/multiagent/interrupt-session.test.node.ts
@@ -1,0 +1,69 @@
+/**
+ * Integration tests for multi-agent interrupt round-trip through a SessionManager:
+ * a fresh orchestrator instance picks up where the previous one paused, with state
+ * restored from `FileStorage`.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { v7 as uuidv7 } from 'uuid'
+import { z } from 'zod'
+import { Agent } from '$/sdk/agent/agent.js'
+import { tool } from '$/sdk/tools/tool-factory.js'
+import { TextBlock } from '$/sdk/types/messages.js'
+import { Graph, Status } from '$/sdk/multiagent/index.js'
+import { bedrock } from '../__fixtures__/model-providers.js'
+import { makeSessionManager } from './_interrupt-helpers.js'
+
+const interruptingWeatherTool = tool({
+  name: 'weather_tool',
+  description: 'Returns the current weather.',
+  inputSchema: z.object({}),
+  callback: async (_input, context) =>
+    context!.interrupt({ name: 'weather_interrupt', reason: 'need weather' }) as string,
+})
+
+describe.skipIf(bedrock.skip)('Multi-agent interrupt session round-trip', () => {
+  const createModel = (maxTokens = 1024) => bedrock.createModel({ maxTokens })
+
+  let storageDir: string
+  beforeAll(async () => {
+    storageDir = join(tmpdir(), `strands-multiagent-interrupt-session-${uuidv7()}`)
+    await fs.mkdir(storageDir, { recursive: true })
+  })
+  afterAll(async () => {
+    await fs.rm(storageDir, { recursive: true, force: true })
+  })
+
+  it('Graph: tool-interrupt persists and resumes with fresh orchestrator', async () => {
+    const sessionId = `graph-tool-${uuidv7()}`
+    const buildGraph = (): Graph => {
+      const agent = new Agent({
+        model: createModel(),
+        printer: false,
+        id: 'weather',
+        tools: [interruptingWeatherTool],
+        systemPrompt: 'Use the weather tool then answer.',
+      })
+      return new Graph({
+        nodes: [agent],
+        edges: [],
+        sessionManager: makeSessionManager(sessionId, storageDir),
+      })
+    }
+
+    // Pass a ContentBlock[] so the invocation input round-trips through
+    // FileStorage JSON as block data and rehydrates into a valid agent message
+    // when the node runs on resume.
+    const firstResult = await buildGraph().invoke([new TextBlock('What is the weather?')])
+    expect(firstResult.status).toBe(Status.INTERRUPTED)
+    expect(firstResult.interrupts![0]!.source).toBe('tool')
+
+    const interrupt = firstResult.interrupts![0]!
+    const finalResult = await buildGraph().invoke([
+      { interruptResponse: { interruptId: interrupt.id, response: 'cloudy' } },
+    ])
+    expect(finalResult.status).toBe(Status.COMPLETED)
+  })
+})


### PR DESCRIPTION
## Description

Extends the single-agent interrupt feature to the `Graph` and `Swarm` multi-agent orchestrators. A tool or hook callback anywhere in the tree can now pause execution, surface the pending interrupt through the aggregate result, and resume on a fresh orchestrator invocation with `InterruptResponseContent[]`. Orchestrator-level hooks get their own interruption point via `BeforeNodeCallEvent.interrupt()`, so a node can be gated before it runs.

### Motivation

Interrupts were load-bearing for human-in-the-loop flows at the single-agent level but inaccessible to anyone using `Graph` or `Swarm`. A child agent's `stopReason: 'interrupt'` was ignored by the orchestrator aggregation, and `MultiAgentInput` explicitly rejected response inputs (the old code carried a comment "Graph interrupts will be handled separately"). This PR makes that a fully supported flow: interrupts bubble up through any orchestrator depth, are routable by id on resume, and survive process boundaries via the existing `SessionManager` snapshot machinery.

### Public API changes

**New `Status.INTERRUPTED` and `ResultStatus`.** `NodeResult.status` and `MultiAgentResult.status` can now be `'INTERRUPTED'`. Precedence in `MultiAgentResult._resolveStatus` is `FAILED > INTERRUPTED > CANCELLED > COMPLETED` — parallel-graph short-circuit aborts siblings as `CANCELLED`, but the actionable "resume me" signal is what surfaces at the top.

**`NodeResult.interrupts` / `MultiAgentResult.interrupts`.** Aggregated across the tree:

```typescript
const result = await graph.invoke('do a thing')
if (result.status === Status.INTERRUPTED) {
  for (const interrupt of result.interrupts!) {
    // interrupt.id, interrupt.name, interrupt.source, interrupt.reason
  }
}
```

`source` is a new union: `'tool' | 'hook' | 'multiagent-hook'`. It lets consumers filter by origin without subscribing to different event types.

**Resume via `invoke([InterruptResponseContent, ...])`** on `Graph`/`Swarm`:

```typescript
const final = await graph.invoke([
  { interruptResponse: { interruptId: interrupt.id, response: 'approved' } }
])
```

Responses route to whichever node holds an `Interrupt` with the matching id. Works same-instance (retained via an in-memory stash) or across a `SessionManager` restore. Unknown ids throw.

**`BeforeNodeCallEvent.interrupt()`** — orchestrator-level hooks can now pause a node before it runs, mirroring the tool/hook interrupt API on single-agent:

```typescript
graph.addHook(BeforeNodeCallEvent, (event) => {
  const { approved } = event.interrupt<{ approved: boolean }>({
    name: 'node_approval',
    reason: `approve ${event.nodeId}?`,
  })
  if (!approved) event.cancel = 'rejected'
})
```

On first pass the hook throws `InterruptError` and the node never runs. On resume with the matching response, `event.interrupt(...)` returns the stored response synchronously and execution continues. Handled in the orchestrator layer, not inside the wrapped agent, so nodes that never ran don't accumulate phantom agent state.

**New `InterruptEvent`** in the hook event stream. Emitted once per interrupt before the interrupt result materializes on `AgentResult`:

```typescript
agent.addHook(InterruptEvent, (event) => {
  // event.interrupt.source === 'tool' | 'hook'
})
```

A single event type discriminated by `interrupt.source` rather than per-origin event classes — consumers almost always observe "something interrupted" uniformly (logging, tracing, metrics, UI updates). The source is a filter, not a subscription boundary.

**`MultiAgentInvokeOptions.cancelSignal`.** `Graph` and `Swarm` now accept a `cancelSignal`, composed with internal signals via `AbortSignal.any`. Nested orchestrators inherit external cancellation. Closes a pre-existing gap where a nested `MultiAgentNode` could run past an outer timeout/abort.

### Design notes

**`_pendingInput` on `MultiAgentState`.** Hook-gated source nodes that never ran on the first invocation need their original content input replayed on resume — nothing else carries it. The node's `resumeSnapshot` is empty (nothing happened yet), there are no upstream results to derive input from, and the resume call only supplies `InterruptResponseContent[]`. The input belongs to the invocation, not to any single node — parallel source nodes share it, downstream nodes that get scheduled on resume after an upstream completes can also need it. Lives on `MultiAgentState` (invocation-scoped), underscore-prefixed and `@internal`-tagged. Serialization rides the existing `stateToJSONSymbol` path, so SessionManager round-trip is automatic.

**Nested multi-agent interrupt resume — follow-up.** This PR does not solve cross-orchestrator interrupt resume when a nested orchestrator (a `MultiAgentNode` wrapping an inner `Graph` or `Swarm`) has no `SessionManager` of its own. The interrupt bubbles up correctly on the first run; on resume the outer routes the response to the nested `MultiAgentNode`, which spins up a fresh inner `MultiAgentState` whose `NodeState.interrupts` don't contain the original id — `groupInterruptResponsesByNode` throws and the nested node ends `FAILED`. Pinned by a test in `src/multiagent/__tests__/interrupts.test.ts`. The fix requires making nested orchestrator state part of the outer snapshot, or propagating the `SessionManager` down — larger shape changes than this PR should carry. The single-SessionManager workflow (outer with `sessionManager`, nested without) works today; the gap is real but narrow.

## Related Issues

Resolves:

- strands-agents/sdk-typescript#481
- strands-agents/sdk-typescript#482 
- strands-agents/sdk-typescript#872

## Documentation PR

Follow Up

## Type of Change

New feature

## Testing

236 multi-agent unit tests and 16 multi-agent integration tests cover: tool-callback interrupts inside a child agent, orchestrator-hook interrupts via `BeforeNodeCallEvent.interrupt()`, parallel short-circuit with cancelled siblings, same-instance resume, `SessionManager` `FileStorage` round-trip (including `ContentBlock[]` input), and nested-orchestrator interrupt propagation.

One Bedrock integ test (`Swarm + hook-gate + session round-trip`) was dropped because it triggered a pre-existing `Agent` bug in the structured-output forced-retry path (not introduced by this PR). Writeup attached as a separate follow-up issue. Coverage for that path is retained at the unit level via `MockSnapshotStorage`; `FileStorage` round-trip is covered by the Graph + tool + session test, which exercises `ContentBlock[]` input through the JSON serialization boundary.

- [x] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
