### PR TITLE
fix: replace Node 22+ globSync with readdirSync in strands-dev CLI

### DIFF
--- a/strandly/src/cli.ts
+++ b/strandly/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 
 import { execSync } from 'node:child_process'
-import { existsSync, globSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { program } from 'commander'
 
@@ -230,7 +230,9 @@ function generate(opts?: { check?: boolean }): void {
 
   // Tag generated TS/WASM type declarations.
   for (const dir of ['strands-wasm/generated', 'strands-ts/generated']) {
-    for (const file of globSync('**/*.d.ts', { cwd: join(ROOT, dir) })) {
+    for (const file of readdirSync(join(ROOT, dir), { recursive: true, encoding: 'utf-8' }).filter((f) =>
+      f.endsWith('.d.ts')
+    )) {
       const path = join(ROOT, dir, file)
       const content = readFileSync(path, 'utf-8')
       if (!content.startsWith('// @generated')) {


### PR DESCRIPTION
## Description

The `strands-dev` CLI imports `globSync` from `node:fs`, which is only available in Node 22+. The project targets Node 20 (per `.node-version`), so `npm run dev -- bootstrap` fails with:

```
SyntaxError: The requested module 'node:fs' does not provide an export named 'globSync'
```

This replaces `globSync` with `readdirSync` using the `recursive: true` option (available since Node 18.17) and a `.d.ts` filter — functionally equivalent, compatible with Node 20.

## Type of Change

Bug fix

## Testing

- [x] I ran `npm run check`
- Verified `npm run dev -- bootstrap` completes successfully on Node 20.19.0

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] I have added any necessary tests that prove my fix is effective or my feature works
