### PR TITLE
fix: structured tool output user/assistant bug fix

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1332,6 +1332,37 @@ describe('Agent', () => {
       expect(result.structuredOutput).toEqual({ value: 42 })
     })
 
+    it('does not send assistant-ended conversation when forcing structured output retry', async () => {
+      // Regression for https://github.com/strands-agents/sdk-typescript/issues/1039
+      // When the model responds with plain text instead of calling the structured output tool,
+      // the forced-retry model call must not see a conversation ending with an assistant message.
+      // Bedrock/Anthropic-family models reject assistant message prefill.
+      const schema = z.object({ value: z.number() })
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'Plain text, no tool call' })
+        .addTurn({ type: 'toolUseBlock', name: 'strands_structured_output', toolUseId: 'tool-1', input: { value: 42 } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      // Snapshot the role sequence at each model call, since `messages` is passed by reference
+      // and mutates during the agent loop.
+      const roleSnapshots: string[][] = []
+      const originalStream = model.stream.bind(model)
+      vi.spyOn(model, 'stream').mockImplementation((messages, options) => {
+        roleSnapshots.push(messages.map((m) => m.role))
+        return originalStream(messages, options)
+      })
+
+      const agent = new Agent({ model, structuredOutputSchema: schema })
+      await agent.invoke('Test')
+
+      expect(roleSnapshots.length).toBeGreaterThanOrEqual(2)
+
+      // The forced-retry (second) call must not see a conversation ending with an assistant turn.
+      const secondCallRoles = roleSnapshots[1]!
+      expect(secondCallRoles[secondCallRoles.length - 1]).toBe('user')
+    })
+
     it('throws StructuredOutputError when model refuses to use tool after forcing', async () => {
       const schema = z.object({ value: z.number() })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -910,26 +910,30 @@ export class Agent implements LocalAgent, InvokableAgent {
             const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice)
 
             if (modelResult.stopReason !== 'toolUse') {
-              // If structured output is required, force it
-              if (structuredOutputTool) {
-                if (structuredOutputChoice) {
-                  throw new StructuredOutputError(
-                    'The model failed to invoke the structured output tool even after it was forced.'
-                  )
-                }
-
-                structuredOutputChoice = { tool: { name: STRUCTURED_OUTPUT_TOOL_NAME } }
+              // Schema set, we already forced, and the model still refused.
+              // Throw before closing the span so the cycle span records the error.
+              if (structuredOutputTool && structuredOutputChoice) {
+                throw new StructuredOutputError(
+                  'The model failed to invoke the structured output tool even after it was forced.'
+                )
               }
 
               this._meter.endCycle(cycleStartTime)
               this._tracer.endAgentLoopSpan(cycleSpan)
 
-              yield this._appendMessage(modelResult.message, invocationState)
-
-              if (structuredOutputChoice) {
+              // Schema set, model ignored the tool — drop the response and force the tool next cycle.
+              // Appending the plain-text turn here would leave the conversation ending on an
+              // assistant message, which providers like Bedrock reject as assistant prefill.
+              if (structuredOutputTool) {
+                structuredOutputChoice = { tool: { name: STRUCTURED_OUTPUT_TOOL_NAME } }
+                logger.debug(
+                  'structured output schema set but model responded with plain text; forcing tool use on next cycle'
+                )
                 continue
               }
 
+              // Normal end of turn.
+              yield this._appendMessage(modelResult.message, invocationState)
               result = new AgentResult({
                 stopReason: modelResult.stopReason,
                 lastMessage: modelResult.message,


### PR DESCRIPTION
## Description

When an `Agent` with a `structuredOutputSchema` received plain text from the model on the first turn (instead of a `strands_structured_output` tool call), the forced-retry path appended that assistant message to `agent.messages` before looping, so the retry model call saw a conversation ending on an assistant turn. Providers that disallow assistant prefill (Bedrock, Anthropic) rejected the call:

> This model does not support assistant message prefill. The conversation must end with a user message.

The fix restructures the `stopReason !== 'toolUse'` branch into three ordered cases:

1. **Schema set, already forced, still refused** → throw `StructuredOutputError` (unchanged behavior; reordered so the cycle span records the error).
2. **Schema set, first refusal** → drop the plain-text response, set `structuredOutputChoice`, `continue`. The drop is the behavioral change — previously the message was appended here.
3. **No schema** → append the assistant message and return normally (byte-equivalent to before).

Flows without a `structuredOutputSchema` are unaffected. The dropped turn is a response the agent is explicitly overriding; keeping it in history would leave `agent.messages` containing both an ignored text reply and the forced tool call for the same turn.

## Related Issues

Resolves #1039

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `npm run check`

Added regression test `does not send assistant-ended conversation when forcing structured output retry` in `agent.test.ts` — spies on `model.stream`, snapshots the role order at each call, and asserts the forced-retry call ends on `'user'`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
