### PR TITLE
fix: throw MaxTokensError when contentBlockStop carries truncated tool_use JSON

### DIFF
--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -323,7 +323,29 @@ describe('Model', () => {
         )
       })
 
-      it('preserves SyntaxError instead of overwriting with MaxTokensError when tool input JSON is malformed', async () => {
+      it('throws MaxTokensError when stopReason is maxTokens and contentBlockStop carries truncated tool_use JSON', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelMessageStartEvent', role: 'assistant' }
+          yield {
+            type: 'modelContentBlockStartEvent',
+            start: { type: 'toolUseStart', toolUseId: 'tool1', name: 'get_weather' },
+          }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'toolUseInputDelta', input: '{"location"' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'maxTokens' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        await expect(async () => await collectGenerator(provider.streamAggregated(messages))).rejects.toThrow(
+          MaxTokensError
+        )
+      })
+
+      it('re-throws SyntaxError when tool_use JSON is malformed and stop reason is not maxTokens', async () => {
         const provider = new TestModelProvider(async function* () {
           yield { type: 'modelMessageStartEvent', role: 'assistant' }
           yield {
@@ -335,7 +357,7 @@ describe('Model', () => {
             delta: { type: 'toolUseInputDelta', input: '{invalid json' },
           }
           yield { type: 'modelContentBlockStopEvent' }
-          yield { type: 'modelMessageStopEvent', stopReason: 'maxTokens' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
         })
 
         const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -349,6 +349,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       let finalStopReason: StopReason | null = null
       let metadata: ModelMetadataEvent | undefined = undefined
       let redactionMessage: string | undefined = undefined
+      let pendingParseError: SyntaxError | null = null
 
       for await (const event_data of this.stream(messages, options)) {
         const event = this._convert_to_class_event(event_data)
@@ -426,7 +427,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
             } catch (e: unknown) {
               if (e instanceof SyntaxError) {
                 logger.error('unable to parse JSON string', e)
-                throw e
+                pendingParseError = e
               }
             }
             break
@@ -472,6 +473,18 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       if (!stoppedMessage || !finalStopReason) {
         // If we exit the loop without completing a message or stop reason, throw an error
         throw new ModelError('Stream ended without completing a message')
+      }
+
+      // If tool_use JSON failed to parse and the stream stopped due to maxTokens, the JSON was
+      // truncated by the token limit — surface MaxTokensError rather than a bare SyntaxError.
+      if (pendingParseError) {
+        if (finalStopReason === 'maxTokens') {
+          throw new MaxTokensError(
+            'Model reached maximum token limit (tool_use JSON was truncated). This is an unrecoverable state that requires intervention.',
+            stoppedMessage
+          )
+        }
+        throw pendingParseError
       }
 
       // Attach metadata after redaction so it applies to the final message.


### PR DESCRIPTION
## Problem

When a Bedrock model hits its token limit mid-tool-call, the stream emits `contentBlockStop` before `messageStop`. At that point `JSON.parse` fails on the incomplete input, throwing a `SyntaxError` — before the subsequent `messageStop { stopReason: 'maxTokens' }` is processed. The `SyntaxError` propagates to the caller as a generic `ModelError`, hiding the `MaxTokensError` that callers need to recover from:

```typescript
try {
  await agent.invoke(...)
} catch (e) {
  if (e instanceof MaxTokensError) { /* never reached */ }
  // Caller sees opaque SyntaxError wrapped in ModelError
}
```

Reported in issue strands-agents/sdk-python#2451.

## Solution

In `streamAggregated`, defer the `SyntaxError` instead of throwing it immediately:

1. Save the error in `pendingParseError` and let the loop continue to consume the remaining stream events.
2. After the loop, if `pendingParseError` is set:
   - If `finalStopReason === 'maxTokens'` → throw `MaxTokensError` (truncation by token limit).
   - Otherwise → re-throw the original `SyntaxError` (genuinely malformed JSON from the model).

## Testing

- Updated the existing test that was asserting the old (incorrect) behavior: now it expects `MaxTokensError` when `contentBlockStop` arrives with truncated JSON and `stopReason === 'maxTokens'`.
- Added a new test for the non-`maxTokens` path: malformed JSON with `stopReason === 'endTurn'` still surfaces `ModelError(cause: SyntaxError)`.