### PR TITLE
feat(bedrock): add TTL support for prompt caching

### DIFF
--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -53,6 +53,7 @@ export type {
   ToolResultBlockData,
   ReasoningBlockData,
   CachePointBlockData,
+  CacheTTL,
   GuardContentBlockData,
   GuardContentText,
   GuardContentImage,

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -53,7 +53,6 @@ export type {
   ToolResultBlockData,
   ReasoningBlockData,
   CachePointBlockData,
-  CacheTTL,
   GuardContentBlockData,
   GuardContentText,
   GuardContentImage,
@@ -184,6 +183,7 @@ export type {
   BedrockModelOptions,
   BedrockGuardrailConfig,
   BedrockGuardrailRedactionConfig,
+  BedrockCacheTTL,
 } from './models/bedrock.js'
 
 // Agent streaming event types

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -183,6 +183,7 @@ export type {
   BedrockModelOptions,
   BedrockGuardrailConfig,
   BedrockGuardrailRedactionConfig,
+  BedrockCacheConfig,
   BedrockCacheTTL,
 } from './models/bedrock.js'
 

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -736,6 +736,50 @@ describe('BedrockModel', () => {
         modelId: expect.any(String),
       })
     })
+
+    it('preserves ttl on user-supplied cache point blocks in messages', async () => {
+      const provider = new BedrockModel()
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new TextBlock('Message with 1h cache point'),
+            new CachePointBlock({ cacheType: 'default', ttl: '1h' }),
+          ],
+        }),
+      ]
+
+      collectIterator(provider.stream(messages))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith({
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: 'Message with 1h cache point' }, { cachePoint: { type: 'default', ttl: '1h' } }],
+          },
+        ],
+        modelId: expect.any(String),
+      })
+    })
+
+    it('preserves ttl on cache point blocks in system prompt', async () => {
+      const provider = new BedrockModel()
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        systemPrompt: [
+          new TextBlock('You are a helpful assistant'),
+          new CachePointBlock({ cacheType: 'default', ttl: '5m' }),
+        ],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([
+        { text: 'You are a helpful assistant' },
+        { cachePoint: { type: 'default', ttl: '5m' } },
+      ])
+    })
   })
 
   describe.each([
@@ -1563,6 +1607,60 @@ describe('BedrockModel', () => {
       const assistantMsg = call?.messages?.[1]
       const assistantLastBlock = assistantMsg?.content?.[assistantMsg.content.length - 1]
       expect(assistantLastBlock).not.toStrictEqual({ cachePoint: { type: 'default' } })
+    })
+
+    it('propagates cacheConfig.ttl to auto-injected cache points on tools and last user message', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', ttl: '1h' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        toolSpecs: [
+          {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { type: 'object' },
+          },
+        ],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.toolConfig?.tools).toStrictEqual([
+        {
+          toolSpec: {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { json: { type: 'object' } },
+          },
+        },
+        { cachePoint: { type: 'default', ttl: '1h' } },
+      ])
+      const userMsg = call?.messages?.[0]
+      const lastBlock = userMsg?.content?.[userMsg.content.length - 1]
+      expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default', ttl: '1h' } })
+    })
+
+    it('omits ttl on auto-injected cache points when cacheConfig.ttl is not set', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        toolSpecs: [
+          {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { type: 'object' },
+          },
+        ],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      const toolsLast = call?.toolConfig?.tools?.[call.toolConfig.tools.length - 1]
+      expect(toolsLast).toStrictEqual({ cachePoint: { type: 'default' } })
+      const userMsg = call?.messages?.[0]
+      const lastBlock = userMsg?.content?.[userMsg.content.length - 1]
+      expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default' } })
     })
 
     it('does not mutate the original messages array', async () => {

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -1609,8 +1609,10 @@ describe('BedrockModel', () => {
       expect(assistantLastBlock).not.toStrictEqual({ cachePoint: { type: 'default' } })
     })
 
-    it('propagates cacheConfig.ttl to auto-injected cache points on tools and last user message', async () => {
-      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', ttl: '1h' } })
+    it('propagates cacheConfig ttls independently to tools and last user message', async () => {
+      const provider = new BedrockModel({
+        cacheConfig: { strategy: 'auto', ttlTool: '1h', ttlMessages: '5m' },
+      })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {
         toolSpecs: [
@@ -1637,10 +1639,56 @@ describe('BedrockModel', () => {
       ])
       const userMsg = call?.messages?.[0]
       const lastBlock = userMsg?.content?.[userMsg.content.length - 1]
+      expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default', ttl: '5m' } })
+    })
+
+    it('propagates only ttlTool when ttlMessages is not set', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', ttlTool: '1h' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        toolSpecs: [
+          {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { type: 'object' },
+          },
+        ],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      const toolsLast = call?.toolConfig?.tools?.[call.toolConfig.tools.length - 1]
+      expect(toolsLast).toStrictEqual({ cachePoint: { type: 'default', ttl: '1h' } })
+      const userMsg = call?.messages?.[0]
+      const lastBlock = userMsg?.content?.[userMsg.content.length - 1]
+      expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default' } })
+    })
+
+    it('propagates only ttlMessages when ttlTool is not set', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', ttlMessages: '1h' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        toolSpecs: [
+          {
+            name: 'calculator',
+            description: 'Calculate',
+            inputSchema: { type: 'object' },
+          },
+        ],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      const toolsLast = call?.toolConfig?.tools?.[call.toolConfig.tools.length - 1]
+      expect(toolsLast).toStrictEqual({ cachePoint: { type: 'default' } })
+      const userMsg = call?.messages?.[0]
+      const lastBlock = userMsg?.content?.[userMsg.content.length - 1]
       expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default', ttl: '1h' } })
     })
 
-    it('omits ttl on auto-injected cache points when cacheConfig.ttl is not set', async () => {
+    it('omits ttl on auto-injected cache points when no ttl is set', async () => {
       const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -1611,7 +1611,7 @@ describe('BedrockModel', () => {
 
     it('propagates cacheConfig ttls independently to tools and last user message', async () => {
       const provider = new BedrockModel({
-        cacheConfig: { strategy: 'auto', ttlTool: '1h', ttlMessages: '5m' },
+        cacheConfig: { strategy: 'auto', toolsTTL: '1h', messagesTTL: '5m' },
       })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {
@@ -1642,8 +1642,8 @@ describe('BedrockModel', () => {
       expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default', ttl: '5m' } })
     })
 
-    it('propagates only ttlTool when ttlMessages is not set', async () => {
-      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', ttlTool: '1h' } })
+    it('propagates only toolsTTL when messagesTTL is not set', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', toolsTTL: '1h' } })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {
         toolSpecs: [
@@ -1665,8 +1665,8 @@ describe('BedrockModel', () => {
       expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default' } })
     })
 
-    it('propagates only ttlMessages when ttlTool is not set', async () => {
-      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', ttlMessages: '1h' } })
+    it('propagates only messagesTTL when toolsTTL is not set', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', messagesTTL: '1h' } })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {
         toolSpecs: [

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -781,7 +781,7 @@ describe('BedrockModel', () => {
       ])
     })
 
-    it('rejects invalid ttl on user-supplied cache point with a descriptive error', async () => {
+    it('forwards arbitrary ttl strings without client-side validation (Bedrock validates server-side)', async () => {
       const provider = new BedrockModel()
       const messages = [
         new Message({
@@ -790,9 +790,12 @@ describe('BedrockModel', () => {
         }),
       ]
 
-      await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
-        /Invalid Bedrock cache TTL for CachePointBlock\.ttl: "2h"\. Expected one of "5m", "1h"\./
-      )
+      collectIterator(provider.stream(messages))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      const userMsg = call?.messages?.[0]
+      const lastBlock = userMsg?.content?.[userMsg.content.length - 1]
+      expect(lastBlock).toStrictEqual({ cachePoint: { type: 'default', ttl: '2h' } })
     })
   })
 

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -780,6 +780,20 @@ describe('BedrockModel', () => {
         { cachePoint: { type: 'default', ttl: '5m' } },
       ])
     })
+
+    it('rejects invalid ttl on user-supplied cache point with a descriptive error', async () => {
+      const provider = new BedrockModel()
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('Hello'), new CachePointBlock({ cacheType: 'default', ttl: '2h' })],
+        }),
+      ]
+
+      await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
+        /Invalid Bedrock cache TTL for CachePointBlock\.ttl: "2h"\. Expected one of "5m", "1h"\./
+      )
+    })
   })
 
   describe.each([

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -10,6 +10,7 @@
 import {
   BedrockRuntimeClient,
   type BedrockRuntimeClientConfig,
+  type CachePointBlock as BedrockCachePointBlock,
   type ContentBlock as BedrockContentBlock,
   type ContentBlockDeltaEvent as BedrockContentBlockDeltaEvent,
   type ContentBlockStartEvent as BedrockContentBlockStartEvent,
@@ -124,6 +125,18 @@ const DEFAULT_REDACT_INPUT_MESSAGE = '[User input redacted.]'
  * Default message for redacted output.
  */
 const DEFAULT_REDACT_OUTPUT_MESSAGE = '[Assistant output redacted.]'
+
+/**
+ * TTL durations accepted by Bedrock for prompt-cache checkpoints.
+ *
+ * Bedrock currently accepts `'5m'` (default) and `'1h'`. Note that Bedrock requires
+ * checkpoint TTLs to be **non-increasing** across `toolConfig` → system → messages —
+ * setting a longer TTL on a later checkpoint than an earlier one will be rejected by
+ * the service.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
+ */
+export type BedrockCacheTTL = '5m' | '1h'
 
 /**
  * Redaction configuration for Bedrock guardrails.
@@ -679,8 +692,12 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       )
 
       if (this._shouldEnableCaching()) {
-        const ttl = this._config.cacheConfig?.ttlTool
-        tools.push({ cachePoint: { type: 'default', ...(ttl !== undefined && { ttl }) } })
+        const cachePoint: BedrockCachePointBlock = { type: 'default' }
+        const ttl = this._config.cacheConfig?.toolsTTL
+        if (ttl !== undefined) {
+          cachePoint.ttl = ttl as BedrockCacheTTL
+        }
+        tools.push({ cachePoint })
       }
 
       const toolConfig: ToolConfiguration = {
@@ -836,8 +853,12 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     if (lastUserIdx !== null) {
       const lastMsg = messages[lastUserIdx]
       if (lastMsg && lastMsg.content) {
-        const ttl = this._config.cacheConfig?.ttlMessages
-        lastMsg.content.push({ cachePoint: { type: 'default', ...(ttl !== undefined && { ttl }) } })
+        const cachePoint: BedrockCachePointBlock = { type: 'default' }
+        const ttl = this._config.cacheConfig?.messagesTTL
+        if (ttl !== undefined) {
+          cachePoint.ttl = ttl as BedrockCacheTTL
+        }
+        lastMsg.content.push({ cachePoint })
         logger.debug(`msg_idx=<${lastUserIdx}> | added cache point to last user message`)
       }
     }
@@ -1042,8 +1063,13 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         }
       }
 
-      case 'cachePointBlock':
-        return { cachePoint: { type: block.cacheType, ...(block.ttl !== undefined && { ttl: block.ttl }) } }
+      case 'cachePointBlock': {
+        const cachePoint: BedrockCachePointBlock = { type: block.cacheType }
+        if (block.ttl !== undefined) {
+          cachePoint.ttl = block.ttl as BedrockCacheTTL
+        }
+        return { cachePoint }
+      }
 
       case 'imageBlock':
         return {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -679,7 +679,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       )
 
       if (this._shouldEnableCaching()) {
-        const ttl = this._config.cacheConfig?.ttl
+        const ttl = this._config.cacheConfig?.ttlTool
         tools.push({ cachePoint: { type: 'default', ...(ttl && { ttl }) } })
       }
 
@@ -836,7 +836,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     if (lastUserIdx !== null) {
       const lastMsg = messages[lastUserIdx]
       if (lastMsg && lastMsg.content) {
-        const ttl = this._config.cacheConfig?.ttl
+        const ttl = this._config.cacheConfig?.ttlMessages
         lastMsg.content.push({ cachePoint: { type: 'default', ...(ttl && { ttl }) } })
         logger.debug(`msg_idx=<${lastUserIdx}> | added cache point to last user message`)
       }

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -136,7 +136,34 @@ const DEFAULT_REDACT_OUTPUT_MESSAGE = '[Assistant output redacted.]'
  *
  * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
  */
-export type BedrockCacheTTL = '5m' | '1h'
+const BEDROCK_CACHE_TTLS = ['5m', '1h'] as const
+export type BedrockCacheTTL = (typeof BEDROCK_CACHE_TTLS)[number]
+
+/**
+ * Bedrock-specific prompt-caching configuration. Narrows the TTL fields on the common
+ * {@link CacheConfig} to the values accepted by Bedrock.
+ */
+export interface BedrockCacheConfig extends CacheConfig {
+  /** TTL applied to the auto-injected cache point appended after `toolConfig.tools`. */
+  toolsTTL?: BedrockCacheTTL
+
+  /** TTL applied to the auto-injected cache point appended to the last user message. */
+  messagesTTL?: BedrockCacheTTL
+}
+
+/**
+ * Asserts that a TTL string passed via a user-supplied `CachePointBlock` matches one of
+ * Bedrock's accepted values. Throws with the offending field name to make the
+ * misconfiguration easy to locate, and narrows the type for the caller.
+ */
+function validateBedrockCacheTTL(value: string, field: string): asserts value is BedrockCacheTTL {
+  if (!(BEDROCK_CACHE_TTLS as readonly string[]).includes(value)) {
+    throw new Error(
+      `Invalid Bedrock cache TTL for ${field}: ${JSON.stringify(value)}. ` +
+        `Expected one of ${BEDROCK_CACHE_TTLS.map((v) => JSON.stringify(v)).join(', ')}.`
+    )
+  }
+}
 
 /**
  * Redaction configuration for Bedrock guardrails.
@@ -251,7 +278,7 @@ export interface BedrockModelConfig extends BaseModelConfig {
    *
    * @see https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
    */
-  cacheConfig?: CacheConfig
+  cacheConfig?: BedrockCacheConfig
 
   /**
    * Additional fields to include in the Bedrock request.
@@ -695,7 +722,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         const cachePoint: BedrockCachePointBlock = { type: 'default' }
         const ttl = this._config.cacheConfig?.toolsTTL
         if (ttl !== undefined) {
-          cachePoint.ttl = ttl as BedrockCacheTTL
+          cachePoint.ttl = ttl
         }
         tools.push({ cachePoint })
       }
@@ -856,7 +883,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         const cachePoint: BedrockCachePointBlock = { type: 'default' }
         const ttl = this._config.cacheConfig?.messagesTTL
         if (ttl !== undefined) {
-          cachePoint.ttl = ttl as BedrockCacheTTL
+          cachePoint.ttl = ttl
         }
         lastMsg.content.push({ cachePoint })
         logger.debug(`msg_idx=<${lastUserIdx}> | added cache point to last user message`)
@@ -1066,7 +1093,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       case 'cachePointBlock': {
         const cachePoint: BedrockCachePointBlock = { type: block.cacheType }
         if (block.ttl !== undefined) {
-          cachePoint.ttl = block.ttl as BedrockCacheTTL
+          validateBedrockCacheTTL(block.ttl, 'CachePointBlock.ttl')
+          cachePoint.ttl = block.ttl
         }
         return { cachePoint }
       }

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -679,7 +679,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       )
 
       if (this._shouldEnableCaching()) {
-        tools.push({ cachePoint: { type: 'default' } })
+        const ttl = this._config.cacheConfig?.ttl
+        tools.push({ cachePoint: { type: 'default', ...(ttl && { ttl }) } })
       }
 
       const toolConfig: ToolConfiguration = {
@@ -835,7 +836,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     if (lastUserIdx !== null) {
       const lastMsg = messages[lastUserIdx]
       if (lastMsg && lastMsg.content) {
-        lastMsg.content.push({ cachePoint: { type: 'default' } })
+        const ttl = this._config.cacheConfig?.ttl
+        lastMsg.content.push({ cachePoint: { type: 'default', ...(ttl && { ttl }) } })
         logger.debug(`msg_idx=<${lastUserIdx}> | added cache point to last user message`)
       }
     }
@@ -1041,7 +1043,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       }
 
       case 'cachePointBlock':
-        return { cachePoint: { type: block.cacheType } }
+        return { cachePoint: { type: block.cacheType, ...(block.ttl && { ttl: block.ttl }) } }
 
       case 'imageBlock':
         return {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -680,7 +680,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
       if (this._shouldEnableCaching()) {
         const ttl = this._config.cacheConfig?.ttlTool
-        tools.push({ cachePoint: { type: 'default', ...(ttl && { ttl }) } })
+        tools.push({ cachePoint: { type: 'default', ...(ttl !== undefined && { ttl }) } })
       }
 
       const toolConfig: ToolConfiguration = {
@@ -837,7 +837,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       const lastMsg = messages[lastUserIdx]
       if (lastMsg && lastMsg.content) {
         const ttl = this._config.cacheConfig?.ttlMessages
-        lastMsg.content.push({ cachePoint: { type: 'default', ...(ttl && { ttl }) } })
+        lastMsg.content.push({ cachePoint: { type: 'default', ...(ttl !== undefined && { ttl }) } })
         logger.debug(`msg_idx=<${lastUserIdx}> | added cache point to last user message`)
       }
     }
@@ -1043,7 +1043,7 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       }
 
       case 'cachePointBlock':
-        return { cachePoint: { type: block.cacheType, ...(block.ttl && { ttl: block.ttl }) } }
+        return { cachePoint: { type: block.cacheType, ...(block.ttl !== undefined && { ttl: block.ttl }) } }
 
       case 'imageBlock':
         return {

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -11,6 +11,7 @@ import {
   BedrockRuntimeClient,
   type BedrockRuntimeClientConfig,
   type CachePointBlock as BedrockCachePointBlock,
+  type CacheTTL as BedrockSdkCacheTTL,
   type ContentBlock as BedrockContentBlock,
   type ContentBlockDeltaEvent as BedrockContentBlockDeltaEvent,
   type ContentBlockStartEvent as BedrockContentBlockStartEvent,
@@ -129,19 +130,22 @@ const DEFAULT_REDACT_OUTPUT_MESSAGE = '[Assistant output redacted.]'
 /**
  * TTL durations accepted by Bedrock for prompt-cache checkpoints.
  *
- * Bedrock currently accepts `'5m'` (default) and `'1h'`. Note that Bedrock requires
- * checkpoint TTLs to be **non-increasing** across `toolConfig` → system → messages —
- * setting a longer TTL on a later checkpoint than an earlier one will be rejected by
- * the service.
+ * Bedrock currently accepts `'5m'` (default) and `'1h'`. The `(string & {})` branch keeps
+ * autocomplete on the known values while letting callers pass any string forward — Bedrock
+ * validates the value server-side and rejects unsupported values with `ValidationException`,
+ * so this stays correct as AWS adds new TTL values without an SDK update.
+ *
+ * Bedrock also requires checkpoint TTLs to be **non-increasing** across
+ * `toolConfig` → system → messages — setting a longer TTL on a later checkpoint than an
+ * earlier one will be rejected by the service.
  *
  * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
  */
-const BEDROCK_CACHE_TTLS = ['5m', '1h'] as const
-export type BedrockCacheTTL = (typeof BEDROCK_CACHE_TTLS)[number]
+export type BedrockCacheTTL = '5m' | '1h' | (string & {})
 
 /**
- * Bedrock-specific prompt-caching configuration. Narrows the TTL fields on the common
- * {@link CacheConfig} to the values accepted by Bedrock.
+ * Bedrock-specific prompt-caching configuration. Narrows the TTL fields onto the common
+ * {@link CacheConfig} for the Bedrock provider.
  */
 export interface BedrockCacheConfig extends CacheConfig {
   /** TTL applied to the auto-injected cache point appended after `toolConfig.tools`. */
@@ -149,20 +153,6 @@ export interface BedrockCacheConfig extends CacheConfig {
 
   /** TTL applied to the auto-injected cache point appended to the last user message. */
   messagesTTL?: BedrockCacheTTL
-}
-
-/**
- * Asserts that a TTL string passed via a user-supplied `CachePointBlock` matches one of
- * Bedrock's accepted values. Throws with the offending field name to make the
- * misconfiguration easy to locate, and narrows the type for the caller.
- */
-function validateBedrockCacheTTL(value: string, field: string): asserts value is BedrockCacheTTL {
-  if (!(BEDROCK_CACHE_TTLS as readonly string[]).includes(value)) {
-    throw new Error(
-      `Invalid Bedrock cache TTL for ${field}: ${JSON.stringify(value)}. ` +
-        `Expected one of ${BEDROCK_CACHE_TTLS.map((v) => JSON.stringify(v)).join(', ')}.`
-    )
-  }
 }
 
 /**
@@ -722,7 +712,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         const cachePoint: BedrockCachePointBlock = { type: 'default' }
         const ttl = this._config.cacheConfig?.toolsTTL
         if (ttl !== undefined) {
-          cachePoint.ttl = ttl
+          // Bedrock validates TTL values server-side, so accept any string here.
+          cachePoint.ttl = ttl as BedrockSdkCacheTTL
         }
         tools.push({ cachePoint })
       }
@@ -883,7 +874,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         const cachePoint: BedrockCachePointBlock = { type: 'default' }
         const ttl = this._config.cacheConfig?.messagesTTL
         if (ttl !== undefined) {
-          cachePoint.ttl = ttl
+          // Bedrock validates TTL values server-side, so accept any string here.
+          cachePoint.ttl = ttl as BedrockSdkCacheTTL
         }
         lastMsg.content.push({ cachePoint })
         logger.debug(`msg_idx=<${lastUserIdx}> | added cache point to last user message`)
@@ -1093,8 +1085,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       case 'cachePointBlock': {
         const cachePoint: BedrockCachePointBlock = { type: block.cacheType }
         if (block.ttl !== undefined) {
-          validateBedrockCacheTTL(block.ttl, 'CachePointBlock.ttl')
-          cachePoint.ttl = block.ttl
+          // Bedrock validates TTL values server-side, so accept any string here.
+          cachePoint.ttl = block.ttl as BedrockSdkCacheTTL
         }
         return { cachePoint }
       }

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -1,5 +1,4 @@
 import {
-  type CacheTTL,
   type ContentBlock,
   Message,
   type MessageMetadata,
@@ -78,15 +77,17 @@ export interface CacheConfig {
 
   /**
    * Optional TTL applied to the auto-injected cache point appended after `toolConfig.tools`.
-   * When omitted, the provider's default TTL is used.
+   * When omitted, the provider's default TTL is used. The accepted value space is
+   * provider-specific.
    */
-  ttlTool?: CacheTTL
+  toolsTTL?: string
 
   /**
    * Optional TTL applied to the auto-injected cache point appended to the last user message.
-   * When omitted, the provider's default TTL is used.
+   * When omitted, the provider's default TTL is used. The accepted value space is
+   * provider-specific.
    */
-  ttlMessages?: CacheTTL
+  messagesTTL?: string
 }
 
 /**

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -77,12 +77,16 @@ export interface CacheConfig {
   strategy: 'auto' | 'anthropic'
 
   /**
-   * Optional TTL applied to auto-injected cache points (after tools and the last user message).
+   * Optional TTL applied to the auto-injected cache point appended after `toolConfig.tools`.
    * When omitted, the provider's default TTL is used.
-   *
-   * Use a per-block `ttl` on a {@link CachePointBlock} to override on a specific cache point.
    */
-  ttl?: CacheTTL
+  ttlTool?: CacheTTL
+
+  /**
+   * Optional TTL applied to the auto-injected cache point appended to the last user message.
+   * When omitted, the provider's default TTL is used.
+   */
+  ttlMessages?: CacheTTL
 }
 
 /**

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -1,4 +1,5 @@
 import {
+  type CacheTTL,
   type ContentBlock,
   Message,
   type MessageMetadata,
@@ -74,6 +75,14 @@ export interface CacheConfig {
    * - "anthropic": Force enable Anthropic-style caching (useful for application inference profiles)
    */
   strategy: 'auto' | 'anthropic'
+
+  /**
+   * Optional TTL applied to auto-injected cache points (after tools and the last user message).
+   * When omitted, the provider's default TTL is used.
+   *
+   * Use a per-block `ttl` on a {@link CachePointBlock} to override on a specific cache point.
+   */
+  ttl?: CacheTTL
 }
 
 /**

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -74,20 +74,6 @@ export interface CacheConfig {
    * - "anthropic": Force enable Anthropic-style caching (useful for application inference profiles)
    */
   strategy: 'auto' | 'anthropic'
-
-  /**
-   * Optional TTL applied to the auto-injected cache point appended after `toolConfig.tools`.
-   * When omitted, the provider's default TTL is used. The accepted value space is
-   * provider-specific.
-   */
-  toolsTTL?: string
-
-  /**
-   * Optional TTL applied to the auto-injected cache point appended to the last user message.
-   * When omitted, the provider's default TTL is used. The accepted value space is
-   * provider-specific.
-   */
-  messagesTTL?: string
 }
 
 /**

--- a/strands-ts/src/types/__tests__/messages.test.ts
+++ b/strands-ts/src/types/__tests__/messages.test.ts
@@ -207,8 +207,11 @@ describe('CachePointBlock', () => {
   test('roundtrips ttl via fromJSON', () => {
     const block = CachePointBlock.fromJSON({ cachePoint: { cacheType: 'default', ttl: '1h' } })
 
-    expect(block.cacheType).toBe('default')
-    expect(block.ttl).toBe('1h')
+    expect(block).toEqual({
+      type: 'cachePointBlock',
+      cacheType: 'default',
+      ttl: '1h',
+    })
   })
 })
 

--- a/strands-ts/src/types/__tests__/messages.test.ts
+++ b/strands-ts/src/types/__tests__/messages.test.ts
@@ -177,6 +177,39 @@ describe('CachePointBlock', () => {
       cacheType: 'default',
     })
   })
+
+  test('creates cache point block with ttl', () => {
+    const block = new CachePointBlock({ cacheType: 'default', ttl: '1h' })
+
+    expect(block).toEqual({
+      type: 'cachePointBlock',
+      cacheType: 'default',
+      ttl: '1h',
+    })
+  })
+
+  test('serializes ttl in toJSON', () => {
+    const block = new CachePointBlock({ cacheType: 'default', ttl: '5m' })
+
+    expect(block.toJSON()).toEqual({
+      cachePoint: { cacheType: 'default', ttl: '5m' },
+    })
+  })
+
+  test('omits ttl in toJSON when not set', () => {
+    const block = new CachePointBlock({ cacheType: 'default' })
+
+    expect(block.toJSON()).toEqual({
+      cachePoint: { cacheType: 'default' },
+    })
+  })
+
+  test('roundtrips ttl via fromJSON', () => {
+    const block = CachePointBlock.fromJSON({ cachePoint: { cacheType: 'default', ttl: '1h' } })
+
+    expect(block.cacheType).toBe('default')
+    expect(block.ttl).toBe('1h')
+  })
 })
 
 describe('JsonBlock', () => {

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -531,15 +531,6 @@ export class ReasoningBlock
 }
 
 /**
- * TTL duration for a cache point.
- *
- * Bedrock currently accepts `'5m'` (default) and `'1h'`.
- *
- * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
- */
-export type CacheTTL = '5m' | '1h'
-
-/**
  * Data for a cache point block.
  */
 export interface CachePointBlockData {
@@ -550,8 +541,12 @@ export interface CachePointBlockData {
 
   /**
    * Optional TTL for the cache entry. When omitted, the provider's default TTL is used.
+   *
+   * The accepted value space is provider-specific. For example, the Bedrock provider only
+   * accepts the values defined by `BedrockCacheTTL` (`'5m'` and `'1h'`). Other providers
+   * may accept different values or ignore this field.
    */
-  ttl?: CacheTTL
+  ttl?: string
 }
 
 /**
@@ -570,9 +565,10 @@ export class CachePointBlock implements CachePointBlockData, JSONSerializable<{ 
   readonly cacheType: 'default'
 
   /**
-   * Optional TTL for the cache entry.
+   * Optional TTL for the cache entry. See {@link CachePointBlockData.ttl} for the
+   * provider-specific value space.
    */
-  readonly ttl?: CacheTTL
+  readonly ttl?: string
 
   constructor(data: CachePointBlockData) {
     this.cacheType = data.cacheType

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -531,6 +531,15 @@ export class ReasoningBlock
 }
 
 /**
+ * TTL duration for a cache point.
+ *
+ * Bedrock currently accepts `'5m'` (default) and `'1h'`.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
+ */
+export type CacheTTL = '5m' | '1h'
+
+/**
  * Data for a cache point block.
  */
 export interface CachePointBlockData {
@@ -538,6 +547,11 @@ export interface CachePointBlockData {
    * The cache type. Currently only 'default' is supported.
    */
   cacheType: 'default'
+
+  /**
+   * Optional TTL for the cache entry. When omitted, the provider's default TTL is used.
+   */
+  ttl?: CacheTTL
 }
 
 /**
@@ -555,8 +569,16 @@ export class CachePointBlock implements CachePointBlockData, JSONSerializable<{ 
    */
   readonly cacheType: 'default'
 
+  /**
+   * Optional TTL for the cache entry.
+   */
+  readonly ttl?: CacheTTL
+
   constructor(data: CachePointBlockData) {
     this.cacheType = data.cacheType
+    if (data.ttl !== undefined) {
+      this.ttl = data.ttl
+    }
   }
 
   /**
@@ -567,6 +589,7 @@ export class CachePointBlock implements CachePointBlockData, JSONSerializable<{ 
     return {
       cachePoint: {
         cacheType: this.cacheType,
+        ...(this.ttl !== undefined && { ttl: this.ttl }),
       },
     }
   }


### PR DESCRIPTION
## Summary

- Adds optional `ttl` field to `CachePointBlock` so user-supplied cache points can opt into Bedrock's extended TTL (`'5m'` / `'1h'`). The Bedrock formatter preserves it end-to-end.
- Adds optional `ttlTool` and `ttlMessages` fields to `CacheConfig`, applied independently to the SDK's auto-injected cache points (after `toolConfig.tools` and on the last user message). When unset, behavior is unchanged.

Per-target TTL control is needed because Bedrock requires checkpoint TTLs to be **non-increasing** across `toolConfig` → system → messages. A single shared `ttl` would force users into a uniform value and could not satisfy this rule when callers want different durations per checkpoint.

Mirrors sdk-python feature parity:
- strands-agents/sdk-python#1660 — user-supplied `cachePoint.ttl` preservation
- strands-agents/sdk-python#2232 — TTL propagation onto auto-injected cache points (split fields, equivalent to `cache_tools_ttl` + `CacheConfig.ttl` on the Python side)

API reference: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html

Closes #1088

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test` — full unit suite passes (2729 tests), including new tests:
  - `CachePointBlock` ttl in constructor / `toJSON` / `fromJSON`
  - Bedrock formatter preserves `ttl` on user-supplied cache points (in messages and system prompt)
  - Bedrock auto-inject propagates `cacheConfig.ttlTool` and `cacheConfig.ttlMessages` independently
  - Backward compat: omitting both fields produces the same output as before

## Example usage

```ts
import { BedrockModel, CachePointBlock, TextBlock } from '@strands-agents/sdk'

// 1) User-supplied cache point with TTL (preserved end-to-end):
new BedrockModel({ modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0' })
  .stream(messages, {
    systemPrompt: [
      new TextBlock(largeContext),
      new CachePointBlock({ cacheType: 'default', ttl: '1h' }),
    ],
  })

// 2) Auto-inject with independent TTLs per checkpoint
//    (must respect Bedrock's non-increasing TTL rule across tools -> system -> messages):
new BedrockModel({
  modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
  cacheConfig: { strategy: 'auto', ttlTool: '1h', ttlMessages: '5m' },
})

// 3) Auto-inject with a single TTL on just the messages checkpoint:
new BedrockModel({
  modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
  cacheConfig: { strategy: 'auto', ttlMessages: '1h' },
})
```