### PR TITLE
chore: update anthropic-provider

### DIFF
--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -270,6 +270,24 @@ describe('AnthropicModel', () => {
       expect(events).toContainEqual({ type: 'modelMessageStopEvent', stopReason: 'toolUse' })
     })
 
+    it.each([
+      ['pause_turn', 'pauseTurn'],
+      ['refusal', 'refusal'],
+    ])('maps anthropic stop reason "%s" to "%s"', async (anthropicReason, expected) => {
+      const mockClient = createMockClient(async function* () {
+        yield { type: 'message_start', message: { role: 'assistant', usage: { input_tokens: 1 } } }
+        yield { type: 'message_delta', delta: { stop_reason: anthropicReason }, usage: { output_tokens: 1 } }
+        yield { type: 'message_stop' }
+      })
+
+      const provider = new AnthropicModel({ client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      const events = await collectIterator(provider.stream(messages))
+
+      expect(events).toContainEqual({ type: 'modelMessageStopEvent', stopReason: expected })
+    })
+
     it('handles thinking/reasoning events', async () => {
       const mockClient = createMockClient(async function* () {
         yield { type: 'message_start', message: { role: 'assistant', usage: { input_tokens: 10 } } }
@@ -393,11 +411,12 @@ describe('AnthropicModel', () => {
   describe('request formatting', () => {
     // Helper to capture request arguments
     const setupCapture = () => {
-      const captured: { request: any } = { request: null }
+      const captured: { request: any; options: any } = { request: null, options: null }
       const mockClient = {
         messages: {
-          stream: vi.fn((req) => {
+          stream: vi.fn((req, opts) => {
             captured.request = req
+            captured.options = opts
             return (async function* () {})()
           }),
         },
@@ -565,6 +584,7 @@ describe('AnthropicModel', () => {
         const content = captured.request.messages[0].content[0]
         expect(content.type).toBe('document')
         expect(content.source.media_type).toBe('application/pdf')
+        expect(content.title).toBe('doc.pdf')
       })
 
       it('logs warning for unsupported GuardContentBlock in user message', async () => {
@@ -727,6 +747,49 @@ describe('AnthropicModel', () => {
         expect(content.content).toBe('result')
         expect(warnSpy).toHaveBeenCalled()
         warnSpy.mockRestore()
+      })
+    })
+
+    describe('Beta headers', () => {
+      it('does not pass per-request options when betas is unset', async () => {
+        const { captured, mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        await collectIterator(provider.stream(messages))
+
+        expect(captured.options).toBeUndefined()
+      })
+
+      it('forwards configured betas as a per-request anthropic-beta header', async () => {
+        const { captured, mockClient } = setupCapture()
+        const provider = new AnthropicModel({
+          client: mockClient,
+          betas: ['interleaved-thinking-2025-05-14', 'mcp-client-2025-11-20'],
+        })
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        await collectIterator(provider.stream(messages))
+
+        expect(captured.options).toEqual({
+          headers: { 'anthropic-beta': 'interleaved-thinking-2025-05-14,mcp-client-2025-11-20' },
+        })
+      })
+
+      it('reflects updateConfig({ betas }) on the next request', async () => {
+        const { captured, mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        await collectIterator(provider.stream(messages))
+        expect(captured.options).toBeUndefined()
+
+        provider.updateConfig({ betas: ['interleaved-thinking-2025-05-14'] })
+        await collectIterator(provider.stream(messages))
+
+        expect(captured.options).toEqual({
+          headers: { 'anthropic-beta': 'interleaved-thinking-2025-05-14' },
+        })
       })
     })
   })

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -38,6 +38,16 @@ export interface AnthropicModelConfig extends BaseModelConfig {
   params?: Record<string, unknown>
 
   /**
+   * Beta features to enable via the `anthropic-beta` header.
+   *
+   * No header is sent by default. Provide a list of beta identifiers to opt into
+   * features such as `interleaved-thinking-2025-05-14` or `mcp-client-2025-11-20`.
+   *
+   * @see https://docs.anthropic.com/en/api/beta-headers
+   */
+  betas?: string[]
+
+  /**
    * Whether to use the native Anthropic countTokens API.
    *
    * When `true`, `countTokens()` calls the Anthropic token counting API for
@@ -92,10 +102,6 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       this._client = new Anthropic({
         ...(apiKey ? { apiKey } : {}),
         ...clientConfig,
-        defaultHeaders: {
-          ...clientConfig?.defaultHeaders,
-          'anthropic-beta': 'pdfs-2024-09-25,prompt-caching-2024-07-31',
-        },
       })
     }
   }
@@ -131,7 +137,10 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
         ...(request.tool_choice && { tool_choice: request.tool_choice }),
       }
 
-      const response = await this._client.messages.countTokens(params)
+      const requestOptions = this._buildRequestOptions()
+      const response = requestOptions
+        ? await this._client.messages.countTokens(params, requestOptions)
+        : await this._client.messages.countTokens(params)
 
       logger.debug(`total_tokens=<${response.input_tokens}> | native token count`)
       return response.input_tokens
@@ -144,7 +153,10 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
   async *stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent> {
     try {
       const request = this._formatRequest(messages, options)
-      const stream = this._client.messages.stream(request)
+      const requestOptions = this._buildRequestOptions()
+      const stream = requestOptions
+        ? this._client.messages.stream(request, requestOptions)
+        : this._client.messages.stream(request)
 
       const usage = createEmptyUsage()
 
@@ -279,6 +291,12 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
 
       throw error
     }
+  }
+
+  private _buildRequestOptions(): Anthropic.RequestOptions | undefined {
+    const betas = this._config.betas
+    if (!betas || betas.length === 0) return undefined
+    return { headers: { 'anthropic-beta': betas.join(',') } }
   }
 
   private _formatRequest(messages: Message[], options?: StreamOptions): Anthropic.MessageStreamParams {
@@ -444,6 +462,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
               media_type: 'application/pdf',
               data: encodeBase64(docBlock.source.bytes),
             },
+            ...(docBlock.name && { title: docBlock.name }),
           } as unknown as Anthropic.ContentBlockParam
         }
 
@@ -546,6 +565,10 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
         return 'stopSequence'
       case 'tool_use':
         return 'toolUse'
+      case 'pause_turn':
+        return 'pauseTurn'
+      case 'refusal':
+        return 'refusal'
       default:
         logger.warn(`stop_reason=<${anthropicReason}> | unknown anthropic stop reason`)
         return anthropicReason

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -639,6 +639,8 @@ export class JsonBlock implements JsonBlockData, JSONSerializable<JsonBlockData>
  * - `guardrailIntervened` - A guardrail policy stopped generation
  * - `interrupt` - Agent execution was interrupted for human input
  * - `maxTokens` - Maximum token limit was reached
+ * - `pauseTurn` - Model paused a long-running turn; the response should be sent back to continue
+ * - `refusal` - A streaming classifier intervened to handle a potential policy violation
  * - `stopSequence` - A stop sequence was encountered
  * - `toolUse` - Model wants to use a tool
  * - `modelContextWindowExceeded` - Input exceeded the model's context window
@@ -650,6 +652,8 @@ export type StopReason =
   | 'guardrailIntervened'
   | 'interrupt'
   | 'maxTokens'
+  | 'pauseTurn'
+  | 'refusal'
   | 'stopSequence'
   | 'toolUse'
   | 'modelContextWindowExceeded'


### PR DESCRIPTION
## Description

Three small gaps in the Anthropic provider against the current Anthropic public API:

1. Document blocks dropped their `name` field. The Anthropic API has a `title` slot for this metadata.
2. The streaming stop reasons `pause_turn` and `refusal` were not mapped. `pause_turn` is signalled when a long-running server tool needs the response sent back to continue the turn, and `refusal` is emitted when a streaming classifier intervenes for policy reasons. Both currently land in the default branch and are logged as unknown stop reasons.
3. The `anthropic-beta` header was hard-coded to `pdfs-2024-09-25,prompt-caching-2024-07-31`. Both are GA today, so the defaults add nothing, and there was no escape hatch for users wanting to opt into newer betas such as `interleaved-thinking-2025-05-14` or `mcp-client-2025-11-20`. The Python provider sends no beta header by default; this PR matches that behavior and exposes a typed knob.

## Issue
https://github.com/strands-agents/sdk-typescript/pull/1075

## Public API Changes

1. New `betas?: string[]` option on `AnthropicModelConfig`. Default behavior sends no `anthropic-beta` header.

```ts
// Before: no way to send custom betas without bypassing the SDK
const model = new AnthropicModel({ modelId: 'claude-sonnet-4-6' })

// After: opt into specific betas explicitly
const model = new AnthropicModel({
  modelId: 'claude-sonnet-4-6',
  betas: ['interleaved-thinking-2025-05-14'],
})
```

2. Stop reasons `pauseTurn` and `refusal` now flow through `modelMessageStopEvent` instead of falling through to the unknown branch.

3. `DocumentBlock.name` is forwarded to the Anthropic `title` field on PDF document blocks.

## Breaking Changes

The previously hard-coded `anthropic-beta: pdfs-2024-09-25,prompt-caching-2024-07-31` is no longer sent by default. Both betas are GA on the Messages API and have no functional effect today, so this is a no-op for current users. Anyone explicitly relying on those identifiers being present can restore them via `betas: ['pdfs-2024-09-25', 'prompt-caching-2024-07-31']`.