### PR TITLE
fix: cap Meter invocation history to prevent unbounded memory growth

### DIFF
--- a/strands-ts/src/telemetry/__tests__/meter.test.ts
+++ b/strands-ts/src/telemetry/__tests__/meter.test.ts
@@ -144,16 +144,16 @@ describe('Meter', () => {
     })
 
     it('evicts oldest entries when exceeding max history cap', () => {
-      for (let i = 0; i < 110; i++) {
+      for (let i = 0; i < 60; i++) {
         meter.startNewInvocation()
         meter.startCycle()
       }
 
       const invocations = meter.metrics.agentInvocations
-      expect(invocations).toHaveLength(100)
+      expect(invocations).toHaveLength(50)
       // First retained entry is the 11th invocation (oldest 10 were evicted)
       expect(invocations[0]!.cycles[0]!.cycleId).toBe('cycle-11')
-      expect(invocations[99]!.cycles[0]!.cycleId).toBe('cycle-110')
+      expect(invocations[49]!.cycles[0]!.cycleId).toBe('cycle-60')
     })
   })
 

--- a/strands-ts/src/telemetry/__tests__/meter.test.ts
+++ b/strands-ts/src/telemetry/__tests__/meter.test.ts
@@ -142,6 +142,14 @@ describe('Meter', () => {
       expect(snapshot.agentInvocations).toHaveLength(2)
       expect(snapshot.latestAgentInvocation).toBe(snapshot.agentInvocations[1])
     })
+
+    it('evicts oldest entries when exceeding max history cap', () => {
+      for (let i = 0; i < 110; i++) {
+        meter.startNewInvocation()
+      }
+
+      expect(meter.metrics.agentInvocations).toHaveLength(100)
+    })
   })
 
   describe('startCycle', () => {

--- a/strands-ts/src/telemetry/__tests__/meter.test.ts
+++ b/strands-ts/src/telemetry/__tests__/meter.test.ts
@@ -146,9 +146,14 @@ describe('Meter', () => {
     it('evicts oldest entries when exceeding max history cap', () => {
       for (let i = 0; i < 110; i++) {
         meter.startNewInvocation()
+        meter.startCycle()
       }
 
-      expect(meter.metrics.agentInvocations).toHaveLength(100)
+      const invocations = meter.metrics.agentInvocations
+      expect(invocations).toHaveLength(100)
+      // First retained entry is the 11th invocation (oldest 10 were evicted)
+      expect(invocations[0]!.cycles[0]!.cycleId).toBe('cycle-11')
+      expect(invocations[99]!.cycles[0]!.cycleId).toBe('cycle-110')
     })
   })
 

--- a/strands-ts/src/telemetry/meter.ts
+++ b/strands-ts/src/telemetry/meter.ts
@@ -83,7 +83,7 @@ export interface InvocationMetricsData {
  */
 export interface AgentMetricsData {
   /**
-   * Number of agent loop cycles executed.
+   * Total number of agent loop cycles executed across all invocations.
    */
   cycleCount: number
 
@@ -121,7 +121,7 @@ export interface AgentMetricsData {
   projectedContextSize?: number
 
   /**
-   * Total duration of all cycles in milliseconds.
+   * Total duration of all cycles across all invocations in milliseconds.
    */
   totalDuration?: number
 }
@@ -165,7 +165,7 @@ interface ToolUsageOptions {
  */
 export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
   /**
-   * Number of agent loop cycles executed.
+   * Total number of agent loop cycles executed across all invocations.
    */
   readonly cycleCount: number
 
@@ -206,7 +206,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
   readonly projectedContextSize: number | undefined
 
   /**
-   * Total duration of all cycles in milliseconds.
+   * Total duration of all cycles across all invocations in milliseconds.
    */
   readonly totalDuration: number
 

--- a/strands-ts/src/telemetry/meter.ts
+++ b/strands-ts/src/telemetry/meter.ts
@@ -98,7 +98,8 @@ export interface AgentMetricsData {
   accumulatedMetrics: Metrics
 
   /**
-   * Per-invocation metrics.
+   * Per-invocation metrics for recent invocations.
+   * Only the most recent 100 entries are retained.
    */
   agentInvocations: InvocationMetricsData[]
 
@@ -179,7 +180,9 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
   readonly accumulatedMetrics: Metrics
 
   /**
-   * Per-invocation metrics.
+   * Per-invocation metrics for recent invocations.
+   * Only the most recent 100 entries are retained to prevent unbounded memory growth.
+   * For full history, collect {@link latestAgentInvocation} from each {@link AgentResult}.
    */
   readonly agentInvocations: InvocationMetricsData[]
 

--- a/strands-ts/src/telemetry/meter.ts
+++ b/strands-ts/src/telemetry/meter.ts
@@ -99,7 +99,7 @@ export interface AgentMetricsData {
 
   /**
    * Per-invocation metrics for recent invocations.
-   * Only the most recent 100 entries are retained.
+   * Only the most recent 50 entries are retained.
    */
   agentInvocations: InvocationMetricsData[]
 
@@ -181,7 +181,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
 
   /**
    * Per-invocation metrics for recent invocations.
-   * Only the most recent 100 entries are retained to prevent unbounded memory growth.
+   * Only the most recent 50 entries are retained to prevent unbounded memory growth.
    * For full history, collect {@link latestAgentInvocation} from each {@link AgentResult}.
    */
   readonly agentInvocations: InvocationMetricsData[]
@@ -283,7 +283,7 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
  * Users who need full history can collect per-invocation metrics
  * from successive AgentResult objects.
  */
-const MAX_INVOCATION_HISTORY = 100
+const MAX_INVOCATION_HISTORY = 50
 
 /**
  * Accumulates local metrics during agent invocation.

--- a/strands-ts/src/telemetry/meter.ts
+++ b/strands-ts/src/telemetry/meter.ts
@@ -275,6 +275,14 @@ export class AgentMetrics implements JSONSerializable<AgentMetricsData> {
 }
 
 /**
+ * Maximum number of invocation history entries retained by the Meter.
+ * Prevents unbounded memory growth on long-lived Agent instances.
+ * Users who need full history can collect per-invocation metrics
+ * from successive AgentResult objects.
+ */
+const MAX_INVOCATION_HISTORY = 100
+
+/**
  * Accumulates local metrics during agent invocation.
  *
  * Tracks cycle counts, token usage, tool execution stats, and model latency.
@@ -382,8 +390,13 @@ export class Meter {
   /**
    * Begin tracking a new agent invocation.
    * Creates a new InvocationMetricsData entry for per-invocation metrics.
+   * Evicts the oldest entry when the history exceeds MAX_INVOCATION_HISTORY.
    */
   startNewInvocation(): void {
+    if (this._agentInvocations.length >= MAX_INVOCATION_HISTORY) {
+      this._agentInvocations.shift()
+    }
+
     this._agentInvocations.push({
       cycles: [],
       usage: createEmptyUsage(),


### PR DESCRIPTION
## Description

`Meter._agentInvocations` grows by one entry on every `agent.invoke()` call with no eviction. For long-lived Agent instances serving many requests (stateless API servers, batch processors), this causes silent, unbounded heap growth over time.

This PR caps the retained invocation history at 100 entries. When a new invocation begins and the array is at capacity, the oldest entry is shifted out. Lifetime-accumulated scalars (`cycleCount`, `totalDuration`, `accumulatedUsage`, `toolMetrics`) remain accurate regardless of eviction since they are tracked independently.

Users who need full invocation history can collect `result.metrics.latestAgentInvocation` from each `AgentResult` and store it themselves.

### Design rationale

I considered exposing a `MeterConfig` (with `maxInvocationHistory`) on `AgentConfig`, giving users explicit control over the cap. I opted for a hardcoded limit instead because:

- The unbounded growth is a bug, not a feature. No user intentionally opts into a memory leak. A reasonable default fixes the problem without requiring awareness of it.
- A `MeterConfig` type with a single field adds API surface for a knob most users will never touch. If configurable history retention becomes a real need, it can be added later as a clear feature request.
- The Meter is private on the Agent. Users access per-invocation metrics through `AgentResult`, so the SDK does not need to be a metrics database.
- I suspect most users who care about historical invocation data would prefer looking at it through OTEL exports on a dashboard rather than inspecting the in-process array. The same data (cycle durations, token usage, latency) is already emitted via OTEL counters and histograms as it happens.

The cap of 100 is a reasonable default for conversational agents while keeping memory negligible for server workloads.

## Related Issues

Closes #785

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- All 2589 unit tests pass
- New test verifies eviction at the 100-entry cap

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.