### PR TITLE
feat(interventions): add human in the loop intervention handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,12 @@ sdk-typescript/
 │   │   │   ├── snapshot.ts
 │   │   │   └── validation.ts
 │   │   │
+│   │   ├── vended-interventions/  # Optional vended intervention handlers
+│   │   │   └── hitl/             # Human-in-the-loop approval handler
+│   │   │       ├── __tests__/
+│   │   │       ├── hitl.ts
+│   │   │       └── index.ts
+│   │   │
 │   │   ├── vended-plugins/       # Optional vended plugins
 │   │   │   ├── context-offloader/ # Context offloading plugin
 │   │   │   │   ├── __tests__/
@@ -337,6 +343,7 @@ sdk-typescript/
 - **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
 - **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas
 - **`strands-ts/src/types/`**: Core type definitions used across the SDK
+- **`strands-ts/src/vended-interventions/`**: Optional vended intervention handlers (hitl — not part of core SDK, independently importable)
 - **`strands-ts/src/vended-plugins/`**: Optional vended plugins (context-offloader, skills — not part of core SDK, independently importable)
 - **`strands-ts/src/vended-tools/`**: Optional vended tools (bash, file-editor, http-request, notebook)
 - **`strands-ts/generated/`**: Auto-generated WIT interface type declarations

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -79,6 +79,10 @@
     "./vended-plugins/context-offloader": {
       "types": "./dist/src/vended-plugins/context-offloader/index.d.ts",
       "default": "./dist/src/vended-plugins/context-offloader/index.js"
+    },
+    "./vended-interventions/hitl": {
+      "types": "./dist/src/vended-interventions/hitl/index.d.ts",
+      "default": "./dist/src/vended-interventions/hitl/index.js"
     }
   },
   "scripts": {

--- a/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
+++ b/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
@@ -360,15 +360,49 @@ describe('HumanInTheLoop', () => {
       expect(askCount).toBe(1)
     })
 
+    it('supports custom evaluateTrust function', async () => {
+      let askCount = 0
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-2', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'executed')
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            enableTrust: true,
+            evaluateTrust: (r) => r === 'approve-and-remember',
+            ask: async () => {
+              askCount++
+              return 'approve-and-remember'
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      await agent.invoke('Run tool twice')
+      expect(askCount).toBe(1)
+    })
+
     it('negated tools cannot be trusted even with "t" response', async () => {
       let askCount = 0
+      let toolExecuted = false
 
       const model = new MockMessageModel()
         .addTurn({ type: 'toolUseBlock', name: 'dangerTool', toolUseId: 'tool-1', input: {} })
         .addTurn({ type: 'toolUseBlock', name: 'dangerTool', toolUseId: 'tool-2', input: {} })
         .addTurn({ type: 'textBlock', text: 'Done' })
 
-      const tool = createMockTool('dangerTool', () => 'ran')
+      const tool = createMockTool('dangerTool', () => {
+        toolExecuted = true
+        return 'ran'
+      })
 
       const agent = new Agent({
         model,
@@ -388,7 +422,7 @@ describe('HumanInTheLoop', () => {
 
       await agent.invoke('Run danger twice')
       expect(askCount).toBe(2)
+      expect(toolExecuted).toBe(false)
     })
   })
-
 })

--- a/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
+++ b/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
@@ -216,37 +216,6 @@ describe('HumanInTheLoop', () => {
       expect(prompts[0]).toContain('bob@example.com')
     })
 
-    it('receives the BeforeToolCallEvent for context-aware routing', async () => {
-      const model = new MockMessageModel()
-        .addTurn({ type: 'toolUseBlock', name: 'shell', toolUseId: 'tool-1', input: { command: 'ls -la' } })
-        .addTurn({ type: 'textBlock', text: 'Done' })
-
-      let toolExecuted = false
-      const tool = createMockTool('shell', () => {
-        toolExecuted = true
-        return 'output'
-      })
-
-      const agent = new Agent({
-        model,
-        tools: [tool],
-        interventions: [
-          new HumanInTheLoop({
-            ask: async (_prompt, event) => {
-              const input = event.toolUse.input as { command: string }
-              if (input.command.startsWith('ls')) return 'yes'
-              return 'no'
-            },
-          }),
-        ],
-        printer: false,
-      })
-
-      const result = await agent.invoke('List files')
-      expect(result.stopReason).toBe('endTurn')
-      expect(toolExecuted).toBe(true)
-    })
-
     it('supports custom evaluate function', async () => {
       const model = new MockMessageModel()
         .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })

--- a/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
+++ b/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from 'vitest'
+import { HumanInTheLoop } from '../hitl.js'
+import { Agent } from '../../../agent/agent.js'
+import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../../__fixtures__/tool-helpers.js'
+
+describe('HumanInTheLoop', () => {
+  describe('default config (interrupt/resume)', () => {
+    it('pauses agent with interrupt on any tool call', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'anyTool', toolUseId: 'tool-1', input: { x: 1 } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('anyTool', () => {
+        toolExecuted = true
+        return 'result'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop()],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Do something')
+
+      expect(result.stopReason).toBe('interrupt')
+      expect(result.interrupts).toEqual([
+        expect.objectContaining({
+          name: 'human-in-the-loop',
+          reason: expect.stringContaining('anyTool'),
+        }),
+      ])
+      expect(toolExecuted).toBe(false)
+    })
+  })
+
+  describe('inline mode (with ask callback)', () => {
+    it('allows tool execution when approved', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('myTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ ask: async () => 'yes' })],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Run tool')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+
+    it('denies tool execution when rejected', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Understood' })
+
+      let toolExecuted = false
+      const tool = createMockTool('myTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ ask: async () => 'no' })],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Run tool')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(false)
+    })
+  })
+
+  describe('allowedTools config', () => {
+    it('does not prompt for tools in allowedTools', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'readFile', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('readFile', () => {
+        toolExecuted = true
+        return 'content'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ allowedTools: ['readFile'], ask: async () => 'no' })],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Read it')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+
+    it('prompts for tools not in allowedTools', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'deleteFile', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('deleteFile', () => {
+        toolExecuted = true
+        return 'deleted'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ allowedTools: ['readFile'], ask: async () => 'no' })],
+        printer: false,
+      })
+
+      await agent.invoke('Delete it')
+      expect(toolExecuted).toBe(false)
+    })
+
+    it('allows all tools except negated ones with "!" prefix', async () => {
+      const model = new MockMessageModel()
+        .addTurn([
+          { type: 'toolUseBlock', name: 'readFile', toolUseId: 'tool-1', input: {} },
+          { type: 'toolUseBlock', name: 'deleteFile', toolUseId: 'tool-2', input: {} },
+        ])
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const execLog: string[] = []
+      const readTool = createMockTool('readFile', () => {
+        execLog.push('read')
+        return 'content'
+      })
+      const deleteTool = createMockTool('deleteFile', () => {
+        execLog.push('delete')
+        return 'deleted'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [readTool, deleteTool],
+        interventions: [new HumanInTheLoop({ allowedTools: ['*', '!deleteFile'], ask: async () => 'no' })],
+        printer: false,
+      })
+
+      await agent.invoke('Do both')
+
+      expect(execLog).toContain('read')
+      expect(execLog).not.toContain('delete')
+    })
+
+    it('allows all tools with wildcard "*"', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'dangerousTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('dangerousTool', () => {
+        toolExecuted = true
+        return 'ran'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ allowedTools: ['*'], ask: async () => 'no' })],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Do it')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+  })
+
+  describe('ask callback', () => {
+    it('passes tool name and input in the prompt', async () => {
+      const prompts: string[] = []
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'sendEmail', toolUseId: 'tool-1', input: { to: 'bob@example.com' } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('sendEmail', () => 'sent')
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            ask: async (prompt) => {
+              prompts.push(prompt)
+              return 'yes'
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      await agent.invoke('Send email')
+
+      expect(prompts[0]).toContain('sendEmail')
+      expect(prompts[0]).toContain('bob@example.com')
+    })
+
+    it('supports custom evaluate function', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('myTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            ask: async () => 'magic-word',
+            evaluate: (response) => response === 'magic-word',
+          }),
+        ],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Go')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+  })
+
+  describe('trust mode (enableTrust: true)', () => {
+    it('trusts a tool for the session when response is "t"', async () => {
+      let askCount = 0
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-2', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'executed')
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            enableTrust: true,
+            ask: async () => {
+              askCount++
+              return 't'
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      await agent.invoke('Run tool twice')
+
+      expect(askCount).toBe(1)
+    })
+
+    it('does not trust when enableTrust is false (default)', async () => {
+      let askCount = 0
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-2', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'executed')
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            ask: async () => {
+              askCount++
+              return 'yes'
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      await agent.invoke('Run tool twice')
+
+      expect(askCount).toBe(2)
+    })
+
+    it('"t" response also approves the current tool call', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('myTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ enableTrust: true, ask: async () => 't' })],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Run tool')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+
+    it.each(['trust', 'T', 'TRUST'])('trusts when response is "%s"', async (trustResponse) => {
+      let askCount = 0
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-2', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('myTool', () => 'executed')
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            enableTrust: true,
+            ask: async () => {
+              askCount++
+              return trustResponse
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      await agent.invoke('Run tool twice')
+      expect(askCount).toBe(1)
+    })
+
+    it('negated tools cannot be trusted even with "t" response', async () => {
+      let askCount = 0
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'dangerTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'toolUseBlock', name: 'dangerTool', toolUseId: 'tool-2', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool('dangerTool', () => 'ran')
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            allowedTools: ['*', '!dangerTool'],
+            enableTrust: true,
+            ask: async () => {
+              askCount++
+              return 't'
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      await agent.invoke('Run danger twice')
+      expect(askCount).toBe(2)
+    })
+  })
+
+  describe('stdio mode (ask: "stdio")', () => {
+    it('uses stdio when ask is "stdio" (tested via mock)', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('myTool', () => {
+        toolExecuted = true
+        return 'executed'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [new HumanInTheLoop({ ask: async () => 'yes' })],
+        printer: false,
+      })
+
+      const result = await agent.invoke('Run tool')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
+    })
+  })
+})

--- a/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
+++ b/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
@@ -29,7 +29,7 @@ describe('HumanInTheLoop', () => {
       expect(result.stopReason).toBe('interrupt')
       expect(result.interrupts).toEqual([
         expect.objectContaining({
-          name: 'human-in-the-loop',
+          name: 'strands:human-in-the-loop',
           reason: expect.stringContaining('anyTool'),
         }),
       ])
@@ -214,6 +214,37 @@ describe('HumanInTheLoop', () => {
 
       expect(prompts[0]).toContain('sendEmail')
       expect(prompts[0]).toContain('bob@example.com')
+    })
+
+    it('receives the BeforeToolCallEvent for context-aware routing', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'shell', toolUseId: 'tool-1', input: { command: 'ls -la' } })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      let toolExecuted = false
+      const tool = createMockTool('shell', () => {
+        toolExecuted = true
+        return 'output'
+      })
+
+      const agent = new Agent({
+        model,
+        tools: [tool],
+        interventions: [
+          new HumanInTheLoop({
+            ask: async (_prompt, event) => {
+              const input = event.toolUse.input as { command: string }
+              if (input.command.startsWith('ls')) return 'yes'
+              return 'no'
+            },
+          }),
+        ],
+        printer: false,
+      })
+
+      const result = await agent.invoke('List files')
+      expect(result.stopReason).toBe('endTurn')
+      expect(toolExecuted).toBe(true)
     })
 
     it('supports custom evaluate function', async () => {

--- a/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
+++ b/strands-ts/src/vended-interventions/hitl/__tests__/hitl.test.ts
@@ -276,7 +276,7 @@ describe('HumanInTheLoop', () => {
       expect(askCount).toBe(1)
     })
 
-    it('does not trust when enableTrust is false (default)', async () => {
+    it('does not trust when enableTrust is false even with "t" response', async () => {
       let askCount = 0
 
       const model = new MockMessageModel()
@@ -291,9 +291,10 @@ describe('HumanInTheLoop', () => {
         tools: [tool],
         interventions: [
           new HumanInTheLoop({
+            enableTrust: false,
             ask: async () => {
               askCount++
-              return 'yes'
+              return 't'
             },
           }),
         ],
@@ -302,6 +303,8 @@ describe('HumanInTheLoop', () => {
 
       await agent.invoke('Run tool twice')
 
+      // 't' is not recognized as approval when trust is disabled, so tool is denied both times
+      // but ask is still called both times (no trust memory)
       expect(askCount).toBe(2)
     })
 
@@ -388,28 +391,4 @@ describe('HumanInTheLoop', () => {
     })
   })
 
-  describe('stdio mode (ask: "stdio")', () => {
-    it('uses stdio when ask is "stdio" (tested via mock)', async () => {
-      const model = new MockMessageModel()
-        .addTurn({ type: 'toolUseBlock', name: 'myTool', toolUseId: 'tool-1', input: {} })
-        .addTurn({ type: 'textBlock', text: 'Done' })
-
-      let toolExecuted = false
-      const tool = createMockTool('myTool', () => {
-        toolExecuted = true
-        return 'executed'
-      })
-
-      const agent = new Agent({
-        model,
-        tools: [tool],
-        interventions: [new HumanInTheLoop({ ask: async () => 'yes' })],
-        printer: false,
-      })
-
-      const result = await agent.invoke('Run tool')
-      expect(result.stopReason).toBe('endTurn')
-      expect(toolExecuted).toBe(true)
-    })
-  })
 })

--- a/strands-ts/src/vended-interventions/hitl/hitl.ts
+++ b/strands-ts/src/vended-interventions/hitl/hitl.ts
@@ -138,7 +138,7 @@ export class HumanInTheLoop extends InterventionHandler {
     super()
     this._allowedTools = new Set(config?.allowedTools ?? [])
     this._enableTrust = config?.enableTrust ?? false
-    this._evaluateTrust = config?.evaluateTrust ?? ((r) => this._isTrustResponse(r))
+    this._evaluateTrust = config?.evaluateTrust ?? ((r: JSONValue): boolean => this._isTrustResponse(r))
     this._evaluate = config?.evaluate
     this._ask = config?.ask === 'stdio' ? createStdioAsk(this._enableTrust) : config?.ask
   }
@@ -151,8 +151,10 @@ export class HumanInTheLoop extends InterventionHandler {
 
     const prompt = `Tool "${toolName}" requires human approval. Input: ${JSON.stringify(event.toolUse.input)}`
 
+    const isNegated = this._allowedTools.has(`!${toolName}`)
+
     const evaluate = (response: JSONValue): boolean => {
-      if (this._enableTrust && this._evaluateTrust(response)) {
+      if (!isNegated && this._enableTrust && this._evaluateTrust(response)) {
         this._trustTool(event, toolName)
         return true
       }
@@ -165,7 +167,7 @@ export class HumanInTheLoop extends InterventionHandler {
 
     const response = await this._ask(prompt)
 
-    if (this._enableTrust && this._evaluateTrust(response)) {
+    if (!isNegated && this._enableTrust && this._evaluateTrust(response)) {
       this._trustTool(event, toolName)
       return proceed()
     }

--- a/strands-ts/src/vended-interventions/hitl/hitl.ts
+++ b/strands-ts/src/vended-interventions/hitl/hitl.ts
@@ -1,0 +1,193 @@
+import { InterventionHandler } from '../../interventions/handler.js'
+import { confirm, proceed } from '../../interventions/actions.js'
+import type { InterventionAction } from '../../interventions/actions.js'
+import type { BeforeToolCallEvent } from '../../hooks/events.js'
+import type { JSONValue } from '../../types/json.js'
+
+const TRUST_RESPONSES = new Set(['t', 'trust'])
+const TRUSTED_TOOLS_KEY = 'hitl:trustedTools'
+
+/**
+ * Default CLI prompt that reads from stdin.
+ * Serializes prompts so concurrent tool calls don't collide on stdin.
+ */
+function createDefaultAsk(includeTrust: boolean): (prompt: string) => Promise<JSONValue> {
+  const options = includeTrust ? '(y/n/t)' : '(y/n)'
+  let queue: Promise<unknown> = Promise.resolve()
+
+  return (prompt: string) => {
+    const task = queue.then(async () => {
+      const { createInterface } = await import('node:readline')
+      const rl = createInterface({ input: process.stdin, output: process.stdout })
+      return new Promise<JSONValue>((resolve) => {
+        rl.question(`${prompt} ${options}: `, (answer) => {
+          rl.close()
+          resolve(answer.trim())
+        })
+      })
+    })
+    queue = task.catch(() => {})
+    return task
+  }
+}
+
+/**
+ * Configuration for the {@link HumanInTheLoop} intervention handler.
+ */
+export interface HumanInTheLoopConfig {
+  /**
+   * Tools that can execute WITHOUT human approval. All other tools require approval.
+   *
+   * - Use `'*'` to allow all tools.
+   * - Prefix with `!` to exclude specific tools from `'*'` (they still require approval).
+   *
+   * @example
+   * ```typescript
+   * // Only readFile and listDir run freely; everything else needs approval
+   * { allowedTools: ['readFile', 'listDir'] }
+   *
+   * // All tools run freely (HITL disabled)
+   * { allowedTools: ['*'] }
+   *
+   * // All tools run freely EXCEPT deleteFile and sendEmail
+   * { allowedTools: ['*', '!deleteFile', '!sendEmail'] }
+   * ```
+   */
+  allowedTools?: string[]
+
+  /**
+   * When true, the default CLI prompt includes a "trust" option (t).
+   * If the human responds with 't', the tool is approved AND remembered
+   * in `agent.appState` for the rest of the session (won't ask again).
+   *
+   * Negated tools (`!tool`) cannot be trusted.
+   * Has no effect without an `ask` callback (interrupt/resume mode has no inline session).
+   *
+   * Defaults to `false`.
+   */
+  enableTrust?: boolean
+
+  /**
+   * Custom response validator. Defaults to accepting `true`, `'y'`/`'yes'` (case-insensitive).
+   */
+  evaluate?: (response: JSONValue) => boolean
+
+  /**
+   * Controls how the human's response is collected.
+   *
+   * - **Default** (omitted): uses interrupt/resume — agent pauses, caller resumes with response.
+   * - **`'stdio'`**: prompts via CLI readline (Node.js only). Agent blocks inline until human responds.
+   * - **Custom function**: your own async prompt logic (Slack, web UI, etc.). Agent blocks inline.
+   */
+  ask?: ((prompt: string) => Promise<JSONValue>) | 'stdio'
+}
+
+/**
+ * Human-in-the-loop intervention handler that pauses agent execution
+ * before tool calls to request human approval.
+ *
+ * By default, ALL tools require approval and the agent pauses via interrupt/resume.
+ * Use `allowedTools` to whitelist tools that run freely, and `ask` to provide
+ * inline prompting (CLI, custom UI).
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+ *
+ * // All tools require approval, agent pauses via interrupt (default)
+ * const agent = new Agent({
+ *   interventions: [new HumanInTheLoop()],
+ * })
+ *
+ * // readFile runs freely, everything else pauses for approval
+ * const agent = new Agent({
+ *   interventions: [new HumanInTheLoop({ allowedTools: ['readFile'] })],
+ * })
+ *
+ * // CLI mode — prompts in terminal inline
+ * const agent = new Agent({
+ *   interventions: [new HumanInTheLoop({ ask: 'stdio' })],
+ * })
+ *
+ * // Custom UI — provide your own prompt function
+ * const agent = new Agent({
+ *   interventions: [new HumanInTheLoop({
+ *     ask: async (prompt) => await slackDM(userId, prompt),
+ *   })],
+ * })
+ * ```
+ */
+export class HumanInTheLoop extends InterventionHandler {
+  readonly name = 'human-in-the-loop'
+
+  private readonly _allowedTools: Set<string>
+  private readonly _enableTrust: boolean
+  private readonly _evaluate: ((response: JSONValue) => boolean) | undefined
+  private readonly _ask: ((prompt: string) => Promise<JSONValue>) | undefined
+
+  constructor(config?: HumanInTheLoopConfig) {
+    super()
+    this._allowedTools = new Set(config?.allowedTools ?? [])
+    this._enableTrust = config?.enableTrust ?? false
+    this._evaluate = config?.evaluate
+    this._ask = config?.ask === 'stdio' ? createDefaultAsk(this._enableTrust) : config?.ask
+  }
+
+  override async beforeToolCall(event: BeforeToolCallEvent): Promise<InterventionAction> {
+    const toolName = event.toolUse.name
+    if (!this._requiresApproval(event)) {
+      return proceed()
+    }
+
+    const prompt = `Tool "${toolName}" requires human approval. Input: ${JSON.stringify(event.toolUse.input)}`
+
+    if (!this._ask) {
+      return confirm(prompt, {
+        ...(this._evaluate && { evaluate: this._evaluate }),
+      })
+    }
+
+    const response = await this._ask(prompt)
+
+    if (this._enableTrust && this._isTrustResponse(response)) {
+      this._trustTool(event, toolName)
+      return proceed()
+    }
+
+    return confirm(prompt, {
+      response,
+      ...(this._evaluate && { evaluate: this._evaluate }),
+    })
+  }
+
+  /**
+   * Precedence (first match wins):
+   * 1. Negated (`!tool`) → always requires approval (cannot be trusted)
+   * 2. Trusted at runtime via 't' response (stored in agent.appState) → runs freely
+   * 3. Wildcard (`*`) → runs freely
+   * 4. Explicitly listed → runs freely
+   * 5. Default → requires approval
+   */
+  private _requiresApproval(event: BeforeToolCallEvent): boolean {
+    const toolName = event.toolUse.name
+    if (this._allowedTools.has(`!${toolName}`)) return true
+    const trusted = (event.agent.appState.get(TRUSTED_TOOLS_KEY) as string[] | undefined) ?? []
+    if (trusted.includes(toolName)) return false
+    if (this._allowedTools.has('*')) return false
+    if (this._allowedTools.has(toolName)) return false
+    return true
+  }
+
+  private _trustTool(event: BeforeToolCallEvent, toolName: string): void {
+    const trusted = (event.agent.appState.get(TRUSTED_TOOLS_KEY) as string[] | undefined) ?? []
+    if (!trusted.includes(toolName)) {
+      event.agent.appState.set(TRUSTED_TOOLS_KEY, [...trusted, toolName])
+    }
+  }
+
+  private _isTrustResponse(response: JSONValue): boolean {
+    if (typeof response === 'string') return TRUST_RESPONSES.has(response.toLowerCase().trim())
+    return false
+  }
+}

--- a/strands-ts/src/vended-interventions/hitl/hitl.ts
+++ b/strands-ts/src/vended-interventions/hitl/hitl.ts
@@ -11,11 +11,11 @@ const TRUSTED_TOOLS_KEY = 'hitl:trustedTools'
  * CLI prompt that reads from stdin.
  * Serializes prompts so concurrent tool calls don't collide on stdin.
  */
-function createStdioAsk(includeTrust: boolean): (prompt: string) => Promise<JSONValue> {
+function createStdioAsk(includeTrust: boolean): (prompt: string, event: BeforeToolCallEvent) => Promise<JSONValue> {
   const options = includeTrust ? '(y/n/t)' : '(y/n)'
   let queue: Promise<unknown> = Promise.resolve()
 
-  return (prompt: string) => {
+  return (prompt: string, _event: BeforeToolCallEvent) => {
     const task = queue.then(async () => {
       const { createInterface } = await import('node:readline')
       const rl = createInterface({ input: process.stdin, output: process.stdout })
@@ -85,8 +85,9 @@ export interface HumanInTheLoopConfig {
    * - **Default** (omitted): uses interrupt/resume — agent pauses, caller resumes with response.
    * - **`'stdio'`**: prompts via CLI readline (Node.js only). Agent blocks inline until human responds.
    * - **Custom function**: your own async prompt logic (Slack, web UI, etc.). Agent blocks inline.
+   *   Receives the prompt string and the `BeforeToolCallEvent` for context-aware routing.
    */
-  ask?: ((prompt: string) => Promise<JSONValue>) | 'stdio'
+  ask?: ((prompt: string, event: BeforeToolCallEvent) => Promise<JSONValue>) | 'stdio'
 }
 
 /**
@@ -126,13 +127,13 @@ export interface HumanInTheLoopConfig {
  * ```
  */
 export class HumanInTheLoop extends InterventionHandler {
-  readonly name = 'human-in-the-loop'
+  readonly name = 'strands:human-in-the-loop'
 
   private readonly _allowedTools: Set<string>
   private readonly _enableTrust: boolean
   private readonly _evaluateTrust: (response: JSONValue) => boolean
   private readonly _evaluate: ((response: JSONValue) => boolean) | undefined
-  private readonly _ask: ((prompt: string) => Promise<JSONValue>) | undefined
+  private readonly _ask: ((prompt: string, event: BeforeToolCallEvent) => Promise<JSONValue>) | undefined
 
   constructor(config?: HumanInTheLoopConfig) {
     super()
@@ -165,7 +166,7 @@ export class HumanInTheLoop extends InterventionHandler {
       return confirm(prompt, { evaluate })
     }
 
-    const response = await this._ask(prompt)
+    const response = await this._ask(prompt, event)
 
     if (!isNegated && this._enableTrust && this._evaluateTrust(response)) {
       this._trustTool(event, toolName)

--- a/strands-ts/src/vended-interventions/hitl/hitl.ts
+++ b/strands-ts/src/vended-interventions/hitl/hitl.ts
@@ -11,11 +11,11 @@ const TRUSTED_TOOLS_KEY = 'hitl:trustedTools'
  * CLI prompt that reads from stdin.
  * Serializes prompts so concurrent tool calls don't collide on stdin.
  */
-function createStdioAsk(includeTrust: boolean): (prompt: string, event: BeforeToolCallEvent) => Promise<JSONValue> {
+function createStdioAsk(includeTrust: boolean): (prompt: string) => Promise<JSONValue> {
   const options = includeTrust ? '(y/n/t)' : '(y/n)'
   let queue: Promise<unknown> = Promise.resolve()
 
-  return (prompt: string, _event: BeforeToolCallEvent) => {
+  return (prompt: string) => {
     const task = queue.then(async () => {
       const { createInterface } = await import('node:readline')
       const rl = createInterface({ input: process.stdin, output: process.stdout })
@@ -85,9 +85,8 @@ export interface HumanInTheLoopConfig {
    * - **Default** (omitted): uses interrupt/resume — agent pauses, caller resumes with response.
    * - **`'stdio'`**: prompts via CLI readline (Node.js only). Agent blocks inline until human responds.
    * - **Custom function**: your own async prompt logic (Slack, web UI, etc.). Agent blocks inline.
-   *   Receives the prompt string and the `BeforeToolCallEvent` for context-aware routing.
    */
-  ask?: ((prompt: string, event: BeforeToolCallEvent) => Promise<JSONValue>) | 'stdio'
+  ask?: ((prompt: string) => Promise<JSONValue>) | 'stdio'
 }
 
 /**
@@ -133,7 +132,7 @@ export class HumanInTheLoop extends InterventionHandler {
   private readonly _enableTrust: boolean
   private readonly _evaluateTrust: (response: JSONValue) => boolean
   private readonly _evaluate: ((response: JSONValue) => boolean) | undefined
-  private readonly _ask: ((prompt: string, event: BeforeToolCallEvent) => Promise<JSONValue>) | undefined
+  private readonly _ask: ((prompt: string) => Promise<JSONValue>) | undefined
 
   constructor(config?: HumanInTheLoopConfig) {
     super()
@@ -166,7 +165,7 @@ export class HumanInTheLoop extends InterventionHandler {
       return confirm(prompt, { evaluate })
     }
 
-    const response = await this._ask(prompt, event)
+    const response = await this._ask(prompt)
 
     if (!isNegated && this._enableTrust && this._evaluateTrust(response)) {
       this._trustTool(event, toolName)

--- a/strands-ts/src/vended-interventions/hitl/hitl.ts
+++ b/strands-ts/src/vended-interventions/hitl/hitl.ts
@@ -1,5 +1,5 @@
 import { InterventionHandler } from '../../interventions/handler.js'
-import { confirm, proceed } from '../../interventions/actions.js'
+import { confirm, proceed, defaultEvaluate } from '../../interventions/actions.js'
 import type { InterventionAction } from '../../interventions/actions.js'
 import type { BeforeToolCallEvent } from '../../hooks/events.js'
 import type { JSONValue } from '../../types/json.js'
@@ -8,10 +8,10 @@ const TRUST_RESPONSES = new Set(['t', 'trust'])
 const TRUSTED_TOOLS_KEY = 'hitl:trustedTools'
 
 /**
- * Default CLI prompt that reads from stdin.
+ * CLI prompt that reads from stdin.
  * Serializes prompts so concurrent tool calls don't collide on stdin.
  */
-function createDefaultAsk(includeTrust: boolean): (prompt: string) => Promise<JSONValue> {
+function createStdioAsk(includeTrust: boolean): (prompt: string) => Promise<JSONValue> {
   const options = includeTrust ? '(y/n/t)' : '(y/n)'
   let queue: Promise<unknown> = Promise.resolve()
 
@@ -56,19 +56,26 @@ export interface HumanInTheLoopConfig {
   allowedTools?: string[]
 
   /**
-   * When true, the default CLI prompt includes a "trust" option (t).
-   * If the human responds with 't', the tool is approved AND remembered
+   * When true, trust responses approve the tool AND remember it
    * in `agent.appState` for the rest of the session (won't ask again).
+   * Works in both interrupt/resume and inline `ask` modes.
    *
    * Negated tools (`!tool`) cannot be trusted.
-   * Has no effect without an `ask` callback (interrupt/resume mode has no inline session).
    *
    * Defaults to `false`.
    */
   enableTrust?: boolean
 
   /**
-   * Custom response validator. Defaults to accepting `true`, `'y'`/`'yes'` (case-insensitive).
+   * Custom trust response validator. Defaults to accepting `'t'`/`'trust'` (case-insensitive).
+   * When this returns true, the tool is approved AND trusted for the session.
+   *
+   * Only evaluated when `enableTrust` is true.
+   */
+  evaluateTrust?: (response: JSONValue) => boolean
+
+  /**
+   * Custom approval response validator. Defaults to accepting `true`, `'y'`/`'yes'` (case-insensitive).
    */
   evaluate?: (response: JSONValue) => boolean
 
@@ -123,6 +130,7 @@ export class HumanInTheLoop extends InterventionHandler {
 
   private readonly _allowedTools: Set<string>
   private readonly _enableTrust: boolean
+  private readonly _evaluateTrust: (response: JSONValue) => boolean
   private readonly _evaluate: ((response: JSONValue) => boolean) | undefined
   private readonly _ask: ((prompt: string) => Promise<JSONValue>) | undefined
 
@@ -130,8 +138,9 @@ export class HumanInTheLoop extends InterventionHandler {
     super()
     this._allowedTools = new Set(config?.allowedTools ?? [])
     this._enableTrust = config?.enableTrust ?? false
+    this._evaluateTrust = config?.evaluateTrust ?? ((r) => this._isTrustResponse(r))
     this._evaluate = config?.evaluate
-    this._ask = config?.ask === 'stdio' ? createDefaultAsk(this._enableTrust) : config?.ask
+    this._ask = config?.ask === 'stdio' ? createStdioAsk(this._enableTrust) : config?.ask
   }
 
   override async beforeToolCall(event: BeforeToolCallEvent): Promise<InterventionAction> {
@@ -142,22 +151,28 @@ export class HumanInTheLoop extends InterventionHandler {
 
     const prompt = `Tool "${toolName}" requires human approval. Input: ${JSON.stringify(event.toolUse.input)}`
 
+    const evaluate = (response: JSONValue): boolean => {
+      if (this._enableTrust && this._evaluateTrust(response)) {
+        this._trustTool(event, toolName)
+        return true
+      }
+      return this._evaluate ? this._evaluate(response) : defaultEvaluate(response)
+    }
+
     if (!this._ask) {
-      return confirm(prompt, {
-        ...(this._evaluate && { evaluate: this._evaluate }),
-      })
+      return confirm(prompt, { evaluate })
     }
 
     const response = await this._ask(prompt)
 
-    if (this._enableTrust && this._isTrustResponse(response)) {
+    if (this._enableTrust && this._evaluateTrust(response)) {
       this._trustTool(event, toolName)
       return proceed()
     }
 
     return confirm(prompt, {
       response,
-      ...(this._evaluate && { evaluate: this._evaluate }),
+      evaluate: this._evaluate ?? defaultEvaluate,
     })
   }
 

--- a/strands-ts/src/vended-interventions/hitl/index.ts
+++ b/strands-ts/src/vended-interventions/hitl/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Human-in-the-loop intervention for Strands Agents.
+ *
+ * Pauses agent execution before tool calls to request human approval.
+ * Defaults to prompting in the terminal (CLI), but supports custom UIs
+ * and stateless interrupt/resume for API deployments.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+ *
+ * const agent = new Agent({
+ *   tools: [deleteTool, readTool],
+ *   interventions: [new HumanInTheLoop({ allowedTools: ['readTool'] })],
+ * })
+ *
+ * // Agent automatically prompts in terminal when it tries to use deleteTool
+ * await agent.invoke('Delete the file')
+ * ```
+ */
+
+export { HumanInTheLoop } from './hitl.js'
+export type { HumanInTheLoopConfig } from './hitl.js'

--- a/strands-ts/src/vended-interventions/hitl/index.ts
+++ b/strands-ts/src/vended-interventions/hitl/index.ts
@@ -2,8 +2,8 @@
  * Human-in-the-loop intervention for Strands Agents.
  *
  * Pauses agent execution before tool calls to request human approval.
- * Defaults to prompting in the terminal (CLI), but supports custom UIs
- * and stateless interrupt/resume for API deployments.
+ * Defaults to interrupt/resume mode for stateless deployments.
+ * Pass `ask: 'stdio'` for CLI prompting or a custom `ask` function for other UIs.
  *
  * @example
  * ```typescript
@@ -15,8 +15,8 @@
  *   interventions: [new HumanInTheLoop({ allowedTools: ['readTool'] })],
  * })
  *
- * // Agent automatically prompts in terminal when it tries to use deleteTool
- * await agent.invoke('Delete the file')
+ * // Default: agent pauses with stopReason 'interrupt', caller resumes with response
+ * const result = await agent.invoke('Delete the file')
  * ```
  */
 


### PR DESCRIPTION

## Description

Adds a ready-to-use `HumanInTheLoop` intervention handler that gates tool execution behind human approval, using the `confirm` intervention action.

This is the first vended intervention — a concrete, configurable `InterventionHandler` shipped with the SDK, following the same pattern as vended plugins (`ContextOffloader`, `Skills`).

### Usage

```typescript
import { Agent, InterruptResponseContent } from '@strands-agents/sdk'
import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'

// Default: all tools require approval via interrupt/resume
const agent = new Agent({
  tools: [deleteTool, readTool],
  interventions: [new HumanInTheLoop({ allowedTools: ['read_file'] })],
})

const result = await agent.invoke('Delete the temp files')
// result.stopReason === 'interrupt'
// result.interrupts[0].reason === 'Tool "delete_file" requires human approval. Input: {...}'

// Present the interrupt to your user (web UI, Slack, push notification, etc.)
// Then resume with their response:
const finalResult = await agent.invoke([
  new InterruptResponseContent({
    interruptId: result.interrupts[0].id,
    response: 'yes',  // 'y', 'yes', or true → approved. Anything else → denied.
  }),
])
```

```typescript
// CLI mode: prompts in terminal inline, no interrupt handling needed
const agent = new Agent({
  tools: [deleteTool, readTool],
  interventions: [new HumanInTheLoop({ allowedTools: ['read_file'], ask: 'stdio' })],
})

await agent.invoke('Delete the temp files')
// Terminal: "Tool "delete_file" requires human approval. Input: {...} (y/n): "
```

### Configuration

- **Default** (no `ask`): all tools require approval, agent pauses via interrupt/resume
- **`allowedTools`**: listed tools run freely, everything else requires approval
- **`allowedTools: ['*']`**: all tools run freely (disables HITL)
- **`allowedTools: ['*', '!deleteFile']`**: all tools run freely except `deleteFile`
- **`enableTrust: true`** (opt-in): trust responses approve the tool AND remember it in `agent.appState` for the session. Customizable via `evaluateTrust`.

### `ask` option

Controls how the human's response is collected.

```typescript
// Default (omitted): interrupt/resume — agent pauses, caller resumes with response
// Use this for cloud, API servers, web apps — anywhere the agent can't block inline
new HumanInTheLoop()

// CLI readline (Node.js only) — agent blocks inline until human responds
new HumanInTheLoop({ ask: 'stdio' })

// Custom UI (Slack, web socket, etc.) — agent blocks inline on your callback
new HumanInTheLoop({
  ask: async (prompt) => await slackDM(userId, prompt),
})
```

### Cloud / API server example (interrupt/resume)

```typescript
import { Agent, InterruptResponseContent } from '@strands-agents/sdk'
import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'

const agent = new Agent({
  tools: [deleteTool, readTool],
  interventions: [new HumanInTheLoop({ allowedTools: ['read_file'] })],
  sessionManager,
})

// Request 1: Agent tries to delete → pauses
app.post('/invoke', async (req, res) => {
  const result = await agent.invoke(req.body.prompt)
  if (result.stopReason === 'interrupt') {
    res.json({
      status: 'pending_approval',
      interruptId: result.interrupts[0].id,
      reason: result.interrupts[0].reason,
    })
  } else {
    res.json({ status: 'complete', message: result.message })
  }
})

// Request 2: Client sends back the approval/denial
app.post('/approve', async (req, res) => {
  const result = await agent.invoke([
    new InterruptResponseContent({
      interruptId: req.body.interruptId,
      response: req.body.approved ? 'yes' : 'no',
    }),
  ])
  res.json({ status: 'complete', message: result.message })
})
```

### Approval response format

Defaults to accepting `true`, `'y'`/`'yes'` (case-insensitive). Customizable via `evaluate` option.

## Related Issues

- #883
- #1072

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- 17 unit tests covering: default interrupt mode, allowedTools, wildcard, negation pattern, inline approve/deny, trust mode (t/trust/T), negation-overrides-trust, custom evaluate/evaluateTrust, prompt metadata
- Interactive examples run locally

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.