### PR TITLE
fix: warn on legacy Bedrock cache options

### DIFF
--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -448,6 +448,18 @@ describe('BedrockModel', () => {
         temperature: 0.7,
       })
     })
+
+    it('warns when unsupported legacy cache options are provided', () => {
+      new BedrockModel({
+        cachePrompt: 'default',
+        cacheTools: 'default',
+      } as any)
+
+      expect(warnOnce).toHaveBeenCalledWith(
+        expect.anything(),
+        'unsupported_fields=<cachePrompt,cacheTools> | cachePrompt and cacheTools are not supported by BedrockModel, use cacheConfig instead'
+      )
+    })
   })
 
   describe('format_message', async () => {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -102,6 +102,11 @@ const BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
  */
 const SKIP_COUNT_TOKENS_MODELS = new Set<string>()
 
+type LegacyBedrockCacheOptions = {
+  cachePrompt?: unknown
+  cacheTools?: unknown
+}
+
 /**
  * Mapping of Bedrock stop reasons to SDK stop reasons.
  */
@@ -387,6 +392,14 @@ export class BedrockModel extends Model<BedrockModelConfig> {
    */
   constructor(options?: BedrockModelOptions) {
     super()
+
+    const legacyCacheOptions = options as (BedrockModelOptions & LegacyBedrockCacheOptions) | undefined
+    if (legacyCacheOptions?.cachePrompt !== undefined || legacyCacheOptions?.cacheTools !== undefined) {
+      warnOnce(
+        logger,
+        'unsupported_fields=<cachePrompt,cacheTools> | cachePrompt and cacheTools are not supported by BedrockModel, use cacheConfig instead'
+      )
+    }
 
     const { region, clientConfig, apiKey, ...modelConfig } = options ?? {}
 


### PR DESCRIPTION
## Summary
This adds a small runtime warning when `BedrockModel` receives the stale `cachePrompt` or `cacheTools` fields documented on the older indexed API page. Those fields are not honored by the current provider, so the warning points users to `cacheConfig` instead of silently leaving Bedrock prompt caching disabled.

Fixes #1027.

## Testing
- npm ci --ignore-scripts
- npm run test -w strands-ts -- src/models/__tests__/bedrock.test.ts -t "legacy cache"
- npx prettier --check strands-ts/src/models/bedrock.ts strands-ts/src/models/__tests__/bedrock.test.ts
- git diff --check