### PR TITLE
fix: give maintainers auto integ tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           skip-check: ${{ github.event_name == 'merge_group' }}
           username: ${{ github.event.pull_request.user.login || 'invalid' }}
-          allowed-roles: 'triage,write,admin'
+          allowed-roles: 'triage,write,maintain,admin'
 
   run-integration-tests:
     name: Run integration tests


### PR DESCRIPTION
give us kind ragged maintainers the ability to run integ tests automatically.

please.
pushing the button every time hurts.


<img width="1247" height="413" alt="Screenshot 2026-05-13 at 12 45 24" src="https://github.com/user-attachments/assets/b36ed8bd-eb53-4408-b05c-68c96e5c7fd4" />
<img width="893" height="446" alt="Screenshot 2026-05-13 at 12 46 27" src="https://github.com/user-attachments/assets/0367360f-8d07-46c4-adf8-6509d5e5eac9" />


i cry
