### PR TITLE
perf: make totalDuration and averageCycleTime O(1) on AgentMetrics

### DIFF
--- a/strands-ts/src/telemetry/__tests__/meter.test.ts
+++ b/strands-ts/src/telemetry/__tests__/meter.test.ts
@@ -649,12 +649,14 @@ describe('AgentMetrics', () => {
         accumulatedMetrics: { latencyMs: 0 },
         agentInvocations: [],
         toolMetrics: {},
+        totalDuration: 0,
       })
     })
 
     it('returns data from provided metrics', () => {
       const metrics = new AgentMetrics({
         cycleCount: 2,
+        totalDuration: 8000,
         toolMetrics: {
           search: { callCount: 2, successCount: 1, errorCount: 1, totalTime: 2.0 },
         },
@@ -687,6 +689,7 @@ describe('AgentMetrics', () => {
         toolMetrics: {
           search: { callCount: 2, successCount: 1, errorCount: 1, totalTime: 2.0 },
         },
+        totalDuration: 8000,
       })
     })
   })
@@ -761,33 +764,10 @@ describe('AgentMetrics', () => {
       })
     })
 
-    it('totalDuration sums cycle durations', () => {
-      const metrics = new AgentMetrics({
-        agentInvocations: [
-          {
-            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-            cycles: [
-              { cycleId: 'cycle-1', duration: 3000, usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
-              { cycleId: 'cycle-2', duration: 5000, usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
-            ],
-          },
-        ],
-      })
-      expect(metrics.totalDuration).toBe(8000)
-    })
-
     it('averageCycleTime computes average', () => {
       const metrics = new AgentMetrics({
         cycleCount: 2,
-        agentInvocations: [
-          {
-            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-            cycles: [
-              { cycleId: 'cycle-1', duration: 3000, usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
-              { cycleId: 'cycle-2', duration: 5000, usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
-            ],
-          },
-        ],
+        totalDuration: 8000,
       })
       expect(metrics.averageCycleTime).toBe(4000)
     })
@@ -833,11 +813,6 @@ describe('AgentMetrics', () => {
           successRate: 0,
         },
       })
-    })
-
-    it('totalDuration returns 0 when no invocations exist', () => {
-      const metrics = new AgentMetrics()
-      expect(metrics.totalDuration).toBe(0)
     })
   })
 })

--- a/strands-ts/src/telemetry/__tests__/meter.test.ts
+++ b/strands-ts/src/telemetry/__tests__/meter.test.ts
@@ -73,6 +73,7 @@ describe('Meter', () => {
       const snapshot = meter.metrics
 
       expect(snapshot.cycleCount).toBe(2)
+      expect(snapshot.totalDuration).toBe(8000)
       expect(snapshot.accumulatedUsage).toStrictEqual({ inputTokens: 30, outputTokens: 15, totalTokens: 45 })
       expect(snapshot.accumulatedMetrics).toStrictEqual({ latencyMs: 350 })
       expect(snapshot.toolMetrics).toStrictEqual({

--- a/strands-ts/src/telemetry/meter.ts
+++ b/strands-ts/src/telemetry/meter.ts
@@ -118,6 +118,11 @@ export interface AgentMetricsData {
    * Represents the baseline token count the next invocation will start with.
    */
   projectedContextSize?: number
+
+  /**
+   * Total duration of all cycles in milliseconds.
+   */
+  totalDuration?: number
 }
 
 /**
@@ -197,6 +202,11 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
    */
   readonly projectedContextSize: number | undefined
 
+  /**
+   * Total duration of all cycles in milliseconds.
+   */
+  readonly totalDuration: number
+
   constructor(data?: Partial<AgentMetricsData>) {
     this.cycleCount = data?.cycleCount ?? 0
     this.accumulatedUsage = data?.accumulatedUsage ?? createEmptyUsage()
@@ -205,6 +215,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
     this.toolMetrics = data?.toolMetrics ?? {}
     this.latestContextSize = data?.latestContextSize
     this.projectedContextSize = data?.projectedContextSize
+    this.totalDuration = data?.totalDuration ?? 0
   }
 
   /**
@@ -222,18 +233,10 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
   }
 
   /**
-   * Total duration of all cycles in milliseconds.
-   */
-  get totalDuration(): number {
-    return this.agentInvocations.flatMap((inv) => inv.cycles.map((c) => c.duration)).reduce((sum, d) => sum + d, 0)
-  }
-
-  /**
    * Average cycle duration in milliseconds, or 0 if no cycles exist.
    */
   get averageCycleTime(): number {
-    const durations = this.agentInvocations.flatMap((inv) => inv.cycles.map((c) => c.duration))
-    return durations.length > 0 ? durations.reduce((sum, d) => sum + d, 0) / durations.length : 0
+    return this.cycleCount > 0 ? this.totalDuration / this.cycleCount : 0
   }
 
   /**
@@ -264,6 +267,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
       accumulatedMetrics: this.accumulatedMetrics,
       agentInvocations: this.agentInvocations,
       toolMetrics: this.toolMetrics,
+      totalDuration: this.totalDuration,
       ...(this.latestContextSize !== undefined && { latestContextSize: this.latestContextSize }),
       ...(this.projectedContextSize !== undefined && { projectedContextSize: this.projectedContextSize }),
     }
@@ -316,6 +320,11 @@ export class Meter {
    * Projected context size for the next model call (inputTokens + outputTokens).
    */
   private _projectedContextSize: number | undefined
+
+  /**
+   * Running total of all cycle durations in milliseconds.
+   */
+  private _totalDuration: number = 0
 
   // OTEL instruments (no-op when no MeterProvider is registered)
   private readonly _otelMeter: OtelMeter
@@ -415,6 +424,8 @@ export class Meter {
     const duration = Date.now() - startTime
     this._otelCycleDuration.record(duration)
 
+    this._totalDuration += duration
+
     const latestInvocation = this._latestAgentInvocation
     if (latestInvocation) {
       const cycles = latestInvocation.cycles
@@ -478,6 +489,7 @@ export class Meter {
       accumulatedMetrics: this._accumulatedMetrics,
       agentInvocations: this._agentInvocations,
       toolMetrics: this._toolMetrics,
+      totalDuration: this._totalDuration,
       ...(this._latestContextSize !== undefined && { latestContextSize: this._latestContextSize }),
       ...(this._projectedContextSize !== undefined && { projectedContextSize: this._projectedContextSize }),
     })


### PR DESCRIPTION
## Description

`AgentMetrics.totalDuration` and `averageCycleTime` previously recomputed from the full `agentInvocations[].cycles[].duration` array on every access. For long-lived Agent instances serving many requests, this introduced O(N) cost per access and O(N²) total CPU across N invocations.

This PR promotes `totalDuration` to a first-class field on `AgentMetrics`, accumulated incrementally by `Meter.endCycle()`. `averageCycleTime` becomes a simple division of `totalDuration / cycleCount`. Both are now O(1).

## Related Issues

Closes #785 (partial: addresses the O(N²) getter degradation described in the issue. The unbounded `_agentInvocations` growth is a separate concern.)

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- All 2561 unit tests pass
- Pre-commit hooks (lint, format, type-check, coverage) pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.