### PR TITLE
fix(printer): defer tool announcement until after hooks resolve

### DIFF
--- a/strands-ts/src/agent/__tests__/printer.test.ts
+++ b/strands-ts/src/agent/__tests__/printer.test.ts
@@ -5,6 +5,7 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { BeforeToolCallEvent, BeforeToolsEvent } from '../../hooks/events.js'
 
 describe('AgentPrinter', () => {
   describe('end-to-end scenarios', () => {
@@ -104,7 +105,7 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('\n🔧 Tool #1: calc\n✓ Tool completed\nResult: 4\n')
+      expect(allOutput).toBe('\n  ⏳ calc\n\n🔧 Tool #1: calc\n✓ Tool completed\nResult: 4\n')
     })
 
     it('prints tool error', async () => {
@@ -131,7 +132,71 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      expect(allOutput).toBe('\n🔧 Tool #1: bad_tool\n✗ Tool failed\nError handled\n')
+      expect(allOutput).toBe('\n  ⏳ bad_tool\n\n🔧 Tool #1: bad_tool\n✗ Tool failed\nError handled\n')
+    })
+
+    it('prints denied tool with denied icon', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'dangerous_tool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Tool was denied' })
+
+      const tool = createMockTool(
+        'dangerous_tool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'error' as const,
+            content: [new TextBlock('denied')],
+          })
+      )
+
+      const outputs: string[] = []
+      const mockAppender = (text: string) => outputs.push(text)
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+      ;(agent as any)._printer = new AgentPrinter(mockAppender)
+
+      agent.addHook(BeforeToolCallEvent, (event: BeforeToolCallEvent) => {
+        event.cancel = 'Tool not allowed'
+      })
+
+      await collectGenerator(agent.stream('Test'))
+
+      const allOutput = outputs.join('')
+      expect(allOutput).toBe(
+        '\n  ⏳ dangerous_tool\n\n🚫 Tool #1: dangerous_tool (denied)\n✗ Tool failed\nTool was denied\n'
+      )
+    })
+
+    it('prints batch cancel notice when BeforeToolsEvent cancels', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'tool_a', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const tool = createMockTool(
+        'tool_a',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success' as const,
+            content: [new TextBlock('ok')],
+          })
+      )
+
+      const outputs: string[] = []
+      const mockAppender = (text: string) => outputs.push(text)
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+      ;(agent as any)._printer = new AgentPrinter(mockAppender)
+
+      agent.addHook(BeforeToolsEvent, (event: BeforeToolsEvent) => {
+        event.cancel = true
+      })
+
+      await collectGenerator(agent.stream('Test'))
+
+      const allOutput = outputs.join('')
+      expect(allOutput).toBe('\n  ⏳ tool_a\n\n🚫 All tools denied\n✗ Tool failed\nDone\n')
     })
 
     it('prints comprehensive scenario with all output types', async () => {
@@ -180,22 +245,21 @@ describe('AgentPrinter', () => {
       await collectGenerator(agent.stream('Test'))
 
       const allOutput = outputs.join('')
-      const expected = `Let me help you. 
-💭 Reasoning:
-   I need to use the calculator
-
-🔧 Tool #1: calculator
-✓ Tool completed
-The calculation succeeded. 
-💭 Reasoning:
-   Now trying validation
-
-🔧 Tool #2: validator
-✗ Tool failed
-All done. 
-💭 Reasoning:
-   Task completed successfully
-\n`
+      const expected = [
+        'Let me help you. ',
+        '\n💭 Reasoning:\n   I need to use the calculator\n',
+        '\n  ⏳ calculator\n',
+        '\n🔧 Tool #1: calculator\n',
+        '✓ Tool completed\n',
+        'The calculation succeeded. ',
+        '\n💭 Reasoning:\n   Now trying validation\n',
+        '\n  ⏳ validator\n',
+        '\n🔧 Tool #2: validator\n',
+        '✗ Tool failed\n',
+        'All done. ',
+        '\n💭 Reasoning:\n   Task completed successfully\n',
+        '\n',
+      ].join('')
 
       expect(allOutput).toBe(expected)
     })

--- a/strands-ts/src/agent/printer.ts
+++ b/strands-ts/src/agent/printer.ts
@@ -4,7 +4,7 @@ import type {
   ModelContentBlockDeltaEventData,
   ModelContentBlockStartEventData,
 } from '../models/streaming.js'
-import type { ToolResultEvent } from '../hooks/events.js'
+import type { BeforeToolCallEvent, BeforeToolsEvent, ToolResultEvent } from '../hooks/events.js'
 
 /**
  * Creates a default appender function for the current environment.
@@ -73,6 +73,14 @@ export class AgentPrinter implements Printer {
     switch (event.type) {
       case 'modelStreamUpdateEvent':
         this.handleModelStreamEvent(event.event)
+        break
+
+      case 'beforeToolCallEvent':
+        this.handleBeforeToolCall(event)
+        break
+
+      case 'beforeToolsEvent':
+        this.handleBeforeTools(event)
         break
 
       case 'toolResultEvent':
@@ -163,15 +171,13 @@ export class AgentPrinter implements Printer {
 
   /**
    * Handle content block start events.
-   * Detects tool use starts.
+   * Prints a subtle preview during streaming; the definitive announcement
+   * (with numbering and status icon) comes in beforeToolCallEvent after hooks resolve.
    */
   private handleContentBlockStart(event: ModelContentBlockStartEventData): void {
     if (event.start?.type === 'toolUseStart') {
-      // Tool execution starting
-      this._toolCount++
-      this.write(`\n🔧 Tool #${this._toolCount}: ${event.start.name}\n`)
+      this.write(`\n  ⏳ ${event.start.name}\n`)
     }
-    // Don't assume reasoning blocks on contentBlockStart - wait for reasoningContentDelta
   }
 
   /**
@@ -186,6 +192,31 @@ export class AgentPrinter implements Printer {
       }
       this._inReasoningBlock = false
       this._needReasoningIndent = false
+    }
+  }
+
+  /**
+   * Handle before-tool-call events.
+   * Announces the tool after hooks have resolved, so denied tools get a
+   * distinct indicator instead of looking like they executed.
+   */
+  private handleBeforeToolCall(event: BeforeToolCallEvent): void {
+    this._toolCount++
+    if (event.cancel) {
+      this.write(`\n🚫 Tool #${this._toolCount}: ${event.toolUse.name} (denied)\n`)
+    } else {
+      this.write(`\n🔧 Tool #${this._toolCount}: ${event.toolUse.name}\n`)
+    }
+  }
+
+  /**
+   * Handle before-tools events.
+   * When all tools are batch-cancelled, prints a notice since no individual
+   * BeforeToolCallEvent will fire.
+   */
+  private handleBeforeTools(event: BeforeToolsEvent): void {
+    if (event.cancel) {
+      this.write('\n🚫 All tools denied\n')
     }
   }
 


### PR DESCRIPTION
## Description

The agent printer announced tool usage (`🔧 Tool #N: toolName`) during model streaming on `contentBlockStart`, before `BeforeToolCallEvent` hooks had a chance to cancel or gate execution. This meant tools that were ultimately denied by HITL or permission hooks appeared as if they were executing — the user saw the announcement, then a pause for approval, then either completion or a confusing cancellation.

This PR introduces a two-phase tool announcement:

1. **Streaming phase** — a subtle `⏳ toolName` preview prints immediately when the model decides to use a tool, giving real-time feedback during streaming
2. **Execution phase** — the definitive `🔧 Tool #N: toolName` or `🚫 Tool #N: toolName (denied)` prints after `BeforeToolCallEvent` hooks resolve

Additionally, when `BeforeToolsEvent` batch-cancels all tools, a `🚫 All tools denied` notice is printed.

### Example output — tool approved:

```
  ⏳ read_file

🔧 Tool #1: read_file
✓ Tool completed
```

### Example output — tool denied by HITL hook:

```
  ⏳ delete_file

🚫 Tool #1: delete_file (denied)
✗ Tool failed
```

### Example output — all tools batch-denied:

```
  ⏳ tool_a
  ⏳ tool_b

🚫 All tools denied
✗ Tool failed
✗ Tool failed
```

### Before (old behavior with HITL):

```
🔧 Tool #1: delete_file        ← printed immediately during streaming
                                ← user sees approval prompt here
✗ Tool failed                   ← tool was never actually executed
```

The old behavior made it look like the tool had started executing, which was misleading when the tool was ultimately blocked.

## Related Issues

## Documentation PR

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- All 333 agent tests pass (13 test files)
- TypeScript compilation clean (`tsc --noEmit`)
- Added 2 new tests: individual tool denial via `BeforeToolCallEvent` hook, and batch cancellation via `BeforeToolsEvent` hook
- Existing printer tests updated to verify the two-phase output sequence

## Checklist
- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.