### PR TITLE
feat(mcp): load MCP servers from JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ sdk-typescript/
 │   │   ├── index.ts              # Main SDK entry point
 │   │   ├── interrupt.ts          # Interrupt handling
 │   │   ├── mcp.ts                # MCP client implementation
+│   │   ├── mcp-config.ts         # MCP config file parsing
 │   │   ├── mime.ts               # MIME type utilities
 │   │   └── state-store.ts        # State store implementation
 │   │

--- a/strands-ts/src/__tests__/mcp-config.test.node.ts
+++ b/strands-ts/src/__tests__/mcp-config.test.node.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { McpClient } from '../mcp.js'
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}))
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}))
+
+vi.mock('node:path', () => ({
+  join: (...segments: string[]) => segments.join('/'),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn(function () {}),
+  getDefaultEnvironment: vi.fn(() => ({ PATH: '/usr/bin', HOME: '/home/user' })),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn(function () {}),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: vi.fn(function () {}),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn(function (this: Record<string, unknown>) {
+    this.connect = vi.fn()
+    this.close = vi.fn()
+    this.listTools = vi.fn()
+    this.callTool = vi.fn()
+    this.setRequestHandler = vi.fn()
+    this.setNotificationHandler = vi.fn()
+    this.getServerCapabilities = vi.fn()
+    this.getServerVersion = vi.fn()
+    this.getInstructions = vi.fn()
+    this.experimental = { tasks: { callToolStream: vi.fn() } }
+  }),
+}))
+
+describe('McpClient.loadServers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('transport detection', () => {
+    it('creates StdioClientTransport when command is present', async () => {
+      const clients = await McpClient.loadServers({
+        'my-server': { command: 'node', args: ['server.js'] },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        args: ['server.js'],
+      })
+    })
+
+    it('creates McpClient with url when url is present', async () => {
+      const clients = await McpClient.loadServers({
+        'remote-server': { url: 'https://example.com/mcp' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(StdioClientTransport).not.toHaveBeenCalled()
+      expect(SSEClientTransport).not.toHaveBeenCalled()
+    })
+
+    it('creates SSEClientTransport when transport is "sse"', async () => {
+      const clients = await McpClient.loadServers({
+        'sse-server': { url: 'https://example.com/sse', transport: 'sse' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL('https://example.com/sse'), undefined)
+    })
+
+    it('explicit transport overrides auto-detection', async () => {
+      const clients = await McpClient.loadServers({
+        server: { url: 'https://example.com/mcp', transport: 'sse' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(SSEClientTransport).toHaveBeenCalled()
+      expect(StreamableHTTPClientTransport).not.toHaveBeenCalled()
+    })
+
+    it('interpolates auth credentials for streamable-http', async () => {
+      vi.stubEnv('CLIENT_ID', 'my-id')
+      vi.stubEnv('CLIENT_SECRET', 'my-secret')
+
+      const clients = await McpClient.loadServers({
+        server: {
+          url: 'https://example.com/mcp',
+          auth: { clientId: '${CLIENT_ID}', clientSecret: '${CLIENT_SECRET}' },
+        },
+      })
+
+      expect(clients).toHaveLength(1)
+    })
+
+    it('throws when auth credential references missing env var', async () => {
+      vi.unstubAllEnvs()
+
+      await expect(
+        McpClient.loadServers({
+          server: {
+            url: 'https://example.com/mcp',
+            auth: { clientId: '${MISSING_ID}', clientSecret: 'literal' },
+          },
+        })
+      ).rejects.toThrow('Environment variable "MISSING_ID" is not set')
+    })
+  })
+
+  describe('env interpolation', () => {
+    it('interpolates ${VAR} in env values', async () => {
+      vi.stubEnv('MY_SECRET', 'secret123')
+
+      await McpClient.loadServers({
+        server: { command: 'node', env: { SECRET: '${MY_SECRET}' } },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        env: { PATH: '/usr/bin', HOME: '/home/user', SECRET: 'secret123' },
+      })
+    })
+
+    it('interpolates ${VAR} in headers', async () => {
+      vi.stubEnv('TOKEN', 'abc')
+
+      await McpClient.loadServers({
+        server: { url: 'https://example.com/sse', transport: 'sse', headers: { Authorization: 'Bearer ${TOKEN}' } },
+      })
+
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL('https://example.com/sse'), {
+        requestInit: { headers: { Authorization: 'Bearer abc' } },
+      })
+    })
+
+    it('interpolates ${VAR} in url', async () => {
+      vi.stubEnv('HOST', 'myhost.com')
+
+      const clients = await McpClient.loadServers({
+        server: { url: 'https://${HOST}/mcp', transport: 'sse' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL('https://myhost.com/mcp'), undefined)
+    })
+
+    it('throws when env var is not set', async () => {
+      vi.unstubAllEnvs()
+
+      await expect(
+        McpClient.loadServers({
+          server: { command: 'node', env: { VAL: '${NONEXISTENT_VAR}' } },
+        })
+      ).rejects.toThrow('Environment variable "NONEXISTENT_VAR" is not set')
+    })
+
+    it('skips server with missing env var when continueOnError is true', async () => {
+      vi.unstubAllEnvs()
+
+      const clients = await McpClient.loadServers({
+        broken: { command: 'node', env: { VAL: '${NONEXISTENT_VAR}' }, continueOnError: true },
+        working: { command: 'node' },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(clients[0]!.clientName).toBe('working')
+    })
+
+    it('interpolates ${VAR} in cwd', async () => {
+      vi.stubEnv('PROJECT_DIR', '/home/user/projects')
+
+      await McpClient.loadServers({
+        server: { command: 'node', cwd: '${PROJECT_DIR}/my-server' },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        cwd: '/home/user/projects/my-server',
+      })
+    })
+
+    it('merges env with default environment', async () => {
+      await McpClient.loadServers({
+        server: { command: 'node', env: { CUSTOM: 'value' } },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        env: { PATH: '/usr/bin', HOME: '/home/user', CUSTOM: 'value' },
+      })
+    })
+  })
+
+  describe('file config loading', () => {
+    it('reads and parses a JSON file', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          'my-server': { command: 'node', args: ['server.js'] },
+        })
+      )
+
+      const clients = await McpClient.loadServers('/path/to/config.json')
+
+      expect(readFile).toHaveBeenCalledWith('/path/to/config.json', 'utf-8')
+      expect(clients).toHaveLength(1)
+    })
+
+    it('extracts mcpServers key when present', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          mcpServers: {
+            'server-a': { command: 'node' },
+            'server-b': { url: 'https://example.com' },
+          },
+        })
+      )
+
+      const clients = await McpClient.loadServers('/path/to/config.json')
+
+      expect(clients).toHaveLength(2)
+    })
+
+    it('uses whole object when mcpServers key is absent', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          'server-a': { command: 'node' },
+        })
+      )
+
+      const clients = await McpClient.loadServers('/path/to/config.json')
+
+      expect(clients).toHaveLength(1)
+    })
+
+    it('expands ~ to home directory', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          server: { command: 'node' },
+        })
+      )
+
+      await McpClient.loadServers('~/config/mcp.json')
+
+      expect(readFile).toHaveBeenCalledWith('/home/user/config/mcp.json', 'utf-8')
+    })
+  })
+
+  describe('defaults and per-server overrides', () => {
+    it('per-server continueOnError overrides defaults', async () => {
+      const clients = await McpClient.loadServers(
+        {
+          'strict-server': { command: 'node', continueOnError: false },
+          'lenient-server': { command: 'node', continueOnError: true },
+        },
+        { continueOnError: true }
+      )
+
+      expect(clients[0]!.continueOnError).toBe(false)
+      expect(clients[1]!.continueOnError).toBe(true)
+    })
+
+    it('applies default continueOnError when server does not override', async () => {
+      const clients = await McpClient.loadServers({ server: { command: 'node' } }, { continueOnError: true })
+
+      expect(clients[0]!.continueOnError).toBe(true)
+    })
+
+    it('uses server name as applicationName when not in defaults', async () => {
+      const clients = await McpClient.loadServers({
+        'my-named-server': { command: 'node' },
+      })
+
+      expect(clients[0]!.clientName).toBe('my-named-server')
+    })
+
+    it('uses defaults applicationName over server name', async () => {
+      const clients = await McpClient.loadServers({ server: { command: 'node' } }, { applicationName: 'my-app' })
+
+      expect(clients[0]!.clientName).toBe('my-app')
+    })
+  })
+
+  describe('error cases', () => {
+    it('throws when server has neither command nor url', async () => {
+      await expect(McpClient.loadServers({ bad: {} })).rejects.toThrow(
+        'Server config must include either "command" (stdio) or "url" (http)'
+      )
+    })
+
+    it('throws when stdio transport specified without command', async () => {
+      await expect(McpClient.loadServers({ bad: { transport: 'stdio' } })).rejects.toThrow(
+        'Stdio transport requires "command" field'
+      )
+    })
+
+    it('throws when streamable-http transport specified without url', async () => {
+      await expect(McpClient.loadServers({ bad: { transport: 'streamable-http' } })).rejects.toThrow(
+        'Streamable HTTP transport requires "url" field'
+      )
+    })
+
+    it('throws when sse transport specified without url', async () => {
+      await expect(McpClient.loadServers({ bad: { transport: 'sse' } })).rejects.toThrow(
+        'SSE transport requires "url" field'
+      )
+    })
+
+    it('throws on invalid file path', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockRejectedValue(new Error('ENOENT: no such file or directory'))
+
+      await expect(McpClient.loadServers('/nonexistent/path.json')).rejects.toThrow('ENOENT')
+    })
+
+    it('throws on malformed JSON', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue('not json{{{')
+
+      await expect(McpClient.loadServers('/path/to/bad.json')).rejects.toThrow()
+    })
+
+    it('throws when auth is used with sse transport', async () => {
+      await expect(
+        McpClient.loadServers({
+          server: {
+            url: 'https://example.com',
+            transport: 'sse',
+            auth: { clientId: 'id', clientSecret: 'secret' },
+          },
+        })
+      ).rejects.toThrow('SSE transport does not support auth')
+    })
+
+    it('throws on invalid config shape', async () => {
+      const { readFile } = await import('node:fs/promises')
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify([1, 2, 3]))
+
+      await expect(McpClient.loadServers('/path/to/bad.json')).rejects.toThrow('MCP config must be a JSON object')
+    })
+
+    it('throws when server has both command and url without explicit transport', async () => {
+      await expect(McpClient.loadServers({ bad: { command: 'node', url: 'https://example.com' } })).rejects.toThrow(
+        'Server config has both "command" and "url"'
+      )
+    })
+  })
+
+  describe('disabled', () => {
+    it('skips disabled servers', async () => {
+      const clients = await McpClient.loadServers({
+        active: { command: 'node' },
+        inactive: { command: 'node', disabled: true },
+      })
+
+      expect(clients).toHaveLength(1)
+      expect(clients[0]!.clientName).toBe('active')
+    })
+  })
+
+  describe('env interpolation syntax', () => {
+    it('supports ${env:VAR} namespaced syntax', async () => {
+      vi.stubEnv('MY_TOKEN', 'token123')
+
+      await McpClient.loadServers({
+        server: { command: 'node', env: { TOKEN: '${env:MY_TOKEN}' } },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'node',
+        env: { PATH: '/usr/bin', HOME: '/home/user', TOKEN: 'token123' },
+      })
+    })
+
+    it('interpolates ${VAR} in command and args', async () => {
+      vi.stubEnv('MY_CMD', '/usr/local/bin/server')
+      vi.stubEnv('MY_ARG', '3000')
+
+      await McpClient.loadServers({
+        server: { command: '${MY_CMD}', args: ['--port=${MY_ARG}'] },
+      })
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: '/usr/local/bin/server',
+        args: ['--port=3000'],
+      })
+    })
+  })
+})

--- a/strands-ts/src/__tests__/mcp.test.ts
+++ b/strands-ts/src/__tests__/mcp.test.ts
@@ -1059,7 +1059,7 @@ describe('server metadata getters', () => {
   })
 })
 
-describe('failOpen', () => {
+describe('continueOnError', () => {
   let sdkClientMock: {
     connect: ReturnType<typeof vi.fn>
     listTools: ReturnType<typeof vi.fn>
@@ -1087,17 +1087,17 @@ describe('failOpen', () => {
     await expect(client.connect()).rejects.toThrow('connection refused')
   })
 
-  it('swallows connection failure when failOpen is true', async () => {
-    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+  it('swallows connection failure when continueOnError is true', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, continueOnError: true })
     sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
     sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
 
     await expect(client.connect()).resolves.toBeUndefined()
   })
 
-  it('logs a warning when failOpen swallows a connection failure', async () => {
+  it('logs a warning when continueOnError swallows a connection failure', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
-    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, continueOnError: true })
     sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
     sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
 
@@ -1106,8 +1106,8 @@ describe('failOpen', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('MCP server failed to connect'))
   })
 
-  it('listTools returns empty array when failOpen and connection failed', async () => {
-    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+  it('listTools returns empty array when continueOnError and connection failed', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, continueOnError: true })
     sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
     sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
 
@@ -1116,8 +1116,8 @@ describe('failOpen', () => {
     expect(tools).toEqual([])
   })
 
-  it('callTool throws when failOpen and connection failed', async () => {
-    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+  it('callTool throws when continueOnError and connection failed', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, continueOnError: true })
     sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
     sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
     const tool = new McpTool({ name: 'my_tool', description: '', inputSchema: {}, client })
@@ -1127,8 +1127,8 @@ describe('failOpen', () => {
     )
   })
 
-  it('does not retry connection on subsequent calls after failOpen failure', async () => {
-    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+  it('does not retry connection on subsequent calls after continueOnError failure', async () => {
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, continueOnError: true })
     sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
     sdkClientMock.connect.mockRejectedValue(new Error('connection refused'))
 
@@ -1139,7 +1139,7 @@ describe('failOpen', () => {
   })
 
   it('recovers after explicit connect(true) when server comes back', async () => {
-    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, failOpen: true })
+    const client = new McpClient({ applicationName: 'TestApp', transport: mockTransport, continueOnError: true })
     sdkClientMock = vi.mocked(Client).mock.results.at(-1)!.value
     sdkClientMock.connect.mockRejectedValueOnce(new Error('connection refused'))
     sdkClientMock.listTools.mockResolvedValue({ tools: [] })
@@ -1255,7 +1255,7 @@ describe('McpClient transport resolution', () => {
 
   it('constructs StreamableHTTPClientTransport when url is provided', () => {
     new McpClient({ url: 'https://mcp.example.com' })
-    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), undefined)
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(new URL('https://mcp.example.com'), {})
   })
 
   it('constructs ClientCredentialsProvider when auth is provided', () => {
@@ -1317,7 +1317,7 @@ describe('McpClient transport resolution', () => {
   it('accepts URL instance for url field', () => {
     const url = new URL('https://mcp.example.com/path')
     new McpClient({ url })
-    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(url, undefined)
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(url, {})
   })
 
   it('passes headers as requestInit to transport', () => {

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -269,6 +269,7 @@ export type { Logger } from './logging/types.js'
 
 // MCP Client types and implementations
 export {
+  type McpClientOptions,
   type McpClientConfig,
   type McpClientCredentials,
   type McpTransport,
@@ -277,6 +278,7 @@ export {
   type McpConnectionState,
   McpClient,
 } from './mcp.js'
+export { type McpServerConfig } from './mcp-config.js'
 export type { ElicitationCallback, ElicitationContext } from './types/elicitation.js'
 
 // Session management

--- a/strands-ts/src/mcp-config.ts
+++ b/strands-ts/src/mcp-config.ts
@@ -1,0 +1,188 @@
+import type { McpClientConfig, McpClientCredentials, McpClientOptions, McpTransport, TasksConfig } from './mcp.js'
+import { logger } from './logging/index.js'
+
+/**
+ * Configuration for a single MCP server entry in a config file or object.
+ *
+ * Provide either `command` (stdio transport) or `url` (streamable-http/SSE), not both.
+ * When `transport` is omitted, it is auto-detected from the fields present.
+ */
+export interface McpServerConfig {
+  /** Command to spawn (stdio transport, supports `${VAR}` or `${env:VAR}` interpolation). */
+  command?: string
+  /** Arguments passed to the command (supports `${VAR}` or `${env:VAR}` interpolation). */
+  args?: string[]
+  /** Environment variables passed to the child process (supports `${VAR}` or `${env:VAR}` interpolation). */
+  env?: Record<string, string>
+  /** Working directory for the spawned process (supports `${VAR}` or `${env:VAR}` interpolation). */
+  cwd?: string
+  /** Server endpoint URL (streamable-http or SSE transport, supports `${VAR}` or `${env:VAR}` interpolation). */
+  url?: string
+  /** HTTP headers sent with every request (supports `${VAR}` or `${env:VAR}` interpolation). */
+  headers?: Record<string, string>
+  /** Explicit transport type. When omitted, auto-detected: `command` → stdio, `url` → streamable-http. */
+  transport?: 'stdio' | 'sse' | 'streamable-http'
+  /** Client credentials for OAuth machine-to-machine auth (streamable-http only). */
+  auth?: McpClientCredentials
+  /** When true, this server is skipped during loadServers. */
+  disabled?: boolean
+  /** When true, config or connection failures skip this server instead of throwing. */
+  continueOnError?: boolean
+  /** Task-augmented tool execution configuration (experimental). */
+  tasksConfig?: TasksConfig
+}
+
+/**
+ * Resolves an MCP servers config into an array of client configurations ready for instantiation.
+ *
+ * @param config - A file path to a JSON config, or a flat server map object.
+ * @param defaults - Options applied to all clients unless overridden per-server.
+ * @returns Resolved McpClientConfig array (one per enabled, successfully-resolved server).
+ */
+export async function resolveServerConfigs(
+  config: string | Record<string, McpServerConfig>,
+  defaults?: McpClientOptions
+): Promise<McpClientConfig[]> {
+  const servers = await loadServersObject(config)
+  const results: McpClientConfig[] = []
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (!server || typeof server !== 'object' || Array.isArray(server)) {
+      throw new Error(`Server "${name}" must be an object, got ${Array.isArray(server) ? 'array' : typeof server}`)
+    }
+
+    if (server.disabled) continue
+
+    const continueOnError = server.continueOnError ?? defaults?.continueOnError ?? false
+
+    try {
+      if (server.command && server.url && !server.transport) {
+        throw new Error('Server config has both "command" and "url" — set "transport" explicitly or remove one')
+      }
+
+      const type = server.transport ?? (server.command ? 'stdio' : server.url ? 'streamable-http' : undefined)
+      if (!type) throw new Error('Server config must include either "command" (stdio) or "url" (http)')
+
+      let clientConfig: McpClientConfig
+      switch (type) {
+        case 'stdio':
+          clientConfig = await buildStdioConfig(server)
+          break
+        case 'streamable-http':
+          clientConfig = buildHttpConfig(server)
+          break
+        case 'sse':
+          clientConfig = await buildSseConfig(server)
+          break
+        default: {
+          const _exhaustive: never = type
+          throw new Error(`Unsupported transport type: ${_exhaustive}`)
+        }
+      }
+
+      results.push({ ...baseOptions(name, server, defaults), ...clientConfig })
+    } catch (error) {
+      if (!continueOnError) throw error
+      logger.warn(`server=<${name}>, error=<${error}> | MCP server config failed, skipping (continueOnError)`)
+    }
+  }
+
+  return results
+}
+
+async function buildStdioConfig(server: McpServerConfig): Promise<McpClientConfig> {
+  if (!server.command) throw new Error('Stdio transport requires "command" field')
+  const { StdioClientTransport, getDefaultEnvironment } = await import('@modelcontextprotocol/sdk/client/stdio.js')
+
+  const opts: ConstructorParameters<typeof StdioClientTransport>[0] = {
+    command: interpolateEnv(server.command),
+  }
+  if (server.args) opts.args = server.args.map(interpolateEnv)
+  if (server.env) opts.env = { ...getDefaultEnvironment(), ...interpolateRecord(server.env) }
+  if (server.cwd) opts.cwd = interpolateEnv(server.cwd)
+
+  return { transport: new StdioClientTransport(opts) as McpTransport }
+}
+
+function buildHttpConfig(server: McpServerConfig): McpClientConfig {
+  if (!server.url) throw new Error('Streamable HTTP transport requires "url" field')
+
+  const config: McpClientConfig = { url: interpolateEnv(server.url) }
+  if (server.headers) config.headers = interpolateRecord(server.headers)
+  if (server.auth) {
+    config.auth = {
+      clientId: interpolateEnv(server.auth.clientId),
+      clientSecret: interpolateEnv(server.auth.clientSecret),
+      ...(server.auth.scopes && { scopes: server.auth.scopes.map(interpolateEnv) }),
+    }
+  }
+  return config
+}
+
+async function buildSseConfig(server: McpServerConfig): Promise<McpClientConfig> {
+  if (!server.url) throw new Error('SSE transport requires "url" field')
+  if (server.auth)
+    throw new Error('SSE transport does not support auth — use streamable-http or provide a pre-configured transport')
+
+  const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js')
+  const headers = server.headers ? interpolateRecord(server.headers) : undefined
+
+  return {
+    transport: new SSEClientTransport(
+      new URL(interpolateEnv(server.url)),
+      headers ? { requestInit: { headers } } : undefined
+    ) as McpTransport,
+  }
+}
+
+function baseOptions(name: string, server: McpServerConfig, defaults?: McpClientOptions): McpClientOptions {
+  const opts: McpClientOptions = { ...defaults, applicationName: defaults?.applicationName ?? name }
+  if (server.continueOnError != null) opts.continueOnError = server.continueOnError
+  if (server.tasksConfig != null) opts.tasksConfig = server.tasksConfig
+  return opts
+}
+
+/**
+ * Replaces `$\{VAR\}` and `$\{env:VAR\}` placeholders with their process.env values.
+ * Throws if a referenced variable is not set.
+ *
+ * @example
+ * ```typescript
+ * interpolateEnv('Bearer $\{TOKEN\}')       // → 'Bearer ghp_abc123'
+ * interpolateEnv('$\{env:HOME\}/config')    // → '/home/user/config'
+ * ```
+ */
+function interpolateEnv(value: string): string {
+  return value.replace(/\$\{(?:env:)?([^}]+)\}/g, (_, key: string) => {
+    const resolved = process.env[key]
+    if (resolved === undefined) throw new Error(`Environment variable "${key}" is not set`)
+    return resolved
+  })
+}
+
+/** Applies {@link interpolateEnv} to every value in a string record. */
+function interpolateRecord(record: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(record).map(([k, v]) => [k, interpolateEnv(v)]))
+}
+
+async function loadServersObject(
+  config: string | Record<string, McpServerConfig>
+): Promise<Record<string, McpServerConfig>> {
+  if (typeof config !== 'string') return config
+
+  const { readFile } = await import('node:fs/promises')
+  const { homedir } = await import('node:os')
+  const { join } = await import('node:path')
+
+  const filePath = config.startsWith('~/') ? join(homedir(), config.slice(2)) : config
+  const parsed = JSON.parse(await readFile(filePath, 'utf-8'))
+  const servers = parsed.mcpServers ?? parsed
+
+  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) {
+    throw new Error(
+      'MCP config must be a JSON object mapping server names to configs, e.g. { "my-server": { "command": "node" } }'
+    )
+  }
+
+  return servers
+}

--- a/strands-ts/src/mcp.ts
+++ b/strands-ts/src/mcp.ts
@@ -16,6 +16,7 @@ import type { JSONSchema, JSONValue } from './types/json.js'
 import type { ElicitationCallback } from './types/elicitation.js'
 import { McpTool } from './tools/mcp-tool.js'
 import { logger } from './logging/index.js'
+import { type McpServerConfig, resolveServerConfigs } from './mcp-config.js'
 
 /**
  * Widened transport type that accepts MCP transport implementations without requiring explicit casts.
@@ -74,23 +75,8 @@ export interface McpClientCredentials {
   scopes?: string[]
 }
 
-/** Arguments for configuring an MCP Client. */
-export type McpClientConfig = RuntimeConfig & {
-  /** Pre-constructed transport. Mutually exclusive with `url`. */
-  transport?: McpTransport
-
-  /** Server URL. When provided, a StreamableHTTP transport is constructed automatically. */
-  url?: string | URL
-
-  /** Client credentials for OAuth machine-to-machine auth. Requires `url`. */
-  auth?: McpClientCredentials
-
-  /** Custom OAuth provider for advanced auth flows. Requires `url`. Mutually exclusive with `auth`. */
-  authProvider?: OAuthClientProvider
-
-  /** Custom headers to include on every request to the server. Requires `url`. */
-  headers?: Record<string, string>
-
+/** Behavioral options shared by all MCP client configurations. */
+export interface McpClientOptions extends RuntimeConfig {
   /** Disable OpenTelemetry MCP instrumentation. */
   disableMcpInstrumentation?: boolean
 
@@ -109,10 +95,28 @@ export type McpClientConfig = RuntimeConfig & {
   elicitationCallback?: ElicitationCallback
 
   /** When true, connection failures are logged as warnings instead of throwing. */
-  failOpen?: boolean
+  continueOnError?: boolean
 
   /** Called when the server emits a log message. Defaults to routing through the Strands logger. */
   logHandler?: (params: LoggingMessageNotificationParams) => void
+}
+
+/** Arguments for configuring an MCP Client. */
+export type McpClientConfig = McpClientOptions & {
+  /** Pre-constructed transport. Mutually exclusive with `url`. */
+  transport?: McpTransport
+
+  /** Server URL. When provided, a StreamableHTTP transport is constructed automatically. */
+  url?: string | URL
+
+  /** Client credentials for OAuth machine-to-machine auth. Requires `url`. */
+  auth?: McpClientCredentials
+
+  /** Custom OAuth provider for advanced auth flows. Requires `url`. Mutually exclusive with `auth`. */
+  authProvider?: OAuthClientProvider
+
+  /** Custom headers to include on every request to the server. Requires `url`. */
+  headers?: Record<string, string>
 }
 
 /** MCP Client for interacting with Model Context Protocol servers. */
@@ -123,12 +127,26 @@ export class McpClient {
   /** Default poll timeout for task completion in milliseconds (5 minutes). */
   public static readonly DEFAULT_POLL_TIMEOUT = 300000
 
+  /**
+   * Parses an MCP servers config (file path or object) and returns McpClient instances.
+   *
+   * @param config - A file path to a JSON config, or a flat server map object.
+   * @param defaults - Options applied to all clients unless overridden per-server.
+   * @returns An array of McpClient instances ready to be passed to an Agent.
+   */
+  public static async loadServers(
+    config: string | Record<string, McpServerConfig>,
+    defaults?: McpClientOptions
+  ): Promise<McpClient[]> {
+    return (await resolveServerConfigs(config, defaults)).map((c) => new McpClient(c))
+  }
+
   private _clientName: string
   private _clientVersion: string
   private _transport: Transport
   private _state: McpConnectionState
   private _client: Client
-  private _failOpen: boolean
+  private _continueOnError: boolean
   private _logHandler: (params: LoggingMessageNotificationParams) => void
   private _disableMcpInstrumentation: boolean
   private _tasksConfig: TasksConfig | undefined
@@ -143,7 +161,7 @@ export class McpClient {
     this._clientVersion = args.applicationVersion || '0.0.1'
     this._transport = McpClient._resolveTransport(args)
     this._state = 'disconnected'
-    this._failOpen = args.failOpen ?? false
+    this._continueOnError = args.continueOnError ?? false
     this._logHandler = args.logHandler ?? defaultLogHandler
     this._tasksConfig = args.tasksConfig
     this._elicitationCallback = args.elicitationCallback
@@ -201,12 +219,10 @@ export class McpClient {
       : args.authProvider
 
     const url = args.url instanceof URL ? args.url : new URL(args.url!)
-    return new StreamableHTTPClientTransport(
-      url,
-      authProvider || args.headers
-        ? { ...(authProvider && { authProvider }), ...(args.headers && { requestInit: { headers: args.headers } }) }
-        : undefined
-    ) as Transport
+    return new StreamableHTTPClientTransport(url, {
+      ...(authProvider && { authProvider }),
+      ...(args.headers && { requestInit: { headers: args.headers } }),
+    }) as Transport
   }
 
   get client(): Client {
@@ -229,10 +245,18 @@ export class McpClient {
     return this._state
   }
 
+  get clientName(): string {
+    return this._clientName
+  }
+
+  get continueOnError(): boolean {
+    return this._continueOnError
+  }
+
   /**
    * Connects the MCP client to the server.
    *
-   * Called lazily before any operation that requires a connection. When `failOpen` is true,
+   * Called lazily before any operation that requires a connection. When `continueOnError` is true,
    * connection failures are swallowed and the client enters a `'failed'` state — subsequent
    * calls are no-ops until `connect(true)` is called explicitly to retry.
    *
@@ -258,10 +282,10 @@ export class McpClient {
       await this._client.connect(this._transport)
       this._state = 'connected'
     } catch (error) {
-      if (!this._failOpen) throw error
+      if (!this._continueOnError) throw error
       this._state = 'failed'
       logger.warn(
-        `client=<${this._clientName}>, error=<${error}> | MCP server failed to connect, continuing with failOpen`
+        `client=<${this._clientName}>, error=<${error}> | MCP server failed to connect, continuing (continueOnError)`
       )
     }
   }


### PR DESCRIPTION
## Description

Adds `McpClient.loadServers()` — a static factory that parses an MCP servers config (file path or inline object) and returns ready-to-use `McpClient[]` without any manual transport construction.

**Before** (original manual way):
```ts
import { Agent, McpClient } from '@strands-agents/sdk'
import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'

const agent = new Agent({
  tools: [
    new McpClient({
      transport: new StdioClientTransport({
        command: 'uvx',
        args: ['awslabs.aws-documentation-mcp-server@latest'],
        env: { ...process.env, AWS_PROFILE: process.env.AWS_PROFILE! },
      }),
    }),
    new McpClient({
      transport: new StreamableHTTPClientTransport(
        new URL('https://api.githubcopilot.com/mcp/'),
        { requestInit: { headers: { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } } }
      ),
    }),
  ],
})
```

**After:**
```ts
import { Agent, McpClient } from '@strands-agents/sdk'

// Using template literals (standard TypeScript):
const agent = new Agent({
  tools: await McpClient.loadServers({
    'aws-docs': {
      command: 'uvx',
      args: ['awslabs.aws-documentation-mcp-server@latest'],
      env: { AWS_PROFILE: `${process.env.AWS_PROFILE}` },
    },
    'github': {
      url: 'https://api.githubcopilot.com/mcp/',
      headers: { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
    },
  }),
})
```

```ts
// Using ${VAR} interpolation (same syntax works in JSON config files):
const agent = new Agent({
  tools: await McpClient.loadServers({
    'aws-docs': {
      command: 'uvx',
      args: ['awslabs.aws-documentation-mcp-server@latest'],
      env: { AWS_PROFILE: '${AWS_PROFILE}' },
    },
    'github': {
      url: 'https://api.githubcopilot.com/mcp/',
      headers: { Authorization: 'Bearer ${GITHUB_TOKEN}' },
    },
  }),
})
```

From a file:
```ts
const agent = new Agent({
  tools: await McpClient.loadServers('~/mcp-config.json'),
})
```

Mixed (load from file + manual):
```ts
const agent = new Agent({
  tools: [
    ...(await McpClient.loadServers('~/mcp-config.json')),
    new McpClient({
      url: 'https://my-custom-server.com/mcp',
      headers: { Authorization: `Bearer ${process.env.MY_TOKEN}` },
    }),
  ],
})
```

### Transport auto-detection

When `transport` is not explicitly set, it is inferred from the config fields:
- `command` present → `stdio`
- `url` present → `streamable-http`
- Neither → error

You can override this by setting `transport` explicitly (e.g. `transport: 'sse'` for a legacy server with a `url`).

### Additional changes

- Renames `failOpen` to `continueOnError` for clarity (GitHub Actions precedent). Not a breaking change — `failOpen` was merged days ago with no docs or adoption.
- Adds `auth` field to `McpServerConfig` for OAuth client credentials on streamable-http servers.
- Adds `clientName` and `continueOnError` public getters to `McpClient`.
- Extracts `McpClientOptions` from `McpClientConfig` for clean type reuse.

## Related Issues

strands-agents/sdk-typescript#850, strands-agents/sdk-python#2492

Builds on strands-agents/sdk-typescript#1059 which added url + auth fields to McpClientConfig.

## Type of Change

New feature / enhancement

## Testing

- [x] I ran `npm run check` (lint, typecheck, 2717 tests pass)
- [x] Unit tests cover: transport detection, env interpolation, file loading, defaults/overrides, error cases, continueOnError skip behavior, auth+sse rejection, invalid config shape

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.