### PR TITLE
feat: added bedrock-mantle support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1346,38 +1346,33 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws/bedrock-token-generator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws/bedrock-token-generator/-/bedrock-token-generator-1.1.0.tgz",
+      "integrity": "sha512-i+DkWnfdA4j4sffy9dI4k3OGoOWqN8CTGdtO4IZ3c0kpKYFr6KyqzqLQmoRNrF3ACFcWj6u+J6cbBQ97j9wx5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-providers": "^3.525.0",
+        "@aws-sdk/util-format-url": ">=3.525.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/hash-node": ">=2.1.3",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": ">=3.2.1",
+        "@smithy/signature-v4": ">=2.1.3",
+        "@smithy/types": ">=2.11.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -3743,53 +3738,6 @@
       "resolved": "strands-wasm",
       "link": true
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "dev": true,
@@ -4371,33 +4319,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "dev": true,
@@ -4922,37 +4843,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6744,56 +6634,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -6856,18 +6696,6 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -7477,35 +7305,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "dev": true,
@@ -7587,15 +7386,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -8853,6 +8643,7 @@
         "@aws-sdk/client-secrets-manager": "^3.943.0",
         "@aws-sdk/client-sts": "^3.996.0",
         "@aws-sdk/credential-providers": "^3.943.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
         "@eslint/js": "^9.39.4",
         "@google/genai": "^1.40.0",
         "@opentelemetry/api": "^1.9.0",
@@ -8887,6 +8678,7 @@
         "@ai-sdk/provider": "^3.0.0",
         "@anthropic-ai/sdk": "^0.92.0",
         "@aws-sdk/client-s3": "^3.943.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
         "@google/genai": "^1.40.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@opentelemetry/api": "^1.9.0",
@@ -8911,6 +8703,9 @@
           "optional": true
         },
         "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@aws/bedrock-token-generator": {
           "optional": true
         },
         "@google/genai": {
@@ -9026,44 +8821,6 @@
         "esbuild": "^0.27.4",
         "typescript": "^6.0.2",
         "vitest": "^3.2.1"
-      }
-    },
-    "strands-wasm/node_modules/@vitest/browser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.4.tgz",
-      "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@testing-library/dom": "^10.4.0",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "magic-string": "^0.30.17",
-        "sirv": "^3.0.1",
-        "tinyrainbow": "^2.0.0",
-        "ws": "^8.18.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "playwright": "*",
-        "vitest": "3.2.4",
-        "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        },
-        "safaridriver": {
-          "optional": true
-        },
-        "webdriverio": {
-          "optional": true
-        }
       }
     },
     "strands-wasm/node_modules/@vitest/expect": {

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -123,11 +123,13 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/provider": "^3.0.0",
     "@anthropic-ai/sdk": "^0.92.0",
+    "@aws/bedrock-token-generator": "^1.1.0",
     "@aws-sdk/client-bedrock": "^3.943.0",
     "@aws-sdk/client-s3": "^3.943.0",
     "@aws-sdk/client-secrets-manager": "^3.943.0",
     "@aws-sdk/client-sts": "^3.996.0",
     "@aws-sdk/credential-providers": "^3.943.0",
+    "@smithy/types": "^4.0.0",
     "@eslint/js": "^9.39.4",
     "@google/genai": "^1.40.0",
     "@opentelemetry/api": "^1.9.0",
@@ -175,7 +177,9 @@
     "@a2a-js/sdk": "^0.3.10",
     "@ai-sdk/provider": "^3.0.0",
     "@anthropic-ai/sdk": "^0.92.0",
+    "@aws/bedrock-token-generator": "^1.1.0",
     "@aws-sdk/client-s3": "^3.943.0",
+    "@smithy/types": "^4.0.0",
     "@google/genai": "^1.40.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@opentelemetry/api": "^1.9.0",
@@ -197,6 +201,12 @@
       "optional": true
     },
     "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@aws/bedrock-token-generator": {
+      "optional": true
+    },
+    "@smithy/types": {
       "optional": true
     },
     "express": {

--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import OpenAI from 'openai'
+import { isNode } from '../../../__fixtures__/environment.js'
+import { OpenAIModel } from '../index.js'
+
+vi.mock('openai', () => {
+  const mockConstructor = vi.fn(function (this: unknown) {
+    return {}
+  })
+  return {
+    default: mockConstructor,
+  }
+})
+
+const getTokenProviderMock = vi.fn()
+vi.mock('@aws/bedrock-token-generator', () => ({
+  getTokenProvider: (...args: unknown[]) => getTokenProviderMock(...args),
+}))
+
+const TEST_MODEL_ID = 'openai.gpt-oss-120b'
+const TEST_TOKEN = 'bedrock-api-key-deadbeef&Version=1'
+
+function lastApiKeySetter(): () => Promise<string> {
+  const calls = (OpenAI as unknown as { mock: { calls: unknown[][] } }).mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  const options = calls[calls.length - 1]![0] as { apiKey: () => Promise<string> }
+  expect(typeof options.apiKey).toBe('function')
+  return options.apiKey
+}
+
+describe('OpenAIModel bedrockMantleConfig', () => {
+  let provideTokenMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    if (isNode) {
+      // Mantle pathway shouldn't look at OPENAI_API_KEY — guard against
+      // accidental env leakage by clearing it for the suite.
+      vi.stubEnv('OPENAI_API_KEY', '')
+      vi.stubEnv('AWS_REGION', '')
+      vi.stubEnv('AWS_DEFAULT_REGION', '')
+    }
+    provideTokenMock = vi.fn().mockResolvedValue(TEST_TOKEN)
+    getTokenProviderMock.mockReturnValue(provideTokenMock)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    if (isNode) {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  describe('constructor wiring', () => {
+    it('sets baseURL and installs async apiKey setter that mints a bearer token', async () => {
+      new OpenAIModel({
+        modelId: TEST_MODEL_ID,
+        bedrockMantleConfig: { region: 'us-east-1' },
+      })
+
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1',
+          apiKey: expect.any(Function),
+        })
+      )
+
+      const apiKey = await lastApiKeySetter()()
+      expect(apiKey).toBe(TEST_TOKEN)
+      expect(getTokenProviderMock).toHaveBeenCalledWith({ region: 'us-east-1' })
+    })
+
+    it('forwards optional credentials and expiresInSeconds to getTokenProvider', async () => {
+      const credentials = vi.fn()
+      new OpenAIModel({
+        modelId: TEST_MODEL_ID,
+        bedrockMantleConfig: {
+          region: 'us-west-2',
+          credentials,
+          expiresInSeconds: 900,
+        },
+      })
+
+      await lastApiKeySetter()()
+
+      expect(getTokenProviderMock).toHaveBeenCalledWith({
+        region: 'us-west-2',
+        credentials,
+        expiresInSeconds: 900,
+      })
+    })
+
+    it('mints a fresh token on every apiKey setter call', async () => {
+      new OpenAIModel({
+        modelId: TEST_MODEL_ID,
+        bedrockMantleConfig: { region: 'us-east-1' },
+      })
+
+      const apiKey = lastApiKeySetter()
+      await apiKey()
+      await apiKey()
+      await apiKey()
+
+      // The token provider is created once and reused, but it is invoked per call.
+      expect(getTokenProviderMock).toHaveBeenCalledTimes(1)
+      expect(provideTokenMock).toHaveBeenCalledTimes(3)
+    })
+
+    it('merges with other clientConfig fields while overriding baseURL and apiKey', () => {
+      const http = vi.fn()
+      new OpenAIModel({
+        modelId: TEST_MODEL_ID,
+        clientConfig: {
+          timeout: 42,
+          fetch: http,
+          defaultHeaders: { 'X-Trace-Id': 'abc' },
+        },
+        bedrockMantleConfig: { region: 'us-east-1' },
+      })
+
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://bedrock-mantle.us-east-1.api.aws/v1',
+          apiKey: expect.any(Function),
+          timeout: 42,
+          fetch: http,
+          defaultHeaders: { 'X-Trace-Id': 'abc' },
+        })
+      )
+    })
+
+    it('does not check OPENAI_API_KEY when bedrockMantleConfig is set', () => {
+      // env vars are cleared in beforeEach — this would normally throw, but the
+      // Mantle pathway has its own auth and must bypass the check.
+      expect(
+        () => new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: { region: 'us-east-1' } })
+      ).not.toThrow()
+    })
+
+    it('works for api: "chat" as well as the default responses api', async () => {
+      new OpenAIModel({
+        api: 'chat',
+        modelId: TEST_MODEL_ID,
+        bedrockMantleConfig: { region: 'us-east-1' },
+      })
+      const apiKey = await lastApiKeySetter()()
+      expect(apiKey).toBe(TEST_TOKEN)
+    })
+  })
+
+  describe('validation', () => {
+    it('throws when bedrockMantleConfig is combined with a pre-built client', () => {
+      const client = {} as OpenAI
+      expect(
+        () =>
+          new OpenAIModel({
+            modelId: TEST_MODEL_ID,
+            client,
+            bedrockMantleConfig: { region: 'us-east-1' },
+          })
+      ).toThrow(/bedrockMantleConfig.*pre-built/)
+    })
+
+    it('throws when clientConfig.baseURL is set alongside bedrockMantleConfig', () => {
+      expect(
+        () =>
+          new OpenAIModel({
+            modelId: TEST_MODEL_ID,
+            clientConfig: { baseURL: 'https://example.invalid' },
+            bedrockMantleConfig: { region: 'us-east-1' },
+          })
+      ).toThrow(/baseURL/)
+    })
+
+    it('throws when clientConfig.apiKey is set alongside bedrockMantleConfig', () => {
+      expect(
+        () =>
+          new OpenAIModel({
+            modelId: TEST_MODEL_ID,
+            clientConfig: { apiKey: 'sk-nope' },
+            bedrockMantleConfig: { region: 'us-east-1' },
+          })
+      ).toThrow(/apiKey/)
+    })
+
+    it('throws when top-level apiKey is set alongside bedrockMantleConfig', () => {
+      expect(
+        () =>
+          new OpenAIModel({
+            modelId: TEST_MODEL_ID,
+            apiKey: 'sk-nope',
+            bedrockMantleConfig: { region: 'us-east-1' },
+          })
+      ).toThrow(/apiKey/)
+    })
+  })
+
+  describe('region resolution', () => {
+    it('throws when no region is available from config or env', () => {
+      expect(() => new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: {} })).toThrow(
+        /could not resolve an AWS region/
+      )
+    })
+
+    if (isNode) {
+      it('falls back to AWS_REGION env var', async () => {
+        vi.stubEnv('AWS_REGION', 'eu-west-1')
+        new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: {} })
+        await lastApiKeySetter()()
+        expect(OpenAI).toHaveBeenCalledWith(
+          expect.objectContaining({ baseURL: 'https://bedrock-mantle.eu-west-1.api.aws/v1' })
+        )
+        expect(getTokenProviderMock).toHaveBeenCalledWith({ region: 'eu-west-1' })
+      })
+
+      it('falls back to AWS_DEFAULT_REGION when AWS_REGION is unset', async () => {
+        vi.stubEnv('AWS_DEFAULT_REGION', 'ap-southeast-2')
+        new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: {} })
+        await lastApiKeySetter()()
+        expect(getTokenProviderMock).toHaveBeenCalledWith({ region: 'ap-southeast-2' })
+      })
+
+      it('prefers explicit region over env vars', async () => {
+        vi.stubEnv('AWS_REGION', 'eu-west-1')
+        new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: { region: 'us-east-1' } })
+        await lastApiKeySetter()()
+        expect(getTokenProviderMock).toHaveBeenCalledWith({ region: 'us-east-1' })
+      })
+    }
+  })
+
+  describe('token minting errors', () => {
+    it('wraps token provider failures with actionable context', async () => {
+      provideTokenMock.mockRejectedValueOnce(new Error('no credentials in chain'))
+      new OpenAIModel({ modelId: TEST_MODEL_ID, bedrockMantleConfig: { region: 'us-east-1' } })
+      await expect(lastApiKeySetter()()).rejects.toThrow(/us-east-1/)
+    })
+  })
+})

--- a/strands-ts/src/models/openai/index.ts
+++ b/strands-ts/src/models/openai/index.ts
@@ -23,3 +23,4 @@ export type {
   OpenAIModelOptions,
   OpenAIResponsesConfig,
 } from './types.js'
+export type { BedrockMantleConfig } from './mantle.js'

--- a/strands-ts/src/models/openai/mantle.ts
+++ b/strands-ts/src/models/openai/mantle.ts
@@ -1,0 +1,142 @@
+/**
+ * Internal helpers for routing an {@link OpenAIModel} through Amazon Bedrock's
+ * OpenAI-compatible "Mantle" endpoint.
+ *
+ * Converts a {@link BedrockMantleConfig} into the `baseURL` and `apiKey` the
+ * OpenAI SDK consumes. Tokens are minted on demand via
+ * `@aws/bedrock-token-generator` so long-running agents survive the bearer
+ * token's maximum lifetime.
+ *
+ * `@aws/bedrock-token-generator` is declared as an optional peer dependency, so
+ * the import is lazy: it happens the first time the OpenAI client's async
+ * `apiKey` setter is invoked.
+ */
+
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types'
+
+const MANTLE_DOCS_URL = 'https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html'
+
+/**
+ * Async function that returns a freshly minted Bedrock Mantle bearer token.
+ * Matches the shape returned by `@aws/bedrock-token-generator`'s
+ * `getTokenProvider`.
+ *
+ * @internal
+ */
+export type TokenProvider = () => Promise<string>
+
+/**
+ * Config for routing an OpenAI-compatible client through Amazon Bedrock's
+ * Mantle endpoint.
+ *
+ * When supplied to `OpenAIModel`, this config derives the OpenAI client's
+ * `baseURL` and `apiKey`. It cannot be combined with a pre-built `client`,
+ * a top-level `apiKey`, or `clientConfig.baseURL` / `clientConfig.apiKey`,
+ * since those are derived from this config.
+ */
+export interface BedrockMantleConfig {
+  /**
+   * AWS region hosting the Bedrock Mantle endpoint. If omitted, resolved from
+   * the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variable. An error is
+   * thrown if none resolve.
+   */
+  region?: string
+
+  /**
+   * AWS credentials forwarded to the bearer token generator. Accepts either a
+   * static credential identity or a credential provider function (e.g. the
+   * result of `fromNodeProviderChain()` from `@aws-sdk/credential-providers`).
+   * When omitted, the token generator resolves credentials from the standard
+   * AWS credential chain.
+   */
+  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider
+
+  /**
+   * Bearer token lifetime in seconds, forwarded to the token generator.
+   * Capped at 12 hours by AWS. When omitted, the generator's default applies.
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html
+   */
+  expiresInSeconds?: number
+}
+
+/**
+ * Resolves the AWS region for Mantle, preferring explicit config and falling
+ * back to the standard AWS env vars.
+ *
+ * @internal
+ */
+export function resolveMantleRegion(config: BedrockMantleConfig): string {
+  if (config.region) {
+    return config.region
+  }
+
+  const envRegion = globalThis?.process?.env?.AWS_REGION || globalThis?.process?.env?.AWS_DEFAULT_REGION
+  if (envRegion) {
+    return envRegion
+  }
+
+  throw new Error(
+    "could not resolve an AWS region for Bedrock Mantle. Pass 'region' in " +
+      'bedrockMantleConfig or set AWS_REGION in the environment. ' +
+      `See ${MANTLE_DOCS_URL} for supported regions.`
+  )
+}
+
+/**
+ * Builds the Mantle base URL for a region.
+ *
+ * @internal
+ */
+export function bedrockMantleBaseUrl(region: string): string {
+  return `https://bedrock-mantle.${region}.api.aws/v1`
+}
+
+/**
+ * Builds an async `apiKey` setter (matching the OpenAI SDK's `ApiKeySetter`
+ * signature) that mints a fresh bearer token on every request.
+ *
+ * The `@aws/bedrock-token-generator` package is loaded lazily on first use so
+ * applications that never touch the Mantle pathway don't need it installed.
+ *
+ * @internal
+ */
+export function createMantleApiKeySetter(config: BedrockMantleConfig, region: string): () => Promise<string> {
+  let tokenProviderPromise: Promise<TokenProvider> | null = null
+
+  const initProvider = async (): Promise<TokenProvider> => {
+    const { getTokenProvider } = await loadTokenGenerator()
+    return getTokenProvider({
+      region,
+      ...(config.credentials !== undefined ? { credentials: config.credentials } : {}),
+      ...(config.expiresInSeconds !== undefined ? { expiresInSeconds: config.expiresInSeconds } : {}),
+    })
+  }
+
+  return async (): Promise<string> => {
+    if (tokenProviderPromise === null) {
+      tokenProviderPromise = initProvider()
+    }
+    const provideToken = await tokenProviderPromise
+    try {
+      return await provideToken()
+    } catch (cause) {
+      throw new Error(
+        `failed to mint Bedrock Mantle bearer token for region '${region}' | ` +
+          'verify your AWS credentials and network connectivity',
+        { cause }
+      )
+    }
+  }
+}
+
+async function loadTokenGenerator(): Promise<typeof import('@aws/bedrock-token-generator')> {
+  try {
+    return await import('@aws/bedrock-token-generator')
+  } catch (cause) {
+    throw new Error(
+      "bedrockMantleConfig requires the '@aws/bedrock-token-generator' package | " +
+        "install it with: npm install '@aws/bedrock-token-generator'",
+      { cause }
+    )
+  }
+}

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -18,6 +18,7 @@ import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js
 import { logger } from '../../logging/logger.js'
 import { warnOnce } from '../../logging/warn-once.js'
 import { MODEL_DEFAULTS, defaultModelWarningMessage } from '../defaults.js'
+import { bedrockMantleBaseUrl, createMantleApiKeySetter, resolveMantleRegion } from './mantle.js'
 import { classifyOpenAIError } from './errors.js'
 import { formatChatRequest, mapChatChunkToEvents, warnManagedParams as warnChatManagedParams } from './chat-adapter.js'
 import {
@@ -71,7 +72,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
 
   constructor(options: OpenAIModelOptions) {
     super()
-    const { apiKey, client, clientConfig, api = 'responses', ...modelConfig } = options
+    const { apiKey, client, clientConfig, bedrockMantleConfig, api = 'responses', ...modelConfig } = options
 
     if (api !== 'chat' && api !== 'responses') {
       throw new Error(`Unsupported OpenAI API: '${api}'. Supported values: 'chat', 'responses'`)
@@ -92,8 +93,14 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
       warnChatManagedParams(modelConfig.params)
     }
 
+    if (bedrockMantleConfig && client) {
+      throw new Error("'bedrockMantleConfig' cannot be combined with a pre-built 'client'.")
+    }
+
     if (client) {
       this._client = client
+    } else if (bedrockMantleConfig) {
+      this._client = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig)
     } else {
       const hasEnvKey =
         typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.OPENAI_API_KEY
@@ -257,4 +264,35 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
 
     return error
   }
+}
+
+function buildMantleClient(
+  bedrockMantleConfig: NonNullable<OpenAIModelOptions['bedrockMantleConfig']>,
+  apiKey: OpenAIModelOptions['apiKey'],
+  clientConfig: OpenAIModelOptions['clientConfig']
+): OpenAI {
+  if (apiKey !== undefined) {
+    throw new Error(
+      "'apiKey' cannot be combined with 'bedrockMantleConfig'; the API key is derived from the Mantle config automatically."
+    )
+  }
+
+  const conflicting: string[] = []
+  if (clientConfig?.apiKey !== undefined) conflicting.push('apiKey')
+  if (clientConfig?.baseURL !== undefined) conflicting.push('baseURL')
+  if (conflicting.length > 0) {
+    throw new Error(
+      `clientConfig must not contain ${conflicting.join(', ')} when bedrockMantleConfig is set; ` +
+        'these are derived from the Mantle config automatically.'
+    )
+  }
+
+  // Resolve the region eagerly so missing-region configuration fails fast.
+  const region = resolveMantleRegion(bedrockMantleConfig)
+
+  return new OpenAI({
+    ...clientConfig,
+    baseURL: bedrockMantleBaseUrl(region),
+    apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
+  })
 }

--- a/strands-ts/src/models/openai/types.ts
+++ b/strands-ts/src/models/openai/types.ts
@@ -6,6 +6,7 @@ import type OpenAI from 'openai'
 import type { ApiKeySetter } from 'openai/client'
 import type { ClientOptions } from 'openai'
 import type { BaseModelConfig } from '../model.js'
+import type { BedrockMantleConfig } from './mantle.js'
 
 /**
  * Supported OpenAI API modes.
@@ -117,6 +118,17 @@ interface OpenAIClientOptions {
    * Additional OpenAI client configuration. Only used if `client` is not provided.
    */
   clientConfig?: ClientOptions
+
+  /**
+   * Route requests through Amazon Bedrock's OpenAI-compatible "Mantle"
+   * endpoint. When set, the OpenAI client's `baseURL` and `apiKey` are derived
+   * from this config; the top-level `apiKey`, `clientConfig.apiKey`, and
+   * `clientConfig.baseURL` options must not be passed alongside it. Cannot be
+   * combined with a pre-built `client`. Requires the optional peer dependency
+   * `@aws/bedrock-token-generator`.
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-openai.html
+   */
+  bedrockMantleConfig?: BedrockMantleConfig
 }
 
 /**

--- a/strands-ts/test/integ/models/openai/mantle.test.node.ts
+++ b/strands-ts/test/integ/models/openai/mantle.test.node.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration tests for the OpenAI-compatible Bedrock Mantle pathway.
+ *
+ * Exercises `OpenAIModel` with `bedrockMantleConfig` against the live
+ * `bedrock-mantle.<region>.api.aws/v1` endpoint. Credentials come from the
+ * ambient AWS credential chain (same gate as the other Bedrock integ tests).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '$/sdk/models/openai/index.js'
+
+import { bedrock } from '../../__fixtures__/model-providers.js'
+
+const REGION = 'us-east-1'
+const MODEL_ID = 'openai.gpt-oss-120b'
+
+describe.skipIf(bedrock.skip)('OpenAIModel (Bedrock Mantle) Integration Tests', () => {
+  it('reaches Mantle via bedrockMantleConfig on the Chat Completions API', async () => {
+    const model = new OpenAIModel({
+      api: 'chat',
+      modelId: MODEL_ID,
+      bedrockMantleConfig: { region: REGION },
+    })
+    const agent = new Agent({
+      model,
+      systemPrompt: 'Reply in one short sentence.',
+      printer: false,
+    })
+
+    const result = await agent.invoke('What is 2+2?')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(String(result)).toContain('4')
+  })
+
+  it('reaches Mantle via bedrockMantleConfig on the Responses API', async () => {
+    const model = new OpenAIModel({
+      modelId: MODEL_ID,
+      bedrockMantleConfig: { region: REGION },
+    })
+    const agent = new Agent({
+      model,
+      systemPrompt: 'Reply in one short sentence.',
+      printer: false,
+    })
+
+    const result = await agent.invoke('What is 2+2?')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(String(result)).toContain('4')
+  })
+
+  it('supports server-side stateful conversations', async () => {
+    const model = new OpenAIModel({
+      modelId: MODEL_ID,
+      stateful: true,
+      bedrockMantleConfig: { region: REGION },
+    })
+    const agent = new Agent({
+      model,
+      systemPrompt: 'Reply in one short sentence.',
+      printer: false,
+    })
+
+    await agent.invoke('My name is Alice.')
+    const result = await agent.invoke('What is my name?')
+
+    expect(String(result).toLowerCase()).toContain('alice')
+  })
+
+  it('handles reasoning content across multi-turn conversations', async () => {
+    const model = new OpenAIModel({
+      modelId: MODEL_ID,
+      bedrockMantleConfig: { region: REGION },
+      params: { reasoning: { effort: 'low' } },
+    })
+    const agent = new Agent({
+      model,
+      systemPrompt: 'Reply in one short sentence.',
+      printer: false,
+    })
+
+    const first = await agent.invoke('What is 2+2?')
+    expect(String(first)).toContain('4')
+
+    // Second turn must not throw despite reasoningContent blocks present in
+    // the message history. The local response shape varies by effort level,
+    // so we only assert the round-trip completes cleanly.
+    const second = await agent.invoke('What about 3+3?')
+    expect(second.stopReason).toBe('endTurn')
+  })
+})


### PR DESCRIPTION
## Summary
Mirrors [feat: enable openai provider use aws profile](https://github.com/strands-agents/sdk-python/pull/2230)

Amazon Bedrock's OpenAI-compatible endpoint (Mantle) at `https://bedrock-mantle.<region>.api.aws/v1` serves the Chat Completions and Responses APIs plus Responses-only features like stateful conversations and reasoning controls, capabilities the native Converse API doesn't expose.

Reaching Mantle from `OpenAIModel` today means hand-rolling the plumbing: mint a bearer token via SigV4 (or an AWS helper), build a custom `fetch`/`httpx` pipeline, and pass a bespoke `baseURL` and `apiKey` through `clientConfig`.

This PR adds a first-class `bedrockMantleConfig` option to `OpenAIModel` so the Bedrock routing stops leaking into application code.

This is the last paper-cut of https://github.com/strands-agents/sdk-typescript/issues/904

## Public API Changes

A new optional field on `OpenAIModelOptions` routes requests through Mantle.
A fresh bearer token is minted per request via `@aws/bedrock-token-generator` (new optional peer dependency).

```typescript
import { OpenAIModel } from '@strands-agents/sdk/models/openai'

// Chat Completions via Mantle
new OpenAIModel({
  api: 'chat',
  modelId: 'openai.gpt-oss-120b',
  bedrockMantleConfig: { region: 'us-east-1' },
})

// Responses API with stateful conversations and reasoning
new OpenAIModel({
  modelId: 'openai.gpt-oss-120b',
  stateful: true,
  params: { reasoning: { effort: 'medium' } },
  bedrockMantleConfig: { region: 'us-east-1' },
})
```
## Note

### Region
Region resolution prefers explicit config, then falls back to `AWS_REGION` / `AWS_DEFAULT_REGION`. Credentials come from the standard AWS credential chain unless an explicit `credentials` provider is passed in the config. The pathway cannot be combined with a pre-built `client` or a top-level `apiKey`, and `clientConfig` must not set `baseURL` or `apiKey` (those are derived).

Unlike the Python port, no per-call client reconstruction is needed: the OpenAI Node SDK's async `apiKey` setter is invoked before each request, so tokens are minted per request by the SDK itself.

## Use Cases

- Talk to OpenAI-family models from a Bedrock account using AWS IAM rather   than OpenAI-issued API keys.
- Use Responses-only features (server-side stateful conversations, reasoning effort) without giving up Bedrock's billing, networking, and audit posture.

## Testing

- [x] I ran `npm run check`

Also manually verified end-to-end against the live Mantle endpoint in `us-east-1` (Chat Completions, Responses stateless, Responses stateful multi-turn, Responses with `reasoning.effort` multi-turn).