### PR TITLE
feat(mcp): forward agent cancel signal to MCP server

### DIFF
--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -336,11 +336,45 @@ describe('MCP Integration', () => {
       await client.callTool(tool, { op: 'add' })
 
       expect(sdkClientMock.connect).toHaveBeenCalled()
-      expect(sdkClientMock.callTool).toHaveBeenCalledWith({
-        name: 'calc',
-        arguments: { op: 'add' },
-      })
+      expect(sdkClientMock.callTool).toHaveBeenCalledWith(
+        { name: 'calc', arguments: { op: 'add' } },
+        undefined,
+        undefined
+      )
       expect(sdkClientMock.experimental.tasks.callToolStream).not.toHaveBeenCalled()
+    })
+
+    it('forwards abort signal to SDK callTool', async () => {
+      const tool = new McpTool({ name: 'calc', description: '', inputSchema: {}, client })
+      sdkClientMock.callTool.mockResolvedValue({ content: [] })
+      const controller = new AbortController()
+
+      await client.callTool(tool, { op: 'add' }, { signal: controller.signal })
+
+      expect(sdkClientMock.callTool).toHaveBeenCalledWith({ name: 'calc', arguments: { op: 'add' } }, undefined, {
+        signal: controller.signal,
+      })
+    })
+
+    it('forwards abort signal to callToolStream when tasksConfig is provided', async () => {
+      const resultsLengthBefore = vi.mocked(Client).mock.results.length
+      const taskClient = new McpClient({
+        applicationName: 'TestApp',
+        transport: mockTransport,
+        tasksConfig: {},
+      })
+      const taskSdkClientMock = vi.mocked(Client).mock.results[resultsLengthBefore]!.value
+      const tool = new McpTool({ name: 'calc', description: '', inputSchema: {}, client: taskClient })
+      taskSdkClientMock.experimental.tasks.callToolStream.mockReturnValue(createMockCallToolStream({ content: [] })())
+      const controller = new AbortController()
+
+      await taskClient.callTool(tool, { op: 'add' }, { signal: controller.signal })
+
+      expect(taskSdkClientMock.experimental.tasks.callToolStream).toHaveBeenCalledWith(
+        { name: 'calc', arguments: { op: 'add' } },
+        undefined,
+        { timeout: 60000, maxTotalTimeout: 300000, resetTimeoutOnProgress: true, signal: controller.signal }
+      )
     })
 
     it('uses callToolStream when tasksConfig is provided (empty object)', async () => {
@@ -647,12 +681,28 @@ describe('MCP Integration', () => {
 
     const toolContext: ToolContext = {
       toolUse: { toolUseId: 'id-123', name: 'weather', input: { city: 'NYC' } },
-      agent: {} as LocalAgent,
+      agent: { cancelSignal: new AbortController().signal } as LocalAgent,
       invocationState: {},
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },
     }
+
+    it('forwards agent cancelSignal to callTool', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'text', text: 'ok' }],
+      })
+
+      await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(mockClientWrapper.callTool).toHaveBeenCalledWith(
+        tool,
+        { city: 'NYC' },
+        {
+          signal: toolContext.agent.cancelSignal,
+        }
+      )
+    })
 
     it('returns text results on success', async () => {
       vi.mocked(mockClientWrapper.callTool).mockResolvedValue({

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -268,6 +268,7 @@ export {
   type McpClientConfig,
   type McpClientCredentials,
   type McpTransport,
+  type McpCallToolOptions,
   type TasksConfig,
   type McpConnectionState,
   McpClient,

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -60,6 +60,12 @@ export interface TasksConfig {
 /** Connection state of an MCP client. */
 export type McpConnectionState = 'disconnected' | 'connected' | 'failed'
 
+/** Options for MCP tool invocation. */
+export interface McpCallToolOptions {
+  /** AbortSignal to cancel the in-flight request. */
+  signal?: AbortSignal
+}
+
 /** OAuth client credentials for machine-to-machine authentication. */
 export interface McpClientCredentials {
   clientId: string
@@ -356,14 +362,15 @@ export class McpClient {
    *
    * @param tool - The McpTool instance to invoke.
    * @param args - The arguments to pass to the tool.
+   * @param options - Optional settings for the request.
    * @returns A promise that resolves with the result of the tool invocation.
    */
-  public async callTool(tool: McpTool, args: JSONValue): Promise<JSONValue> {
+  public async callTool(tool: McpTool, args: JSONValue, options?: McpCallToolOptions): Promise<JSONValue> {
     await this.connect()
     if (this._state === 'failed') throw new Error('MCP server failed to connect. Call connect(true) to retry.')
 
     if (args === null || args === undefined) {
-      return await this.callTool(tool, {})
+      return await this.callTool(tool, {}, options)
     }
 
     if (typeof args !== 'object' || Array.isArray(args)) {
@@ -378,20 +385,17 @@ export class McpClient {
 
     // When tasksConfig is undefined, call tools directly without task management
     if (this._tasksConfig === undefined) {
-      return (await this._client.callTool({ name: tool.name, arguments: toolArgs })) as JSONValue
+      return (await this._client.callTool({ name: tool.name, arguments: toolArgs }, undefined, options)) as JSONValue
     }
 
     // When tasksConfig is defined (even as empty object), use task-based invocation
     // which supports long-running tools with progress tracking
-    const stream = this._client.experimental.tasks.callToolStream(
-      { name: tool.name, arguments: toolArgs },
-      undefined, // resultSchema - use default CallToolResultSchema
-      {
-        timeout: this._tasksConfig.ttl ?? McpClient.DEFAULT_TTL,
-        maxTotalTimeout: this._tasksConfig.pollTimeout ?? McpClient.DEFAULT_POLL_TIMEOUT,
-        resetTimeoutOnProgress: true,
-      }
-    )
+    const stream = this._client.experimental.tasks.callToolStream({ name: tool.name, arguments: toolArgs }, undefined, {
+      timeout: this._tasksConfig.ttl ?? McpClient.DEFAULT_TTL,
+      maxTotalTimeout: this._tasksConfig.pollTimeout ?? McpClient.DEFAULT_POLL_TIMEOUT,
+      resetTimeoutOnProgress: true,
+      ...options,
+    })
 
     const result = await takeResult(stream)
     return result as JSONValue

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -46,8 +46,9 @@ export class McpTool extends Tool {
     const { toolUseId, input } = toolContext.toolUse
 
     try {
-      // Input is validated by MCP Client before invocation
-      const rawResult: unknown = await this.mcpClient.callTool(this, input as JSONValue)
+      const rawResult: unknown = await this.mcpClient.callTool(this, input as JSONValue, {
+        signal: toolContext.agent.cancelSignal,
+      })
 
       if (!this._isMcpToolResult(rawResult)) {
         throw new Error('Invalid tool result from MCP Client: missing content array')


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

When an agent is cancelled mid-tool-execution, the MCP SDK now sends notifications/cancelled to the server, allowing it to abort work whose result will be discarded. Previously, cancelled MCP tools ran to completion on the server with no one listening.

Files:
- strands-ts/src/mcp.ts — added options?: { signal?: AbortSignal } to callTool, forwarded to both SDK call paths
- strands-ts/src/tools/mcp-tool.ts — passes toolContext.agent.cancelSignal through
- strands-ts/src/__tests__/mcp.test.ts — updated assertion, added signal forwarding test

## Related Issues

<!-- Link to related issues using #issue-number format -->

#850 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix / enhancement

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
