### PR TITLE
fix: default useNativeTokenCount to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     <a href="https://github.com/strands-agents/sdk-typescript/pulls"><img alt="GitHub open pull requests" src="https://img.shields.io/github/issues-pr/strands-agents/sdk-typescript"/></a>
     <a href="https://github.com/strands-agents/sdk-typescript/blob/main/LICENSE.APACHE"><img alt="License" src="https://img.shields.io/github/license/strands-agents/sdk-typescript"/></a>
     <a href="https://www.npmjs.com/package/@strands-agents/sdk"><img alt="NPM Version" src="https://img.shields.io/npm/v/@strands-agents/sdk"/></a>
+    <a href="https://discord.gg/strands"><img alt="Strands Discord" src="https://img.shields.io/badge/Discord-Strands-5865F2?logo=discord&logoColor=white"/></a>
   </div>
   
   <p>
@@ -325,6 +326,11 @@ We welcome contributions! See our [Contributing Guide](CONTRIBUTING.md) for deta
 - Pull request process
 - Code of Conduct
 - Security issue reporting
+
+---
+
+## Stay in touch with the team
+Come meet the Strands team and other users on [**Discord**](https://discord.com/invite/strands)
 
 ---
 

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -746,10 +746,21 @@ describe('AnthropicModel', () => {
       } as unknown as Anthropic
     }
 
+    it('should use heuristic by default when useNativeTokenCount is not set', async () => {
+      const mockCountTokens = vi.fn()
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+
+      const result = await model.countTokens(messages)
+
+      expect(mockCountTokens).not.toHaveBeenCalled()
+      expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
+    })
+
     it('should return native token count on success', async () => {
       const mockCountTokens = vi.fn(async () => ({ input_tokens: 42 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -760,7 +771,7 @@ describe('AnthropicModel', () => {
     it('should include system prompt in request', async () => {
       const mockCountTokens = vi.fn(async () => ({ input_tokens: 55 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages, { systemPrompt: 'Be helpful.' })
 
@@ -775,7 +786,7 @@ describe('AnthropicModel', () => {
     it('should include tool specs in request', async () => {
       const mockCountTokens = vi.fn(async () => ({ input_tokens: 100 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages, { toolSpecs })
 
@@ -790,7 +801,7 @@ describe('AnthropicModel', () => {
     it('should strip max_tokens from request', async () => {
       const mockCountTokens = vi.fn(async () => ({ input_tokens: 10 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: true })
 
       await model.countTokens(messages)
 
@@ -805,7 +816,7 @@ describe('AnthropicModel', () => {
         throw new Error('Unsupported')
       })
       const client = createCountTokensClient(mockCountTokens)
-      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -818,7 +829,7 @@ describe('AnthropicModel', () => {
         throw new Error('Connection failed')
       })
       const client = createCountTokensClient(mockCountTokens)
-      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6' })
+      const model = new AnthropicModel({ client, modelId: 'claude-sonnet-4-6', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -4171,10 +4171,21 @@ describe('BedrockModel', () => {
       BedrockModel.clearCountTokensCache()
     })
 
+    it('should use heuristic by default when useNativeTokenCount is not set', async () => {
+      const mockSend = vi.fn()
+      mockBedrockClientImplementation({ send: mockSend })
+      const model = new BedrockModel()
+
+      const result = await model.countTokens(messages)
+
+      expect(mockSend).not.toHaveBeenCalled()
+      expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
+    })
+
     it('should return native token count on success', async () => {
       const mockSend = vi.fn(async () => ({ inputTokens: 42 }))
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -4185,7 +4196,7 @@ describe('BedrockModel', () => {
     it('should include system prompt in request', async () => {
       const mockSend = vi.fn(async () => ({ inputTokens: 55 }))
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       const result = await model.countTokens(messages, { systemPrompt: 'Be helpful.' })
 
@@ -4205,7 +4216,7 @@ describe('BedrockModel', () => {
     it('should include tool specs in request', async () => {
       const mockSend = vi.fn(async () => ({ inputTokens: 100 }))
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       const result = await model.countTokens(messages, { toolSpecs })
 
@@ -4235,7 +4246,7 @@ describe('BedrockModel', () => {
     it('should strip inferenceConfig from request', async () => {
       const mockSend = vi.fn(async () => ({ inputTokens: 10 }))
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel({ maxTokens: 100 })
+      const model = new BedrockModel({ maxTokens: 100, useNativeTokenCount: true })
 
       await model.countTokens(messages)
 
@@ -4255,7 +4266,7 @@ describe('BedrockModel', () => {
         throw new Error('API error')
       })
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -4268,7 +4279,7 @@ describe('BedrockModel', () => {
         throw new Error('Connection failed')
       })
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -4283,7 +4294,7 @@ describe('BedrockModel', () => {
         throw unsupportedError
       })
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       // First call: hits API, gets error, caches
       await model.countTokens(messages)
@@ -4303,7 +4314,7 @@ describe('BedrockModel', () => {
         throw accessDeniedError
       })
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       // First call: hits API, gets AccessDeniedException, caches
       await model.countTokens(messages)
@@ -4319,7 +4330,7 @@ describe('BedrockModel', () => {
         throw new Error('Transient network error')
       })
       mockBedrockClientImplementation({ send: mockSend })
-      const model = new BedrockModel()
+      const model = new BedrockModel({ useNativeTokenCount: true })
 
       await model.countTokens(messages)
       expect(mockSend).toHaveBeenCalledTimes(1)

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -1258,10 +1258,21 @@ describe('GoogleModel', () => {
       } as unknown as GoogleGenAI
     }
 
+    it('should use heuristic by default when useNativeTokenCount is not set', async () => {
+      const mockCountTokens = vi.fn()
+      const client = createCountTokensClient(mockCountTokens)
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+
+      const result = await model.countTokens(messages)
+
+      expect(mockCountTokens).not.toHaveBeenCalled()
+      expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
+    })
+
     it('should return native token count on success', async () => {
       const mockCountTokens = vi.fn(async () => ({ totalTokens: 42 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -1272,7 +1283,7 @@ describe('GoogleModel', () => {
     it('should add heuristic estimate for system prompt', async () => {
       const mockCountTokens = vi.fn(async () => ({ totalTokens: 55 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages, { systemPrompt: 'Be helpful.' })
 
@@ -1282,7 +1293,7 @@ describe('GoogleModel', () => {
     it('should add heuristic estimate for tool specs', async () => {
       const mockCountTokens = vi.fn(async () => ({ totalTokens: 100 }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages, { toolSpecs })
 
@@ -1292,7 +1303,7 @@ describe('GoogleModel', () => {
     it('should fall back on null totalTokens', async () => {
       const mockCountTokens = vi.fn(async () => ({ totalTokens: null }))
       const client = createCountTokensClient(mockCountTokens)
-      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -1305,7 +1316,7 @@ describe('GoogleModel', () => {
         throw new Error('Unsupported')
       })
       const client = createCountTokensClient(mockCountTokens)
-      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 
@@ -1318,7 +1329,7 @@ describe('GoogleModel', () => {
         throw new Error('Connection failed')
       })
       const client = createCountTokensClient(mockCountTokens)
-      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash' })
+      const model = new GoogleModel({ client, modelId: 'gemini-2.5-flash', useNativeTokenCount: true })
 
       const result = await model.countTokens(messages)
 

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -40,9 +40,11 @@ export interface AnthropicModelConfig extends BaseModelConfig {
   /**
    * Whether to use the native Anthropic countTokens API.
    *
-   * When `true` (default), `countTokens()` calls the Anthropic token counting API for
-   * accurate counts. When `false`, skips the API call and uses the character-based
-   * heuristic estimator.
+   * When `true`, `countTokens()` calls the Anthropic token counting API for
+   * accurate counts. When `false` or not set (default), skips the API call and uses
+   * the character-based heuristic estimator.
+   *
+   * @defaultValue false
    */
   useNativeTokenCount?: boolean
 }
@@ -117,7 +119,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
-    if (this._config.useNativeTokenCount === false) return super.countTokens(messages, options)
+    if (this._config.useNativeTokenCount !== true) return super.countTokens(messages, options)
 
     try {
       const request = this._formatRequest(messages, options)

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -285,9 +285,11 @@ export interface BedrockModelConfig extends BaseModelConfig {
   /**
    * Whether to use the native Bedrock CountTokens API.
    *
-   * When `true` (default), `countTokens()` calls the Bedrock CountTokens API for
-   * accurate counts. When `false`, skips the API call and uses the character-based
-   * heuristic estimator.
+   * When `true`, `countTokens()` calls the Bedrock CountTokens API for
+   * accurate counts. When `false` or not set (default), skips the API call and uses
+   * the character-based heuristic estimator.
+   *
+   * @defaultValue false
    */
   useNativeTokenCount?: boolean
 }
@@ -510,7 +512,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
-    if (this._config.useNativeTokenCount === false) return super.countTokens(messages, options)
+    if (this._config.useNativeTokenCount !== true) return super.countTokens(messages, options)
 
     const modelId = this._config.modelId ?? MODEL_DEFAULTS.bedrock.modelId
 

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -160,7 +160,7 @@ export class GoogleModel extends Model<GoogleModelConfig> {
    * @returns Total input token count
    */
   override async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
-    if (this._config.useNativeTokenCount === false) return super.countTokens(messages, options)
+    if (this._config.useNativeTokenCount !== true) return super.countTokens(messages, options)
 
     try {
       const params = this._formatRequest(messages, options)

--- a/strands-ts/src/models/google/types.ts
+++ b/strands-ts/src/models/google/types.ts
@@ -45,9 +45,11 @@ export interface GoogleModelConfig extends BaseModelConfig {
   /**
    * Whether to use the native Gemini countTokens API.
    *
-   * When `true` (default), `countTokens()` calls the Gemini token counting API for
-   * accurate counts. When `false`, skips the API call and uses the character-based
-   * heuristic estimator.
+   * When `true`, `countTokens()` calls the Gemini token counting API for
+   * accurate counts. When `false` or not set (default), skips the API call and uses
+   * the character-based heuristic estimator.
+   *
+   * @defaultValue false
    */
   useNativeTokenCount?: boolean
 }


### PR DESCRIPTION
## Description

TS port of https://github.com/strands-agents/sdk-python/pull/2284 

Changes the default value of `useNativeTokenCount` from `true` to `false` across all model providers. Since the event loop calls `countTokens()` before every model invocation, the previous default made an additional network round-trip that adds 25-50% latency for multimodal/image workloads with no indication of why.

Native token counting is now opt-in: users must explicitly set `useNativeTokenCount: true` to enable native API calls.

## Related Issues

Fixes https://github.com/strands-agents/sdk-python/issues/2277

Port of https://github.com/strands-agents/sdk-python/pull/2284 

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
