### PR TITLE
fix: use correct 'citation' delta key for streaming citations in Bedrock provider

### DIFF
--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -969,17 +969,18 @@ describe('BedrockModel', () => {
       })
     })
 
-    it('yields and validates citationsContent events correctly', async () => {
-      // Bedrock wire format uses object-key discrimination
+    it('yields and validates citation events correctly', async () => {
+      // Bedrock streaming sends individual citation deltas with key 'citation'
+      const bedrockCitationDelta = {
+        location: { documentChar: { documentIndex: 0, start: 10, end: 50 } },
+        sourceContent: [{ text: 'source text' }],
+        source: 'doc-0',
+        title: 'Test Doc',
+      }
+
+      // Bedrock non-streaming wire format uses object-key discrimination
       const bedrockCitationsData = {
-        citations: [
-          {
-            location: { documentChar: { documentIndex: 0, start: 10, end: 50 } },
-            sourceContent: [{ text: 'source text' }],
-            source: 'doc-0',
-            title: 'Test Doc',
-          },
-        ],
+        citations: [bedrockCitationDelta],
         content: [{ text: 'generated text' }],
       }
 
@@ -991,7 +992,7 @@ describe('BedrockModel', () => {
               yield { contentBlockStart: {} }
               yield {
                 contentBlockDelta: {
-                  delta: { citationsContent: bedrockCitationsData },
+                  delta: { citation: bedrockCitationDelta },
                 },
               }
               yield { contentBlockStop: {} }
@@ -1036,7 +1037,7 @@ describe('BedrockModel', () => {
               title: 'Test Doc',
             },
           ],
-          content: [{ text: 'generated text' }],
+          content: stream ? [] : [{ text: 'generated text' }],
         },
       })
       expect(events).toContainEqual({ type: 'modelContentBlockStopEvent' })

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -40,6 +40,7 @@ import {
   type CitationLocation as BedrockCitationLocation,
   type Citation as BedrockCitation,
   type CitationsContentBlock as BedrockCitationsContentBlock,
+  type CitationsDelta as BedrockCitationsDelta,
   type GuardrailTraceAssessment,
 } from '@aws-sdk/client-bedrock-runtime'
 import {
@@ -1390,15 +1391,24 @@ export class BedrockModel extends Model<BedrockModelConfig> {
               events.push({ type: 'modelContentBlockDeltaEvent', delta: reasoningDelta })
             }
           },
-          citationsContent: (block: BedrockCitationsContentBlock): void => {
-            if (!block) return
-            const mapped = this._mapBedrockCitationsData(block)
-            const delta: CitationsDelta = {
-              type: 'citationsDelta',
-              citations: mapped.citations,
-              content: mapped.content,
-            }
-            events.push({ type: 'modelContentBlockDeltaEvent', delta })
+          citation: (citation: BedrockCitationsDelta): void => {
+            const location = citation.location ? this._mapBedrockCitationLocation(citation.location) : undefined
+            if (!location) return
+            events.push({
+              type: 'modelContentBlockDeltaEvent',
+              delta: {
+                type: 'citationsDelta',
+                citations: [
+                  {
+                    location,
+                    sourceContent: (citation.sourceContent ?? []).map((sc) => ({ text: sc.text! })),
+                    source: citation.source ?? '',
+                    title: citation.title ?? '',
+                  },
+                ],
+                content: [],
+              },
+            })
           },
         }
 

--- a/strands-ts/test/integ/agent.test.ts
+++ b/strands-ts/test/integ/agent.test.ts
@@ -400,9 +400,12 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
         expect(followUp.lastMessage.content.length).toBeGreaterThan(0)
       })
 
-      it('emits citationsDelta events via agent.stream()', async () => {
+      it.each([
+        { mode: 'non-streaming', stream: false as const },
+        { mode: 'streaming', stream: true as const },
+      ])('emits citationsDelta events in $mode mode', async ({ stream }) => {
         const agent = new Agent({
-          model: createModel({ stream: false }),
+          model: createModel({ stream }),
           printer: false,
         })
 


### PR DESCRIPTION
## Description

When streaming with `ConverseStream`, Bedrock sends citation deltas using the key `citation` (a `ContentBlockDelta.CitationMember`), but the `deltaHandlers` map only defined a `citationsContent` handler. This caused the `citation` key to hit the `else` branch and get logged as unsupported, silently dropping all streaming citations.

The `citationsContent` key is correct for the non-streaming `ContentBlock` type (used in the `Converse` API path). The streaming `ContentBlockDelta` type uses `citation` with a per-citation shape (`CitationsDelta` from the Bedrock SDK).

See [ContentBlockDelta API reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlockDelta.html) for the streaming delta type definition.

The fix renames the delta handler key to `citation` and maps from Bedrock's per-citation `CitationsDelta` shape to the SDK's internal `CitationsDelta` format.

## Related Issues

Closes #910

## Type of Change

Bug fix

## Testing

- Unit tests updated to use the correct Bedrock streaming wire format (`delta: { citation: ... }`)
- Added parametrized integration test covering both streaming and non-streaming citation paths
- Integration test passes against real Bedrock ConverseStream API

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.