### PR TITLE
feat: expose takeSnapshot and loadSnapshot on Agent

### DIFF
--- a/strands-ts/src/agent/__tests__/snapshot.test.ts
+++ b/strands-ts/src/agent/__tests__/snapshot.test.ts
@@ -437,3 +437,276 @@ describe('Snapshot API', () => {
     })
   })
 })
+
+describe('Agent.takeSnapshot / Agent.loadSnapshot (public API)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(MOCK_TIMESTAMP))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('takeSnapshot', () => {
+    it('captures session preset state via the Agent method', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
+      agent.appState.set('key', 'value')
+      agent.systemPrompt = 'Test prompt'
+
+      const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+      expect(snapshot.scope).toBe('agent')
+      expect(snapshot.schemaVersion).toBe(SNAPSHOT_SCHEMA_VERSION)
+      expect(snapshot.createdAt).toBe(MOCK_TIMESTAMP)
+      expect(snapshot.data.messages).toEqual([{ role: 'user', content: [{ text: 'Hello' }] }])
+      expect(snapshot.data.state).toEqual({ key: 'value' })
+      expect(snapshot.data.systemPrompt).toBe('Test prompt')
+      expect(snapshot.appData).toEqual({})
+    })
+
+    it('supports include option to select specific fields', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
+      agent.appState.set('key', 'value')
+
+      const snapshot = agent.takeSnapshot({ include: ['messages'] })
+
+      expect(snapshot.data.messages).toBeDefined()
+      expect(snapshot.data.state).toBeUndefined()
+      expect(snapshot.data.systemPrompt).toBeUndefined()
+    })
+
+    it('supports exclude option to omit specific fields', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot = agent.takeSnapshot({ preset: 'session', exclude: ['interrupts', 'modelState'] })
+
+      expect(snapshot.data.interrupts).toBeUndefined()
+      expect(snapshot.data.modelState).toBeUndefined()
+      expect(snapshot.data.messages).toBeDefined()
+    })
+
+    it('stores appData in the snapshot', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot = agent.takeSnapshot({ preset: 'session', appData: { userId: 'u-123' } })
+
+      expect(snapshot.appData).toEqual({ userId: 'u-123' })
+    })
+
+    it('throws when no fields would be included', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      expect(() => agent.takeSnapshot({})).toThrow('No fields to include in snapshot')
+    })
+  })
+
+  describe('loadSnapshot', () => {
+    it('restores messages from a snapshot', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        createdAt: MOCK_TIMESTAMP,
+        data: {
+          messages: [{ role: 'user', content: [{ text: 'Restored' }] }],
+        },
+        appData: {},
+      }
+
+      agent.loadSnapshot(snapshot)
+
+      expect(agent.messages).toHaveLength(1)
+      expect(agent.messages[0]).toEqual(new Message({ role: 'user', content: [new TextBlock('Restored')] }))
+    })
+
+    it('restores state from a snapshot', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        createdAt: MOCK_TIMESTAMP,
+        data: {
+          state: { restored: 'yes' },
+        },
+        appData: {},
+      }
+
+      agent.loadSnapshot(snapshot)
+
+      expect(agent.appState.get('restored')).toBe('yes')
+    })
+
+    it('restores systemPrompt from a snapshot', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        createdAt: MOCK_TIMESTAMP,
+        data: {
+          systemPrompt: 'Restored prompt',
+        },
+        appData: {},
+      }
+
+      agent.loadSnapshot(snapshot)
+
+      expect(agent.systemPrompt).toBe('Restored prompt')
+    })
+
+    it('throws for incompatible schema version', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: '99.0',
+        createdAt: MOCK_TIMESTAMP,
+        data: {},
+        appData: {},
+      }
+
+      expect(() => agent.loadSnapshot(snapshot)).toThrow('Unsupported snapshot schema version: 99.0')
+    })
+
+    it('throws for wrong scope', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+
+      const snapshot: Snapshot = {
+        scope: 'multiAgent',
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        createdAt: MOCK_TIMESTAMP,
+        data: {},
+        appData: {},
+      }
+
+      expect(() => agent.loadSnapshot(snapshot)).toThrow("Expected snapshot scope 'agent', got 'multiAgent'")
+    })
+
+    it('leaves fields unchanged when absent from snapshot', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Existing')] }))
+      agent.appState.set('existing', 'value')
+      agent.systemPrompt = 'Original prompt'
+
+      // Snapshot only has state — messages and systemPrompt should be untouched
+      const snapshot: Snapshot = {
+        scope: 'agent',
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        createdAt: MOCK_TIMESTAMP,
+        data: {
+          state: { newKey: 'newValue' },
+        },
+        appData: {},
+      }
+
+      agent.loadSnapshot(snapshot)
+
+      expect(agent.messages).toHaveLength(1)
+      expect(agent.systemPrompt).toBe('Original prompt')
+      expect(agent.appState.get('newKey')).toBe('newValue')
+    })
+  })
+
+  describe('round-trip via Agent methods', () => {
+    it('preserves full agent state through takeSnapshot/loadSnapshot cycle', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      agent.messages.push(
+        new Message({ role: 'user', content: [new TextBlock('Hello')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Hi!')] })
+      )
+      agent.appState.set('counter', 42)
+      agent.systemPrompt = 'Be helpful'
+
+      const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+      // Mutate agent state
+      agent.messages.length = 0
+      agent.appState.clear()
+      agent.systemPrompt = 'Different'
+
+      // Restore
+      agent.loadSnapshot(snapshot)
+
+      expect(agent.messages).toHaveLength(2)
+      expect(agent.appState.get('counter')).toBe(42)
+      expect(agent.systemPrompt).toBe('Be helpful')
+    })
+
+    it('snapshot is independent of agent mutations after capture', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Original')] }))
+
+      const snapshot = agent.takeSnapshot({ include: ['messages'] })
+
+      // Mutate agent messages
+      agent.messages.push(new Message({ role: 'assistant', content: [new TextBlock('Added later')] }))
+
+      // Snapshot should still have only the original message
+      expect((snapshot.data.messages as unknown[]).length).toBe(1)
+    })
+
+    it('supports JSON serialization round-trip via Agent methods', () => {
+      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Persist me')] }))
+      agent.appState.set('session', 'abc')
+
+      const snapshot = agent.takeSnapshot({ preset: 'session' })
+      const json = JSON.stringify(snapshot)
+      const parsed = JSON.parse(json) as Snapshot
+
+      const newAgent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+      newAgent.loadSnapshot(parsed)
+
+      expect(newAgent.messages).toHaveLength(1)
+      expect(newAgent.appState.get('session')).toBe('abc')
+    })
+  })
+
+  describe('interrupt state via Agent methods', () => {
+    it('preserves and restores interrupt state for resume', async () => {
+      const model = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'askUser',
+          toolUseId: 'tool-1',
+          input: { question: 'proceed?' },
+        })
+        .addTurn({ type: 'textBlock', text: 'Completed' })
+
+      const tool = createMockTool('askUser', (context) => {
+        const answer = context.interrupt<string>({ name: 'ask', reason: 'Need confirmation' })
+        return `User said: ${answer}`
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      // Trigger interrupt
+      const result = await agent.invoke('Do something')
+      expect(result.stopReason).toBe('interrupt')
+
+      // Snapshot via public method
+      const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+      // Restore into a fresh agent
+      const model2 = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Completed' })
+      const tool2 = createMockTool('askUser', (context) => {
+        const answer = context.interrupt<string>({ name: 'ask', reason: 'Need confirmation' })
+        return `User said: ${answer}`
+      })
+      const restored = new Agent({ model: model2, tools: [tool2], printer: false })
+      restored.loadSnapshot(snapshot)
+
+      // Resume
+      const finalResult = await restored.invoke([
+        { interruptResponse: { interruptId: result.interrupts![0]!.id, response: 'go ahead' } },
+      ])
+
+      expect(finalResult.stopReason).toBe('endTurn')
+    })
+  })
+})

--- a/strands-ts/src/agent/__tests__/snapshot.test.ts
+++ b/strands-ts/src/agent/__tests__/snapshot.test.ts
@@ -448,265 +448,121 @@ describe('Agent.takeSnapshot / Agent.loadSnapshot (public API)', () => {
     vi.useRealTimers()
   })
 
-  describe('takeSnapshot', () => {
-    it('captures session preset state via the Agent method', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
-      agent.appState.set('key', 'value')
-      agent.systemPrompt = 'Test prompt'
+  it('takeSnapshot captures state and loadSnapshot restores it (round-trip)', () => {
+    const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+    agent.messages.push(
+      new Message({ role: 'user', content: [new TextBlock('Hello')] }),
+      new Message({ role: 'assistant', content: [new TextBlock('Hi!')] })
+    )
+    agent.appState.set('counter', 42)
+    agent.systemPrompt = 'Be helpful'
 
-      const snapshot = agent.takeSnapshot({ preset: 'session' })
+    const snapshot = agent.takeSnapshot({ preset: 'session' })
 
-      expect(snapshot.scope).toBe('agent')
-      expect(snapshot.schemaVersion).toBe(SNAPSHOT_SCHEMA_VERSION)
-      expect(snapshot.createdAt).toBe(MOCK_TIMESTAMP)
-      expect(snapshot.data.messages).toEqual([{ role: 'user', content: [{ text: 'Hello' }] }])
-      expect(snapshot.data.state).toEqual({ key: 'value' })
-      expect(snapshot.data.systemPrompt).toBe('Test prompt')
-      expect(snapshot.appData).toEqual({})
+    expect(snapshot).toEqual({
+      scope: 'agent',
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      createdAt: MOCK_TIMESTAMP,
+      data: {
+        messages: [
+          { role: 'user', content: [{ text: 'Hello' }] },
+          { role: 'assistant', content: [{ text: 'Hi!' }] },
+        ],
+        state: { counter: 42 },
+        systemPrompt: 'Be helpful',
+        modelState: {},
+        interrupts: { interrupts: {}, activated: false },
+      },
+      appData: {},
     })
 
-    it('supports include option to select specific fields', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Hello')] }))
-      agent.appState.set('key', 'value')
+    // Mutate agent state
+    agent.messages.length = 0
+    agent.appState.clear()
+    agent.systemPrompt = 'Different'
 
-      const snapshot = agent.takeSnapshot({ include: ['messages'] })
+    // Restore
+    agent.loadSnapshot(snapshot)
 
-      expect(snapshot.data.messages).toBeDefined()
-      expect(snapshot.data.state).toBeUndefined()
-      expect(snapshot.data.systemPrompt).toBeUndefined()
-    })
-
-    it('supports exclude option to omit specific fields', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      const snapshot = agent.takeSnapshot({ preset: 'session', exclude: ['interrupts', 'modelState'] })
-
-      expect(snapshot.data.interrupts).toBeUndefined()
-      expect(snapshot.data.modelState).toBeUndefined()
-      expect(snapshot.data.messages).toBeDefined()
-    })
-
-    it('stores appData in the snapshot', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      const snapshot = agent.takeSnapshot({ preset: 'session', appData: { userId: 'u-123' } })
-
-      expect(snapshot.appData).toEqual({ userId: 'u-123' })
-    })
-
-    it('throws when no fields would be included', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      expect(() => agent.takeSnapshot({})).toThrow('No fields to include in snapshot')
-    })
+    expect(agent.messages).toHaveLength(2)
+    expect(agent.appState.get('counter')).toBe(42)
+    expect(agent.systemPrompt).toBe('Be helpful')
   })
 
-  describe('loadSnapshot', () => {
-    it('restores messages from a snapshot', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+  it('propagates errors from loadSnapshot for invalid snapshots', () => {
+    const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
 
-      const snapshot: Snapshot = {
-        scope: 'agent',
-        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
-        createdAt: MOCK_TIMESTAMP,
-        data: {
-          messages: [{ role: 'user', content: [{ text: 'Restored' }] }],
-        },
-        appData: {},
-      }
+    expect(() =>
+      agent.loadSnapshot({ scope: 'agent', schemaVersion: '99.0', createdAt: '', data: {}, appData: {} })
+    ).toThrow('Unsupported snapshot schema version: 99.0')
 
-      agent.loadSnapshot(snapshot)
-
-      expect(agent.messages).toHaveLength(1)
-      expect(agent.messages[0]).toEqual(new Message({ role: 'user', content: [new TextBlock('Restored')] }))
-    })
-
-    it('restores state from a snapshot', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      const snapshot: Snapshot = {
-        scope: 'agent',
-        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
-        createdAt: MOCK_TIMESTAMP,
-        data: {
-          state: { restored: 'yes' },
-        },
-        appData: {},
-      }
-
-      agent.loadSnapshot(snapshot)
-
-      expect(agent.appState.get('restored')).toBe('yes')
-    })
-
-    it('restores systemPrompt from a snapshot', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      const snapshot: Snapshot = {
-        scope: 'agent',
-        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
-        createdAt: MOCK_TIMESTAMP,
-        data: {
-          systemPrompt: 'Restored prompt',
-        },
-        appData: {},
-      }
-
-      agent.loadSnapshot(snapshot)
-
-      expect(agent.systemPrompt).toBe('Restored prompt')
-    })
-
-    it('throws for incompatible schema version', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      const snapshot: Snapshot = {
-        scope: 'agent',
-        schemaVersion: '99.0',
-        createdAt: MOCK_TIMESTAMP,
-        data: {},
-        appData: {},
-      }
-
-      expect(() => agent.loadSnapshot(snapshot)).toThrow('Unsupported snapshot schema version: 99.0')
-    })
-
-    it('throws for wrong scope', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-
-      const snapshot: Snapshot = {
+    expect(() =>
+      agent.loadSnapshot({
         scope: 'multiAgent',
         schemaVersion: SNAPSHOT_SCHEMA_VERSION,
-        createdAt: MOCK_TIMESTAMP,
+        createdAt: '',
         data: {},
         appData: {},
-      }
+      })
+    ).toThrow("Expected snapshot scope 'agent', got 'multiAgent'")
 
-      expect(() => agent.loadSnapshot(snapshot)).toThrow("Expected snapshot scope 'agent', got 'multiAgent'")
-    })
-
-    it('leaves fields unchanged when absent from snapshot', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Existing')] }))
-      agent.appState.set('existing', 'value')
-      agent.systemPrompt = 'Original prompt'
-
-      // Snapshot only has state — messages and systemPrompt should be untouched
-      const snapshot: Snapshot = {
-        scope: 'agent',
-        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
-        createdAt: MOCK_TIMESTAMP,
-        data: {
-          state: { newKey: 'newValue' },
-        },
-        appData: {},
-      }
-
-      agent.loadSnapshot(snapshot)
-
-      expect(agent.messages).toHaveLength(1)
-      expect(agent.systemPrompt).toBe('Original prompt')
-      expect(agent.appState.get('newKey')).toBe('newValue')
-    })
+    expect(() => agent.takeSnapshot({})).toThrow('No fields to include in snapshot')
   })
 
-  describe('round-trip via Agent methods', () => {
-    it('preserves full agent state through takeSnapshot/loadSnapshot cycle', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      agent.messages.push(
-        new Message({ role: 'user', content: [new TextBlock('Hello')] }),
-        new Message({ role: 'assistant', content: [new TextBlock('Hi!')] })
-      )
-      agent.appState.set('counter', 42)
-      agent.systemPrompt = 'Be helpful'
+  it('supports JSON serialization round-trip', () => {
+    const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+    agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Persist me')] }))
+    agent.appState.set('session', 'abc')
 
-      const snapshot = agent.takeSnapshot({ preset: 'session' })
+    const snapshot = agent.takeSnapshot({ preset: 'session' })
+    const json = JSON.stringify(snapshot)
+    const parsed = JSON.parse(json) as Snapshot
 
-      // Mutate agent state
-      agent.messages.length = 0
-      agent.appState.clear()
-      agent.systemPrompt = 'Different'
+    const newAgent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
+    newAgent.loadSnapshot(parsed)
 
-      // Restore
-      agent.loadSnapshot(snapshot)
-
-      expect(agent.messages).toHaveLength(2)
-      expect(agent.appState.get('counter')).toBe(42)
-      expect(agent.systemPrompt).toBe('Be helpful')
-    })
-
-    it('snapshot is independent of agent mutations after capture', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Original')] }))
-
-      const snapshot = agent.takeSnapshot({ include: ['messages'] })
-
-      // Mutate agent messages
-      agent.messages.push(new Message({ role: 'assistant', content: [new TextBlock('Added later')] }))
-
-      // Snapshot should still have only the original message
-      expect((snapshot.data.messages as unknown[]).length).toBe(1)
-    })
-
-    it('supports JSON serialization round-trip via Agent methods', () => {
-      const agent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      agent.messages.push(new Message({ role: 'user', content: [new TextBlock('Persist me')] }))
-      agent.appState.set('session', 'abc')
-
-      const snapshot = agent.takeSnapshot({ preset: 'session' })
-      const json = JSON.stringify(snapshot)
-      const parsed = JSON.parse(json) as Snapshot
-
-      const newAgent = new Agent({ model: new TestModelProvider(), tools: [], printer: false })
-      newAgent.loadSnapshot(parsed)
-
-      expect(newAgent.messages).toHaveLength(1)
-      expect(newAgent.appState.get('session')).toBe('abc')
-    })
+    expect(newAgent.messages).toHaveLength(1)
+    expect(newAgent.appState.get('session')).toBe('abc')
   })
 
-  describe('interrupt state via Agent methods', () => {
-    it('preserves and restores interrupt state for resume', async () => {
-      const model = new MockMessageModel()
-        .addTurn({
-          type: 'toolUseBlock',
-          name: 'askUser',
-          toolUseId: 'tool-1',
-          input: { question: 'proceed?' },
-        })
-        .addTurn({ type: 'textBlock', text: 'Completed' })
-
-      const tool = createMockTool('askUser', (context) => {
-        const answer = context.interrupt<string>({ name: 'ask', reason: 'Need confirmation' })
-        return `User said: ${answer}`
+  it('preserves and restores interrupt state for resume', async () => {
+    const model = new MockMessageModel()
+      .addTurn({
+        type: 'toolUseBlock',
+        name: 'askUser',
+        toolUseId: 'tool-1',
+        input: { question: 'proceed?' },
       })
+      .addTurn({ type: 'textBlock', text: 'Completed' })
 
-      const agent = new Agent({ model, tools: [tool], printer: false })
-
-      // Trigger interrupt
-      const result = await agent.invoke('Do something')
-      expect(result.stopReason).toBe('interrupt')
-
-      // Snapshot via public method
-      const snapshot = agent.takeSnapshot({ preset: 'session' })
-
-      // Restore into a fresh agent
-      const model2 = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Completed' })
-      const tool2 = createMockTool('askUser', (context) => {
-        const answer = context.interrupt<string>({ name: 'ask', reason: 'Need confirmation' })
-        return `User said: ${answer}`
-      })
-      const restored = new Agent({ model: model2, tools: [tool2], printer: false })
-      restored.loadSnapshot(snapshot)
-
-      // Resume
-      const finalResult = await restored.invoke([
-        { interruptResponse: { interruptId: result.interrupts![0]!.id, response: 'go ahead' } },
-      ])
-
-      expect(finalResult.stopReason).toBe('endTurn')
+    const tool = createMockTool('askUser', (context) => {
+      const answer = context.interrupt<string>({ name: 'ask', reason: 'Need confirmation' })
+      return `User said: ${answer}`
     })
+
+    const agent = new Agent({ model, tools: [tool], printer: false })
+
+    // Trigger interrupt
+    const result = await agent.invoke('Do something')
+    expect(result.stopReason).toBe('interrupt')
+
+    // Snapshot via public method
+    const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+    // Restore into a fresh agent
+    const model2 = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Completed' })
+    const tool2 = createMockTool('askUser', (context) => {
+      const answer = context.interrupt<string>({ name: 'ask', reason: 'Need confirmation' })
+      return `User said: ${answer}`
+    })
+    const restored = new Agent({ model: model2, tools: [tool2], printer: false })
+    restored.loadSnapshot(snapshot)
+
+    // Resume
+    const finalResult = await restored.invoke([
+      { interruptResponse: { interruptId: result.interrupts![0]!.id, response: 'go ahead' } },
+    ])
+
+    expect(finalResult.stopReason).toBe('endTurn')
   })
 })

--- a/strands-ts/src/agent/agent-as-tool.ts
+++ b/strands-ts/src/agent/agent-as-tool.ts
@@ -7,7 +7,6 @@
  */
 
 import type { Agent } from './agent.js'
-import { takeSnapshot, loadSnapshot } from './snapshot.js'
 import type { Snapshot } from '../types/snapshot.js'
 import type { JSONValue } from '../types/json.js'
 import { JsonBlock, TextBlock, ToolResultBlock } from '../types/messages.js'
@@ -111,7 +110,7 @@ export class AgentAsTool extends Tool {
     }
 
     if (!this._preserveContext) {
-      this._initialSnapshot = takeSnapshot(this._agent, { preset: 'session' })
+      this._initialSnapshot = this._agent.takeSnapshot({ preset: 'session' })
     }
 
     this.name = config.name ?? config.agent.name
@@ -159,7 +158,7 @@ export class AgentAsTool extends Tool {
 
       // Reset agent state if not preserving context
       if (this._initialSnapshot) {
-        loadSnapshot(this._agent, this._initialSnapshot)
+        this._agent.loadSnapshot(this._initialSnapshot)
       }
 
       // Stream the sub-agent, forwarding the outer invocation's state so

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -79,6 +79,9 @@ import { warnOnDuplicateRetryStrategyTypes } from '../retry/retry-strategy.js'
 import { InterruptError, InterruptState, interruptFromAgent } from '../interrupt.js'
 import type { InterruptParams } from '../types/interrupt.js'
 import { isInterruptResponseContent, type InterruptResponseContent } from '../types/interrupt.js'
+import { takeSnapshot as takeSnapshotInternal, loadSnapshot as loadSnapshotInternal } from './snapshot.js'
+import type { TakeSnapshotOptions } from './snapshot.js'
+import type { Snapshot } from '../types/snapshot.js'
 
 /**
  * Recursive type definition for nested tool arrays.
@@ -709,6 +712,69 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   public asTool(options?: AgentAsToolOptions): Tool {
     return new AgentAsTool({ agent: this, ...options })
+  }
+
+  /**
+   * Captures a point-in-time snapshot of the agent's current state.
+   *
+   * Use snapshots to checkpoint agent state for later restoration, enabling
+   * use cases like undo/redo, branching conversations, and session persistence.
+   *
+   * Fields are selected via a preset/include/exclude model:
+   * 1. Start with preset fields (e.g. `'session'` captures all fields)
+   * 2. Add any `include` fields
+   * 3. Remove any `exclude` fields
+   *
+   * @param options - Controls which fields to capture and optional app data to store
+   * @returns A {@link Snapshot} containing the captured agent state
+   * @throws Error if no fields would be included after applying options
+   *
+   * @example
+   * ```typescript
+   * // Capture all session-relevant state
+   * const snapshot = agent.takeSnapshot({ preset: 'session' })
+   *
+   * // Capture only messages and state
+   * const partial = agent.takeSnapshot({ include: ['messages', 'state'] })
+   *
+   * // Capture session state but exclude interrupts
+   * const noInterrupts = agent.takeSnapshot({ preset: 'session', exclude: ['interrupts'] })
+   *
+   * // Attach application-owned metadata
+   * const withMeta = agent.takeSnapshot({ preset: 'session', appData: { userId: 'u-123' } })
+   * ```
+   */
+  public takeSnapshot(options: TakeSnapshotOptions): Snapshot {
+    return takeSnapshotInternal(this, options)
+  }
+
+  /**
+   * Restores agent state from a previously captured snapshot.
+   *
+   * Only fields present in `snapshot.data` are restored; absent fields are left
+   * unchanged. This allows partial snapshots to update specific aspects of state
+   * without affecting others.
+   *
+   * @param snapshot - The snapshot to restore from
+   * @throws Error if `snapshot.schemaVersion` is incompatible or scope is wrong
+   *
+   * @example
+   * ```typescript
+   * // Save and restore a conversation checkpoint
+   * const checkpoint = agent.takeSnapshot({ preset: 'session' })
+   *
+   * // ... agent continues processing ...
+   *
+   * // Restore to the checkpoint
+   * agent.loadSnapshot(checkpoint)
+   *
+   * // Restore from a JSON-serialized snapshot (e.g. from storage)
+   * const stored = JSON.parse(savedSnapshotJson)
+   * agent.loadSnapshot(stored)
+   * ```
+   */
+  public loadSnapshot(snapshot: Snapshot): void {
+    loadSnapshotInternal(this, snapshot)
   }
 
   /**

--- a/strands-ts/src/agent/snapshot.ts
+++ b/strands-ts/src/agent/snapshot.ts
@@ -1,14 +1,10 @@
 /**
- * Snapshot API for capturing and restoring agent state.
+ * Snapshot helpers for agent state capture and restoration.
  *
- * This module provides types and utilities for point-in-time capture and restoration
- * of agent state, enabling use cases like checkpointing, undo/redo, and branching
- * conversation flows.
- *
- * NOTE: The takeSnapshot and loadSnapshot functions are currently internal implementation
- * details. We anticipate opening these up as public Agent methods in a future release
- * after API review, but for now they are top-level functions to unblock snapshot
- * functionality without committing to a public API surface.
+ * These functions provide the shared implementation for {@link LocalAgent.takeSnapshot}
+ * and {@link LocalAgent.loadSnapshot}. Since all `LocalAgent` implementations share the
+ * same snapshot logic, these helpers avoid duplication. The canonical public API is
+ * `agent.takeSnapshot()` / `agent.loadSnapshot()` — prefer calling those directly.
  */
 
 import type { JSONValue } from '../types/json.js'
@@ -79,10 +75,8 @@ export type TakeSnapshotOptions = {
 }
 
 /**
- * Takes a snapshot of the agent's current state.
- *
- * NOTE: This is currently an internal implementation detail. We anticipate
- * exposing this as a public Agent method in a future release after API review.
+ * Shared implementation for {@link LocalAgent.takeSnapshot}.
+ * Prefer calling `agent.takeSnapshot(options)` directly.
  *
  * @param agent - The agent to snapshot
  * @param options - Snapshot options
@@ -124,10 +118,8 @@ export function takeSnapshot(agent: LocalAgent, options: TakeSnapshotOptions): S
 }
 
 /**
- * Loads a snapshot into the agent, restoring its state.
- *
- * NOTE: This is currently an internal implementation detail. We anticipate
- * exposing this as a public Agent method in a future release after API review.
+ * Shared implementation for {@link LocalAgent.loadSnapshot}.
+ * Prefer calling `agent.loadSnapshot(snapshot)` directly.
  *
  * @param agent - The agent to restore state into
  * @param snapshot - The snapshot to load

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -17,6 +17,10 @@ export type { AgentConfig, ToolList, ToolExecutorStrategy } from './agent/agent.
 export type { AgentAsToolOptions } from './agent/agent-as-tool.js'
 export type { InvocationState, InvokeArgs, InvokeOptions, LocalAgent } from './types/agent.js'
 
+// Snapshot types
+export { SNAPSHOT_SCHEMA_VERSION } from './types/snapshot.js'
+export type { TakeSnapshotOptions, SnapshotField, SnapshotPreset } from './agent/snapshot.js'
+
 // Error types
 // Note: CancelledError is intentionally not exported — it is an internal
 // control-flow mechanism, never thrown to consumers. See its docstring in errors.ts.

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -19,6 +19,7 @@ export type { InvocationState, InvokeArgs, InvokeOptions, LocalAgent } from './t
 
 // Snapshot types
 export { SNAPSHOT_SCHEMA_VERSION } from './types/snapshot.js'
+export type { Scope, Snapshot } from './types/snapshot.js'
 export type { TakeSnapshotOptions, SnapshotField, SnapshotPreset } from './agent/snapshot.js'
 
 // Error types
@@ -275,7 +276,6 @@ export type {
 export type { SnapshotManifest, SnapshotTriggerCallback, SnapshotTriggerParams } from './session/types.js'
 export type { SessionStorage, SnapshotStorage, SnapshotLocation } from './session/storage.js'
 export { FileStorage } from './session/file-storage.js'
-export type { Scope, Snapshot } from './types/snapshot.js'
 
 // Local Traces
 export { AgentTrace } from './telemetry/tracer.js'

--- a/strands-ts/src/multiagent/nodes.ts
+++ b/strands-ts/src/multiagent/nodes.ts
@@ -1,7 +1,6 @@
 import { Agent } from '../agent/agent.js'
 import type { InvocationState, InvokeOptions, InvokableAgent, AgentStreamEvent } from '../types/agent.js'
 import type { MultiAgentInput } from './multiagent.js'
-import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
 import type { MultiAgentStreamEvent } from './events.js'
 import { NodeStreamUpdateEvent, NodeResultEvent } from './events.js'
 import { NodeResult, Status } from './state.js'
@@ -216,7 +215,7 @@ export class AgentNode extends Node {
     // Only Agent instances support snapshot/restore for state isolation
     const snapshot =
       this._agent instanceof Agent
-        ? takeSnapshot(this._agent, { include: ['messages', 'state', 'modelState'] })
+        ? this._agent.takeSnapshot({ include: ['messages', 'state', 'modelState'] })
         : undefined
     try {
       const invokeOptions: InvokeOptions = {
@@ -248,7 +247,7 @@ export class AgentNode extends Node {
       }
     } finally {
       if (snapshot) {
-        loadSnapshot(this._agent as Agent, snapshot)
+        ;(this._agent as Agent).loadSnapshot(snapshot)
       }
     }
   }

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -31,6 +31,9 @@ import {
   NodeResult,
   Status,
 } from '../../multiagent/index.js'
+import { takeSnapshot, loadSnapshot } from '../../agent/snapshot.js'
+import type { Snapshot } from '../../types/snapshot.js'
+import type { TakeSnapshotOptions } from '../../agent/snapshot.js'
 
 // Test fixtures
 function createMockAgent(id = 'agent'): Agent {
@@ -54,6 +57,12 @@ function createMockAgent(id = 'agent'): Agent {
     } as any,
     modelState: new StateStore(),
     systemPrompt: 'Test prompt',
+    takeSnapshot(options: TakeSnapshotOptions): Snapshot {
+      return takeSnapshot(agent as any, options)
+    },
+    loadSnapshot(snapshot: Snapshot): void {
+      loadSnapshot(agent as any, snapshot)
+    },
   } as unknown as Agent
   return agent
 }

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -5,7 +5,6 @@ import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
 import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
-import { takeSnapshot, loadSnapshot } from '../agent/snapshot.js'
 import { logger } from '../logging/logger.js'
 import type { MultiAgentPlugin, MultiAgent } from '../multiagent/index.js'
 import { MultiAgentState } from '../multiagent/state.js'
@@ -144,7 +143,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }): Promise<void> {
     const isAgent = 'messages' in params.target
     const snapshot = isAgent
-      ? takeSnapshot(params.target as LocalAgent, { preset: 'session' })
+      ? (params.target as LocalAgent).takeSnapshot({ preset: 'session' })
       : takeMultiAgentSnapshot(params.target as Graph | Swarm, params.state)
     const snapshotId = params.isLatest ? 'latest' : uuidV7()
     const location = isAgent
@@ -191,7 +190,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     if (!snapshot) return false
 
     if (isAgent) {
-      loadSnapshot(params.target as LocalAgent, snapshot)
+      ;(params.target as LocalAgent).loadSnapshot(snapshot)
     } else {
       loadMultiAgentSnapshot(params.target as Graph | Swarm, snapshot, params.state)
     }
@@ -250,7 +249,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   /** Captures one snapshot and writes it to both immutable history and snapshot_latest. */
   private async _saveImmutableAndLatest(agent: LocalAgent): Promise<void> {
-    const snapshot = takeSnapshot(agent, { preset: 'session' })
+    const snapshot = agent.takeSnapshot({ preset: 'session' })
     const snapshotId = uuidV7()
     await Promise.all([
       this._storage.snapshot.saveSnapshot({ location: this._location(agent), snapshotId, isLatest: false, snapshot }),

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -3,6 +3,8 @@ import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason, 
 import type { Interrupt } from '../interrupt.js'
 import type { InterruptResponseContent, InterruptResponseContentData } from './interrupt.js'
 import type { AgentTrace } from '../telemetry/tracer.js'
+import type { Snapshot } from './snapshot.js'
+import type { TakeSnapshotOptions } from '../agent/snapshot.js'
 import type {
   BeforeInvocationEvent,
   AfterInvocationEvent,
@@ -267,6 +269,23 @@ export interface LocalAgent {
     callback: HookCallback<T>,
     options?: HookCallbackOptions
   ): HookCleanup
+
+  /**
+   * Captures a point-in-time snapshot of the agent's current state.
+   *
+   * @param options - Controls which fields to capture and optional app data to store
+   * @returns A Snapshot containing the captured agent state
+   */
+  takeSnapshot(options: TakeSnapshotOptions): Snapshot
+
+  /**
+   * Restores agent state from a previously captured snapshot.
+   *
+   * Only fields present in `snapshot.data` are restored; absent fields are left unchanged.
+   *
+   * @param snapshot - The snapshot to restore from
+   */
+  loadSnapshot(snapshot: Snapshot): void
 }
 
 /**


### PR DESCRIPTION
## Description

Exposes `takeSnapshot` and `loadSnapshot` as public methods on the `Agent` class and the `LocalAgent` interface, matching the Python SDK's public API. Previously these were internal helper functions that consumers couldn't access directly.

```typescript
const agent = new Agent({ systemPrompt: 'You are a helpful assistant' })
await agent.invoke('Hello!')

// Capture a snapshot
const snapshot = agent.takeSnapshot({ preset: 'session' })

// Continue working...
await agent.invoke('Tell me a joke')

// Restore to the earlier state
agent.loadSnapshot(snapshot)
```

The standalone helper functions in `agent/snapshot.ts` are retained as the shared implementation (since all `LocalAgent` implementations use the same logic), but their docs now direct callers to use `agent.takeSnapshot()` / `agent.loadSnapshot()` instead. All internal call sites (`SessionManager`, `AgentAsTool`, `multiagent/nodes`) have been migrated to use the instance methods.

New public exports from the package: `TakeSnapshotOptions`, `SnapshotField`, `SnapshotPreset`, and `SNAPSHOT_SCHEMA_VERSION`.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

https://github.com/strands-agents/docs/pull/733

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
