### PR TITLE
fix(wasm): update deps and externalize node-only modules for WASM build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1345,7 +1345,7 @@
     },
     "node_modules/@aws/bedrock-token-generator": {
       "version": "1.1.0",
-      "resolved": "https://github.com/pgrayy/wasm-deps/releases/download/v44.0.3/aws-bedrock-token-generator-1.1.0.tgz",
+      "resolved": "https://github.com/pgrayy/wasm-deps/releases/download/token-gen-v1.1.0/aws-bedrock-token-generator-1.1.0.tgz",
       "integrity": "sha512-5A+Vkyj75mEsBRAQyhRchW3qmNXXG1yKffHwZB8UZ/KYKvK7Wa+/Vq31L8B+pkvTjnnAAW1GhPLtgs9ElgTU6g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2110,7 +2110,6 @@
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -2331,6 +2330,7 @@
       "version": "1.9.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3886,6 +3886,7 @@
       "version": "8.59.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -4252,6 +4253,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4292,7 +4294,6 @@
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -4666,7 +4667,6 @@
     "node_modules/cors": {
       "version": "2.8.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -5372,6 +5372,7 @@
       "version": "10.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5720,7 +5721,6 @@
     "node_modules/eventsource": {
       "version": "3.0.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -5746,6 +5746,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5789,7 +5790,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
       "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -6365,7 +6365,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -6538,7 +6537,6 @@
     "node_modules/jose": {
       "version": "6.2.2",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -6584,8 +6582,7 @@
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7204,7 +7201,6 @@
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -8120,6 +8116,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8576,6 +8573,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -8583,7 +8581,6 @@
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
@@ -8813,7 +8810,7 @@
       "name": "@strands-agents/wasm",
       "version": "0.0.1-development",
       "dependencies": {
-        "@aws/bedrock-token-generator": "https://github.com/pgrayy/wasm-deps/releases/download/v44.0.3/aws-bedrock-token-generator-1.1.0.tgz",
+        "@aws/bedrock-token-generator": "https://github.com/pgrayy/wasm-deps/releases/download/token-gen-v1.1.0/aws-bedrock-token-generator-1.1.0.tgz",
         "@strands-agents/sdk": "*",
         "zod": "^4.1.12"
       },

--- a/strands-py-wasm/pyproject.toml
+++ b/strands-py-wasm/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    # Pinned to pgrayy/wasm-deps until upstream PRs land. Imports as `wasmtime`.
-    "pgrayy-wasmtime @ git+https://github.com/pgrayy/wasm-deps.git@ed34d105ee3db091ef4bcf5aabacb1586e122e96#subdirectory=wasmtime-py",
+    # Imports as `wasmtime`. Pinned to pgrayy fork until upstream PRs land.
+    "pgrayy-wasmtime>=46.0.6,<47.0.0",
 ]
 
 
@@ -42,10 +42,6 @@ Homepage = "https://github.com/strands-agents/sdk-typescript"
 "Bug Tracker" = "https://github.com/strands-agents/sdk-typescript/issues"
 Documentation = "https://strandsagents.com"
 
-
-[tool.hatch.metadata]
-# pgrayy-wasmtime is pinned via a git URL until upstream PRs land.
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/strands"]

--- a/strands-wasm/build.js
+++ b/strands-wasm/build.js
@@ -35,7 +35,15 @@ await build({
   platform: 'browser',
   target: 'es2022',
   define: { 'import.meta.vitest': 'undefined' },
-  external: ['strands:*', 'fs', 'path'],
+  external: [
+    '@modelcontextprotocol/sdk/client/sse.js',
+    '@modelcontextprotocol/sdk/client/stdio.js',
+    'child_process',
+    'fs',
+    'node:*',
+    'path',
+    'strands:*',
+  ],
   outfile: 'dist/bundle.js',
   logLevel: 'info',
 });

--- a/strands-wasm/package.json
+++ b/strands-wasm/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf dist node_modules package-lock.json"
   },
   "dependencies": {
-    "@aws/bedrock-token-generator": "https://github.com/pgrayy/wasm-deps/releases/download/v44.0.3/aws-bedrock-token-generator-1.1.0.tgz",
+    "@aws/bedrock-token-generator": "https://github.com/pgrayy/wasm-deps/releases/download/token-gen-v1.1.0/aws-bedrock-token-generator-1.1.0.tgz",
     "@strands-agents/sdk": "*",
     "zod": "^4.1.12"
   },


### PR DESCRIPTION
## Motivation

PR #1070 (`feat(mcp): load MCP servers from JSON`) introduced `mcp-config.ts` which dynamically imports `node:fs/promises`, `node:os`, and `node:path`. It also dynamically imports `@modelcontextprotocol/sdk/client/stdio.js` (which statically imports `node:process` and `node:stream`). When esbuild bundles with `platform: "browser"` and a single `outfile`, it eagerly resolves dynamic imports and inlines their contents, hoisting those Node-only static imports to the top level of the bundle. componentize-js (StarlingMonkey) then fails at module initialization because it cannot resolve `node:process`.

This also updates the `pgrayy-wasmtime` and `@aws/bedrock-token-generator` dependency versions to their latest published releases.

## Public API Changes

No public API changes.

## Type of Change

Bug fix

## Testing

- Verified `npm run build -w strands-wasm` produces `strands-agent.wasm` successfully