### PR TITLE
feat: Add barrel exports for vended-tools and vended-plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ sdk-typescript/
 │   │   │       └── index.ts
 │   │   │
 │   │   ├── vended-plugins/       # Optional vended plugins
+│   │   │   ├── index.ts          # Barrel export for all plugins
 │   │   │   ├── context-offloader/ # Context offloading plugin
 │   │   │   │   ├── __tests__/
 │   │   │   │   ├── plugin.ts
@@ -203,6 +204,7 @@ sdk-typescript/
 │   │   │       └── index.ts
 │   │   │
 │   │   ├── vended-tools/         # Optional vended tools
+│   │   │   ├── index.ts          # Barrel export for all tools
 │   │   │   ├── bash/
 │   │   │   ├── file-editor/
 │   │   │   ├── http-request/

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -87,6 +87,14 @@
     "./vended-interventions/steering": {
       "types": "./dist/src/vended-interventions/steering/index.d.ts",
       "default": "./dist/src/vended-interventions/steering/index.js"
+    },
+    "./vended-tools": {
+      "types": "./dist/src/vended-tools/index.d.ts",
+      "default": "./dist/src/vended-tools/index.js"
+    },
+    "./vended-plugins": {
+      "types": "./dist/src/vended-plugins/index.d.ts",
+      "default": "./dist/src/vended-plugins/index.js"
     }
   },
   "scripts": {

--- a/strands-ts/src/vended-plugins/index.ts
+++ b/strands-ts/src/vended-plugins/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Barrel export for all vended plugins.
+ *
+ * Provides a single import path for consumers who want all built-in plugins:
+ * ```typescript
+ * import { AgentSkills, ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins'
+ * ```
+ */
+
+export * from './skills/index.js'
+export * from './context-offloader/index.js'

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Barrel export for all vended tools.
+ *
+ * Provides a single import path for consumers who want all built-in tools:
+ * ```typescript
+ * import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
+ * ```
+ *
+ * Note: This module requires a Node.js environment because the `bash` tool
+ * imports `child_process`. For browser-compatible usage, import individual
+ * tools via their subpath exports (e.g., `@strands-agents/sdk/vended-tools/notebook`).
+ */
+
+export * from './bash/index.js'
+export * from './file-editor/index.js'
+export * from './http-request/index.js'
+export * from './notebook/index.js'

--- a/strands-ts/test/packages/cjs-module/cjs.js
+++ b/strands-ts/test/packages/cjs-module/cjs.js
@@ -12,6 +12,19 @@ async function main() {
   const { httpRequest } = await import('@strands-agents/sdk/vended-tools/http-request')
   const { bash } = await import('@strands-agents/sdk/vended-tools/bash')
 
+  const {
+    bash: barrelBash,
+    fileEditor: barrelFileEditor,
+    httpRequest: barrelHttpRequest,
+    notebook: barrelNotebook,
+  } = await import('@strands-agents/sdk/vended-tools')
+
+  const {
+    AgentSkills,
+    ContextOffloader,
+    InMemoryStorage,
+  } = await import('@strands-agents/sdk/vended-plugins')
+
   const { BedrockModel: BedrockFromSubpath } = await import('@strands-agents/sdk/models/bedrock')
   const { OpenAIModel } = await import('@strands-agents/sdk/models/openai')
   const { AnthropicModel } = await import('@strands-agents/sdk/models/anthropic')
@@ -67,6 +80,18 @@ async function main() {
     throw new Error('BedrockModel from subpath should match main export')
   }
   console.log('✓ Model subpath exports verified')
+
+  // Verify barrel exports match individual subpath exports
+  if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+    throw new Error('Barrel vended-tools exports do not match individual subpath exports')
+  }
+  console.log('✓ Barrel vended-tools exports verified')
+
+  // Verify barrel vended-plugins exports are constructible
+  if (typeof AgentSkills !== 'function' || typeof ContextOffloader !== 'function' || typeof InMemoryStorage !== 'function') {
+    throw new Error('Barrel vended-plugins exports are not constructible')
+  }
+  console.log('✓ Barrel vended-plugins exports verified')
 
   // Reference remaining imports so static analysis doesn't flag them unused.
   void OpenAIModel

--- a/strands-ts/test/packages/esm-module/esm.js
+++ b/strands-ts/test/packages/esm-module/esm.js
@@ -10,6 +10,19 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'
 
+import {
+  bash as barrelBash,
+  fileEditor as barrelFileEditor,
+  httpRequest as barrelHttpRequest,
+  notebook as barrelNotebook,
+} from '@strands-agents/sdk/vended-tools'
+
+import {
+  AgentSkills,
+  ContextOffloader,
+  InMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins'
+
 // Verify model subpath exports
 import { BedrockModel as BedrockFromSubpath } from '@strands-agents/sdk/models/bedrock'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
@@ -110,3 +123,15 @@ if (BedrockFromSubpath !== BedrockModel) {
   throw new Error('BedrockModel from subpath should match main export')
 }
 console.log('✓ Model subpath exports verified')
+
+// Verify barrel exports match individual subpath exports
+if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+  throw new Error('Barrel vended-tools exports do not match individual subpath exports')
+}
+console.log('✓ Barrel vended-tools exports verified')
+
+// Verify barrel vended-plugins exports are constructible
+if (typeof AgentSkills !== 'function' || typeof ContextOffloader !== 'function' || typeof InMemoryStorage !== 'function') {
+  throw new Error('Barrel vended-plugins exports are not constructible')
+}
+console.log('✓ Barrel vended-plugins exports verified')

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -27,6 +27,19 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'
 
+import {
+  bash as barrelBash,
+  fileEditor as barrelFileEditor,
+  httpRequest as barrelHttpRequest,
+  notebook as barrelNotebook,
+} from '@strands-agents/sdk/vended-tools'
+
+import {
+  AgentSkills as BarrelAgentSkills,
+  ContextOffloader as BarrelContextOffloader,
+  InMemoryStorage as BarrelInMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins'
+
 import { BedrockModel as BedrockFromSubpath } from '@strands-agents/sdk/models/bedrock'
 import { Graph, Swarm, MultiAgentState } from '@strands-agents/sdk/multiagent'
 import { AgentSkills } from '@strands-agents/sdk/vended-plugins/skills'
@@ -115,5 +128,13 @@ if (!(ctxErr instanceof Error)) {
 
 void AgentResult
 console.log('[pack-test] Error + result types importable')
+
+if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+  throw new Error('Barrel vended-tools exports do not match individual subpath exports')
+}
+if (BarrelAgentSkills !== AgentSkills || BarrelContextOffloader !== ContextOffloader || BarrelInMemoryStorage !== InMemoryStorage) {
+  throw new Error('Barrel vended-plugins exports do not match individual subpath exports')
+}
+console.log('[pack-test] barrel exports match individual subpath exports')
 
 console.log('[pack-test] OK')


### PR DESCRIPTION
## Description

Adds barrel exports for `@strands-agents/sdk/vended-tools` and `@strands-agents/sdk/vended-plugins` so consumers can import all vended tools or plugins from a single subpath instead of importing each one individually.

Before:
```typescript
import { bash } from '@strands-agents/sdk/vended-tools/bash'
import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
```

After:
```typescript
import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
```

Individual subpath imports still work — the barrel is additive. The `vended-tools` barrel requires Node.js (because `bash` imports `child_process`); browser consumers should continue using individual subpath imports.

## Related Issues

None

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

Barrel exports are verified in the existing CJS, ESM, and npm-pack test fixtures. Each fixture imports via the barrel and asserts identity equality with the individual subpath exports.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.