### PR TITLE
fix: return empty content array for null/undefined tool results

### DIFF
--- a/strands-ts/src/tools/__tests__/tool.test.ts
+++ b/strands-ts/src/tools/__tests__/tool.test.ts
@@ -257,7 +257,7 @@ describe('FunctionTool', () => {
         expect(receivedInput).toEqual(inputData)
       })
 
-      it('handles null return values correctly', async () => {
+      it('handles null return values with empty content', async () => {
         const tool = new FunctionTool({
           name: 'nullTool',
           description: 'Returns null',
@@ -273,16 +273,11 @@ describe('FunctionTool', () => {
           type: 'toolResultBlock',
           toolUseId: 'test-null',
           status: 'success',
-          content: [
-            expect.objectContaining({
-              type: 'textBlock',
-              text: '<null>',
-            }),
-          ],
+          content: [],
         })
       })
 
-      it('handles undefined return values correctly', async () => {
+      it('handles undefined return values with empty content', async () => {
         const tool = new FunctionTool({
           name: 'undefinedTool',
           description: 'Returns undefined',
@@ -299,12 +294,32 @@ describe('FunctionTool', () => {
           type: 'toolResultBlock',
           toolUseId: 'test-undefined',
           status: 'success',
-          content: [
-            expect.objectContaining({
-              type: 'textBlock',
-              text: '<undefined>',
-            }),
-          ],
+          content: [],
+        })
+      })
+
+      it('handles void (no return) callbacks with empty content', async () => {
+        const tool = new FunctionTool({
+          name: 'voidTool',
+          description: 'Side-effectful tool with no return value',
+          inputSchema: { type: 'object', properties: { name: { type: 'string' } } },
+          // @ts-expect-error void is not assignable to JSONValue, but this is the real-world pattern for side-effectful tools
+          callback: (input: unknown): void => {
+            const { name } = input as { name: string }
+            // side effect only — console.log(`Hello, ${name}!`)
+            void name
+          },
+        })
+
+        const { result } = await collectGenerator(
+          tool.stream(createMockContext({ name: 'voidTool', toolUseId: 'test-void', input: { name: 'Alice' } }))
+        )
+
+        expect(result).toEqual({
+          type: 'toolResultBlock',
+          toolUseId: 'test-void',
+          status: 'success',
+          content: [],
         })
       })
 

--- a/strands-ts/src/tools/function-tool.ts
+++ b/strands-ts/src/tools/function-tool.ts
@@ -250,7 +250,7 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
    * - Arrays of content blocks → used directly as content array
    * - Strings → TextBlock
    * - Numbers, Booleans → TextBlock (converted to string)
-   * - null, undefined → TextBlock (special string representation)
+   * - null, undefined → empty content array (side-effectful tool with no return value)
    * - Objects → JsonBlock (with deep copy)
    * - Arrays (non-content blocks) → JsonBlock wrapped in \{ $value: array \} (with deep copy)
    *
@@ -269,21 +269,13 @@ export class FunctionTool extends Tool implements InvokableTool<unknown, JSONVal
         })
       }
 
-      // Handle null with special string representation as text content
-      if (value === null) {
+      // Handle null/undefined (void tools) with empty content — side-effectful tools
+      // that don't return a value should signal success without a misleading placeholder.
+      if (value === null || value === undefined) {
         return new ToolResultBlock({
           toolUseId,
           status: 'success',
-          content: [new TextBlock('<null>')],
-        })
-      }
-
-      // Handle undefined with special string representation as text content
-      if (value === undefined) {
-        return new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [new TextBlock('<undefined>')],
+          content: [],
         })
       }
 


### PR DESCRIPTION
## Problem

When a tool callback returns `null` or `undefined` (void/side-effectful tools), `_wrapInToolResult` was producing a `TextBlock` with the placeholder text `'<null>'` or `'<undefined>'`. These strings:
- look like internal placeholders to both humans and models
- are not valid JSON (unlike Python's `json.dumps(None)` → `"null"`)
- create confusion for side-effectful tools (delete, send, log) that have no meaningful return value

Fixes strands-agents/sdk-python#2529.

## Solution

Replace the separate `null` and `undefined` handlers with a single combined check that returns an empty content array:

```typescript
if (value === null || value === undefined) {
  return new ToolResultBlock({
    toolUseId,
    status: 'success',
    content: [],
  })
}
```

An empty content array correctly signals success without a misleading placeholder. This matches the common expectation for side-effectful tools.

## Testing

- Updated existing `null` and `undefined` test cases to assert `content: []`
- Added a new `void` callback test covering the real-world side-effectful tool pattern (see issue example with `greet`)
- All 2834 unit tests pass; no type errors