### PR TITLE
feat(interventions): add confirm action with built-in approve/deny semantics

### DIFF
--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -12,6 +12,7 @@ import {
 import { Message, TextBlock } from '../../types/messages.js'
 import { deny } from '../actions.js'
 import type { InterventionAction, Guide, Transform, Proceed } from '../actions.js'
+import { Interrupt, InterruptState } from '../../interrupt.js'
 
 class DenyHandler extends InterventionHandler {
   readonly name = 'deny-handler'
@@ -321,6 +322,144 @@ describe('InterventionRegistry', () => {
 
       await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow()
       expect(laterCalled).not.toHaveBeenCalled()
+    })
+
+    function preloadInterruptResponse(handlerName: string, response: unknown) {
+      const interruptId = `hook:beforeToolCall:${toolUse.toolUseId}:${handlerName}`
+      const interruptState = (agent as unknown as { _interruptState: InterruptState })._interruptState
+      interruptState.interrupts[interruptId] = new Interrupt({
+        id: interruptId,
+        name: handlerName,
+        response: response as never,
+        source: 'hook',
+      })
+    }
+
+    describe('approve/deny on resume', () => {
+      const DENIED = 'INTERRUPTED: Interrupt denied execution'
+
+      it.each([
+        [true, false],
+        ['yes', false],
+        ['y', false],
+        ['Y', false],
+        ['YES', false],
+        ['  yes  ', false],
+        ['no', DENIED],
+        [false, DENIED],
+        [null, DENIED],
+        ['', DENIED],
+      ])('response %j → cancel=%j', async (response, expectedCancel) => {
+        preloadInterruptResponse('interrupt-handler', response)
+        new InterventionRegistry([new InterruptHandler()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        await hookRegistry.invokeCallbacks(event)
+        expect(event.cancel).toBe(expectedCancel)
+      })
+    })
+
+    it('uses custom isApproved when provided', async () => {
+      class CustomApprovalHandler extends InterventionHandler {
+        readonly name = 'custom-approval'
+        override beforeToolCall(): InterventionAction {
+          return {
+            type: 'interrupt',
+            prompt: 'approve?',
+            isApproved: (response) => response === 'custom-yes',
+          }
+        }
+      }
+
+      // 'yes' would pass default isApproved but fails custom
+      preloadInterruptResponse('custom-approval', 'yes')
+
+      new InterventionRegistry([new CustomApprovalHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('INTERRUPTED: Interrupt denied execution')
+    })
+
+    it('custom isApproved approves when its condition is met', async () => {
+      class CustomApprovalHandler extends InterventionHandler {
+        readonly name = 'custom-approval'
+        override beforeToolCall(): InterventionAction {
+          return {
+            type: 'interrupt',
+            prompt: 'approve?',
+            isApproved: (response) => response === 'custom-yes',
+          }
+        }
+      }
+
+      preloadInterruptResponse('custom-approval', 'custom-yes')
+
+      new InterventionRegistry([new CustomApprovalHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe(false)
+    })
+
+    it('approved interrupt does not short-circuit later handlers', async () => {
+      preloadInterruptResponse('interrupt-handler', 'yes')
+
+      const laterCalled = vi.fn()
+
+      class LaterHandler extends InterventionHandler {
+        readonly name = 'later'
+        override beforeToolCall(): InterventionAction {
+          laterCalled()
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new InterruptHandler(), new LaterHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe(false)
+      expect(laterCalled).toHaveBeenCalled()
+    })
+
+    it('InterruptError respects onError=throw (default) — propagates', async () => {
+      new InterventionRegistry([new InterruptHandler()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
+    })
+
+    it('InterruptError respects onError=proceed — skips interrupt, tool proceeds', async () => {
+      class InterruptProceedOnError extends InterventionHandler {
+        readonly name = 'interrupt-proceed-onerror'
+        override readonly onError = 'proceed' as const
+        override beforeToolCall(): InterventionAction {
+          return { type: 'interrupt', prompt: 'approve?' }
+        }
+      }
+
+      new InterventionRegistry([new InterruptProceedOnError()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe(false)
+    })
+
+    it('InterruptError respects onError=deny — converts to denial', async () => {
+      class InterruptDenyOnError extends InterventionHandler {
+        readonly name = 'interrupt-deny-onerror'
+        override readonly onError = 'deny' as const
+        override beforeToolCall(): InterventionAction {
+          return { type: 'interrupt', prompt: 'approve?' }
+        }
+      }
+
+      new InterventionRegistry([new InterruptDenyOnError()], hookRegistry)
+
+      const event = makeBeforeToolCallEvent()
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toContain('DENIED: Handler threw: Interrupt raised')
     })
   })
 

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -30,11 +30,11 @@ class GuideHandler extends InterventionHandler {
   }
 }
 
-class InterruptHandler extends InterventionHandler {
-  readonly name = 'interrupt-handler'
+class ConfirmHandler extends InterventionHandler {
+  readonly name = 'confirm-handler'
 
   override beforeToolCall(): InterventionAction {
-    return { type: 'interrupt', prompt: 'approve this action?' }
+    return { type: 'confirm', prompt: 'approve this action?' }
   }
 }
 
@@ -299,9 +299,9 @@ describe('InterventionRegistry', () => {
     })
   })
 
-  describe('interrupt', () => {
-    it('calls event.interrupt() on BeforeToolCallEvent', async () => {
-      new InterventionRegistry([new InterruptHandler()], hookRegistry)
+  describe('confirm', () => {
+    it('calls event.interrupt() on BeforeToolCallEvent for confirm action', async () => {
+      new InterventionRegistry([new ConfirmHandler()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
       await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
@@ -318,7 +318,7 @@ describe('InterventionRegistry', () => {
         }
       }
 
-      new InterventionRegistry([new InterruptHandler(), new LaterHandler()], hookRegistry)
+      new InterventionRegistry([new ConfirmHandler(), new LaterHandler()], hookRegistry)
 
       await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow()
       expect(laterCalled).not.toHaveBeenCalled()
@@ -336,7 +336,7 @@ describe('InterventionRegistry', () => {
     }
 
     describe('approve/deny on resume', () => {
-      const DENIED = 'INTERRUPTED: Interrupt denied execution'
+      const DENIED = 'DENIED: Confirm denied execution'
 
       it.each([
         [true, false],
@@ -350,8 +350,8 @@ describe('InterventionRegistry', () => {
         [null, DENIED],
         ['', DENIED],
       ])('response %j → cancel=%j', async (response, expectedCancel) => {
-        preloadInterruptResponse('interrupt-handler', response)
-        new InterventionRegistry([new InterruptHandler()], hookRegistry)
+        preloadInterruptResponse('confirm-handler', response)
+        new InterventionRegistry([new ConfirmHandler()], hookRegistry)
 
         const event = makeBeforeToolCallEvent()
         await hookRegistry.invokeCallbacks(event)
@@ -359,36 +359,36 @@ describe('InterventionRegistry', () => {
       })
     })
 
-    it('uses custom isApproved when provided', async () => {
+    it('uses custom evaluate when provided', async () => {
       class CustomApprovalHandler extends InterventionHandler {
         readonly name = 'custom-approval'
         override beforeToolCall(): InterventionAction {
           return {
-            type: 'interrupt',
+            type: 'confirm',
             prompt: 'approve?',
-            isApproved: (response) => response === 'custom-yes',
+            evaluate: (response) => response === 'custom-yes',
           }
         }
       }
 
-      // 'yes' would pass default isApproved but fails custom
+      // 'yes' would pass default evaluate but fails custom
       preloadInterruptResponse('custom-approval', 'yes')
 
       new InterventionRegistry([new CustomApprovalHandler()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
       await hookRegistry.invokeCallbacks(event)
-      expect(event.cancel).toBe('INTERRUPTED: Interrupt denied execution')
+      expect(event.cancel).toBe('DENIED: Confirm denied execution')
     })
 
-    it('custom isApproved approves when its condition is met', async () => {
+    it('custom evaluate approves when its condition is met', async () => {
       class CustomApprovalHandler extends InterventionHandler {
         readonly name = 'custom-approval'
         override beforeToolCall(): InterventionAction {
           return {
-            type: 'interrupt',
+            type: 'confirm',
             prompt: 'approve?',
-            isApproved: (response) => response === 'custom-yes',
+            evaluate: (response) => response === 'custom-yes',
           }
         }
       }
@@ -402,8 +402,8 @@ describe('InterventionRegistry', () => {
       expect(event.cancel).toBe(false)
     })
 
-    it('approved interrupt does not short-circuit later handlers', async () => {
-      preloadInterruptResponse('interrupt-handler', 'yes')
+    it('approved confirm does not short-circuit later handlers', async () => {
+      preloadInterruptResponse('confirm-handler', 'yes')
 
       const laterCalled = vi.fn()
 
@@ -415,7 +415,7 @@ describe('InterventionRegistry', () => {
         }
       }
 
-      new InterventionRegistry([new InterruptHandler(), new LaterHandler()], hookRegistry)
+      new InterventionRegistry([new ConfirmHandler(), new LaterHandler()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
       await hookRegistry.invokeCallbacks(event)
@@ -423,8 +423,8 @@ describe('InterventionRegistry', () => {
       expect(laterCalled).toHaveBeenCalled()
     })
 
-    it('denied interrupt short-circuits later handlers', async () => {
-      preloadInterruptResponse('interrupt-handler', 'no')
+    it('denied confirm short-circuits later handlers', async () => {
+      preloadInterruptResponse('confirm-handler', 'no')
       const laterCalled = vi.fn()
 
       class LaterHandler extends InterventionHandler {
@@ -435,20 +435,20 @@ describe('InterventionRegistry', () => {
         }
       }
 
-      new InterventionRegistry([new InterruptHandler(), new LaterHandler()], hookRegistry)
+      new InterventionRegistry([new ConfirmHandler(), new LaterHandler()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
       await hookRegistry.invokeCallbacks(event)
-      expect(event.cancel).toBe('INTERRUPTED: Interrupt denied execution')
+      expect(event.cancel).toBe('DENIED: Confirm denied execution')
       expect(laterCalled).not.toHaveBeenCalled()
     })
 
     it('InterruptError always propagates regardless of onError policy', async () => {
       class InterruptProceedOnError extends InterventionHandler {
-        readonly name = 'interrupt-proceed-onerror'
+        readonly name = 'confirm-proceed-onerror'
         override readonly onError = 'proceed' as const
         override beforeToolCall(): InterventionAction {
-          return { type: 'interrupt', prompt: 'approve?' }
+          return { type: 'confirm', prompt: 'approve?' }
         }
       }
 
@@ -613,8 +613,8 @@ describe('InterventionRegistry', () => {
       expect(event.cancel).toBe('DENIED: not authorized')
     })
 
-    it('interrupt short-circuits before guide can accumulate', async () => {
-      new InterventionRegistry([new InterruptHandler(), new GuideHandler()], hookRegistry)
+    it('confirm short-circuits before guide can accumulate', async () => {
+      new InterventionRegistry([new ConfirmHandler(), new GuideHandler()], hookRegistry)
 
       await expect(hookRegistry.invokeCallbacks(makeBeforeToolCallEvent())).rejects.toThrow('Interrupt raised')
     })
@@ -766,13 +766,13 @@ describe('InterventionRegistry', () => {
       const { logger } = await import('../../logging/logger.js')
       const warnSpy = vi.spyOn(logger, 'warn')
 
-      // Force an interrupt return on beforeInvocation (which doesn't support it)
+      // Force a confirm return on beforeInvocation (which doesn't support it)
       // via cast to test the runtime warning path
       class InterruptOnInvocation extends InterventionHandler {
-        readonly name = 'interrupt-invocation'
+        readonly name = 'confirm-invocation'
         override beforeInvocation() {
-          // Force an interrupt return via any cast to test the runtime warning
-          return { type: 'interrupt', prompt: 'test' } as never
+          // Force a confirm return via any cast to test the runtime warning
+          return { type: 'confirm', prompt: 'test' } as never
         }
       }
 

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -336,7 +336,7 @@ describe('InterventionRegistry', () => {
     }
 
     describe('approve/deny on resume', () => {
-      const DENIED = 'DENIED: Confirm denied execution'
+      const DENIED = 'CONFIRMATION_FAILED: approve this action?'
 
       it.each([
         [true, false],
@@ -378,7 +378,7 @@ describe('InterventionRegistry', () => {
 
       const event = makeBeforeToolCallEvent()
       await hookRegistry.invokeCallbacks(event)
-      expect(event.cancel).toBe('DENIED: Confirm denied execution')
+      expect(event.cancel).toBe('CONFIRMATION_FAILED: approve?')
     })
 
     it('custom evaluate approves when its condition is met', async () => {
@@ -439,7 +439,7 @@ describe('InterventionRegistry', () => {
 
       const event = makeBeforeToolCallEvent()
       await hookRegistry.invokeCallbacks(event)
-      expect(event.cancel).toBe('DENIED: Confirm denied execution')
+      expect(event.cancel).toBe('CONFIRMATION_FAILED: approve this action?')
       expect(laterCalled).not.toHaveBeenCalled()
     })
 

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -443,6 +443,74 @@ describe('InterventionRegistry', () => {
       expect(laterCalled).not.toHaveBeenCalled()
     })
 
+    describe('preemptive response (inline mode)', () => {
+      it('approves when response is an approved value', async () => {
+        class InlineConfirmHandler extends InterventionHandler {
+          readonly name = 'inline-confirm'
+          override beforeToolCall(): InterventionAction {
+            return { type: 'confirm', prompt: 'approve?', response: 'yes' }
+          }
+        }
+
+        new InterventionRegistry([new InlineConfirmHandler()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        await hookRegistry.invokeCallbacks(event)
+        expect(event.cancel).toBe(false)
+      })
+
+      it('denies when response is a non-approved value', async () => {
+        class InlineConfirmHandler extends InterventionHandler {
+          readonly name = 'inline-confirm'
+          override beforeToolCall(): InterventionAction {
+            return { type: 'confirm', prompt: 'approve?', response: 'no' }
+          }
+        }
+
+        new InterventionRegistry([new InlineConfirmHandler()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        await hookRegistry.invokeCallbacks(event)
+        expect(event.cancel).toBe('CONFIRMATION_FAILED: approve?')
+      })
+
+      it('uses custom evaluate with preemptive response', async () => {
+        class OtpHandler extends InterventionHandler {
+          readonly name = 'otp-handler'
+          override beforeToolCall(): InterventionAction {
+            return {
+              type: 'confirm',
+              prompt: 'Enter OTP:',
+              response: '123456',
+              evaluate: (r) => r === '123456',
+            }
+          }
+        }
+
+        new InterventionRegistry([new OtpHandler()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        await hookRegistry.invokeCallbacks(event)
+        expect(event.cancel).toBe(false)
+      })
+
+      it('passes response to event.interrupt() as preemptive value', async () => {
+        class InlineConfirmHandler extends InterventionHandler {
+          readonly name = 'inline-confirm'
+          override beforeToolCall(): InterventionAction {
+            return { type: 'confirm', prompt: 'approve?', response: 'yes' }
+          }
+        }
+
+        new InterventionRegistry([new InlineConfirmHandler()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        const interruptSpy = vi.spyOn(event, 'interrupt')
+        await hookRegistry.invokeCallbacks(event)
+        expect(interruptSpy).toHaveBeenCalledWith(expect.objectContaining({ response: 'yes' }))
+      })
+    })
+
     it.each(['proceed', 'deny'] as const)(
       'InterruptError always propagates regardless of onError=%s',
       async (onError) => {

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -423,14 +423,27 @@ describe('InterventionRegistry', () => {
       expect(laterCalled).toHaveBeenCalled()
     })
 
-    it('InterruptError respects onError=throw (default) — propagates', async () => {
-      new InterventionRegistry([new InterruptHandler()], hookRegistry)
+    it('denied interrupt short-circuits later handlers', async () => {
+      preloadInterruptResponse('interrupt-handler', 'no')
+      const laterCalled = vi.fn()
+
+      class LaterHandler extends InterventionHandler {
+        readonly name = 'later'
+        override beforeToolCall(): InterventionAction {
+          laterCalled()
+          return { type: 'proceed' }
+        }
+      }
+
+      new InterventionRegistry([new InterruptHandler(), new LaterHandler()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
-      await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
+      await hookRegistry.invokeCallbacks(event)
+      expect(event.cancel).toBe('INTERRUPTED: Interrupt denied execution')
+      expect(laterCalled).not.toHaveBeenCalled()
     })
 
-    it('InterruptError respects onError=proceed — skips interrupt, tool proceeds', async () => {
+    it('InterruptError always propagates regardless of onError policy', async () => {
       class InterruptProceedOnError extends InterventionHandler {
         readonly name = 'interrupt-proceed-onerror'
         override readonly onError = 'proceed' as const
@@ -442,24 +455,7 @@ describe('InterventionRegistry', () => {
       new InterventionRegistry([new InterruptProceedOnError()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
-      await hookRegistry.invokeCallbacks(event)
-      expect(event.cancel).toBe(false)
-    })
-
-    it('InterruptError respects onError=deny — converts to denial', async () => {
-      class InterruptDenyOnError extends InterventionHandler {
-        readonly name = 'interrupt-deny-onerror'
-        override readonly onError = 'deny' as const
-        override beforeToolCall(): InterventionAction {
-          return { type: 'interrupt', prompt: 'approve?' }
-        }
-      }
-
-      new InterventionRegistry([new InterruptDenyOnError()], hookRegistry)
-
-      const event = makeBeforeToolCallEvent()
-      await hookRegistry.invokeCallbacks(event)
-      expect(event.cancel).toContain('DENIED: Handler threw: Interrupt raised')
+      await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
     })
   })
 

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -300,7 +300,7 @@ describe('InterventionRegistry', () => {
   })
 
   describe('confirm', () => {
-    it('calls event.interrupt() on BeforeToolCallEvent for confirm action', async () => {
+    it('pauses agent when no response is provided', async () => {
       new InterventionRegistry([new ConfirmHandler()], hookRegistry)
 
       const event = makeBeforeToolCallEvent()
@@ -494,7 +494,7 @@ describe('InterventionRegistry', () => {
         expect(event.cancel).toBe(false)
       })
 
-      it('passes response to event.interrupt() as preemptive value', async () => {
+      it('passes response as preemptive value so agent never pauses', async () => {
         class InlineConfirmHandler extends InterventionHandler {
           readonly name = 'inline-confirm'
           override beforeToolCall(): InterventionAction {
@@ -507,7 +507,22 @@ describe('InterventionRegistry', () => {
         const event = makeBeforeToolCallEvent()
         const interruptSpy = vi.spyOn(event, 'interrupt')
         await hookRegistry.invokeCallbacks(event)
-        expect(interruptSpy).toHaveBeenCalledWith(expect.objectContaining({ response: 'yes' }))
+        expect(interruptSpy).toHaveBeenCalledWith({ name: 'inline-confirm', reason: 'approve?', response: 'yes' })
+      })
+
+      it('denies when response is falsy but defined (false)', async () => {
+        class InlineConfirmHandler extends InterventionHandler {
+          readonly name = 'inline-confirm'
+          override beforeToolCall(): InterventionAction {
+            return { type: 'confirm', prompt: 'approve?', response: false }
+          }
+        }
+
+        new InterventionRegistry([new InlineConfirmHandler()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        await hookRegistry.invokeCallbacks(event)
+        expect(event.cancel).toBe('CONFIRMATION_FAILED: approve?')
       })
     })
 

--- a/strands-ts/src/interventions/__tests__/registry.test.ts
+++ b/strands-ts/src/interventions/__tests__/registry.test.ts
@@ -443,20 +443,23 @@ describe('InterventionRegistry', () => {
       expect(laterCalled).not.toHaveBeenCalled()
     })
 
-    it('InterruptError always propagates regardless of onError policy', async () => {
-      class InterruptProceedOnError extends InterventionHandler {
-        readonly name = 'confirm-proceed-onerror'
-        override readonly onError = 'proceed' as const
-        override beforeToolCall(): InterventionAction {
-          return { type: 'confirm', prompt: 'approve?' }
+    it.each(['proceed', 'deny'] as const)(
+      'InterruptError always propagates regardless of onError=%s',
+      async (onError) => {
+        class ConfirmWithOnError extends InterventionHandler {
+          readonly name = 'confirm-onerror'
+          override readonly onError = onError
+          override beforeToolCall(): InterventionAction {
+            return { type: 'confirm', prompt: 'approve?' }
+          }
         }
+
+        new InterventionRegistry([new ConfirmWithOnError()], hookRegistry)
+
+        const event = makeBeforeToolCallEvent()
+        await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
       }
-
-      new InterventionRegistry([new InterruptProceedOnError()], hookRegistry)
-
-      const event = makeBeforeToolCallEvent()
-      await expect(hookRegistry.invokeCallbacks(event)).rejects.toThrow('Interrupt raised')
-    })
+    )
   })
 
   describe('transform', () => {

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -12,6 +12,9 @@ const APPROVED_RESPONSES = new Set(['y', 'yes'])
 /**
  * Default evaluate function for the confirm action.
  * Accepts: true, 'y'/'yes' (case-insensitive, whitespace-trimmed).
+ *
+ * @param response - The human's response value to evaluate.
+ * @returns true if the response is considered an approval, false otherwise.
  */
 export function defaultEvaluate(response: JSONValue): boolean {
   if (response === true) return true
@@ -84,7 +87,7 @@ export type Guide = { type: 'guide'; feedback: string; reason?: string }
  * Two modes depending on whether `response` is provided:
  * - With `response`: passed as a preemptive value to the interrupt system, agent
  *   never pauses. Handlers collect the response themselves (e.g. via readline).
- * - Without `response`: uses the interrupt system to pause the agent for external resume.
+ * - Without `response`: breaks out of the agent loop to pause for external resume.
  *
  * The response is checked against `evaluate` (defaults to accepting `true` or
  * `'y'`/`'yes'` case-insensitive). If denied, sets event.cancel.

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -67,30 +67,31 @@ export type Deny = { type: 'deny'; reason: string }
 export type Guide = { type: 'guide'; feedback: string; reason?: string }
 
 /**
- * Pause for human approval. Calls event.interrupt() to halt agent execution
- * until the user responds. On resume, the response is checked against an
- * `evaluate` function (defaults to accepting `true` or `'y'`/`'yes'`
- * case-insensitive). If denied, sets event.cancel. Only supported on beforeToolCall.
+ * Request human approval before proceeding. Only supported on beforeToolCall.
  *
- * @param prompt - The message shown to the human for approval. Not shown to the model.
- * @param reason - Optional metadata for debugging/logging. Not shown to the model.
- * @param evaluate - Optional custom validator for the human's response. Defaults to
- *   accepting `true` or `'y'`/`'yes'` (case-insensitive).
+ * Two modes depending on whether `response` is provided:
+ * - With `response`: passed as a preemptive value to the interrupt system, agent
+ *   never pauses. Handlers collect the response themselves (e.g. via readline).
+ * - Without `response`: uses the interrupt system to pause the agent for external resume.
+ *
+ * The response is checked against `evaluate` (defaults to accepting `true` or
+ * `'y'`/`'yes'` case-insensitive). If denied, sets event.cancel.
  *
  * @example
  * ```typescript
- * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
- *   if (this.requiresApproval(event.toolUse.name)) {
- *     return confirm(`Approve ${event.toolUse.name}?`)
- *   }
- *   return proceed()
- * }
+ * // Inline mode (handler collected the response already)
+ * const answer = await this._ask(prompt)
+ * return confirm(prompt, { response: answer })
+ *
+ * // Stateless mode (interrupt/resume)
+ * return confirm(`Approve ${event.toolUse.name}?`)
  * ```
  */
 export type Confirm = {
   type: 'confirm'
   prompt: string
   reason?: string
+  response?: JSONValue
   evaluate?: (response: JSONValue) => boolean
 }
 
@@ -126,13 +127,13 @@ export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => v
  * | Proceed   | —                | —              | —               | —             | —              |
  * | Deny      | cancel           | cancel         | cancel          | —             | —              |
  * | Guide     | cancel+          | cancel+        | inject          | —             | inject + retry |
- * | Confirm | —                | interrupt      | —               | —             | —              |
+ * | Confirm   | —                | confirm        | —               | —             | —              |
  * | Transform | apply            | apply          | apply           | apply         | apply          |
  *
  * — = no-op (logged in audit trail, warns at runtime)
  * cancel = sets event.cancel, short-circuits (remaining handlers skipped)
  * cancel+ = sets event.cancel with accumulated feedback from all guiding handlers
- * interrupt = calls event.interrupt(), checks response with evaluate, sets cancel if denied
+ * confirm = collects response (via ask or interrupt), checks with evaluate, sets cancel if denied
  * inject = appends accumulated feedback as a user message so the model sees it on this call
  * inject + retry = appends accumulated feedback and retries so the model sees guidance
  * apply = calls action.apply(event) for in-place mutation, later handlers see the change
@@ -165,14 +166,19 @@ export function guide(feedback: string, options?: { reason?: string }): Guide {
 }
 
 /**
- * Pause for human approval.
+ * Request human approval.
  * @param prompt - Message shown to the human. Not shown to the model.
  * @param options - Options: reason (debug metadata), evaluate (custom response
- * validator, defaults to accepting true or y/yes case-insensitive).
+ * validator, defaults to accepting true or y/yes case-insensitive), response
+ * (pre-collected value to skip pausing the agent).
  */
 export function confirm(
   prompt: string,
-  options?: { reason?: string; evaluate?: (response: JSONValue) => boolean }
+  options?: {
+    reason?: string
+    response?: JSONValue
+    evaluate?: (response: JSONValue) => boolean
+  }
 ): Confirm {
   return { type: 'confirm', prompt, ...options }
 }

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -69,29 +69,29 @@ export type Guide = { type: 'guide'; feedback: string; reason?: string }
 /**
  * Pause for human approval. Calls event.interrupt() to halt agent execution
  * until the user responds. On resume, the response is checked against an
- * `isApproved` function (defaults to accepting `true` or `'y'`/`'yes'`
+ * `evaluate` function (defaults to accepting `true` or `'y'`/`'yes'`
  * case-insensitive). If denied, sets event.cancel. Only supported on beforeToolCall.
  *
  * @param prompt - The message shown to the human for approval. Not shown to the model.
  * @param reason - Optional metadata for debugging/logging. Not shown to the model.
- * @param isApproved - Optional custom validator for the human's response. Defaults to
+ * @param evaluate - Optional custom validator for the human's response. Defaults to
  *   accepting `true` or `'y'`/`'yes'` (case-insensitive).
  *
  * @example
  * ```typescript
  * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
  *   if (this.requiresApproval(event.toolUse.name)) {
- *     return interrupt(`Approve ${event.toolUse.name}?`)
+ *     return confirm(`Approve ${event.toolUse.name}?`)
  *   }
  *   return proceed()
  * }
  * ```
  */
-export type Interrupt = {
-  type: 'interrupt'
+export type Confirm = {
+  type: 'confirm'
   prompt: string
   reason?: string
-  isApproved?: (response: JSONValue) => boolean
+  evaluate?: (response: JSONValue) => boolean
 }
 
 /**
@@ -126,18 +126,18 @@ export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => v
  * | Proceed   | —                | —              | —               | —             | —              |
  * | Deny      | cancel           | cancel         | cancel          | —             | —              |
  * | Guide     | cancel+          | cancel+        | inject          | —             | inject + retry |
- * | Interrupt | —                | interrupt      | —               | —             | —              |
+ * | Confirm | —                | interrupt      | —               | —             | —              |
  * | Transform | apply            | apply          | apply           | apply         | apply          |
  *
  * — = no-op (logged in audit trail, warns at runtime)
  * cancel = sets event.cancel, short-circuits (remaining handlers skipped)
  * cancel+ = sets event.cancel with accumulated feedback from all guiding handlers
- * interrupt = calls event.interrupt(), checks response with isApproved, sets cancel if denied
+ * interrupt = calls event.interrupt(), checks response with evaluate, sets cancel if denied
  * inject = appends accumulated feedback as a user message so the model sees it on this call
  * inject + retry = appends accumulated feedback and retries so the model sees guidance
  * apply = calls action.apply(event) for in-place mutation, later handlers see the change
  */
-export type InterventionAction = Proceed | Deny | Guide | Interrupt | Transform
+export type InterventionAction = Proceed | Deny | Guide | Confirm | Transform
 
 /**
  * Allow the operation to continue.
@@ -167,11 +167,14 @@ export function guide(feedback: string, options?: { reason?: string }): Guide {
 /**
  * Pause for human approval.
  * @param prompt - Message shown to the human. Not shown to the model.
- * @param options - Options: reason (debug metadata), isApproved (custom response
+ * @param options - Options: reason (debug metadata), evaluate (custom response
  * validator, defaults to accepting true or y/yes case-insensitive).
  */
-export function interrupt(prompt: string, options?: { reason?: string; isApproved?: (response: JSONValue) => boolean }): Interrupt {
-  return { type: 'interrupt', prompt, ...options }
+export function confirm(
+  prompt: string,
+  options?: { reason?: string; evaluate?: (response: JSONValue) => boolean }
+): Confirm {
+  return { type: 'confirm', prompt, ...options }
 }
 
 /**

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -7,6 +7,18 @@ import type {
 } from '../hooks/events.js'
 import type { JSONValue } from '../types/json.js'
 
+const APPROVED_RESPONSES = new Set(['y', 'yes'])
+
+/**
+ * Default evaluate function for the confirm action.
+ * Accepts: true, 'y'/'yes' (case-insensitive, whitespace-trimmed).
+ */
+export function defaultEvaluate(response: JSONValue): boolean {
+  if (response === true) return true
+  if (typeof response === 'string') return APPROVED_RESPONSES.has(response.toLowerCase().trim())
+  return false
+}
+
 export type LifecycleEvent =
   | BeforeInvocationEvent
   | BeforeToolCallEvent
@@ -133,7 +145,7 @@ export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => v
  * — = no-op (logged in audit trail, warns at runtime)
  * cancel = sets event.cancel, short-circuits (remaining handlers skipped)
  * cancel+ = sets event.cancel with accumulated feedback from all guiding handlers
- * confirm = collects response (via ask or interrupt), checks with evaluate, sets cancel if denied
+ * confirm = uses preemptive response or interrupt, checks with evaluate, sets cancel if denied
  * inject = appends accumulated feedback as a user message so the model sees it on this call
  * inject + retry = appends accumulated feedback and retries so the model sees guidance
  * apply = calls action.apply(event) for in-place mutation, later handlers see the change
@@ -180,7 +192,7 @@ export function confirm(
     evaluate?: (response: JSONValue) => boolean
   }
 ): Confirm {
-  return { type: 'confirm', prompt, ...options }
+  return { type: 'confirm', prompt, evaluate: defaultEvaluate, ...options }
 }
 
 /**

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -5,6 +5,7 @@ import type {
   BeforeModelCallEvent,
   AfterModelCallEvent,
 } from '../hooks/events.js'
+import type { JSONValue } from '../types/json.js'
 
 export type LifecycleEvent =
   | BeforeInvocationEvent
@@ -67,22 +68,31 @@ export type Guide = { type: 'guide'; feedback: string; reason?: string }
 
 /**
  * Pause for human approval. Calls event.interrupt() to halt agent execution
- * until the user responds. Only supported on beforeToolCall.
+ * until the user responds. On resume, the response is checked against an
+ * `isApproved` function (defaults to accepting `true` or `'y'`/`'yes'`
+ * case-insensitive). If denied, sets event.cancel. Only supported on beforeToolCall.
  *
  * @param prompt - The message shown to the human for approval. Not shown to the model.
  * @param reason - Optional metadata for debugging/logging. Not shown to the model.
+ * @param isApproved - Optional custom validator for the human's response. Defaults to
+ *   accepting `true` or `'y'`/`'yes'` (case-insensitive).
  *
  * @example
  * ```typescript
  * override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
  *   if (this.requiresApproval(event.toolUse.name)) {
- *     return { type: 'interrupt', prompt: `Approve ${event.toolUse.name}?` }
+ *     return interrupt(`Approve ${event.toolUse.name}?`)
  *   }
- *   return { type: 'proceed' }
+ *   return proceed()
  * }
  * ```
  */
-export type Interrupt = { type: 'interrupt'; prompt: string; reason?: string }
+export type Interrupt = {
+  type: 'interrupt'
+  prompt: string
+  reason?: string
+  isApproved?: (response: JSONValue) => boolean
+}
 
 /**
  * Modify event content in-place. The `apply` function mutates the event before
@@ -122,7 +132,7 @@ export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => v
  * — = no-op (logged in audit trail, warns at runtime)
  * cancel = sets event.cancel, short-circuits (remaining handlers skipped)
  * cancel+ = sets event.cancel with accumulated feedback from all guiding handlers
- * interrupt = calls event.interrupt() for native pause/resume (human-in-the-loop)
+ * interrupt = calls event.interrupt(), checks response with isApproved, sets cancel if denied
  * inject = appends accumulated feedback as a user message so the model sees it on this call
  * inject + retry = appends accumulated feedback and retries so the model sees guidance
  * apply = calls action.apply(event) for in-place mutation, later handlers see the change
@@ -144,9 +154,20 @@ export function guide(feedback: string, reason?: string): Guide {
   return { type: 'guide', feedback, ...(reason !== undefined && { reason }) }
 }
 
-/** Pause for human approval. */
-export function interrupt(prompt: string, reason?: string): Interrupt {
-  return { type: 'interrupt', prompt, ...(reason !== undefined && { reason }) }
+/**
+ * Pause for human approval.
+ * @param prompt - Message shown to the human.
+ * @param reason - Optional metadata for debugging/logging.
+ * @param isApproved - Optional custom response validator. Defaults to accepting
+ *   `true` or `'y'`/`'yes'` (case-insensitive).
+ */
+export function interrupt(prompt: string, reason?: string, isApproved?: (response: JSONValue) => boolean): Interrupt {
+  return {
+    type: 'interrupt',
+    prompt,
+    ...(reason !== undefined && { reason }),
+    ...(isApproved !== undefined && { isApproved }),
+  }
 }
 
 /** Modify event content in-place. */

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -139,33 +139,46 @@ export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => v
  */
 export type InterventionAction = Proceed | Deny | Guide | Interrupt | Transform
 
-/** Allow the operation to continue. */
+/**
+ * Allow the operation to continue.
+ * @param options - Options: reason (debug metadata).
+ */
 export function proceed(options?: { reason?: string }): Proceed {
   return { type: 'proceed', ...options }
 }
 
-/** Block the operation. */
+/**
+ * Block the operation.
+ * @param reason - Why the operation was blocked. Shown to the model.
+ */
 export function deny(reason: string): Deny {
   return { type: 'deny', reason }
 }
 
-/** Provide feedback to steer behavior. */
+/**
+ * Provide feedback to steer behavior.
+ * @param feedback - The guidance text shown to the model.
+ * @param options - Options: reason (debug metadata).
+ */
 export function guide(feedback: string, options?: { reason?: string }): Guide {
   return { type: 'guide', feedback, ...options }
 }
 
 /**
  * Pause for human approval.
- * @param prompt - Message shown to the human.
- * @param options.reason - Optional metadata for debugging/logging.
- * @param options.isApproved - Optional custom response validator. Defaults to accepting
- *   `true` or `'y'`/`'yes'` (case-insensitive).
+ * @param prompt - Message shown to the human. Not shown to the model.
+ * @param options - Options: reason (debug metadata), isApproved (custom response
+ * validator, defaults to accepting true or y/yes case-insensitive).
  */
 export function interrupt(prompt: string, options?: { reason?: string; isApproved?: (response: JSONValue) => boolean }): Interrupt {
   return { type: 'interrupt', prompt, ...options }
 }
 
-/** Modify event content in-place. */
+/**
+ * Modify event content in-place.
+ * @param apply - Function that mutates the event.
+ * @param options - Options: reason (debug metadata).
+ */
 export function transform(apply: (event: LifecycleEvent) => void, options?: { reason?: string }): Transform {
   return { type: 'transform', apply, ...options }
 }

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -95,7 +95,7 @@ export type Guide = { type: 'guide'; feedback: string; reason?: string }
  * @example
  * ```typescript
  * // Inline mode (handler collected the response already)
- * const answer = await this._ask(prompt)
+ * const answer = await rl.question(`${prompt} (y/n): `)
  * return confirm(prompt, { response: answer })
  *
  * // Stateless mode (interrupt/resume)

--- a/strands-ts/src/interventions/actions.ts
+++ b/strands-ts/src/interventions/actions.ts
@@ -140,8 +140,8 @@ export type Transform = { type: 'transform'; apply: (event: LifecycleEvent) => v
 export type InterventionAction = Proceed | Deny | Guide | Interrupt | Transform
 
 /** Allow the operation to continue. */
-export function proceed(reason?: string): Proceed {
-  return { type: 'proceed', ...(reason !== undefined && { reason }) }
+export function proceed(options?: { reason?: string }): Proceed {
+  return { type: 'proceed', ...options }
 }
 
 /** Block the operation. */
@@ -150,27 +150,22 @@ export function deny(reason: string): Deny {
 }
 
 /** Provide feedback to steer behavior. */
-export function guide(feedback: string, reason?: string): Guide {
-  return { type: 'guide', feedback, ...(reason !== undefined && { reason }) }
+export function guide(feedback: string, options?: { reason?: string }): Guide {
+  return { type: 'guide', feedback, ...options }
 }
 
 /**
  * Pause for human approval.
  * @param prompt - Message shown to the human.
- * @param reason - Optional metadata for debugging/logging.
- * @param isApproved - Optional custom response validator. Defaults to accepting
+ * @param options.reason - Optional metadata for debugging/logging.
+ * @param options.isApproved - Optional custom response validator. Defaults to accepting
  *   `true` or `'y'`/`'yes'` (case-insensitive).
  */
-export function interrupt(prompt: string, reason?: string, isApproved?: (response: JSONValue) => boolean): Interrupt {
-  return {
-    type: 'interrupt',
-    prompt,
-    ...(reason !== undefined && { reason }),
-    ...(isApproved !== undefined && { isApproved }),
-  }
+export function interrupt(prompt: string, options?: { reason?: string; isApproved?: (response: JSONValue) => boolean }): Interrupt {
+  return { type: 'interrupt', prompt, ...options }
 }
 
 /** Modify event content in-place. */
-export function transform(apply: (event: LifecycleEvent) => void, reason?: string): Transform {
-  return { type: 'transform', apply, ...(reason !== undefined && { reason }) }
+export function transform(apply: (event: LifecycleEvent) => void, options?: { reason?: string }): Transform {
+  return { type: 'transform', apply, ...options }
 }

--- a/strands-ts/src/interventions/handler.ts
+++ b/strands-ts/src/interventions/handler.ts
@@ -5,7 +5,7 @@ import type {
   BeforeModelCallEvent,
   AfterModelCallEvent,
 } from '../hooks/events.js'
-import type { Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
+import type { Proceed, Deny, Guide, Confirm, Transform } from './actions.js'
 
 type Awaitable<T> = T | Promise<T>
 
@@ -49,7 +49,7 @@ export abstract class InterventionHandler {
     return { type: 'proceed' }
   }
 
-  beforeToolCall(_event: BeforeToolCallEvent): Awaitable<Proceed | Deny | Guide | Interrupt | Transform> {
+  beforeToolCall(_event: BeforeToolCallEvent): Awaitable<Proceed | Deny | Guide | Confirm | Transform> {
     return { type: 'proceed' }
   }
 

--- a/strands-ts/src/interventions/index.ts
+++ b/strands-ts/src/interventions/index.ts
@@ -1,5 +1,5 @@
-export type { InterventionAction, LifecycleEvent, Proceed, Deny, Guide, Interrupt, Transform } from './actions.js'
-import { proceed, deny, guide, interrupt, transform } from './actions.js'
-export const InterventionActions = { proceed, deny, guide, interrupt, transform }
+export type { InterventionAction, LifecycleEvent, Proceed, Deny, Guide, Confirm, Transform } from './actions.js'
+import { proceed, deny, guide, confirm, transform } from './actions.js'
+export const InterventionActions = { proceed, deny, guide, confirm, transform }
 export { InterventionHandler } from './handler.js'
 export type { OnError } from './handler.js'

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -30,7 +30,7 @@ type LifecycleMethod = 'beforeInvocation' | 'beforeToolCall' | 'afterToolCall' |
  *
  * Registers one hook callback per lifecycle event type, then dispatches to
  * all handlers that override that method — in registration order, with
- * short-circuiting on Deny (and denied Interrupts) and accumulation for Guide.
+ * short-circuiting on Deny (and denied Confirms) and accumulation for Guide.
  *
  * See {@link InterventionAction} for the action-to-event compatibility matrix.
  */
@@ -105,14 +105,14 @@ export class InterventionRegistry {
         case 'deny':
           event.cancel = `DENIED: ${action.reason}`
           return true
-        case 'interrupt': {
+        case 'confirm': {
           // event.interrupt() throws InterruptError on first call (pausing the agent).
           // InterruptError always propagates (bypasses onError) since it's intentional
           // control flow, not a handler failure. On resume, returns the human's response.
           const response = event.interrupt<JSONValue>({ name: handlerName, reason: action.prompt })
-          const check = action.isApproved ?? isApproved
+          const check = action.evaluate ?? isApproved
           if (!check(response)) {
-            event.cancel = `INTERRUPTED: Interrupt denied execution`
+            event.cancel = `DENIED: Confirm denied execution`
             return true
           }
           return false
@@ -199,7 +199,7 @@ export class InterventionRegistry {
    * Iterate handlers in registration order and resolve the winning action.
    *
    * - Deny short-circuits immediately (remaining handlers are skipped).
-   * - Interrupt pauses for human input; if denied short-circuits, if approved continues.
+   * - Confirm pauses for human input; if denied short-circuits, if approved continues.
    * - Guide feedback strings accumulate across handlers and are applied at the end.
    * - Transform is applied in-place so later handlers see the mutation.
    * - If a handler throws, behavior depends on {@link InterventionHandler.onError}:
@@ -253,7 +253,7 @@ export class InterventionRegistry {
     }
 
     // Guide feedback accumulates across handlers. Only applied if
-    // no earlier handler short-circuited (deny/interrupt).
+    // no earlier handler short-circuited (deny/confirm).
     if (guides.length > 0) {
       logger.debug(`event=<${method}> | applying accumulated guide from ${guides.length} handler(s)`)
       const feedback = guides.map((g) => `[${g.handlerName}] ${g.action.feedback}`).join('\n')

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -11,6 +11,7 @@ import { HookOrder } from '../hooks/types.js'
 import { Message, TextBlock } from '../types/messages.js'
 import type { Guide, InterventionAction } from './actions.js'
 import { InterventionHandler } from './handler.js'
+import { InterruptError } from '../interrupt.js'
 import { logger } from '../logging/logger.js'
 import type { JSONValue } from '../types/json.js'
 
@@ -105,6 +106,9 @@ export class InterventionRegistry {
           event.cancel = `DENIED: ${action.reason}`
           return true
         case 'interrupt': {
+          // event.interrupt() throws InterruptError on first call (pausing the agent).
+          // InterruptError always propagates (bypasses onError) since it's intentional
+          // control flow, not a handler failure. On resume, returns the human's response.
           const response = event.interrupt<JSONValue>({ name: handlerName, reason: action.prompt })
           const check = action.isApproved ?? isApproved
           if (!check(response)) {
@@ -233,6 +237,11 @@ export class InterventionRegistry {
             return
           }
         } catch (error) {
+          // InterruptError is intentional control flow (pauses the agent),
+          // not a handler failure. Always propagate regardless of onError.
+          if (error instanceof InterruptError) {
+            throw error
+          }
           const errorAction = this._handleError(handler, method, error)
           if (errorAction) {
             if (apply(errorAction, handler.name)) {

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -12,6 +12,15 @@ import { Message, TextBlock } from '../types/messages.js'
 import type { Guide, InterventionAction } from './actions.js'
 import { InterventionHandler } from './handler.js'
 import { logger } from '../logging/logger.js'
+import type { JSONValue } from '../types/json.js'
+
+const APPROVED_RESPONSES = new Set(['y', 'yes'])
+
+function isApproved(response: JSONValue): boolean {
+  if (response === true) return true
+  if (typeof response === 'string') return APPROVED_RESPONSES.has(response.toLowerCase().trim())
+  return false
+}
 
 type LifecycleMethod = 'beforeInvocation' | 'beforeToolCall' | 'afterToolCall' | 'beforeModelCall' | 'afterModelCall'
 
@@ -20,7 +29,7 @@ type LifecycleMethod = 'beforeInvocation' | 'beforeToolCall' | 'afterToolCall' |
  *
  * Registers one hook callback per lifecycle event type, then dispatches to
  * all handlers that override that method — in registration order, with
- * short-circuiting on Deny/Interrupt and accumulation for Guide.
+ * short-circuiting on Deny (and denied Interrupts) and accumulation for Guide.
  *
  * See {@link InterventionAction} for the action-to-event compatibility matrix.
  */
@@ -95,9 +104,15 @@ export class InterventionRegistry {
         case 'deny':
           event.cancel = `DENIED: ${action.reason}`
           return true
-        case 'interrupt':
-          event.interrupt({ name: handlerName, reason: action.prompt })
-          return true
+        case 'interrupt': {
+          const response = event.interrupt<JSONValue>({ name: handlerName, reason: action.prompt })
+          const check = action.isApproved ?? isApproved
+          if (!check(response)) {
+            event.cancel = `INTERRUPTED: Interrupt denied execution`
+            return true
+          }
+          return false
+        }
         case 'guide':
           event.cancel = `GUIDANCE: ${action.feedback}`
           return false
@@ -179,7 +194,8 @@ export class InterventionRegistry {
   /**
    * Iterate handlers in registration order and resolve the winning action.
    *
-   * - Deny / Interrupt short-circuit immediately (remaining handlers are skipped).
+   * - Deny short-circuits immediately (remaining handlers are skipped).
+   * - Interrupt pauses for human input; if denied short-circuits, if approved continues.
    * - Guide feedback strings accumulate across handlers and are applied at the end.
    * - Transform is applied in-place so later handlers see the mutation.
    * - If a handler throws, behavior depends on {@link InterventionHandler.onError}:

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -106,12 +106,17 @@ export class InterventionRegistry {
           event.cancel = `DENIED: ${action.reason}`
           return true
         case 'confirm': {
-          // event.interrupt() throws InterruptError on first call (pausing the agent).
-          // InterruptError always propagates (bypasses onError) since it's intentional
-          // control flow, not a handler failure. On resume, returns the human's response.
-          const response = event.interrupt<JSONValue>({ name: handlerName, reason: action.prompt })
+          // If response is provided, it's passed as a preemptive value to
+          // event.interrupt() — the interrupt is registered but never pauses.
+          // If no response, event.interrupt() throws InterruptError on first
+          // call (pausing the agent for external resume).
+          const result = event.interrupt<JSONValue>({
+            name: handlerName,
+            reason: action.prompt,
+            ...(action.response !== undefined && { response: action.response }),
+          })
           const check = action.evaluate ?? isApproved
-          if (!check(response)) {
+          if (!check(result)) {
             event.cancel = `CONFIRMATION_FAILED: ${action.prompt}`
             return true
           }

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -112,7 +112,7 @@ export class InterventionRegistry {
           const response = event.interrupt<JSONValue>({ name: handlerName, reason: action.prompt })
           const check = action.evaluate ?? isApproved
           if (!check(response)) {
-            event.cancel = `DENIED: Confirm denied execution`
+            event.cancel = `CONFIRMATION_FAILED: ${action.prompt}`
             return true
           }
           return false

--- a/strands-ts/src/interventions/registry.ts
+++ b/strands-ts/src/interventions/registry.ts
@@ -10,18 +10,11 @@ import type { HookRegistry } from '../hooks/registry.js'
 import { HookOrder } from '../hooks/types.js'
 import { Message, TextBlock } from '../types/messages.js'
 import type { Guide, InterventionAction } from './actions.js'
+import { defaultEvaluate } from './actions.js'
 import { InterventionHandler } from './handler.js'
 import { InterruptError } from '../interrupt.js'
 import { logger } from '../logging/logger.js'
 import type { JSONValue } from '../types/json.js'
-
-const APPROVED_RESPONSES = new Set(['y', 'yes'])
-
-function isApproved(response: JSONValue): boolean {
-  if (response === true) return true
-  if (typeof response === 'string') return APPROVED_RESPONSES.has(response.toLowerCase().trim())
-  return false
-}
 
 type LifecycleMethod = 'beforeInvocation' | 'beforeToolCall' | 'afterToolCall' | 'beforeModelCall' | 'afterModelCall'
 
@@ -115,7 +108,7 @@ export class InterventionRegistry {
             reason: action.prompt,
             ...(action.response !== undefined && { response: action.response }),
           })
-          const check = action.evaluate ?? isApproved
+          const check = action.evaluate ?? defaultEvaluate
           if (!check(result)) {
             event.cancel = `CONFIRMATION_FAILED: ${action.prompt}`
             return true


### PR DESCRIPTION
## Description

Adds the `confirm` action to the intervention system. A handler returns `confirm(prompt)` to request human approval before a tool executes. The registry evaluates the response (default: accepts `true`, `'y'`, `'yes'`) and either lets execution continue or blocks the tool with `CONFIRMATION_FAILED: <prompt>`.

Two modes:
- **Stateless:** No `response` provided → breaks out of the agent loop for external resume via `InterruptResponseContent`.
- **Inline:** `response` provided → passed as a preemptive value to the interrupt system, agent never pauses. Handlers collect input themselves (e.g., readline) and pass it through.

Also:
- Renames `Interrupt` → `Confirm`, `isApproved` → `evaluate`
- `InterruptError` always propagates regardless of `onError` policy (it's control flow, not a handler failure)
- All action factories now use options objects for optional params

## API Changes

### Action factory signatures

```typescript
// All factories now use options objects for optional params
proceed(options?: { reason?: string }): Proceed
deny(reason: string): Deny
guide(feedback: string, options?: { reason?: string }): Guide
confirm(prompt: string, options?: { reason?: string; response?: JSONValue; evaluate?: (response: JSONValue) => boolean }): Confirm
transform(apply: (event: LifecycleEvent) => void, options?: { reason?: string }): Transform
```

### `Confirm` action type

```typescript
type Confirm = {
  type: 'confirm'
  prompt: string
  reason?: string
  response?: JSONValue
  evaluate?: (response: JSONValue) => boolean
}
```

### Default `evaluate` behavior

Accepts: `true`, `'y'`/`'yes'` (case-insensitive, whitespace-trimmed). Everything else is denied.

### Cancel message format

When confirmation fails, `event.cancel` is set to `CONFIRMATION_FAILED: <prompt>`, including the original prompt for debuggability. This is distinct from `DENIED: <reason>` used by the `deny` action.

## Examples

### Stateless mode (interrupt/resume)

```typescript
import { InterventionHandler, InterruptResponseContent } from '@strands-agents/sdk'
import { confirm, proceed } from '@strands-agents/sdk/interventions/actions'

class ApproveDeletes extends InterventionHandler {
  readonly name = 'approve-deletes'

  override beforeToolCall(event: BeforeToolCallEvent): InterventionAction {
    if (event.toolUse.name === 'deleteFile') {
      return confirm(`Tool "deleteFile" wants to delete: ${JSON.stringify(event.toolUse.input)}`)
    }
    return proceed()
  }
}

const agent = new Agent({
  tools: [deleteTool],
  interventions: [new ApproveDeletes()],
})

const result = await agent.invoke('Delete important.txt')
// result.stopReason === 'interrupt'
// result.interrupts[0].reason === 'Tool "deleteFile" wants to delete: {"path":"/important.txt"}'

// Resume with approval
const final = await agent.invoke([
  new InterruptResponseContent({
    interruptId: result.interrupts[0].id,
    response: 'yes', // or true, or 'y'
  }),
])
// final.stopReason === 'endTurn' — tool ran

// Or resume with denial
const denied = await agent.invoke([
  new InterruptResponseContent({
    interruptId: result.interrupts[0].id,
    response: 'no',
  }),
])
// denied.stopReason === 'endTurn' — tool was blocked
```

### Inline mode (handler collects response, agent never pauses)

```typescript
import * as readline from 'readline/promises'
import { InterventionHandler } from '@strands-agents/sdk'
import { confirm, proceed } from '@strands-agents/sdk/interventions/actions'

const rl = readline.createInterface({ input: process.stdin, output: process.stdout })

class CliApproval extends InterventionHandler {
  readonly name = 'cli-approval'

  override async beforeToolCall(event: BeforeToolCallEvent): Promise<InterventionAction> {
    const toolName = event.toolUse.name
    if (toolName === 'deleteFile') {
      const prompt = `Tool "${toolName}" wants to delete: ${JSON.stringify(event.toolUse.input)}`
      const response = await rl.question(`${prompt} (y/n): `)
      return confirm(prompt, { response })
    }
    return proceed()
  }
}

const agent = new Agent({
  tools: [deleteTool],
  interventions: [new CliApproval()],
})

// Agent never pauses — blocks at readline, resolves normally after human responds
await agent.invoke('Delete important.txt')
// Terminal: Tool "deleteFile" wants to delete: {"path":"/important.txt"} (y/n): y
// Tool runs immediately
```

### Custom `evaluate` (OTP confirmation)

```typescript
class OtpGate extends InterventionHandler {
  readonly name = 'otp-gate'

  override async beforeToolCall(event: BeforeToolCallEvent): Promise<InterventionAction> {
    if (event.toolUse.name === 'transferFunds') {
      const expectedOtp = generateOtp()
      sendOtpToUser(expectedOtp)
      const response = await rl.question('Enter the OTP sent to your phone: ')
      return confirm('OTP verification', {
        response,
        evaluate: (r) => r === expectedOtp,
      })
    }
    return proceed()
  }
}
```

## Related Issues

Builds on #883 (interventions primitive)

## Type of Change

New feature

## Testing

- [x] I ran `npm run check`
- Parameterized tests for approved responses (`true`, `'yes'`, `'y'`, `'YES'`, `'  yes  '`) and denied responses (`'no'`, `false`, `null`, `''`)
- Custom `evaluate` override (both deny and approve paths)
- Preemptive `response` (inline mode): approve, deny, custom evaluate, passes response to interrupt system
- `InterruptError` always propagates regardless of `onError` policy
- Approved confirm does not short-circuit later handlers
- Denied confirm short-circuits later handlers

## Revisions

1. **Initial:** Added `isApproved` check to the `interrupt` action in the registry. On resume, checks response and sets `event.cancel` if denied.
2. **Custom validator:** Added optional `isApproved` function on the `Interrupt` type so handlers can override the default approval logic.
3. **Options objects:** Changed all factory functions from positional optional params to options objects (`interrupt(prompt, { reason, isApproved })`), following SDK convention.
4. **InterruptError bypass:** Added then removed then re-added `InterruptError` propagation in `_dispatch`. Final decision: always propagates (it's control flow, not a handler error).
5. **Rename:** `Interrupt` → `Confirm`, `isApproved` → `evaluate`, cancel prefix `DENIED:` → `CONFIRMATION_FAILED:`.
6. **`ask` callback on action:** Added `ask` to the `Confirm` type so the registry could collect responses inline. Registry became async to support `await action.ask(prompt)`.
7. **`ask` → `response`:** Replaced `ask` callback with a plain `response: JSONValue` field. Handlers own the I/O (collect the response themselves), then pass it through as a preemptive value to the interrupt system. Registry stays sync. Actions stay pure data.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings