### PR TITLE
feat: base Sandbox interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,14 @@ sdk-typescript/
 │   │   │   ├── retry-strategy.ts               # RetryStrategy union type + dedup helper
 │   │   │   └── index.ts
 │   │   │
+│   │   ├── sandbox/              # Sandbox abstraction for agent code execution
+│   │   │   ├── __tests__/
+│   │   │   ├── base.ts           # Abstract Sandbox class
+│   │   │   ├── posix-shell.ts    # PosixShellSandbox with shell-based defaults
+│   │   │   ├── stream-process.ts # ChildProcess-to-AsyncGenerator bridge
+│   │   │   ├── constants.ts      # Language validation pattern
+│   │   │   └── types.ts          # ExecutionResult, StreamChunk, FileInfo, OutputFile
+│   │   │
 │   │   ├── session/              # Session management
 │   │   │   ├── __tests__/
 │   │   │   ├── session-manager.ts
@@ -174,6 +182,9 @@ sdk-typescript/
 │   │   │   ├── serializable.ts
 │   │   │   ├── snapshot.ts
 │   │   │   └── validation.ts
+│   │   │
+│   │   ├── utils/                # Shared utility functions
+│   │   │   └── shell-quote.ts    # Shell-safe string escaping
 │   │   │
 │   │   ├── vended-interventions/ # Optional vended intervention handlers
 │   │   │   ├── hitl/             # Human-in-the-loop approval handler
@@ -353,10 +364,12 @@ sdk-typescript/
 - **`strands-ts/src/plugins/`**: Plugin system for extending agent functionality
 - **`strands-ts/src/registry/`**: Tool registry implementation
 - **`strands-ts/src/retry/`**: Retry strategies for model calls (backoff strategies, abstract `ModelRetryStrategy` plugin base class, concrete `DefaultModelRetryStrategy`)
+- **`strands-ts/src/sandbox/`**: Sandbox abstraction for agent code execution (abstract `Sandbox` base class, `PosixShellSandbox` base for shell-based implementations)
 - **`strands-ts/src/session/`**: Session management (file, S3, custom storage)
 - **`strands-ts/src/telemetry/`**: OpenTelemetry tracing and metrics
 - **`strands-ts/src/tools/`**: Tool definitions, types, and structured output validation with Zod schemas
 - **`strands-ts/src/types/`**: Core type definitions used across the SDK
+- **`strands-ts/src/utils/`**: Shared utility functions
 - **`strands-ts/src/vended-interventions/`**: Optional vended intervention handlers (hitl, steering — not part of core SDK, independently importable)
 - **`strands-ts/src/vended-plugins/`**: Optional vended plugins (context-offloader, skills — not part of core SDK, independently importable)
 - **`strands-ts/src/vended-tools/`**: Optional vended tools (bash, file-editor, http-request, notebook)

--- a/strands-ts/eslint.config.js
+++ b/strands-ts/eslint.config.js
@@ -55,6 +55,9 @@ function sdkRules(options) {
         process: 'readonly',
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
+        atob: 'readonly',
+        btoa: 'readonly',
+        crypto: 'readonly',
       },
     },
     plugins: {

--- a/strands-ts/src/__fixtures__/test-sandbox.node.ts
+++ b/strands-ts/src/__fixtures__/test-sandbox.node.ts
@@ -1,0 +1,29 @@
+import { PosixShellSandbox } from '../sandbox/posix-shell.js'
+import { shellQuote } from '../utils/shell-quote.js'
+import { streamProcess } from '../sandbox/stream-process.js'
+import type { ExecuteOptions } from '../sandbox/base.js'
+import type { ExecutionResult, StreamChunk } from '../sandbox/types.js'
+
+/**
+ * Test sandbox that executes commands within a specific working directory.
+ *
+ * Extends PosixShellSandbox so it exercises the same code paths real sandboxes
+ * use: base64 file encoding, shell quoting, ls parsing, etc.
+ */
+export class TestSandbox extends PosixShellSandbox {
+  readonly workingDir: string
+
+  constructor(workingDir: string) {
+    super()
+    this.workingDir = workingDir
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    const cwd = options?.cwd ?? this.workingDir
+    const fullCommand = `cd ${shellQuote(cwd)} && ${command}`
+    yield* streamProcess('sh', ['-c', fullCommand], { timeout: options?.timeout, signal: options?.signal })
+  }
+}

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -303,6 +303,11 @@ export { AgentTrace } from './telemetry/tracer.js'
 // Local Metrics
 export { AgentMetrics } from './telemetry/meter.js'
 
+// Sandbox
+export { Sandbox, type ExecuteOptions } from './sandbox/base.js'
+export { PosixShellSandbox } from './sandbox/posix-shell.js'
+export type { StreamType, StreamChunk, FileInfo, OutputFile, ExecutionResult } from './sandbox/types.js'
+
 // Multi-agent orchestration
 export { Graph } from './multiagent/index.js'
 export { Swarm } from './multiagent/index.js'

--- a/strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import { TestSandbox } from '../../__fixtures__/test-sandbox.node.js'
+import { streamProcess } from '../stream-process.js'
+import type { ExecutionResult, StreamChunk } from '../types.js'
+
+const TEST_DIR = '/tmp/strands-test-shell-sandbox'
+
+describe.skipIf(process.platform === 'win32')('PosixShellSandbox', () => {
+  let sandbox: TestSandbox
+
+  beforeEach(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true })
+    fs.mkdirSync(TEST_DIR, { recursive: true })
+    sandbox = new TestSandbox(TEST_DIR)
+  })
+
+  afterEach(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  describe('execute (via shell commands)', () => {
+    it('runs a command', async () => {
+      const result = await sandbox.execute('echo hello')
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('hello\n')
+    })
+
+    it('runs in workingDir', async () => {
+      const result = await sandbox.execute('pwd')
+      expect(result.stdout.trim()).toContain('strands-test-shell-sandbox')
+    })
+
+    it('respects cwd option', async () => {
+      const result = await sandbox.execute('pwd', { cwd: '/tmp' })
+      expect(result.stdout.trim()).toMatch(/\/tmp$/)
+    })
+  })
+
+  describe('executeCode (via shell quoting)', () => {
+    it('runs python code through shell', async () => {
+      const result = await sandbox.executeCode('print(2 + 2)', 'python3')
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('4\n')
+    })
+
+    it('handles code with special characters', async () => {
+      const result = await sandbox.executeCode('print(\'hello "world"\')', 'python3')
+      expect(result.stdout).toBe('hello "world"\n')
+    })
+
+    it('handles code with single quotes', async () => {
+      const result = await sandbox.executeCode('print("it\'s working")', 'python3')
+      expect(result.stdout).toBe("it's working\n")
+    })
+  })
+
+  describe('language validation', () => {
+    it('rejects path traversal', async () => {
+      await expect(sandbox.executeCode('x', '../../../bin/sh')).rejects.toThrow('invalid characters')
+    })
+
+    it('rejects shell metacharacters', async () => {
+      await expect(sandbox.executeCode('x', 'python;rm -rf /')).rejects.toThrow('invalid characters')
+    })
+
+    it('rejects spaces', async () => {
+      await expect(sandbox.executeCode('x', 'python -c')).rejects.toThrow('invalid characters')
+    })
+
+    it('allows valid interpreters', async () => {
+      const result = await sandbox.executeCode('print("safe")', 'python3')
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('allows dots and hyphens', async () => {
+      const result = await sandbox.executeCode('x', 'fake-lang.99')
+      expect(result.exitCode).toBe(127)
+    })
+  })
+
+  describe('read/write (via base64 encoding over shell)', () => {
+    it('text file roundtrip', async () => {
+      await sandbox.writeText('test.txt', 'hello shell')
+      const text = await sandbox.readText('test.txt')
+      expect(text).toBe('hello shell')
+    })
+
+    it('binary file roundtrip', async () => {
+      const bytes = new Uint8Array([0, 1, 2, 127, 128, 254, 255])
+      await sandbox.writeFile('binary.bin', bytes)
+      const read = await sandbox.readFile('binary.bin')
+      expect(Array.from(read)).toStrictEqual(Array.from(bytes))
+    })
+
+    it('all 256 byte values roundtrip', async () => {
+      const bytes = new Uint8Array(256)
+      for (let i = 0; i < 256; i++) bytes[i] = i
+      await sandbox.writeFile('all-bytes.bin', bytes)
+      const read = await sandbox.readFile('all-bytes.bin')
+      expect(Array.from(read)).toStrictEqual(Array.from(bytes))
+    })
+
+    it('creates parent directories', async () => {
+      await sandbox.writeText('deep/nested/file.txt', 'deep')
+      const text = await sandbox.readText('deep/nested/file.txt')
+      expect(text).toBe('deep')
+    })
+
+    it('handles unicode content', async () => {
+      const content = '日本語 🚀 émojis'
+      await sandbox.writeText('unicode.txt', content)
+      const text = await sandbox.readText('unicode.txt')
+      expect(text).toBe(content)
+    })
+
+    it('handles shell metacharacters in content', async () => {
+      const content = '$(rm -rf /) `whoami` && || $HOME'
+      await sandbox.writeText('meta.txt', content)
+      const text = await sandbox.readText('meta.txt')
+      expect(text).toBe(content)
+    })
+
+    it('throws on nonexistent file', async () => {
+      await expect(sandbox.readFile('nope.txt')).rejects.toThrow()
+    })
+  })
+
+  describe('remove', () => {
+    it('removes a file', async () => {
+      await sandbox.writeText('delete-me.txt', 'bye')
+      await sandbox.removeFile('delete-me.txt')
+      await expect(sandbox.readFile('delete-me.txt')).rejects.toThrow()
+    })
+
+    it('throws on nonexistent file', async () => {
+      await expect(sandbox.removeFile('nope.txt')).rejects.toThrow()
+    })
+  })
+
+  describe('list (via ls -1ap parsing)', () => {
+    it('lists directory contents', async () => {
+      await sandbox.writeText('a.txt', 'a')
+      await sandbox.writeText('b.txt', 'b')
+      const files = await sandbox.listFiles('.')
+      const names = files.map((f) => f.name)
+      expect(names).toContain('a.txt')
+      expect(names).toContain('b.txt')
+    })
+
+    it('identifies directories', async () => {
+      await sandbox.execute('mkdir -p subdir')
+      const files = await sandbox.listFiles('.')
+      const subdir = files.find((f) => f.name === 'subdir')
+      expect(subdir?.isDir).toBe(true)
+    })
+
+    it('excludes . and .. entries', async () => {
+      await sandbox.writeText('file.txt', '')
+      const files = await sandbox.listFiles('.')
+      const names = files.map((f) => f.name)
+      expect(names).not.toContain('.')
+      expect(names).not.toContain('..')
+    })
+
+    it('throws on nonexistent directory', async () => {
+      await expect(sandbox.listFiles('/tmp/nonexistent-dir-xyz')).rejects.toThrow()
+    })
+
+    it('throws when path is a file, not a directory', async () => {
+      await sandbox.writeText('not-a-dir.txt', 'hello')
+      await expect(sandbox.listFiles('not-a-dir.txt')).rejects.toThrow()
+    })
+  })
+
+  describe('shellQuote', () => {
+    it('handles paths with spaces', async () => {
+      await sandbox.execute('mkdir -p "with spaces"')
+      await sandbox.writeText('with spaces/file.txt', 'spaced')
+      const text = await sandbox.readText('with spaces/file.txt')
+      expect(text).toBe('spaced')
+    })
+
+    it('handles paths with single quotes', async () => {
+      await sandbox.execute('mkdir -p "it\'s"')
+      await sandbox.writeText("it's/file.txt", 'quoted')
+      const text = await sandbox.readText("it's/file.txt")
+      expect(text).toBe('quoted')
+    })
+  })
+
+  describe('timeout', () => {
+    it('kills process on timeout', async () => {
+      const start = Date.now()
+      await expect(sandbox.execute('sleep 60', { timeout: 0.2 })).rejects.toThrow('timed out')
+      const elapsed = Date.now() - start
+      expect(elapsed).toBeLessThan(2000)
+    })
+
+    it('does not timeout fast commands', async () => {
+      const result = await sandbox.execute('echo fast', { timeout: 5 })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('fast\n')
+    })
+  })
+
+  describe('abort signal', () => {
+    it('kills process when signal is aborted', async () => {
+      const controller = new AbortController()
+      const promise = sandbox.execute('sleep 60', { signal: controller.signal })
+      setTimeout(() => controller.abort(), 100)
+      await expect(promise).rejects.toThrow('aborted')
+    })
+
+    it('rejects immediately if signal is already aborted', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      await expect(sandbox.execute('sleep 60', { signal: controller.signal })).rejects.toThrow('aborted')
+    })
+  })
+
+  describe('concurrent execution', () => {
+    it('handles multiple concurrent commands', async () => {
+      const results = await Promise.all([
+        sandbox.execute('echo one'),
+        sandbox.execute('echo two'),
+        sandbox.execute('echo three'),
+      ])
+      expect(results.map((r) => r.stdout.trim()).sort()).toStrictEqual(['one', 'three', 'two'])
+    })
+
+    it('handles concurrent file writes to different files', async () => {
+      await Promise.all([
+        sandbox.writeText('a.txt', 'aaa'),
+        sandbox.writeText('b.txt', 'bbb'),
+        sandbox.writeText('c.txt', 'ccc'),
+      ])
+      const [a, b, c] = await Promise.all([
+        sandbox.readText('a.txt'),
+        sandbox.readText('b.txt'),
+        sandbox.readText('c.txt'),
+      ])
+      expect(a).toBe('aaa')
+      expect(b).toBe('bbb')
+      expect(c).toBe('ccc')
+    })
+  })
+
+  describe('streaming', () => {
+    it('yields StreamChunks then ExecutionResult', async () => {
+      const chunks: Array<{ type: string }> = []
+      for await (const chunk of sandbox.executeStreaming('echo hello')) {
+        chunks.push(chunk)
+      }
+      const streamChunks = chunks.filter((c) => c.type === 'streamChunk')
+      const results = chunks.filter((c) => c.type === 'executionResult')
+      expect(streamChunks.length).toBeGreaterThan(0)
+      expect(results).toHaveLength(1)
+    })
+  })
+
+  describe('streamProcess edge cases', () => {
+    it('returns exit code 127 when command is not found', async () => {
+      const result = await sandbox.execute('nonexistent_binary_xyz_12345')
+      expect(result.exitCode).toBe(127)
+      expect(result.stderr).toContain('not found')
+    })
+
+    it('maps signal termination to 128 + signal number', async () => {
+      // sh -c 'kill -9 $$' sends SIGKILL to itself → exit code 128 + 9 = 137
+      const result = await sandbox.execute("sh -c 'kill -9 $$'")
+      expect(result.exitCode).toBe(137)
+    })
+
+    it('returns enoentMessage when spawned binary does not exist', async () => {
+      const chunks: (StreamChunk | ExecutionResult)[] = []
+      for await (const chunk of streamProcess('nonexistent_binary_xyz_12345', [], {
+        enoentMessage: 'binary not found',
+      })) {
+        chunks.push(chunk)
+      }
+      const result = chunks.find((c): c is ExecutionResult => c.type === 'executionResult')
+      expect(result).toStrictEqual({
+        type: 'executionResult',
+        exitCode: 127,
+        stdout: '',
+        stderr: 'binary not found',
+        outputFiles: [],
+      })
+    })
+  })
+})

--- a/strands-ts/src/sandbox/base.ts
+++ b/strands-ts/src/sandbox/base.ts
@@ -1,0 +1,173 @@
+/**
+ * Base sandbox interface.
+ *
+ * Defines the abstract {@link Sandbox} class that all sandbox implementations
+ * must extend. The class provides six abstract operations (command execution,
+ * code execution, and file I/O) and convenience wrappers for common patterns.
+ */
+
+import type { ExecutionResult, FileInfo, StreamChunk } from './types.js'
+
+/**
+ * Options for command and code execution.
+ */
+export interface ExecuteOptions {
+  /** Maximum execution time in seconds. `undefined` means no timeout. */
+  timeout?: number | undefined
+  /** Working directory for execution. `undefined` means use the sandbox default. */
+  cwd?: string | undefined
+  /** Abort signal to cancel execution. The process is killed when the signal fires. */
+  signal?: AbortSignal | undefined
+}
+
+/**
+ * Abstract execution environment.
+ *
+ * A Sandbox provides the runtime context where tools execute code,
+ * run commands, and interact with a filesystem. Multiple tools share
+ * the same Sandbox instance, giving them a common working directory
+ * and filesystem.
+ *
+ * Streaming methods (`executeStreaming`, `executeCodeStreaming`) are the abstract primitives.
+ * Non-streaming convenience methods (`execute`, `executeCode`) consume
+ * the stream and return the final result.
+ */
+export abstract class Sandbox {
+  /**
+   * Execute a shell command, streaming output.
+   *
+   * Yields {@link StreamChunk} objects for stdout and stderr as output
+   * arrives. The final yield is an {@link ExecutionResult} with the
+   * exit code and complete output.
+   *
+   * @param command - The shell command to execute.
+   * @param options - Execution options (timeout, cwd).
+   * @returns Async iterable yielding StreamChunks followed by a final ExecutionResult.
+   */
+  abstract executeStreaming(command: string, options?: ExecuteOptions): AsyncIterable<StreamChunk | ExecutionResult>
+
+  /**
+   * Execute source code via a language interpreter, streaming output.
+   *
+   * @param code - The source code to execute.
+   * @param language - The interpreter to use (e.g., `"python3"`, `"node"`).
+   * @param options - Execution options (timeout, cwd).
+   * @returns Async iterable yielding StreamChunks followed by a final ExecutionResult.
+   */
+  abstract executeCodeStreaming(
+    code: string,
+    language: string,
+    options?: ExecuteOptions
+  ): AsyncIterable<StreamChunk | ExecutionResult>
+
+  /**
+   * Read a file from the sandbox filesystem as raw bytes.
+   *
+   * Returns `Uint8Array` to support both text and binary files.
+   * Use {@link readText} for a convenience wrapper that decodes to a string.
+   *
+   * @param path - Path to the file to read.
+   * @returns The file contents as raw bytes.
+   * @throws Error if the file does not exist.
+   */
+  abstract readFile(path: string): Promise<Uint8Array>
+
+  /**
+   * Write raw bytes to a file in the sandbox filesystem.
+   *
+   * Implementations should create parent directories if they do not exist.
+   * Use {@link writeText} for a convenience wrapper that encodes a string.
+   *
+   * @param path - Path to the file to write.
+   * @param content - The content to write.
+   */
+  abstract writeFile(path: string, content: Uint8Array): Promise<void>
+
+  /**
+   * Remove a file from the sandbox filesystem.
+   *
+   * @param path - Path to the file to remove.
+   * @throws Error if the file does not exist.
+   */
+  abstract removeFile(path: string): Promise<void>
+
+  /**
+   * List files in a sandbox directory.
+   *
+   * Returns {@link FileInfo} entries with name, isDir, and size metadata.
+   * Fields `isDir` and `size` may be `undefined` if the backend cannot
+   * determine them.
+   *
+   * @param path - Path to the directory to list.
+   * @returns Array of FileInfo entries for the directory contents.
+   * @throws Error if the directory does not exist.
+   */
+  abstract listFiles(path: string): Promise<FileInfo[]>
+
+  // ---- Non-streaming convenience methods ----
+
+  /**
+   * Execute a shell command and return the result.
+   *
+   * Consumes {@link executeStreaming} and returns the final {@link ExecutionResult}.
+   * Use `executeStreaming` when you need to process output as it arrives.
+   *
+   * @param command - The shell command to execute.
+   * @param options - Execution options (timeout, cwd).
+   * @returns The execution result with exit code and output.
+   */
+  async execute(command: string, options?: ExecuteOptions): Promise<ExecutionResult> {
+    for await (const chunk of this.executeStreaming(command, options)) {
+      if (chunk.type === 'executionResult') {
+        return chunk
+      }
+    }
+    throw new Error('executeStreaming() did not yield an ExecutionResult')
+  }
+
+  /**
+   * Execute source code and return the result.
+   *
+   * Consumes {@link executeCodeStreaming} and returns the final {@link ExecutionResult}.
+   * Use `executeCodeStreaming` when you need to process output as it arrives.
+   *
+   * @param code - The source code to execute.
+   * @param language - The interpreter to use.
+   * @param options - Execution options (timeout, cwd).
+   * @returns The execution result with exit code and output.
+   */
+  async executeCode(code: string, language: string, options?: ExecuteOptions): Promise<ExecutionResult> {
+    for await (const chunk of this.executeCodeStreaming(code, language, options)) {
+      if (chunk.type === 'executionResult') {
+        return chunk
+      }
+    }
+    throw new Error('executeCodeStreaming() did not yield an ExecutionResult')
+  }
+
+  /**
+   * Read a text file from the sandbox filesystem.
+   *
+   * Convenience wrapper over {@link readFile} that decodes bytes as UTF-8.
+   * For other encodings, call `readFile` and decode manually.
+   *
+   * @param path - Path to the file to read.
+   * @returns The file contents decoded as a UTF-8 string.
+   */
+  async readText(path: string): Promise<string> {
+    return new TextDecoder().decode(await this.readFile(path))
+  }
+
+  /**
+   * Write a text file to the sandbox filesystem.
+   *
+   * Convenience wrapper over {@link writeFile} that encodes a string as UTF-8.
+   * For other encodings, encode manually and call `writeFile`.
+   *
+   * @param path - Path to the file to write.
+   * @param content - The text content to write.
+   */
+  async writeText(path: string, content: string): Promise<void> {
+    await this.writeFile(path, new TextEncoder().encode(content))
+  }
+}

--- a/strands-ts/src/sandbox/constants.ts
+++ b/strands-ts/src/sandbox/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Regex pattern for validating language/interpreter names.
+ * Allows alphanumeric characters, dots, hyphens, and underscores.
+ * Rejects path separators, spaces, and shell metacharacters to prevent injection.
+ */
+export const LANGUAGE_PATTERN = /^[a-zA-Z0-9._-]+$/

--- a/strands-ts/src/sandbox/posix-shell.ts
+++ b/strands-ts/src/sandbox/posix-shell.ts
@@ -1,0 +1,90 @@
+/**
+ * Shell sandbox with default implementations for file and code operations.
+ *
+ * Subclasses only need to implement {@link PosixShellSandbox.executeStreaming} —
+ * all other operations are implemented by running shell commands through it.
+ * Use this for remote environments where only shell access is available
+ * (Docker containers, SSH connections, cloud runtimes).
+ */
+
+import { Sandbox } from './base.js'
+import type { ExecuteOptions } from './base.js'
+import { LANGUAGE_PATTERN } from './constants.js'
+import type { ExecutionResult, FileInfo, StreamChunk } from './types.js'
+import { shellQuote } from '../utils/shell-quote.js'
+
+/**
+ * Abstract sandbox that provides shell-based defaults for file and code operations.
+ * Assumes a POSIX-compatible shell (sh/bash) on the target.
+ *
+ * Subclasses only need to implement {@link executeStreaming}. The remaining
+ * operations — `executeCodeStreaming`, `readFile`, `writeFile`, `removeFile`,
+ * and `listFiles` — are implemented via shell commands piped through
+ * `executeStreaming`.
+ *
+ * Subclasses may override any method with a native implementation for
+ * better performance or to handle edge cases (e.g., binary-safe file
+ * transfer via Docker stdin pipes, or native API calls for cloud backends).
+ */
+export abstract class PosixShellSandbox extends Sandbox {
+  async *executeCodeStreaming(
+    code: string,
+    language: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    if (!LANGUAGE_PATTERN.test(language)) {
+      throw new Error(`language parameter contains invalid characters: ${language}`)
+    }
+    const encoded = btoa(Array.from(new TextEncoder().encode(code), (b) => String.fromCharCode(b)).join(''))
+    const eof = `STRANDS_EOF_${crypto.randomUUID().slice(0, 16)}`
+    yield* this.executeStreaming(`base64 -d << '${eof}' | ${language}\n${encoded}\n${eof}`, options)
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    const result = await this.execute(`base64 < ${shellQuote(path)}`)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to read file: ${path}`)
+    }
+    return Uint8Array.from(atob(result.stdout.replace(/\s/g, '')), (c) => c.charCodeAt(0))
+  }
+
+  async writeFile(path: string, content: Uint8Array): Promise<void> {
+    const encoded = btoa(Array.from(content, (b) => String.fromCharCode(b)).join(''))
+    const quoted = shellQuote(path)
+    const eof = `STRANDS_EOF_${crypto.randomUUID().slice(0, 16)}`
+    const cmd = `mkdir -p "$(dirname ${quoted})" && base64 -d << '${eof}' > ${quoted}\n${encoded}\n${eof}`
+    const result = await this.execute(cmd)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to write file: ${path}`)
+    }
+  }
+
+  async removeFile(path: string): Promise<void> {
+    const result = await this.execute(`rm ${shellQuote(path)}`)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to remove file: ${path}`)
+    }
+  }
+
+  async listFiles(path: string): Promise<FileInfo[]> {
+    const quoted = shellQuote(path)
+    const result = await this.execute(`test -d ${quoted} || exit 1; env QUOTING_STYLE=literal ls -1ap ${quoted}`)
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to list directory: ${path}`)
+    }
+
+    const entries: FileInfo[] = []
+    for (const raw of result.stdout.split('\n')) {
+      const line = raw.replace(/\r$/, '')
+      if (!line || line === './' || line === '../') {
+        continue
+      }
+      const isDir = line.endsWith('/')
+      const name = isDir ? line.slice(0, -1) : line
+      if (name) {
+        entries.push({ name, isDir })
+      }
+    }
+    return entries
+  }
+}

--- a/strands-ts/src/sandbox/stream-process.ts
+++ b/strands-ts/src/sandbox/stream-process.ts
@@ -1,0 +1,181 @@
+/**
+ * Spawn a process and stream its stdout/stderr as an async generator.
+ */
+
+import { spawn } from 'child_process'
+import type { ExecutionResult, StreamChunk } from './types.js'
+
+const SIGNAL_CODES: Record<string, number> = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGABRT: 6,
+  SIGKILL: 9,
+  SIGSEGV: 11,
+  SIGPIPE: 13,
+  SIGTERM: 15,
+}
+
+/**
+ * Options for {@link streamProcess}.
+ */
+export interface StreamProcessOptions {
+  /** Maximum execution time in seconds. */
+  timeout?: number | undefined
+  /** Abort signal to cancel execution. */
+  signal?: AbortSignal | undefined
+  /** Custom error message when the spawned binary is not found (ENOENT). */
+  enoentMessage?: string | undefined
+}
+
+/**
+ * Spawn a command and stream its stdout/stderr, yielding the final result.
+ *
+ * Bridges Node.js event emitters to an async generator. Chunks are
+ * yielded incrementally as the process produces output. The final
+ * yield is an ExecutionResult with the exit code and complete output.
+ *
+ * All listeners are attached synchronously before any await to prevent
+ * missed events from fast-completing processes.
+ *
+ * @param command - The binary to spawn.
+ * @param args - Arguments to pass to the binary.
+ * @param options - Timeout, abort signal, and ENOENT handling options.
+ * @returns An async generator yielding StreamChunks followed by a final ExecutionResult.
+ */
+export async function* streamProcess(
+  command: string,
+  args: string[],
+  options?: StreamProcessOptions
+): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+  const proc = spawn(command, args)
+  const chunks: StreamChunk[] = []
+  let stdout = ''
+  let stderr = ''
+  let done = false
+  let terminating = false
+  let exitCode = 0
+  let error: Error | undefined
+  let enoent = false
+  let resolveWait: (() => void) | undefined
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+  let killTimer: ReturnType<typeof setTimeout> | undefined
+
+  const wake = (): void => {
+    if (resolveWait) {
+      resolveWait()
+      resolveWait = undefined
+    }
+  }
+
+  const terminate = (reason: Error): void => {
+    if (terminating || done) return
+    terminating = true
+    error = reason
+    proc.kill('SIGTERM')
+    wake()
+    killTimer = setTimeout(() => {
+      if (!done) proc.kill('SIGKILL')
+    }, 1000)
+  }
+
+  proc.stdout?.on('data', (data) => {
+    const text = String(data)
+    stdout += text
+    chunks.push({ type: 'streamChunk', data: text, streamType: 'stdout' })
+    wake()
+  })
+
+  proc.stderr?.on('data', (data) => {
+    const text = String(data)
+    stderr += text
+    chunks.push({ type: 'streamChunk', data: text, streamType: 'stderr' })
+    wake()
+  })
+
+  proc.on('close', (code, signal) => {
+    if (!done) {
+      if (code !== null) {
+        exitCode = code
+      } else if (signal) {
+        exitCode = 128 + (SIGNAL_CODES[signal] ?? 1)
+      } else {
+        exitCode = 1
+      }
+      done = true
+      wake()
+    }
+  })
+
+  proc.on('error', (err) => {
+    if (!done) {
+      if (options?.enoentMessage && 'code' in err && err.code === 'ENOENT') {
+        enoent = true
+      } else {
+        error = err
+      }
+      done = true
+      wake()
+    }
+  })
+
+  const onAbort = (): void => terminate(new Error('Execution aborted'))
+
+  if (options?.signal) {
+    if (options.signal.aborted) {
+      onAbort()
+    } else {
+      options.signal.addEventListener('abort', onAbort, { once: true })
+    }
+  }
+
+  if (options?.timeout !== undefined) {
+    timeoutHandle = setTimeout(() => {
+      terminate(new Error(`Execution timed out after ${options.timeout} seconds`))
+    }, options.timeout * 1000)
+  }
+
+  try {
+    while (true) {
+      if (chunks.length > 0) {
+        const batch = chunks.splice(0, chunks.length)
+        for (const chunk of batch) {
+          yield chunk
+        }
+      }
+
+      if (done || terminating) break
+
+      await new Promise<void>((resolve) => {
+        resolveWait = resolve
+        setTimeout(resolve, 50)
+      })
+    }
+
+    if (enoent) {
+      yield {
+        type: 'executionResult',
+        exitCode: 127,
+        stdout: '',
+        stderr: options!.enoentMessage!,
+        outputFiles: [],
+      } satisfies ExecutionResult
+      return
+    }
+
+    if (error) throw error
+
+    yield {
+      type: 'executionResult',
+      exitCode,
+      stdout,
+      stderr,
+      outputFiles: [],
+    } satisfies ExecutionResult
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
+    if (killTimer !== undefined) clearTimeout(killTimer)
+    if (options?.signal) options.signal.removeEventListener('abort', onAbort)
+    if (!done) proc.kill()
+  }
+}

--- a/strands-ts/src/sandbox/types.ts
+++ b/strands-ts/src/sandbox/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Data types for the sandbox abstraction.
+ *
+ * These types represent the inputs and outputs of sandbox operations —
+ * execution results, file metadata, and streaming chunks.
+ */
+
+/**
+ * Type of a streaming output chunk — distinguishes stdout from stderr.
+ */
+export type StreamType = 'stdout' | 'stderr'
+
+/**
+ * A typed chunk of streaming output from command or code execution.
+ *
+ * Allows consumers to distinguish stdout from stderr during streaming,
+ * enabling richer UIs and more precise output handling.
+ */
+export interface StreamChunk {
+  readonly type: 'streamChunk'
+  readonly data: string
+  readonly streamType: StreamType
+}
+
+/**
+ * Metadata about a file or directory in a sandbox.
+ *
+ * Provides minimal structured information that lets tools distinguish
+ * files from directories and report sizes. `isDir` and `size` are
+ * `undefined` when the backend cannot determine them accurately.
+ */
+export interface FileInfo {
+  readonly name: string
+  readonly isDir?: boolean
+  readonly size?: number
+}
+
+/**
+ * A file produced as output by code execution.
+ *
+ * Used to carry binary artifacts (images, charts, PDFs, compiled files)
+ * from sandbox execution back to the agent. Shell-based sandboxes
+ * typically return an empty array. Jupyter-backed or API-backed
+ * sandboxes can populate this with generated artifacts.
+ */
+export interface OutputFile {
+  readonly name: string
+  readonly content: Uint8Array
+  readonly mimeType: string
+}
+
+/**
+ * Result of command or code execution in a sandbox.
+ */
+export interface ExecutionResult {
+  readonly type: 'executionResult'
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+  readonly outputFiles: OutputFile[]
+}

--- a/strands-ts/src/utils/shell-quote.ts
+++ b/strands-ts/src/utils/shell-quote.ts
@@ -1,0 +1,13 @@
+/**
+ * Shell-escape a string for safe inclusion in a shell command.
+ *
+ * Wraps the value in single quotes and escapes any embedded single quotes
+ * using the '\'' pattern. Single quotes disable all shell expansion
+ * (variables, backticks, globbing), making this safe against injection.
+ *
+ * @param value - The string to escape.
+ * @returns The shell-escaped string wrapped in single quotes.
+ */
+export function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'"
+}


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Introduces the `Sandbox` interface, the core abstraction that decouples tool logic from where code runs.

This is the base interface only. Concrete implementations (Docker, SSH), vended tools/plugins and the Agent integration ship in follow-up PRs (incrementally broken off from the parent mega-PR #1011).

## What's Included

Core Interface (src/sandbox/base.ts)

- Sandbox abstract class
  - 6 abstract methods:
    - `executeStreaming(command, options?)` — stream stdout/stderr from a shell command
    - `executeCodeStreaming(code, language, options?)` — stream output from code execution via interpreter
    - `readFile(path)` — read file as Uint8Array
    - `writeFile(path, content)` — write Uint8Array, creates parent directories
    - `removeFile(path)` — delete a file
    - `listFiles(path)` — list directory contents as FileInfo[]
  - 4 convenience methods on the base class:
    - `execute(command, options?)` — non-streaming wrapper over executeStreaming
    - `executeCode(code, language, options?)` — non-streaming wrapper over executeCodeStreaming
    - `readText(path)` — UTF-8 decode wrapper over readFile
    - `writeText(path, content)` — UTF-8 encode wrapper over writeFile

Shell-Based Defaults (src/sandbox/posix-shell.ts)

- `PosixShellSandbox` abstract class (subclasses implement only executeStreaming)
  - Code execution via base64-encoded heredoc piped to interpreter
  - File read/write via base64 encoding over shell
  - Directory listing via ls -1ap with test -d guard

## Related Issues

<!-- Link to related issues using #issue-number format -->

- #1011 (parent mega-PR containing interfaces, implementation, integration)
- https://github.com/strands-agents/sdk-python/pull/2198 (original Python PR)
- https://github.com/strands-agents/docs/pull/681 (original Python design)

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
