### PR TITLE
feat(mcp): support url + auth fields on McpClientConfig

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -7,6 +7,8 @@ import {
   ElicitRequestSchema,
   UrlElicitationRequiredError,
 } from '@modelcontextprotocol/sdk/types.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ClientCredentialsProvider } from '@modelcontextprotocol/sdk/client/auth-extensions.js'
 import { McpClient } from '../mcp.js'
 import { McpTool } from '../tools/mcp-tool.js'
 import { JsonBlock, type TextBlock, type ToolResultBlock } from '../types/messages.js'
@@ -28,6 +30,18 @@ function createMockCallToolStream(result: unknown) {
     yield { type: 'result', result }
   }
 }
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn(function () {
+    return { start: vi.fn(), send: vi.fn(), close: vi.fn() }
+  }),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/auth-extensions.js', () => ({
+  ClientCredentialsProvider: vi.fn(function () {
+    return { redirectUrl: undefined, clientMetadata: { client_id: 'test' } }
+  }),
+}))
 
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: vi.fn(function () {
@@ -1181,5 +1195,104 @@ describe('log routing', () => {
     capturedHandler({ params })
 
     expect(customHandler).toHaveBeenCalledWith(params)
+  })
+})
+
+describe('McpClient transport resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('constructs StreamableHTTPClientTransport when url is provided', () => {
+    new McpClient({ url: 'https://mcp.example.com' })
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), undefined)
+  })
+
+  it('constructs ClientCredentialsProvider when auth is provided', () => {
+    new McpClient({ url: 'https://mcp.example.com', auth: { clientId: 'id', clientSecret: 'secret' } })
+    expect(ClientCredentialsProvider).toHaveBeenCalledWith({ clientId: 'id', clientSecret: 'secret' })
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), {
+      authProvider: expect.anything(),
+    })
+  })
+
+  it('passes scopes as space-separated string', () => {
+    new McpClient({
+      url: 'https://mcp.example.com',
+      auth: { clientId: 'id', clientSecret: 'secret', scopes: ['read', 'write'] },
+    })
+    expect(ClientCredentialsProvider).toHaveBeenCalledWith({
+      clientId: 'id',
+      clientSecret: 'secret',
+      scope: 'read write',
+    })
+  })
+
+  it('passes custom authProvider to transport', () => {
+    const customProvider = { redirectUrl: undefined, clientMetadata: {} } as never
+    new McpClient({ url: 'https://mcp.example.com', authProvider: customProvider })
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), {
+      authProvider: customProvider,
+    })
+  })
+
+  it('throws when both transport and url are provided', () => {
+    expect(() => new McpClient({ transport: mockTransport, url: 'https://mcp.example.com' } as never)).toThrow(
+      'provide either "transport" or "url", not both'
+    )
+  })
+
+  it('throws when neither transport nor url is provided', () => {
+    expect(() => new McpClient({} as never)).toThrow('either "transport" or "url" must be provided')
+  })
+
+  it('throws when auth is provided with transport', () => {
+    expect(
+      () => new McpClient({ transport: mockTransport, auth: { clientId: 'x', clientSecret: 'y' } } as never)
+    ).toThrow('"auth", "authProvider", and "headers" require "url"')
+  })
+
+  it('throws when both auth and authProvider are provided', () => {
+    const customProvider = {} as never
+    expect(
+      () =>
+        new McpClient({
+          url: 'https://mcp.example.com',
+          auth: { clientId: 'x', clientSecret: 'y' },
+          authProvider: customProvider,
+        } as never)
+    ).toThrow('provide either "auth" or "authProvider", not both')
+  })
+
+  it('accepts URL instance for url field', () => {
+    const url = new URL('https://mcp.example.com/path')
+    new McpClient({ url })
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(url, undefined)
+  })
+
+  it('passes headers as requestInit to transport', () => {
+    new McpClient({ url: 'https://mcp.example.com', headers: { 'X-Api-Key': 'abc' } })
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), {
+      requestInit: { headers: { 'X-Api-Key': 'abc' } },
+    })
+  })
+
+  it('passes both auth and headers to transport', () => {
+    new McpClient({
+      url: 'https://mcp.example.com',
+      auth: { clientId: 'id', clientSecret: 'secret' },
+      headers: { 'X-Trace': '123' },
+    })
+    expect(ClientCredentialsProvider).toHaveBeenCalledWith({ clientId: 'id', clientSecret: 'secret' })
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), {
+      authProvider: expect.anything(),
+      requestInit: { headers: { 'X-Trace': '123' } },
+    })
+  })
+
+  it('throws when headers is provided with transport', () => {
+    expect(() => new McpClient({ transport: mockTransport, headers: { 'X-Foo': 'bar' } } as never)).toThrow(
+      '"auth", "authProvider", and "headers" require "url"'
+    )
   })
 })

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -264,7 +264,14 @@ export { configureLogging } from './logging/logger.js'
 export type { Logger } from './logging/types.js'
 
 // MCP Client types and implementations
-export { type McpClientConfig, type McpTransport, type TasksConfig, type McpConnectionState, McpClient } from './mcp.js'
+export {
+  type McpClientConfig,
+  type McpClientCredentials,
+  type McpTransport,
+  type TasksConfig,
+  type McpConnectionState,
+  McpClient,
+} from './mcp.js'
 export type { ElicitationCallback, ElicitationContext } from './types/elicitation.js'
 
 // Session management

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -1,5 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ClientCredentialsProvider } from '@modelcontextprotocol/sdk/client/auth-extensions.js'
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import { takeResult } from '@modelcontextprotocol/sdk/shared/responseMessage.js'
 import {
   ElicitRequestSchema,
@@ -57,9 +60,30 @@ export interface TasksConfig {
 /** Connection state of an MCP client. */
 export type McpConnectionState = 'disconnected' | 'connected' | 'failed'
 
+/** OAuth client credentials for machine-to-machine authentication. */
+export interface McpClientCredentials {
+  clientId: string
+  clientSecret: string
+  /** OAuth scopes to request. Joined with spaces before sending to the token endpoint. */
+  scopes?: string[]
+}
+
 /** Arguments for configuring an MCP Client. */
 export type McpClientConfig = RuntimeConfig & {
-  transport: McpTransport
+  /** Pre-constructed transport. Mutually exclusive with `url`. */
+  transport?: McpTransport
+
+  /** Server URL. When provided, a StreamableHTTP transport is constructed automatically. */
+  url?: string | URL
+
+  /** Client credentials for OAuth machine-to-machine auth. Requires `url`. */
+  auth?: McpClientCredentials
+
+  /** Custom OAuth provider for advanced auth flows. Requires `url`. Mutually exclusive with `auth`. */
+  authProvider?: OAuthClientProvider
+
+  /** Custom headers to include on every request to the server. Requires `url`. */
+  headers?: Record<string, string>
 
   /** Disable OpenTelemetry MCP instrumentation. */
   disableMcpInstrumentation?: boolean
@@ -111,7 +135,7 @@ export class McpClient {
   constructor(args: McpClientConfig) {
     this._clientName = args.applicationName || 'strands-agents-ts-sdk'
     this._clientVersion = args.applicationVersion || '0.0.1'
-    this._transport = args.transport as Transport
+    this._transport = McpClient._resolveTransport(args)
     this._state = 'disconnected'
     this._failOpen = args.failOpen ?? false
     this._logHandler = args.logHandler ?? defaultLogHandler
@@ -141,6 +165,42 @@ export class McpClient {
     })
 
     this._disableMcpInstrumentation = args.disableMcpInstrumentation ?? false
+  }
+
+  private static _resolveTransport(args: McpClientConfig): Transport {
+    if (args.transport && args.url) {
+      throw new Error('McpClientConfig: provide either "transport" or "url", not both')
+    }
+    if (!args.transport && !args.url) {
+      throw new Error('McpClientConfig: either "transport" or "url" must be provided')
+    }
+    if (args.transport) {
+      if (args.auth || args.authProvider || args.headers) {
+        throw new Error(
+          'McpClientConfig: "auth", "authProvider", and "headers" require "url" (not compatible with "transport")'
+        )
+      }
+      return args.transport as Transport
+    }
+    if (args.auth && args.authProvider) {
+      throw new Error('McpClientConfig: provide either "auth" or "authProvider", not both')
+    }
+
+    const authProvider = args.auth
+      ? new ClientCredentialsProvider({
+          clientId: args.auth.clientId,
+          clientSecret: args.auth.clientSecret,
+          ...(args.auth.scopes && { scope: args.auth.scopes.join(' ') }),
+        })
+      : args.authProvider
+
+    const url = args.url instanceof URL ? args.url : new URL(args.url!)
+    return new StreamableHTTPClientTransport(
+      url,
+      authProvider || args.headers
+        ? { ...(authProvider && { authProvider }), ...(args.headers && { requestInit: { headers: args.headers } }) }
+        : undefined
+    ) as Transport
   }
 
   get client(): Client {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

## Description

`McpClient` now supports declarative connection config — `url`, `auth`, and `headers` fields — enabling authenticated MCP connections without manually setting transports and providers.
- When `url` is provided, a StreamableHTTP transport is constructed automatically — no manual transport setup required. 
- When `auth` is provided, a ClientCredentialsProvider handles OAuth token acquisition and refresh automatically via OIDC discovery. A raw `authProvider` field supports custom OAuth flows beyond client credentials (i.e. pre-acquired tokens, etc). 
- The `headers` field allows custom request headers without dropping back to manual transport construction.

```typescript
// Before: manual transport + provider wiring
const provider = new ClientCredentialsProvider({ clientId: '...', clientSecret: '...' })
const transport = new StreamableHTTPClientTransport(url, { authProvider: provider })
new McpClient({ transport })
```

```typescript
// After: OAuth with client credentials
new McpClient({ url: 'https://mcp.example.com', auth: { clientId: '...', clientSecret: '...' } })

// After: custom headers (e.g. static API keys)
new McpClient({ url: 'https://mcp.example.com', headers: { 'X-Api-Key': '...' } })

// After: custom auth provider (advanced flows)
new McpClient({ url: 'https://mcp.example.com', authProvider: myOAuthProvider })
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

#850 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

Will have a sweeping docs PR for the MCP enhancements once complete

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature (enhancement)

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
