### PR TITLE
feat: normalize tool-name and update correct MessageAddedEvent behavior

### DIFF
--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -205,8 +205,9 @@ export class AfterInvocationEvent extends HookableEvent {
 
 /**
  * Event triggered when the framework adds a message to the conversation history.
- * Fired during the agent loop execution for framework-generated messages.
- * Does not fire for initial messages from AgentConfig or user input messages.
+ * Fired for user input, assistant responses, and tool-result messages added
+ * during agent execution. Does not fire for messages preloaded via
+ * `AgentConfig.messages` or messages manually pushed to `agent.messages`.
  */
 export class MessageAddedEvent extends HookableEvent {
   readonly type = 'messageAddedEvent' as const

--- a/strands-ts/src/registry/__tests__/tool-registry.test.ts
+++ b/strands-ts/src/registry/__tests__/tool-registry.test.ts
@@ -49,6 +49,14 @@ describe('ToolRegistry', () => {
       )
     })
 
+    it("throws ToolValidationError when a name differs only by '-' vs '_'", () => {
+      registry.add(createMockTool({ name: 'foo-bar' }))
+      expect(() => registry.add(createMockTool({ name: 'foo_bar' }))).toThrow(ToolValidationError)
+      expect(() => registry.add(createMockTool({ name: 'foo_bar' }))).toThrow(
+        "Tool name 'foo_bar' already exists as 'foo-bar'. Cannot add a duplicate tool which differs by a '-' or '_'"
+      )
+    })
+
     it('throws ToolValidationError for an invalid tool name pattern', () => {
       expect(() => registry.add(createMockTool({ name: 'invalid name!' }))).toThrow(ToolValidationError)
       expect(() => registry.add(createMockTool({ name: 'invalid name!' }))).toThrow(
@@ -127,6 +135,11 @@ describe('ToolRegistry', () => {
 
     it('validates tool properties', () => {
       expect(() => registry.addOrReplace([createMockTool({ name: 'invalid name!' })])).toThrow(ToolValidationError)
+    })
+
+    it("throws ToolValidationError when a new tool name differs only by '-' vs '_'", () => {
+      registry.add(createMockTool({ name: 'foo-bar' }))
+      expect(() => registry.addOrReplace([createMockTool({ name: 'foo_bar' })])).toThrow(ToolValidationError)
     })
   })
 

--- a/strands-ts/src/registry/tool-registry.ts
+++ b/strands-ts/src/registry/tool-registry.ts
@@ -31,6 +31,7 @@ export class ToolRegistry {
       if (this._tools.has(t.name)) {
         throw new ToolValidationError(`Tool with name '${t.name}' already registered`)
       }
+      this._checkNormalizedConflict(t.name)
       this._tools.set(t.name, t)
     }
   }
@@ -44,6 +45,9 @@ export class ToolRegistry {
   addOrReplace(newTools: Tool[]): void {
     for (const tool of newTools) {
       this._validateProperties(tool)
+      if (!this._tools.has(tool.name)) {
+        this._checkNormalizedConflict(tool.name)
+      }
       this._tools.set(tool.name, tool)
     }
   }
@@ -100,6 +104,18 @@ export class ToolRegistry {
     if (tool.description !== undefined && tool.description !== null) {
       if (typeof tool.description !== 'string' || tool.description.length < 1) {
         throw new ToolValidationError('Tool description must be a non-empty string')
+      }
+    }
+  }
+
+  private _checkNormalizedConflict(name: string): void {
+    const normalized = name.replaceAll('-', '_')
+    for (const existing of this._tools.keys()) {
+      if (existing !== name && existing.replaceAll('-', '_') === normalized) {
+        throw new ToolValidationError(
+          `Tool name '${name}' already exists as '${existing}'.` +
+            " Cannot add a duplicate tool which differs by a '-' or '_'"
+        )
       }
     }
   }


### PR DESCRIPTION
## Description

### Normalize tool name
Reject tool-name registrations that collide with an existing name when only `-` vs `_` differs (e.g., registering `foo_bar` when `foo-bar` already exists now throws `ToolValidationError`). Some model providers normalize or reject these characters in tool names, so names that look distinct locally can collide remotely. This matches the Python SDK's behavior in `strands/tools/registry.py` and closes a parity gap.

- `ToolRegistry.add()` now runs a normalized-name check after the exact-match check.
- `ToolRegistry.addOrReplace()` runs the same check only when the exact name does not already exist, so replacing a tool with itself still works.
- Error message matches the Python SDK verbatim.


### MessageAddedEvent behavior

Updated the correct behavior of MessageAddedEvent:

- Fired for user input, assistant responses, and tool-result messages added during agent execution. 
- Does not fire for messages preloaded via `AgentConfig.messages` or messages manually pushed to `agent.messages`.


## Related Issues

https://github.com/strands-agents/sdk-typescript/issues/904

## Documentation PR

N/A

## Type of Change

Breaking change (previously-accepted registrations of `foo-bar` + `foo_bar` now throw). In practice these collisions are almost always latent bugs.

## Testing

- [x] I ran `npm run check`
- Added two unit tests covering `add()` and `addOrReplace()` paths in `strands-ts/src/registry/__tests__/tool-registry.test.ts`.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.