### PR TITLE
feat(offloader): add search results tool

### DIFF
--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -574,5 +574,38 @@ describe('ContextOffloader', () => {
       expect(result).toContain('line 2')
       expect(result).toContain('line 3')
     })
+
+    it('returns first N lines when only context_lines is provided', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getRetrievalTool(plugin).invoke({
+        reference: ref,
+        context_lines: 10,
+      })) as string
+
+      expect(result).toContain('[Lines 1-10 of 20]')
+      expect(result).toContain('line 1')
+      expect(result).toContain('line 10')
+      expect(result).not.toContain('line 11')
+    })
+
+    it('returns first line when context_lines is 0', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getRetrievalTool(plugin).invoke({
+        reference: ref,
+        context_lines: 0,
+      })) as string
+
+      expect(result).toContain('[Lines 1-1 of 10]')
+      expect(result).toContain('line 1')
+      expect(result).not.toContain('line 2')
+    })
   })
 })

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -69,11 +69,12 @@ describe('ContextOffloader', () => {
       expect(agent.trackedHooks[0]!.eventType).toBe(AfterToolCallEvent)
     })
 
-    it('returns retrieval tool by default', () => {
+    it('returns retrieval and search tools by default', () => {
       const plugin = new ContextOffloader({ storage: new InMemoryStorage() })
       const tools = plugin.getTools()
-      expect(tools).toHaveLength(1)
+      expect(tools).toHaveLength(2)
       expect(tools[0]!.name).toBe('retrieve_offloaded_content')
+      expect(tools[1]!.name).toBe('search_offloaded_content')
     })
 
     it('returns empty tools when includeRetrievalTool is false', () => {
@@ -121,6 +122,23 @@ describe('ContextOffloader', () => {
       plugin.initAgent(agent)
 
       const event = makeEvent([new TextBlock('x'.repeat(1000))], { toolName: 'retrieve_offloaded_content' })
+      await invokeTrackedHook(agent, event)
+
+      expect((event.result.content[0] as TextBlock).text).toBe('x'.repeat(1000))
+    })
+
+    it('does not offload search tool results', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+        includeRetrievalTool: true,
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))], { toolName: 'search_offloaded_content' })
       await invokeTrackedHook(agent, event)
 
       expect((event.result.content[0] as TextBlock).text).toBe('x'.repeat(1000))
@@ -215,7 +233,7 @@ describe('ContextOffloader', () => {
       expect(event.result).toBe(originalResult)
     })
 
-    it('includes retrieval tool guidance when enabled', async () => {
+    it('includes search and retrieval tool guidance when enabled', async () => {
       const storage = new InMemoryStorage()
       const plugin = new ContextOffloader({
         storage,
@@ -230,6 +248,7 @@ describe('ContextOffloader', () => {
       await invokeTrackedHook(agent, event)
 
       const preview = (event.result.content[0] as TextBlock).text
+      expect(preview).toContain('search_offloaded_content')
       expect(preview).toContain('retrieve_offloaded_content')
     })
 
@@ -353,6 +372,224 @@ describe('ContextOffloader', () => {
         reference: 'nonexistent',
       })
       expect(result).toContain('Error: reference not found')
+    })
+  })
+
+  describe('search tool', () => {
+    function getSearchTool(plugin: ContextOffloader) {
+      const tools = plugin.getTools()
+      return tools[1]! as unknown as { invoke(input: unknown): Promise<unknown> }
+    }
+
+    it('finds matching lines with context', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'line 10',
+        context_lines: 2,
+      })) as string
+
+      expect(result).toContain('1 match for /line 10/')
+      expect(result).toContain('> 10| line 10')
+      expect(result).toContain('   8| line 8')
+      expect(result).toContain('  12| line 12')
+    })
+
+    it('returns line range without pattern', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        line_range: { start: 5, end: 10 },
+      })) as string
+
+      expect(result).toContain('[Lines 5-10 of 50]')
+      expect(result).toContain('  5| line 5')
+      expect(result).toContain(' 10| line 10')
+      expect(result).not.toContain('line 4')
+      expect(result).not.toContain('line 11')
+    })
+
+    it('searches within line range when both provided', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 30 }, (_, i) => `item ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'item 1',
+        line_range: { start: 10, end: 20 },
+        context_lines: 0,
+      })) as string
+
+      expect(result).toContain('in lines 10-20')
+      expect(result).toContain('> 10| item 10')
+      expect(result).toContain('> 11| item 11')
+      expect(result).not.toContain('> 1|')
+    })
+
+    it('respects custom context_lines', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'line 10',
+        context_lines: 0,
+      })) as string
+
+      expect(result).toContain('> 10| line 10')
+      expect(result).not.toContain('line 9')
+      expect(result).not.toContain('line 11')
+    })
+
+    it('returns error for binary content', async () => {
+      const storage = new InMemoryStorage()
+      const ref = await storage.store('k1', new Uint8Array([137, 80, 78, 71]), 'image/png')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'test',
+      })) as string
+
+      expect(result).toContain('Error: cannot search binary content (image/png)')
+    })
+
+    it('falls back to literal match on invalid regex', async () => {
+      const storage = new InMemoryStorage()
+      const content = 'foo (bar\nbaz\nfoo (bar again'
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'foo (bar',
+        context_lines: 0,
+      })) as string
+
+      expect(result).toContain('2 matches')
+      expect(result).toContain('> 1| foo (bar')
+      expect(result).toContain('> 3| foo (bar again')
+    })
+
+    it('returns error for missing reference', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: 'nonexistent',
+        pattern: 'test',
+      })) as string
+
+      expect(result).toContain('Error: reference not found')
+    })
+
+    it('searches JSON content', async () => {
+      const storage = new InMemoryStorage()
+      const json = JSON.stringify({ name: 'test', items: [1, 2, 3] }, null, 2)
+      const ref = await storage.store('k1', new TextEncoder().encode(json), 'application/json')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'items',
+        context_lines: 1,
+      })) as string
+
+      expect(result).toContain('1 match for /items/')
+      expect(result).toContain('items')
+    })
+
+    it('reports no matches', async () => {
+      const storage = new InMemoryStorage()
+      const content = 'hello\nworld\n'
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'nonexistent',
+      })) as string
+
+      expect(result).toContain("No matches found for pattern 'nonexistent'")
+    })
+
+    it('truncates output when too many matches', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 500 }, (_, i) => `match line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 50,
+        previewTokens: 10,
+        includeRetrievalTool: true,
+      })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'match',
+        context_lines: 0,
+      })) as string
+
+      expect(result).toContain('output truncated, narrow your search')
+      expect(result.length).toBeLessThan(content.length)
+    })
+
+    it('merges overlapping context into single group', async () => {
+      const storage = new InMemoryStorage()
+      const content = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n')
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        pattern: 'line [45]',
+        context_lines: 2,
+      })) as string
+
+      expect(result).toContain('2 matches')
+      // Lines 4 and 5 are adjacent — with context_lines=2 they should merge into one group
+      expect(result).not.toContain('---')
+    })
+
+    it('returns error when line_range.start > totalLines', async () => {
+      const storage = new InMemoryStorage()
+      const content = 'line 1\nline 2\nline 3'
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        line_range: { start: 100, end: 200 },
+      })) as string
+
+      expect(result).toContain('beyond content length (3 lines)')
+    })
+
+    it('clamps line_range.end to actual content length', async () => {
+      const storage = new InMemoryStorage()
+      const content = 'line 1\nline 2\nline 3'
+      const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
+
+      const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
+      const result = (await getSearchTool(plugin).invoke({
+        reference: ref,
+        line_range: { start: 2, end: 100 },
+      })) as string
+
+      expect(result).toContain('[Lines 2-3 of 3]')
+      expect(result).toContain('line 2')
+      expect(result).toContain('line 3')
     })
   })
 })

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -69,12 +69,11 @@ describe('ContextOffloader', () => {
       expect(agent.trackedHooks[0]!.eventType).toBe(AfterToolCallEvent)
     })
 
-    it('returns retrieval and search tools by default', () => {
+    it('returns retrieval tool by default', () => {
       const plugin = new ContextOffloader({ storage: new InMemoryStorage() })
       const tools = plugin.getTools()
-      expect(tools).toHaveLength(2)
+      expect(tools).toHaveLength(1)
       expect(tools[0]!.name).toBe('retrieve_offloaded_content')
-      expect(tools[1]!.name).toBe('search_offloaded_content')
     })
 
     it('returns empty tools when includeRetrievalTool is false', () => {
@@ -122,23 +121,6 @@ describe('ContextOffloader', () => {
       plugin.initAgent(agent)
 
       const event = makeEvent([new TextBlock('x'.repeat(1000))], { toolName: 'retrieve_offloaded_content' })
-      await invokeTrackedHook(agent, event)
-
-      expect((event.result.content[0] as TextBlock).text).toBe('x'.repeat(1000))
-    })
-
-    it('does not offload search tool results', async () => {
-      const storage = new InMemoryStorage()
-      const plugin = new ContextOffloader({
-        storage,
-        maxResultTokens: 10,
-        previewTokens: 5,
-        includeRetrievalTool: true,
-      })
-      const agent = createMockAgent()
-      plugin.initAgent(agent)
-
-      const event = makeEvent([new TextBlock('x'.repeat(1000))], { toolName: 'search_offloaded_content' })
       await invokeTrackedHook(agent, event)
 
       expect((event.result.content[0] as TextBlock).text).toBe('x'.repeat(1000))
@@ -233,7 +215,7 @@ describe('ContextOffloader', () => {
       expect(event.result).toBe(originalResult)
     })
 
-    it('includes search and retrieval tool guidance when enabled', async () => {
+    it('includes retrieval tool guidance when enabled', async () => {
       const storage = new InMemoryStorage()
       const plugin = new ContextOffloader({
         storage,
@@ -248,8 +230,9 @@ describe('ContextOffloader', () => {
       await invokeTrackedHook(agent, event)
 
       const preview = (event.result.content[0] as TextBlock).text
-      expect(preview).toContain('search_offloaded_content')
       expect(preview).toContain('retrieve_offloaded_content')
+      expect(preview).toContain('pattern')
+      expect(preview).toContain('line_range')
     })
 
     it('respects custom previewTokens', async () => {
@@ -375,10 +358,10 @@ describe('ContextOffloader', () => {
     })
   })
 
-  describe('search tool', () => {
-    function getSearchTool(plugin: ContextOffloader) {
+  describe('search via retrieval tool', () => {
+    function getRetrievalTool(plugin: ContextOffloader) {
       const tools = plugin.getTools()
-      return tools[1]! as unknown as { invoke(input: unknown): Promise<unknown> }
+      return tools[0]! as unknown as { invoke(input: unknown): Promise<unknown> }
     }
 
     it('finds matching lines with context', async () => {
@@ -387,7 +370,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'line 10',
         context_lines: 2,
@@ -405,7 +388,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         line_range: { start: 5, end: 10 },
       })) as string
@@ -423,7 +406,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'item 1',
         line_range: { start: 10, end: 20 },
@@ -442,7 +425,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'line 10',
         context_lines: 0,
@@ -458,7 +441,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new Uint8Array([137, 80, 78, 71]), 'image/png')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'test',
       })) as string
@@ -472,7 +455,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'foo (bar',
         context_lines: 0,
@@ -486,7 +469,7 @@ describe('ContextOffloader', () => {
     it('returns error for missing reference', async () => {
       const storage = new InMemoryStorage()
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: 'nonexistent',
         pattern: 'test',
       })) as string
@@ -500,7 +483,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(json), 'application/json')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'items',
         context_lines: 1,
@@ -516,7 +499,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'nonexistent',
       })) as string
@@ -535,7 +518,7 @@ describe('ContextOffloader', () => {
         previewTokens: 10,
         includeRetrievalTool: true,
       })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'match',
         context_lines: 0,
@@ -551,7 +534,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         pattern: 'line [45]',
         context_lines: 2,
@@ -568,7 +551,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         line_range: { start: 100, end: 200 },
       })) as string
@@ -582,7 +565,7 @@ describe('ContextOffloader', () => {
       const ref = await storage.store('k1', new TextEncoder().encode(content), 'text/plain')
 
       const plugin = new ContextOffloader({ storage, includeRetrievalTool: true })
-      const result = (await getSearchTool(plugin).invoke({
+      const result = (await getRetrievalTool(plugin).invoke({
         reference: ref,
         line_range: { start: 2, end: 100 },
       })) as string

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/search.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/search.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest'
+import { searchContent, isSearchableContent } from '../search.js'
+
+describe('isSearchableContent', () => {
+  it('returns true for text/* types', () => {
+    expect(isSearchableContent('text/plain')).toBe(true)
+    expect(isSearchableContent('text/html')).toBe(true)
+  })
+
+  it('returns true for application/json', () => {
+    expect(isSearchableContent('application/json')).toBe(true)
+  })
+
+  it('returns false for binary types', () => {
+    expect(isSearchableContent('image/png')).toBe(false)
+    expect(isSearchableContent('video/mp4')).toBe(false)
+    expect(isSearchableContent('application/pdf')).toBe(false)
+  })
+})
+
+describe('searchContent', () => {
+  const maxChars = 10_000
+
+  describe('empty content', () => {
+    it('returns empty message for empty string', () => {
+      expect(searchContent('', { context_lines: 5, pattern: 'x' }, maxChars)).toBe('Content is empty (0 lines).')
+    })
+
+    it('returns empty message for single empty line', () => {
+      expect(searchContent('\n', { context_lines: 5, line_range: { start: 1, end: 1 } }, maxChars)).not.toContain(
+        'Content is empty'
+      )
+    })
+  })
+
+  describe('line_range validation', () => {
+    const text = 'line 1\nline 2\nline 3\nline 4\nline 5'
+
+    it('returns error when start > end', () => {
+      const result = searchContent(text, { context_lines: 5, line_range: { start: 5, end: 2 } }, maxChars)
+      expect(result).toContain('must be <= line_range.end')
+    })
+
+    it('returns error when start > total lines', () => {
+      const result = searchContent(text, { context_lines: 5, line_range: { start: 100, end: 200 } }, maxChars)
+      expect(result).toContain('beyond content length (5 lines)')
+    })
+
+    it('clamps end to total lines', () => {
+      const result = searchContent(text, { context_lines: 5, line_range: { start: 3, end: 999 } }, maxChars)
+      expect(result).toContain('[Lines 3-5 of 5]')
+      expect(result).toContain('line 3')
+      expect(result).toContain('line 5')
+    })
+  })
+
+  describe('pattern search', () => {
+    const text = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')
+
+    it('finds a single match with context', () => {
+      const result = searchContent(text, { pattern: 'line 10', context_lines: 2 }, maxChars)
+      expect(result).toContain('[1 match for /line 10/]')
+      expect(result).toContain('> 10| line 10')
+      expect(result).toContain('   8| line 8')
+      expect(result).toContain('  12| line 12')
+      expect(result).not.toContain('line 7')
+    })
+
+    it('finds multiple matches', () => {
+      const result = searchContent(text, { pattern: 'line [12]0', context_lines: 0 }, maxChars)
+      expect(result).toContain('2 matches')
+      expect(result).toContain('> 10| line 10')
+      expect(result).toContain('> 20| line 20')
+    })
+
+    it('returns no-match message when pattern not found', () => {
+      const result = searchContent(text, { pattern: 'nonexistent', context_lines: 5 }, maxChars)
+      expect(result).toContain("No matches found for pattern 'nonexistent'")
+      expect(result).toContain('searched 20 lines')
+    })
+
+    it('uses context_lines: 0 for no context', () => {
+      const result = searchContent(text, { pattern: 'line 5', context_lines: 0 }, maxChars)
+      expect(result).toContain('> 5| line 5')
+      expect(result).not.toContain('line 4')
+      expect(result).not.toContain('line 6')
+    })
+
+    it('merges overlapping context into one group', () => {
+      const result = searchContent(text, { pattern: 'line [67]', context_lines: 2 }, maxChars)
+      expect(result).toContain('2 matches')
+      expect(result).not.toContain('---')
+    })
+
+    it('separates non-overlapping groups with ---', () => {
+      const result = searchContent(text, { pattern: 'line (1|20)', context_lines: 0 }, maxChars)
+      expect(result).toContain('---')
+    })
+
+    it('falls back to literal match on invalid regex', () => {
+      const text = 'foo (bar\nbaz\nfoo (bar again'
+      const result = searchContent(text, { pattern: 'foo (bar', context_lines: 0 }, maxChars)
+      expect(result).toContain('2 matches')
+      expect(result).toContain('> 1| foo (bar')
+      expect(result).toContain('> 3| foo (bar again')
+    })
+
+    it('sanitizes pattern in header', () => {
+      const text = 'test line\nanother line'
+      const result = searchContent(text, { pattern: 'test]\nline', context_lines: 0 }, maxChars)
+      // The header should not contain raw ] or newlines
+      const header = result.split('\n')[0]!
+      expect(header).not.toContain(']/')
+      expect(header).not.toContain('\n')
+    })
+  })
+
+  describe('pattern search with line_range', () => {
+    const text = Array.from({ length: 30 }, (_, i) => `item ${i + 1}`).join('\n')
+
+    it('searches only within the specified range', () => {
+      const result = searchContent(
+        text,
+        { pattern: 'item 1', line_range: { start: 10, end: 20 }, context_lines: 0 },
+        maxChars
+      )
+      expect(result).toContain('in lines 10-20')
+      expect(result).toContain('> 10| item 10')
+      expect(result).toContain('> 11| item 11')
+      expect(result).not.toContain('> 1|')
+    })
+
+    it('reports no matches within range', () => {
+      const result = searchContent(
+        text,
+        { pattern: 'item 5', line_range: { start: 10, end: 20 }, context_lines: 0 },
+        maxChars
+      )
+      expect(result).toContain('No matches found')
+      expect(result).toContain('in lines 10-20')
+    })
+  })
+
+  describe('line range (no pattern)', () => {
+    const text = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n')
+
+    it('returns specified range with header', () => {
+      const result = searchContent(text, { line_range: { start: 5, end: 10 }, context_lines: 5 }, maxChars)
+      expect(result).toContain('[Lines 5-10 of 50]')
+      expect(result).toContain('  5| line 5')
+      expect(result).toContain(' 10| line 10')
+    })
+
+    it('does not show lines outside range', () => {
+      const result = searchContent(text, { line_range: { start: 5, end: 10 }, context_lines: 5 }, maxChars)
+      expect(result).not.toContain('line 4')
+      expect(result).not.toContain('line 11')
+    })
+
+    it('does not include --- separators for contiguous lines', () => {
+      const result = searchContent(text, { line_range: { start: 1, end: 10 }, context_lines: 5 }, maxChars)
+      expect(result).not.toContain('---')
+    })
+  })
+
+  describe('truncation', () => {
+    it('truncates pattern results when output exceeds maxChars', () => {
+      const text = Array.from({ length: 500 }, (_, i) => `match line ${i + 1}`).join('\n')
+      const result = searchContent(text, { pattern: 'match', context_lines: 0 }, 200)
+      expect(result).toContain('output truncated, narrow your search')
+      expect(result.length).toBeLessThanOrEqual(250) // 200 + truncation message
+    })
+
+    it('truncates line range results when output exceeds maxChars', () => {
+      const text = Array.from({ length: 500 }, (_, i) => `line ${i + 1}`).join('\n')
+      const result = searchContent(text, { line_range: { start: 1, end: 500 }, context_lines: 5 }, 200)
+      expect(result).toContain('output truncated, narrow your range')
+      expect(result.length).toBeLessThanOrEqual(250)
+    })
+
+    it('does not truncate when output fits within maxChars', () => {
+      const text = 'short\ncontent'
+      const result = searchContent(text, { line_range: { start: 1, end: 2 }, context_lines: 5 }, maxChars)
+      expect(result).not.toContain('truncated')
+    })
+  })
+})

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -170,7 +170,8 @@ export class ContextOffloader implements Plugin {
     return tool({
       name: RETRIEVAL_TOOL_NAME,
       description:
-        'Access offloaded content by reference. Use when you see an offload placeholder with a reference.\n\n' +
+        'When a tool result was too large to keep in context, it was stored externally and replaced with a preview and a reference. ' +
+        'Use this tool with that reference to access the stored content.\n\n' +
         'Returns:\n' +
         '  - With pattern: matching lines with line numbers and surrounding context\n' +
         '  - With line_range: the specified span of lines with line numbers\n' +
@@ -198,9 +199,14 @@ export class ContextOffloader implements Plugin {
 
           const text = new TextDecoder().decode(result.content)
           const contextLines = input.context_lines ?? 5
-          const lineRange = input.line_range ?? (!input.pattern ? { start: 1, end: Math.max(1, contextLines) } : undefined)
+          const lineRange =
+            input.line_range ?? (!input.pattern ? { start: 1, end: Math.max(1, contextLines) } : undefined)
 
-          return searchContent(text, { pattern: input.pattern, line_range: lineRange, context_lines: contextLines }, maxChars)
+          return searchContent(
+            text,
+            { pattern: input.pattern, line_range: lineRange, context_lines: contextLines },
+            maxChars
+          )
         } catch {
           return `Error: reference not found: ${input.reference}`
         }

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -17,29 +17,27 @@ const CHARS_PER_TOKEN = 4
 const DEFAULT_MAX_RESULT_TOKENS = 2_500
 const DEFAULT_PREVIEW_TOKENS = 1_000
 const RETRIEVAL_TOOL_NAME = 'retrieve_offloaded_content'
-const SEARCH_TOOL_NAME = 'search_offloaded_content'
 
-const searchInputSchema = z
-  .object({
-    reference: z.string().describe('The storage reference from the offload placeholder.'),
-    pattern: z.string().optional().describe('Regex or keyword pattern to search for in the content.'),
-    line_range: z
-      .object({
-        start: z.number().int().min(1).describe('Start line number (1-indexed, inclusive).'),
-        end: z.number().int().min(1).describe('End line number (1-indexed, inclusive).'),
-      })
-      .optional()
-      .describe('Range of lines to retrieve (1-indexed, inclusive).'),
-    context_lines: z
-      .number()
-      .int()
-      .min(0)
-      .default(5)
-      .describe('Number of lines of context before/after each match. Defaults to 5.'),
-  })
-  .refine((data) => data.pattern !== undefined || data.line_range !== undefined, {
-    message: "At least one of 'pattern' or 'line_range' must be provided.",
-  })
+const retrievalInputSchema = z.object({
+  reference: z.string().describe('The storage reference from the offload placeholder.'),
+  pattern: z
+    .string()
+    .optional()
+    .describe('Regex or keyword pattern to search for. Returns matching lines with context instead of full content.'),
+  line_range: z
+    .object({
+      start: z.number().int().min(1).describe('Start line number (1-indexed, inclusive).'),
+      end: z.number().int().min(1).describe('End line number (1-indexed, inclusive).'),
+    })
+    .optional()
+    .describe('Range of lines to retrieve (1-indexed, inclusive). Returns only this span instead of full content.'),
+  context_lines: z
+    .number()
+    .int()
+    .min(0)
+    .default(5)
+    .describe('Number of lines of context before/after each match. Only used with pattern. Defaults to 5.'),
+})
 
 function slicePreview(text: string, previewTokens: number): string {
   const maxChars = previewTokens * CHARS_PER_TOKEN
@@ -109,7 +107,7 @@ export interface ContextOffloaderConfig {
   maxResultTokens?: number
   /** Number of tokens to keep as an inline preview. Defaults to 1,000. */
   previewTokens?: number
-  /** Whether to register the `retrieve_offloaded_content` and `search_offloaded_content` tools. Defaults to true. */
+  /** Whether to register the `retrieve_offloaded_content` tool. Defaults to true. */
   includeRetrievalTool?: boolean
 }
 
@@ -138,7 +136,6 @@ export class ContextOffloader implements Plugin {
   private readonly _previewTokens: number
   private readonly _includeRetrievalTool: boolean
   private _retrievalTool: Tool | undefined
-  private _searchTool: Tool | undefined
 
   constructor(config: ContextOffloaderConfig) {
     const maxResultTokens = config.maxResultTokens ?? DEFAULT_MAX_RESULT_TOKENS
@@ -161,51 +158,39 @@ export class ContextOffloader implements Plugin {
   getTools(): Tool[] {
     if (!this._includeRetrievalTool) return []
     if (!this._retrievalTool) this._retrievalTool = this._createRetrievalTool()
-    if (!this._searchTool) this._searchTool = this._createSearchTool()
-    return [this._retrievalTool, this._searchTool]
+    return [this._retrievalTool]
   }
 
   private _createRetrievalTool(): Tool {
     const storage = this._storage
-    return tool({
-      name: RETRIEVAL_TOOL_NAME,
-      description:
-        'Retrieve offloaded content by reference. Use this tool when you see a placeholder with a reference (ref: ...) and need the full content. Only use this as a fallback if the data cannot be accessed using your existing tools.',
-      inputSchema: z.object({
-        reference: z.string().describe('The reference string from the offload placeholder.'),
-      }),
-      callback: async (input) => {
-        try {
-          const result = await storage.retrieve(input.reference)
-          return decodeStoredContent(result.content, result.contentType, input.reference)
-        } catch {
-          return `Error: reference not found: ${input.reference}`
-        }
-      },
-    })
-  }
-
-  private _createSearchTool(): Tool {
-    const storage = this._storage
     const maxChars = this._maxResultTokens * CHARS_PER_TOKEN
 
     return tool({
-      name: SEARCH_TOOL_NAME,
+      name: RETRIEVAL_TOOL_NAME,
       description:
-        'Search offloaded content by reference. When a tool result was too large and got offloaded, ' +
-        'use this to find specific information without loading the full content back into context. ' +
-        'Provide a regex/keyword pattern to grep for matching lines (returned with surrounding context), ' +
-        'or a line_range to read a specific span of lines. You can combine both to search within a range. ' +
-        'Line numbers in results can be used in follow-up line_range calls for deeper exploration.',
-      inputSchema: searchInputSchema,
+        'Retrieve offloaded content by reference. Use this when you see a placeholder with a reference (ref: ...). ' +
+        'Prefer using pattern or line_range to retrieve only what you need — this avoids loading the full content back into context. ' +
+        'Only omit pattern/line_range as a last resort when you truly need the entire content. ' +
+        'Line numbers in search results can be used in follow-up line_range calls for deeper exploration.\n\n' +
+        'Examples:\n' +
+        '  - { reference: "ref_1", pattern: "error" } — find lines containing "error"\n' +
+        '  - { reference: "ref_1", pattern: "function\\\\s+\\\\w+", context_lines: 3 } — regex search with 3 lines context\n' +
+        '  - { reference: "ref_1", line_range: { start: 10, end: 25 } } — read lines 10-25\n' +
+        '  - { reference: "ref_1", pattern: "TODO", line_range: { start: 1, end: 50 } } — search within a range',
+      inputSchema: retrievalInputSchema,
       callback: async (input) => {
         try {
           const result = await storage.retrieve(input.reference)
-          if (!isSearchableContent(result.contentType)) {
-            return `Error: cannot search binary content (${result.contentType}). Use retrieve_offloaded_content for binary data.`
+
+          if (input.pattern || input.line_range) {
+            if (!isSearchableContent(result.contentType)) {
+              return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range to retrieve the full content.`
+            }
+            const text = new TextDecoder().decode(result.content)
+            return searchContent(text, input, maxChars)
           }
-          const text = new TextDecoder().decode(result.content)
-          return searchContent(text, input, maxChars)
+
+          return decodeStoredContent(result.content, result.contentType, input.reference)
         } catch {
           return `Error: reference not found: ${input.reference}`
         }
@@ -262,10 +247,10 @@ export class ContextOffloader implements Plugin {
       'Tool result was offloaded to external storage due to size.\n' + 'Use the preview below to answer if possible.\n'
     if (this._includeRetrievalTool) {
       guidance +=
-        'Use search_offloaded_content with a reference and either:\n' +
+        'Use retrieve_offloaded_content with a reference and either:\n' +
         '  - pattern: regex or keyword to find matching lines with context\n' +
         '  - line_range: { start, end } to read a specific span of lines\n' +
-        'You can also use retrieve_offloaded_content to get the full content as a fallback.'
+        'Only retrieve the full content (omit pattern/line_range) as a last resort.'
     } else {
       guidance += 'Use your available tools to selectively access the data you need.'
     }
@@ -281,12 +266,8 @@ export class ContextOffloader implements Plugin {
   private async _handleToolResult(event: AfterToolCallEvent): Promise<void> {
     if (event.result.status === 'error') return
 
-    // Skip results from retrieval/search tools to prevent circular offloading
-    if (
-      this._includeRetrievalTool &&
-      (event.toolUse.name === RETRIEVAL_TOOL_NAME || event.toolUse.name === SEARCH_TOOL_NAME)
-    )
-      return
+    // Skip results from the retrieval tool to prevent circular offloading
+    if (this._includeRetrievalTool && event.toolUse.name === RETRIEVAL_TOOL_NAME) return
 
     const content = event.result.content
     const toolUseId = event.result.toolUseId

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -11,11 +11,35 @@ import { z } from 'zod'
 import { logger } from '../../logging/logger.js'
 import type { JSONValue } from '../../types/json.js'
 import type { Storage } from './storage.js'
+import { isSearchableContent, searchContent } from './search.js'
 
 const CHARS_PER_TOKEN = 4
 const DEFAULT_MAX_RESULT_TOKENS = 2_500
 const DEFAULT_PREVIEW_TOKENS = 1_000
 const RETRIEVAL_TOOL_NAME = 'retrieve_offloaded_content'
+const SEARCH_TOOL_NAME = 'search_offloaded_content'
+
+const searchInputSchema = z
+  .object({
+    reference: z.string().describe('The storage reference from the offload placeholder.'),
+    pattern: z.string().optional().describe('Regex or keyword pattern to search for in the content.'),
+    line_range: z
+      .object({
+        start: z.number().int().min(1).describe('Start line number (1-indexed, inclusive).'),
+        end: z.number().int().min(1).describe('End line number (1-indexed, inclusive).'),
+      })
+      .optional()
+      .describe('Range of lines to retrieve (1-indexed, inclusive).'),
+    context_lines: z
+      .number()
+      .int()
+      .min(0)
+      .default(5)
+      .describe('Number of lines of context before/after each match. Defaults to 5.'),
+  })
+  .refine((data) => data.pattern !== undefined || data.line_range !== undefined, {
+    message: "At least one of 'pattern' or 'line_range' must be provided.",
+  })
 
 function slicePreview(text: string, previewTokens: number): string {
   const maxChars = previewTokens * CHARS_PER_TOKEN
@@ -85,7 +109,7 @@ export interface ContextOffloaderConfig {
   maxResultTokens?: number
   /** Number of tokens to keep as an inline preview. Defaults to 1,000. */
   previewTokens?: number
-  /** Whether to register the `retrieve_offloaded_content` tool. Defaults to true. */
+  /** Whether to register the `retrieve_offloaded_content` and `search_offloaded_content` tools. Defaults to true. */
   includeRetrievalTool?: boolean
 }
 
@@ -114,6 +138,7 @@ export class ContextOffloader implements Plugin {
   private readonly _previewTokens: number
   private readonly _includeRetrievalTool: boolean
   private _retrievalTool: Tool | undefined
+  private _searchTool: Tool | undefined
 
   constructor(config: ContextOffloaderConfig) {
     const maxResultTokens = config.maxResultTokens ?? DEFAULT_MAX_RESULT_TOKENS
@@ -135,10 +160,9 @@ export class ContextOffloader implements Plugin {
 
   getTools(): Tool[] {
     if (!this._includeRetrievalTool) return []
-    if (!this._retrievalTool) {
-      this._retrievalTool = this._createRetrievalTool()
-    }
-    return [this._retrievalTool]
+    if (!this._retrievalTool) this._retrievalTool = this._createRetrievalTool()
+    if (!this._searchTool) this._searchTool = this._createSearchTool()
+    return [this._retrievalTool, this._searchTool]
   }
 
   private _createRetrievalTool(): Tool {
@@ -154,6 +178,34 @@ export class ContextOffloader implements Plugin {
         try {
           const result = await storage.retrieve(input.reference)
           return decodeStoredContent(result.content, result.contentType, input.reference)
+        } catch {
+          return `Error: reference not found: ${input.reference}`
+        }
+      },
+    })
+  }
+
+  private _createSearchTool(): Tool {
+    const storage = this._storage
+    const maxChars = this._maxResultTokens * CHARS_PER_TOKEN
+
+    return tool({
+      name: SEARCH_TOOL_NAME,
+      description:
+        'Search offloaded content by reference. When a tool result was too large and got offloaded, ' +
+        'use this to find specific information without loading the full content back into context. ' +
+        'Provide a regex/keyword pattern to grep for matching lines (returned with surrounding context), ' +
+        'or a line_range to read a specific span of lines. You can combine both to search within a range. ' +
+        'Line numbers in results can be used in follow-up line_range calls for deeper exploration.',
+      inputSchema: searchInputSchema,
+      callback: async (input) => {
+        try {
+          const result = await storage.retrieve(input.reference)
+          if (!isSearchableContent(result.contentType)) {
+            return `Error: cannot search binary content (${result.contentType}). Use retrieve_offloaded_content for binary data.`
+          }
+          const text = new TextDecoder().decode(result.content)
+          return searchContent(text, input, maxChars)
         } catch {
           return `Error: reference not found: ${input.reference}`
         }
@@ -207,11 +259,15 @@ export class ContextOffloader implements Plugin {
       .join('\n')
 
     let guidance =
-      'Tool result was offloaded to external storage due to size.\n' +
-      'Use the preview below to answer if possible.\n' +
-      'Use your available tools to selectively access the data you need.'
+      'Tool result was offloaded to external storage due to size.\n' + 'Use the preview below to answer if possible.\n'
     if (this._includeRetrievalTool) {
-      guidance += '\nYou can also use retrieve_offloaded_content with a reference to get the full content.'
+      guidance +=
+        'Use search_offloaded_content with a reference and either:\n' +
+        '  - pattern: regex or keyword to find matching lines with context\n' +
+        '  - line_range: { start, end } to read a specific span of lines\n' +
+        'You can also use retrieve_offloaded_content to get the full content as a fallback.'
+    } else {
+      guidance += 'Use your available tools to selectively access the data you need.'
     }
 
     return (
@@ -225,8 +281,12 @@ export class ContextOffloader implements Plugin {
   private async _handleToolResult(event: AfterToolCallEvent): Promise<void> {
     if (event.result.status === 'error') return
 
-    // Skip results from the retrieval tool to prevent circular offloading
-    if (this._includeRetrievalTool && event.toolUse.name === RETRIEVAL_TOOL_NAME) return
+    // Skip results from retrieval/search tools to prevent circular offloading
+    if (
+      this._includeRetrievalTool &&
+      (event.toolUse.name === RETRIEVAL_TOOL_NAME || event.toolUse.name === SEARCH_TOOL_NAME)
+    )
+      return
 
     const content = event.result.content
     const toolUseId = event.result.toolUseId

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -19,25 +19,25 @@ const DEFAULT_PREVIEW_TOKENS = 1_000
 const RETRIEVAL_TOOL_NAME = 'retrieve_offloaded_content'
 
 const retrievalInputSchema = z.object({
-  reference: z.string().describe('The storage reference from the offload placeholder.'),
+  reference: z.string().describe('The reference string from the offload placeholder (e.g. "mem_1_tool-123_0").'),
   pattern: z
     .string()
     .optional()
-    .describe('Regex or keyword pattern to search for. Returns matching lines with context instead of full content.'),
+    .describe('Regex or keyword to grep for. Returns only matching lines with context — not the full content.'),
   line_range: z
     .object({
-      start: z.number().int().min(1).describe('Start line number (1-indexed, inclusive).'),
-      end: z.number().int().min(1).describe('End line number (1-indexed, inclusive).'),
+      start: z.number().int().min(1).describe('First line to return (1-indexed).'),
+      end: z.number().int().min(1).describe('Last line to return (1-indexed).'),
     })
     .optional()
-    .describe('Range of lines to retrieve (1-indexed, inclusive). Returns only this span instead of full content.'),
+    .describe('Return only this span of lines. Combine with pattern to search within the range.'),
   context_lines: z
     .number()
     .int()
     .min(0)
     .optional()
     .describe(
-      'Lines to show before AND after each match, like grep -C (default: 5). When provided without pattern or line_range, returns the first N lines.'
+      'Lines before AND after each match (like grep -C). Default: 5. Without pattern/line_range, returns first N lines.'
     ),
 })
 
@@ -170,16 +170,19 @@ export class ContextOffloader implements Plugin {
     return tool({
       name: RETRIEVAL_TOOL_NAME,
       description:
-        'Retrieve offloaded content by reference. Use this when you see a placeholder with a reference (ref: ...). ' +
-        'Prefer using pattern or line_range to retrieve only what you need — this avoids loading the full content back into context. ' +
-        'Only omit pattern/line_range as a last resort when you truly need the entire content. ' +
-        'Search params only work on text content — omit them for binary. ' +
-        'Line numbers in search results can be used in follow-up line_range calls for deeper exploration.\n\n' +
+        'Access offloaded content by reference. Use when you see an offload placeholder with a reference.\n\n' +
+        'Returns:\n' +
+        '  - With pattern: matching lines with line numbers and surrounding context\n' +
+        '  - With line_range: the specified span of lines with line numbers\n' +
+        '  - Without pattern/line_range: the full original content (use sparingly — re-injects all tokens)\n\n' +
+        'Constraints:\n' +
+        '  - pattern/line_range/context_lines only work on text content. For binary content, omit them.\n' +
+        '  - Line numbers in results are 1-indexed and can be used in follow-up line_range calls.\n\n' +
         'Examples:\n' +
-        '  - { reference: "ref_1", pattern: "error" } — find lines containing "error"\n' +
-        '  - { reference: "ref_1", pattern: "error|warning", context_lines: 3 } — regex search with 3 lines context\n' +
-        '  - { reference: "ref_1", line_range: { start: 10, end: 25 } } — read lines 10-25\n' +
-        '  - { reference: "ref_1", pattern: "TODO", line_range: { start: 1, end: 50 } } — search within a range',
+        '  { reference: "ref_1", pattern: "error" } → lines containing "error" with 5 lines context\n' +
+        '  { reference: "ref_1", pattern: "error|warning", context_lines: 3 } → regex, 3 lines context\n' +
+        '  { reference: "ref_1", line_range: { start: 10, end: 25 } } → lines 10-25\n' +
+        '  { reference: "ref_1", pattern: "TODO", line_range: { start: 1, end: 50 } } → search within range',
       inputSchema: retrievalInputSchema,
       callback: async (input) => {
         try {

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -35,8 +35,10 @@ const retrievalInputSchema = z.object({
     .number()
     .int()
     .min(0)
-    .default(5)
-    .describe('Number of lines of context before/after each match. Only used with pattern. Defaults to 5.'),
+    .optional()
+    .describe(
+      'Lines of context around each match (default: 5). When provided without pattern or line_range, returns the first N lines.'
+    ),
 })
 
 function slicePreview(text: string, previewTokens: number): string {
@@ -174,20 +176,25 @@ export class ContextOffloader implements Plugin {
         'Line numbers in search results can be used in follow-up line_range calls for deeper exploration.\n\n' +
         'Examples:\n' +
         '  - { reference: "ref_1", pattern: "error" } — find lines containing "error"\n' +
-        '  - { reference: "ref_1", pattern: "function\\\\s+\\\\w+", context_lines: 3 } — regex search with 3 lines context\n' +
+        '  - { reference: "ref_1", pattern: "error|warning", context_lines: 3 } — regex search with 3 lines context\n' +
         '  - { reference: "ref_1", line_range: { start: 10, end: 25 } } — read lines 10-25\n' +
         '  - { reference: "ref_1", pattern: "TODO", line_range: { start: 1, end: 50 } } — search within a range',
       inputSchema: retrievalInputSchema,
       callback: async (input) => {
         try {
           const result = await storage.retrieve(input.reference)
+          const contextLines = input.context_lines ?? 5
 
-          if (input.pattern || input.line_range) {
+          if (input.pattern || input.line_range || input.context_lines !== undefined) {
             if (!isSearchableContent(result.contentType)) {
-              return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range to retrieve the full content.`
+              return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range/context_lines to retrieve the full content.`
             }
             const text = new TextDecoder().decode(result.content)
-            return searchContent(text, input, maxChars)
+            if (!input.pattern && !input.line_range) {
+              const end = Math.max(1, contextLines)
+              return searchContent(text, { context_lines: contextLines, line_range: { start: 1, end } }, maxChars)
+            }
+            return searchContent(text, { ...input, context_lines: contextLines }, maxChars)
           }
 
           return decodeStoredContent(result.content, result.contentType, input.reference)

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -37,7 +37,7 @@ const retrievalInputSchema = z.object({
     .min(0)
     .optional()
     .describe(
-      'Lines of context around each match (default: 5). When provided without pattern or line_range, returns the first N lines.'
+      'Lines to show before AND after each match, like grep -C (default: 5). When provided without pattern or line_range, returns the first N lines.'
     ),
 })
 
@@ -173,6 +173,7 @@ export class ContextOffloader implements Plugin {
         'Retrieve offloaded content by reference. Use this when you see a placeholder with a reference (ref: ...). ' +
         'Prefer using pattern or line_range to retrieve only what you need — this avoids loading the full content back into context. ' +
         'Only omit pattern/line_range as a last resort when you truly need the entire content. ' +
+        'Search params only work on text content — omit them for binary. ' +
         'Line numbers in search results can be used in follow-up line_range calls for deeper exploration.\n\n' +
         'Examples:\n' +
         '  - { reference: "ref_1", pattern: "error" } — find lines containing "error"\n' +
@@ -183,21 +184,20 @@ export class ContextOffloader implements Plugin {
       callback: async (input) => {
         try {
           const result = await storage.retrieve(input.reference)
-          const contextLines = input.context_lines ?? 5
 
-          if (input.pattern || input.line_range || input.context_lines !== undefined) {
-            if (!isSearchableContent(result.contentType)) {
-              return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range/context_lines to retrieve the full content.`
-            }
-            const text = new TextDecoder().decode(result.content)
-            if (!input.pattern && !input.line_range) {
-              const end = Math.max(1, contextLines)
-              return searchContent(text, { context_lines: contextLines, line_range: { start: 1, end } }, maxChars)
-            }
-            return searchContent(text, { ...input, context_lines: contextLines }, maxChars)
+          if (!input.pattern && !input.line_range && input.context_lines === undefined) {
+            return decodeStoredContent(result.content, result.contentType, input.reference)
           }
 
-          return decodeStoredContent(result.content, result.contentType, input.reference)
+          if (!isSearchableContent(result.contentType)) {
+            return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range/context_lines to retrieve the full content.`
+          }
+
+          const text = new TextDecoder().decode(result.content)
+          const contextLines = input.context_lines ?? 5
+          const lineRange = input.line_range ?? (!input.pattern ? { start: 1, end: Math.max(1, contextLines) } : undefined)
+
+          return searchContent(text, { pattern: input.pattern, line_range: lineRange, context_lines: contextLines }, maxChars)
         } catch {
           return `Error: reference not found: ${input.reference}`
         }
@@ -251,15 +251,16 @@ export class ContextOffloader implements Plugin {
       .join('\n')
 
     let guidance =
-      'Tool result was offloaded to external storage due to size.\n' + 'Use the preview below to answer if possible.\n'
+      'Tool result was offloaded to external storage due to size.\n' +
+      'Use the preview below if it answers your question.\n'
     if (this._includeRetrievalTool) {
       guidance +=
-        'Use retrieve_offloaded_content with a reference and either:\n' +
+        'If you need more detail, use retrieve_offloaded_content with a reference and:\n' +
         '  - pattern: regex or keyword to find matching lines with context\n' +
         '  - line_range: { start, end } to read a specific span of lines\n' +
-        'Only retrieve the full content (omit pattern/line_range) as a last resort.'
+        'Retrieve full content (omit pattern/line_range) as a last resort.'
     } else {
-      guidance += 'Use your available tools to selectively access the data you need.'
+      guidance += 'If you need more detail, use your available tools to access specific data.'
     }
 
     return (

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -30,6 +30,8 @@ function formatLines(lines: string[], indices: number[], matchedSet: Set<number>
   return output.join('\n')
 }
 
+// Mitigates ReDoS from overly long patterns. Short pathological patterns (e.g. `(a+)+$`)
+// are still possible but unlikely since the agent provides the pattern, not end users.
 const MAX_PATTERN_LENGTH = 200
 
 /** Finds lines matching a pattern, expands with context, and formats with truncation. */

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -10,9 +10,9 @@ function truncate(output: string, maxChars: number, message: string): string {
   if (output.length <= maxChars) return output
 
   const cut = output.lastIndexOf('\n', maxChars)
-  if (cut <= 0) return output
+  const sliceEnd = cut > 0 ? cut : maxChars
 
-  return output.slice(0, cut) + `\n\n[${message}]`
+  return output.slice(0, sliceEnd) + `\n\n[${message}]`
 }
 
 /** Formats line indices with line numbers, `>` prefixes for matches, and `---` separators for gaps. */
@@ -30,6 +30,8 @@ function formatLines(lines: string[], indices: number[], matchedSet: Set<number>
   return output.join('\n')
 }
 
+const MAX_PATTERN_LENGTH = 200
+
 /** Finds lines matching a pattern, expands with context, and formats with truncation. */
 function searchByPattern(
   lines: string[],
@@ -41,10 +43,14 @@ function searchByPattern(
   scopeLabel: string
 ): string {
   let regex: RegExp
+  const safeInput =
+    pattern.length > MAX_PATTERN_LENGTH
+      ? pattern.slice(0, MAX_PATTERN_LENGTH).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      : pattern
   try {
-    regex = new RegExp(pattern)
+    regex = new RegExp(safeInput)
   } catch {
-    regex = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    regex = new RegExp(safeInput.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
   }
 
   const matchedSet = new Set<number>()
@@ -63,7 +69,7 @@ function searchByPattern(
     }
   }
 
-  const safePattern = pattern.replace(/[\n\r\]]/g, ' ')
+  const safePattern = pattern.replace(/[\n\r/\]]/g, ' ').slice(0, 50)
   const header = `[${matchedSet.size} match${matchedSet.size > 1 ? 'es' : ''} for /${safePattern}/${scopeLabel}]`
   const body = formatLines(
     lines,
@@ -81,9 +87,22 @@ function searchByLineRange(lines: string[], start: number, end: number, totalLin
   return truncate(`${header}\n\n${body}`, maxChars, 'output truncated, narrow your range')
 }
 
+const TEXT_APPLICATION_TYPES = new Set([
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/typescript',
+  'application/yaml',
+  'application/x-yaml',
+  'application/toml',
+  'application/sql',
+  'application/graphql',
+  'application/xhtml+xml',
+])
+
 /** Returns whether the given MIME content type can be searched as text. */
 export function isSearchableContent(contentType: string): boolean {
-  return contentType.startsWith('text/') || contentType === 'application/json'
+  return contentType.startsWith('text/') || TEXT_APPLICATION_TYPES.has(contentType)
 }
 
 /**

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -1,0 +1,132 @@
+/**
+ * Search and formatting utilities for offloaded content.
+ *
+ * Provides grep-like pattern matching and line-range random access over stored
+ * text content, with output capped to a character budget.
+ */
+
+/** Cuts output at the last newline before {@link maxChars} and appends a truncation message. */
+function truncate(output: string, maxChars: number, message: string): string {
+  if (output.length <= maxChars) return output
+
+  const cut = output.lastIndexOf('\n', maxChars)
+  if (cut <= 0) return output
+
+  return output.slice(0, cut) + `\n\n[${message}]`
+}
+
+/** Formats line indices with line numbers, `>` prefixes for matches, and `---` separators for gaps. */
+function formatLines(lines: string[], indices: number[], matchedSet: Set<number>): string {
+  if (indices.length === 0) return ''
+  const padWidth = String(indices[indices.length - 1]! + 1).length
+  const output: string[] = []
+  for (let i = 0; i < indices.length; i++) {
+    const idx = indices[i]!
+    if (i > 0 && idx > indices[i - 1]! + 1) output.push('---')
+    const lineNum = String(idx + 1).padStart(padWidth)
+    const prefix = matchedSet.has(idx) ? '>' : ' '
+    output.push(`${prefix} ${lineNum}| ${lines[idx]}`)
+  }
+  return output.join('\n')
+}
+
+/** Finds lines matching a pattern, expands with context, and formats with truncation. */
+function searchByPattern(
+  lines: string[],
+  pattern: string,
+  scopeStart: number,
+  scopeEnd: number,
+  contextLines: number,
+  maxChars: number,
+  scopeLabel: string
+): string {
+  let regex: RegExp
+  try {
+    regex = new RegExp(pattern)
+  } catch {
+    regex = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  }
+
+  const matchedSet = new Set<number>()
+  for (let i = scopeStart; i <= scopeEnd; i++) {
+    if (regex.test(lines[i]!)) matchedSet.add(i)
+  }
+
+  if (matchedSet.size === 0) {
+    return `No matches found for pattern '${pattern}'${scopeLabel} (searched ${scopeEnd - scopeStart + 1} lines).`
+  }
+
+  const visible = new Set<number>()
+  for (const idx of matchedSet) {
+    for (let i = Math.max(scopeStart, idx - contextLines); i <= Math.min(scopeEnd, idx + contextLines); i++) {
+      visible.add(i)
+    }
+  }
+
+  const safePattern = pattern.replace(/[\n\r\]]/g, ' ')
+  const header = `[${matchedSet.size} match${matchedSet.size > 1 ? 'es' : ''} for /${safePattern}/${scopeLabel}]`
+  const body = formatLines(
+    lines,
+    [...visible].sort((a, b) => a - b),
+    matchedSet
+  )
+  return truncate(`${header}\n\n${body}`, maxChars, 'output truncated, narrow your search')
+}
+
+/** Formats a contiguous range of lines with truncation. */
+function searchByLineRange(lines: string[], start: number, end: number, totalLines: number, maxChars: number): string {
+  const indices = Array.from({ length: end - start + 1 }, (_, i) => start + i)
+  const header = `[Lines ${start + 1}-${end + 1} of ${totalLines}]`
+  const body = formatLines(lines, indices, new Set())
+  return truncate(`${header}\n\n${body}`, maxChars, 'output truncated, narrow your range')
+}
+
+/** Returns whether the given MIME content type can be searched as text. */
+export function isSearchableContent(contentType: string): boolean {
+  return contentType.startsWith('text/') || contentType === 'application/json'
+}
+
+/**
+ * Search offloaded text content by pattern or line range.
+ *
+ * @param text - The full text content to search
+ * @param input - Search parameters (pattern, line_range, context_lines)
+ * @param maxChars - Maximum output size in characters; results are truncated beyond this
+ * @returns Formatted search results with line numbers, or an error/empty message
+ */
+export function searchContent(
+  text: string,
+  input: {
+    pattern?: string | undefined
+    line_range?: { start: number; end: number } | undefined
+    context_lines: number
+  },
+  maxChars: number
+): string {
+  const lines = text.split('\n')
+  const totalLines = lines.length
+
+  if (totalLines === 0 || (totalLines === 1 && lines[0] === '')) {
+    return 'Content is empty (0 lines).'
+  }
+
+  let scopeStart = 0
+  let scopeEnd = totalLines - 1
+  if (input.line_range) {
+    if (input.line_range.start > input.line_range.end) {
+      return `Error: line_range.start (${input.line_range.start}) must be <= line_range.end (${input.line_range.end}).`
+    }
+    if (input.line_range.start > totalLines) {
+      return `Error: line_range.start (${input.line_range.start}) is beyond content length (${totalLines} lines).`
+    }
+    scopeStart = input.line_range.start - 1
+    scopeEnd = Math.min(input.line_range.end - 1, totalLines - 1)
+  }
+
+  if (input.pattern) {
+    const scopeLabel = input.line_range ? ` in lines ${input.line_range.start}-${scopeEnd + 1}` : ''
+    return searchByPattern(lines, input.pattern, scopeStart, scopeEnd, input.context_lines, maxChars, scopeLabel)
+  }
+
+  return searchByLineRange(lines, scopeStart, scopeEnd, totalLines, maxChars)
+}


### PR DESCRIPTION

## Description

Adds search capabilities (pattern matching and line-range access) to the existing `retrieve_offloaded_content` tool in the context offloader plugin.

Previously, the retrieval tool returned the entire offloaded blob, re-injecting the full token cost into context — defeating the purpose of offloading. Now the same tool supports optional parameters to retrieve only what's needed:

- **Pattern search**: grep-like regex/keyword matching with configurable context lines
- **Line range access**: random access by line numbers (like `read_file` for stored content)
- **Combined**: search within a specific line range
- **Head**: pass only `context_lines` to peek at the first N lines
- **Full retrieval**: omit all optional params to get everything (discouraged as a last resort)

Search output is always capped at `maxResultTokens * CHARS_PER_TOKEN` characters. Results include line numbers that can be used in follow-up `line_range` calls for deeper exploration.

Works with all storage backends (InMemoryStorage, FileStorage, S3Storage) since it operates on the `Storage` interface.

### API Surface

**No breaking changes.** The existing `retrieve_offloaded_content` tool gains three optional parameters:

```typescript
{
  reference: string          // Required — same as before
  pattern?: string           // Regex or keyword to grep for
  line_range?: {             // Specific line span to read
    start: number            // 1-indexed, inclusive
    end: number              // 1-indexed, inclusive
  }
  context_lines?: number     // Lines of context around matches (default: 5)
}
```

| Call | Behavior |
|------|----------|
| `{ reference }` | Full content |
| `{ reference, context_lines: 10 }` | First 10 lines |
| `{ reference, pattern: "error" }` | Matching lines + 5 lines context (default) |
| `{ reference, pattern: "error", context_lines: 2 }` | Matching lines + 2 lines context |
| `{ reference, line_range: { start: 10, end: 25 } }` | Lines 10–25 |
| `{ reference, pattern: "x", line_range: {...}, context_lines: 3 }` | Search within range, 3 lines context |

**Config:** `includeRetrievalTool` (default `true`) still controls whether the tool is registered. No new config options.

### Example: What the agent sees

**Step 1: Tool result gets offloaded (replaces original result inline)**

```
[Offloaded: 1 blocks, ~10,000 tokens]
Tool result was offloaded to external storage due to size.
Use the preview below to answer if possible.
Use retrieve_offloaded_content with a reference and either:
  - pattern: regex or keyword to find matching lines with context
  - line_range: { start, end } to read a specific span of lines
Only retrieve the full content (omit pattern/line_range) as a last resort.

{"users":[{"id":1,"name":"Alice","role":"admin"},{"id":2,"name":"Bob","role":"user"},{"id":3,"name":"Charlie","rol

[Stored references:]
  mem_1_tool-123_0 (json, 42,000 bytes)
```

**Step 2: Agent calls `retrieve_offloaded_content` with a pattern**

Input: `{ reference: "mem_1_tool-123_0", pattern: "admin", context_lines: 2 }`

Result:
```
[2 matches for /admin/]

   1| {
   2|   "users": [
>  3|     { "id": 1, "name": "Alice", "role": "admin" },
   4|     { "id": 2, "name": "Bob", "role": "user" },
   5|     { "id": 3, "name": "Charlie", "role": "user" },
---
  48|     { "id": 15, "name": "Dana", "role": "user" },
> 49|     { "id": 16, "name": "Eve", "role": "admin" },
  50|     { "id": 17, "name": "Frank", "role": "user" }
  51|   ]
```

**Step 3: Agent calls with a line_range (random access)**

Input: `{ reference: "mem_1_tool-123_0", line_range: { start: 45, end: 55 } }`

Result:
```
[Lines 45-55 of 200]

  45|     { "id": 14, "name": "Mallory", "role": "user" },
  46|     { "id": 15, "name": "Dana", "role": "user" },
  47|     { "id": 16, "name": "Eve", "role": "admin" },
  48|     { "id": 17, "name": "Frank", "role": "user" },
  49|     { "id": 18, "name": "Grace", "role": "user" },
  50|     { "id": 19, "name": "Heidi", "role": "moderator" },
  51|     { "id": 20, "name": "Ivan", "role": "user" },
  52|     { "id": 21, "name": "Judy", "role": "admin" },
  53|     { "id": 22, "name": "Karl", "role": "user" },
  54|     { "id": 23, "name": "Liam", "role": "user" },
  55|     { "id": 24, "name": "Mia", "role": "user" }
```

**Step 4: If the search matches too many lines, output is truncated:**

```
[500 matches for /user/]

>  2|   "users": [
>  3|     { "id": 1, "name": "Alice", "role": "admin" },
>  4|     { "id": 2, "name": "Bob", "role": "user" },
>  5|     { "id": 3, "name": "Charlie", "role": "user" },
...

[output truncated, narrow your search]
```

**Error cases:**

- Binary content: `Error: cannot search binary content (image/png). Omit pattern/line_range/context_lines to retrieve the full content.`
- No matches: `No matches found for pattern 'nonexistent' (searched 200 lines).`
- Bad range: `Error: line_range.start (500) is beyond content length (200 lines).`

## Related Issues
https://github.com/strands-agents/sdk-typescript/pull/974

## Documentation PR

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- [x] Added 24 unit tests for search logic (`search.test.ts`) + 13 integration tests via plugin
- [x] All 88 context-offloader tests pass

## Checklist
- [X] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [] I have updated the documentation accordingly
- [] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.