### PR TITLE
feat: add per-invocation limits (turns / outputTokens / totalTokens)

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1927,7 +1927,7 @@ describe('normalizeToolUseNames', () => {
     })
   })
 
-  describe('budget caps', () => {
+  describe('limits', () => {
     const toolUseTurn = (
       toolUseId: string,
       usage: { inputTokens: number; outputTokens: number; totalTokens: number }
@@ -1947,7 +1947,7 @@ describe('normalizeToolUseNames', () => {
           })
       )
 
-    describe('when maxTurns is reached', () => {
+    describe('when limits.turns is reached', () => {
       it('runs the cycle to completion and bails at top of next iteration', async () => {
         const model = new MockMessageModel()
           .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 5, totalTokens: 15 }))
@@ -1955,14 +1955,14 @@ describe('normalizeToolUseNames', () => {
 
         const agent = new Agent({ model, tools: [passthroughTool()] })
 
-        const result = await agent.invoke('go', { maxTurns: 1 })
+        const result = await agent.invoke('go', { limits: { turns: 1 } })
 
         // Bail after tools — lastMessage is the user toolResult, so we don't
         // use expectAgentResult (which assumes role 'assistant').
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxTurnsExceeded',
+            stopReason: 'limitTurns',
             lastMessage: expect.objectContaining({
               role: 'user',
               content: expect.arrayContaining([expect.any(ToolResultBlock)]),
@@ -1977,7 +1977,7 @@ describe('normalizeToolUseNames', () => {
       })
     })
 
-    describe('when budget is generous', () => {
+    describe('when limits is generous', () => {
       it('does not trip and the model ends naturally', async () => {
         const model = new MockMessageModel().addTurn(
           { type: 'textBlock', text: 'done' },
@@ -1985,7 +1985,7 @@ describe('normalizeToolUseNames', () => {
         )
         const agent = new Agent({ model })
 
-        const result = await agent.invoke('go', { maxTurns: 5, maxOutputTokens: 1000, maxTotalTokens: 1000 })
+        const result = await agent.invoke('go', { limits: { turns: 5, outputTokens: 1000, totalTokens: 1000 } })
 
         expect(result).toEqual(
           expectAgentResult({
@@ -1998,20 +1998,20 @@ describe('normalizeToolUseNames', () => {
       })
     })
 
-    describe('when maxOutputTokens is reached', () => {
-      it('returns maxOutputTokensExceeded once cumulative outputTokens hits the cap', async () => {
+    describe('when limits.outputTokens is reached', () => {
+      it('returns limitOutputTokens once cumulative outputTokens hits the cap', async () => {
         const model = new MockMessageModel()
           .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 60, totalTokens: 70 }))
           .addTurn(...toolUseTurn('tool-2', { inputTokens: 10, outputTokens: 60, totalTokens: 70 }))
 
         const agent = new Agent({ model, tools: [passthroughTool()] })
 
-        const result = await agent.invoke('go', { maxOutputTokens: 100 })
+        const result = await agent.invoke('go', { limits: { outputTokens: 100 } })
 
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxOutputTokensExceeded',
+            stopReason: 'limitOutputTokens',
             lastMessage: expect.objectContaining({
               role: 'user',
               content: expect.arrayContaining([expect.any(ToolResultBlock)]),
@@ -2032,12 +2032,12 @@ describe('normalizeToolUseNames', () => {
 
         const agent = new Agent({ model, tools: [passthroughTool()] })
 
-        const result = await agent.invoke('go', { maxOutputTokens: 100 })
+        const result = await agent.invoke('go', { limits: { outputTokens: 100 } })
 
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxOutputTokensExceeded',
+            stopReason: 'limitOutputTokens',
             metrics: expectLoopMetrics({
               cycleCount: 1,
               toolNames: ['loop'],
@@ -2048,20 +2048,20 @@ describe('normalizeToolUseNames', () => {
       })
     })
 
-    describe('when maxTotalTokens is reached', () => {
-      it('returns maxTotalTokensExceeded once cumulative totalTokens hits the cap', async () => {
+    describe('when limits.totalTokens is reached', () => {
+      it('returns limitTotalTokens once cumulative totalTokens hits the cap', async () => {
         const model = new MockMessageModel()
           .addTurn(...toolUseTurn('tool-1', { inputTokens: 200, outputTokens: 100, totalTokens: 300 }))
           .addTurn(...toolUseTurn('tool-2', { inputTokens: 200, outputTokens: 100, totalTokens: 300 }))
 
         const agent = new Agent({ model, tools: [passthroughTool()] })
 
-        const result = await agent.invoke('go', { maxTotalTokens: 500 })
+        const result = await agent.invoke('go', { limits: { totalTokens: 500 } })
 
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxTotalTokensExceeded',
+            stopReason: 'limitTotalTokens',
             lastMessage: expect.objectContaining({
               role: 'user',
               content: expect.arrayContaining([expect.any(ToolResultBlock)]),
@@ -2076,7 +2076,7 @@ describe('normalizeToolUseNames', () => {
       })
     })
 
-    describe('when the model ends naturally on the same turn the budget would trip', () => {
+    describe('when the model ends naturally on the same turn the limit would trip', () => {
       it('returns endTurn — the model answer wins', async () => {
         const model = new MockMessageModel().addTurn(
           { type: 'textBlock', text: 'final answer' },
@@ -2084,7 +2084,7 @@ describe('normalizeToolUseNames', () => {
         )
         const agent = new Agent({ model })
 
-        const result = await agent.invoke('go', { maxTotalTokens: 500 })
+        const result = await agent.invoke('go', { limits: { totalTokens: 500 } })
 
         expect(result).toEqual(
           expectAgentResult({
@@ -2097,7 +2097,7 @@ describe('normalizeToolUseNames', () => {
       })
     })
 
-    describe('when multiple budgets trip simultaneously', () => {
+    describe('when multiple limits trip simultaneously', () => {
       const heavyUsage = { inputTokens: 100, outputTokens: 100, totalTokens: 200 }
 
       const buildAgent = (): Agent => {
@@ -2107,37 +2107,39 @@ describe('normalizeToolUseNames', () => {
         return new Agent({ model, tools: [passthroughTool()] })
       }
 
-      it('prefers maxTurns when all three trip', async () => {
-        const result = await buildAgent().invoke('go', { maxTurns: 1, maxTotalTokens: 1, maxOutputTokens: 1 })
+      it('prefers turns when all three trip', async () => {
+        const result = await buildAgent().invoke('go', {
+          limits: { turns: 1, totalTokens: 1, outputTokens: 1 },
+        })
 
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxTurnsExceeded',
+            stopReason: 'limitTurns',
             metrics: expectLoopMetrics({ cycleCount: 1, toolNames: ['loop'] }),
           })
         )
       })
 
-      it('prefers maxTotalTokens over maxOutputTokens', async () => {
-        const result = await buildAgent().invoke('go', { maxTotalTokens: 1, maxOutputTokens: 1 })
+      it('prefers totalTokens over outputTokens', async () => {
+        const result = await buildAgent().invoke('go', { limits: { totalTokens: 1, outputTokens: 1 } })
 
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxTotalTokensExceeded',
+            stopReason: 'limitTotalTokens',
             metrics: expectLoopMetrics({ cycleCount: 1, toolNames: ['loop'] }),
           })
         )
       })
 
-      it('falls back to maxOutputTokens when no higher-priority cap is set', async () => {
-        const result = await buildAgent().invoke('go', { maxOutputTokens: 1 })
+      it('falls back to outputTokens when no higher-priority cap is set', async () => {
+        const result = await buildAgent().invoke('go', { limits: { outputTokens: 1 } })
 
         expect(result).toEqual(
           expect.objectContaining({
             type: 'agentResult',
-            stopReason: 'maxOutputTokensExceeded',
+            stopReason: 'limitOutputTokens',
             metrics: expectLoopMetrics({ cycleCount: 1, toolNames: ['loop'] }),
           })
         )
@@ -2145,8 +2147,8 @@ describe('normalizeToolUseNames', () => {
     })
 
     describe('when the same agent is reused across invocations', () => {
-      it('scopes the budget to the current invocation, not lifetime', async () => {
-        // Each turn uses 50 output tokens. With maxOutputTokens: 75, a single
+      it('scopes the limit to the current invocation, not lifetime', async () => {
+        // Each turn uses 50 output tokens. With limits.outputTokens: 75, a single
         // invocation tolerates one turn but trips on the second. If the cap
         // were lifetime-scoped, the second `invoke()` would trip on its first
         // turn (75 cumulative across both calls).
@@ -2162,22 +2164,22 @@ describe('normalizeToolUseNames', () => {
 
         const agent = new Agent({ model })
 
-        const r1 = await agent.invoke('go', { maxOutputTokens: 75 })
+        const r1 = await agent.invoke('go', { limits: { outputTokens: 75 } })
         expect(r1.stopReason).toBe('endTurn')
         expect(r1.metrics?.latestAgentInvocation?.cycles.length).toBe(1)
 
-        const r2 = await agent.invoke('go again', { maxOutputTokens: 75 })
+        const r2 = await agent.invoke('go again', { limits: { outputTokens: 75 } })
         expect(r2.stopReason).toBe('endTurn')
         expect(r2.metrics?.latestAgentInvocation?.cycles.length).toBe(1)
       })
     })
 
-    describe('when a budget option is invalid', () => {
+    describe('when a limit is invalid', () => {
       it.each([
-        ['negative', { maxTurns: -1 }],
-        ['zero', { maxTurns: 0 }],
-        ['NaN', { maxOutputTokens: NaN }],
-        ['Infinity', { maxTotalTokens: Infinity }],
+        ['negative', { limits: { turns: -1 } }],
+        ['zero', { limits: { turns: 0 } }],
+        ['NaN', { limits: { outputTokens: NaN } }],
+        ['Infinity', { limits: { totalTokens: Infinity } }],
       ])('rejects %s with TypeError', async (_label, options) => {
         const agent = new Agent({ model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'never reached' }) })
         await expect(agent.invoke('go', options)).rejects.toThrow(TypeError)
@@ -2185,16 +2187,16 @@ describe('normalizeToolUseNames', () => {
     })
 
     describe('when invoked via stream()', () => {
-      it('returns maxTurnsExceeded as the generator return value', async () => {
+      it('returns limitTurns as the generator return value', async () => {
         const model = new MockMessageModel()
           .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 5, totalTokens: 15 }))
           .addTurn(...toolUseTurn('tool-2', { inputTokens: 10, outputTokens: 5, totalTokens: 15 }))
 
         const agent = new Agent({ model, tools: [passthroughTool()] })
 
-        const { result } = await collectGenerator(agent.stream('go', { maxTurns: 1 }))
+        const { result } = await collectGenerator(agent.stream('go', { limits: { turns: 1 } }))
 
-        expect(result).toEqual(expect.objectContaining({ type: 'agentResult', stopReason: 'maxTurnsExceeded' }))
+        expect(result).toEqual(expect.objectContaining({ type: 'agentResult', stopReason: 'limitTurns' }))
       })
     })
   })

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1926,4 +1926,276 @@ describe('normalizeToolUseNames', () => {
       setterSpy.mockRestore()
     })
   })
+
+  describe('budget caps', () => {
+    const toolUseTurn = (
+      toolUseId: string,
+      usage: { inputTokens: number; outputTokens: number; totalTokens: number }
+    ): Parameters<MockMessageModel['addTurn']> => [
+      { type: 'toolUseBlock', name: 'loop', toolUseId, input: {} },
+      { usage },
+    ]
+
+    const passthroughTool = (): ReturnType<typeof createMockTool> =>
+      createMockTool(
+        'loop',
+        (context) =>
+          new ToolResultBlock({
+            toolUseId: context.toolUse.toolUseId,
+            status: 'success' as const,
+            content: [new TextBlock('ok')],
+          })
+      )
+
+    describe('when maxTurns is reached', () => {
+      it('runs the cycle to completion and bails at top of next iteration', async () => {
+        const model = new MockMessageModel()
+          .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 5, totalTokens: 15 }))
+          .addTurn(...toolUseTurn('tool-2', { inputTokens: 20, outputTokens: 5, totalTokens: 25 }))
+
+        const agent = new Agent({ model, tools: [passthroughTool()] })
+
+        const result = await agent.invoke('go', { maxTurns: 1 })
+
+        // Bail after tools — lastMessage is the user toolResult, so we don't
+        // use expectAgentResult (which assumes role 'assistant').
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxTurnsExceeded',
+            lastMessage: expect.objectContaining({
+              role: 'user',
+              content: expect.arrayContaining([expect.any(ToolResultBlock)]),
+            }),
+            metrics: expectLoopMetrics({
+              cycleCount: 1,
+              toolNames: ['loop'],
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            }),
+          })
+        )
+      })
+    })
+
+    describe('when budget is generous', () => {
+      it('does not trip and the model ends naturally', async () => {
+        const model = new MockMessageModel().addTurn(
+          { type: 'textBlock', text: 'done' },
+          { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } }
+        )
+        const agent = new Agent({ model })
+
+        const result = await agent.invoke('go', { maxTurns: 5, maxOutputTokens: 1000, maxTotalTokens: 1000 })
+
+        expect(result).toEqual(
+          expectAgentResult({
+            stopReason: 'endTurn',
+            messageText: 'done',
+            cycleCount: 1,
+            usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+          })
+        )
+      })
+    })
+
+    describe('when maxOutputTokens is reached', () => {
+      it('returns maxOutputTokensExceeded once cumulative outputTokens hits the cap', async () => {
+        const model = new MockMessageModel()
+          .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 60, totalTokens: 70 }))
+          .addTurn(...toolUseTurn('tool-2', { inputTokens: 10, outputTokens: 60, totalTokens: 70 }))
+
+        const agent = new Agent({ model, tools: [passthroughTool()] })
+
+        const result = await agent.invoke('go', { maxOutputTokens: 100 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxOutputTokensExceeded',
+            lastMessage: expect.objectContaining({
+              role: 'user',
+              content: expect.arrayContaining([expect.any(ToolResultBlock)]),
+            }),
+            metrics: expectLoopMetrics({
+              cycleCount: 2,
+              toolNames: ['loop'],
+              usage: { inputTokens: 20, outputTokens: 120, totalTokens: 140 },
+            }),
+          })
+        )
+      })
+
+      it('uses at-most (>=) semantics: stops when count exactly equals the cap', async () => {
+        const model = new MockMessageModel()
+          .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 100, totalTokens: 110 }))
+          .addTurn(...toolUseTurn('tool-2', { inputTokens: 10, outputTokens: 100, totalTokens: 110 }))
+
+        const agent = new Agent({ model, tools: [passthroughTool()] })
+
+        const result = await agent.invoke('go', { maxOutputTokens: 100 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxOutputTokensExceeded',
+            metrics: expectLoopMetrics({
+              cycleCount: 1,
+              toolNames: ['loop'],
+              usage: { inputTokens: 10, outputTokens: 100, totalTokens: 110 },
+            }),
+          })
+        )
+      })
+    })
+
+    describe('when maxTotalTokens is reached', () => {
+      it('returns maxTotalTokensExceeded once cumulative totalTokens hits the cap', async () => {
+        const model = new MockMessageModel()
+          .addTurn(...toolUseTurn('tool-1', { inputTokens: 200, outputTokens: 100, totalTokens: 300 }))
+          .addTurn(...toolUseTurn('tool-2', { inputTokens: 200, outputTokens: 100, totalTokens: 300 }))
+
+        const agent = new Agent({ model, tools: [passthroughTool()] })
+
+        const result = await agent.invoke('go', { maxTotalTokens: 500 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxTotalTokensExceeded',
+            lastMessage: expect.objectContaining({
+              role: 'user',
+              content: expect.arrayContaining([expect.any(ToolResultBlock)]),
+            }),
+            metrics: expectLoopMetrics({
+              cycleCount: 2,
+              toolNames: ['loop'],
+              usage: { inputTokens: 400, outputTokens: 200, totalTokens: 600 },
+            }),
+          })
+        )
+      })
+    })
+
+    describe('when the model ends naturally on the same turn the budget would trip', () => {
+      it('returns endTurn — the model answer wins', async () => {
+        const model = new MockMessageModel().addTurn(
+          { type: 'textBlock', text: 'final answer' },
+          { usage: { inputTokens: 300, outputTokens: 300, totalTokens: 600 } }
+        )
+        const agent = new Agent({ model })
+
+        const result = await agent.invoke('go', { maxTotalTokens: 500 })
+
+        expect(result).toEqual(
+          expectAgentResult({
+            stopReason: 'endTurn',
+            messageText: 'final answer',
+            cycleCount: 1,
+            usage: { inputTokens: 300, outputTokens: 300, totalTokens: 600 },
+          })
+        )
+      })
+    })
+
+    describe('when multiple budgets trip simultaneously', () => {
+      const heavyUsage = { inputTokens: 100, outputTokens: 100, totalTokens: 200 }
+
+      const buildAgent = (): Agent => {
+        const model = new MockMessageModel()
+          .addTurn(...toolUseTurn('tool-1', heavyUsage))
+          .addTurn(...toolUseTurn('tool-2', heavyUsage))
+        return new Agent({ model, tools: [passthroughTool()] })
+      }
+
+      it('prefers maxTurns when all three trip', async () => {
+        const result = await buildAgent().invoke('go', { maxTurns: 1, maxTotalTokens: 1, maxOutputTokens: 1 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxTurnsExceeded',
+            metrics: expectLoopMetrics({ cycleCount: 1, toolNames: ['loop'] }),
+          })
+        )
+      })
+
+      it('prefers maxTotalTokens over maxOutputTokens', async () => {
+        const result = await buildAgent().invoke('go', { maxTotalTokens: 1, maxOutputTokens: 1 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxTotalTokensExceeded',
+            metrics: expectLoopMetrics({ cycleCount: 1, toolNames: ['loop'] }),
+          })
+        )
+      })
+
+      it('falls back to maxOutputTokens when no higher-priority cap is set', async () => {
+        const result = await buildAgent().invoke('go', { maxOutputTokens: 1 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxOutputTokensExceeded',
+            metrics: expectLoopMetrics({ cycleCount: 1, toolNames: ['loop'] }),
+          })
+        )
+      })
+    })
+
+    describe('when a zero cap trips on iteration 1', () => {
+      it('synthesizes an assistant message since none has been appended yet', async () => {
+        const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'never reached' })
+        const agent = new Agent({ model })
+
+        const result = await agent.invoke('go', { maxTurns: 0 })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            type: 'agentResult',
+            stopReason: 'maxTurnsExceeded',
+            lastMessage: expect.objectContaining({ role: 'assistant', content: [] }),
+            metrics: expectLoopMetrics({ cycleCount: 0 }),
+          })
+        )
+      })
+    })
+
+    describe('when the same agent is reused across invocations', () => {
+      it('scopes the budget to the current invocation, not lifetime', async () => {
+        // Each turn uses 50 output tokens. With maxOutputTokens: 75, a single
+        // invocation tolerates one turn but trips on the second. If the cap
+        // were lifetime-scoped, the second `invoke()` would trip on its first
+        // turn (75 cumulative across both calls).
+        const model = new MockMessageModel()
+          .addTurn({ type: 'textBlock', text: 'first' }, { usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 } })
+          .addTurn({ type: 'textBlock', text: 'second' }, { usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 } })
+
+        const agent = new Agent({ model })
+
+        const r1 = await agent.invoke('go', { maxOutputTokens: 75 })
+        const r2 = await agent.invoke('go again', { maxOutputTokens: 75 })
+
+        expect(r1.stopReason).toBe('endTurn')
+        expect(r2.stopReason).toBe('endTurn')
+      })
+    })
+
+    describe('when invoked via stream()', () => {
+      it('returns maxTurnsExceeded as the generator return value', async () => {
+        const model = new MockMessageModel()
+          .addTurn(...toolUseTurn('tool-1', { inputTokens: 10, outputTokens: 5, totalTokens: 15 }))
+          .addTurn(...toolUseTurn('tool-2', { inputTokens: 10, outputTokens: 5, totalTokens: 15 }))
+
+        const agent = new Agent({ model, tools: [passthroughTool()] })
+
+        const { result } = await collectGenerator(agent.stream('go', { maxTurns: 1 }))
+
+        expect(result).toEqual(
+          expect.objectContaining({ type: 'agentResult', stopReason: 'maxTurnsExceeded' })
+        )
+      })
+    })
+  })
 })

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -2151,8 +2151,14 @@ describe('normalizeToolUseNames', () => {
         // were lifetime-scoped, the second `invoke()` would trip on its first
         // turn (75 cumulative across both calls).
         const model = new MockMessageModel()
-          .addTurn({ type: 'textBlock', text: 'first' }, { usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 } })
-          .addTurn({ type: 'textBlock', text: 'second' }, { usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 } })
+          .addTurn(
+            { type: 'textBlock', text: 'first' },
+            { usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 } }
+          )
+          .addTurn(
+            { type: 'textBlock', text: 'second' },
+            { usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 } }
+          )
 
         const agent = new Agent({ model })
 
@@ -2188,9 +2194,7 @@ describe('normalizeToolUseNames', () => {
 
         const { result } = await collectGenerator(agent.stream('go', { maxTurns: 1 }))
 
-        expect(result).toEqual(
-          expect.objectContaining({ type: 'agentResult', stopReason: 'maxTurnsExceeded' })
-        )
+        expect(result).toEqual(expect.objectContaining({ type: 'agentResult', stopReason: 'maxTurnsExceeded' }))
       })
     })
   })

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -2144,24 +2144,6 @@ describe('normalizeToolUseNames', () => {
       })
     })
 
-    describe('when a zero cap trips on iteration 1', () => {
-      it('synthesizes an assistant message since none has been appended yet', async () => {
-        const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'never reached' })
-        const agent = new Agent({ model })
-
-        const result = await agent.invoke('go', { maxTurns: 0 })
-
-        expect(result).toEqual(
-          expect.objectContaining({
-            type: 'agentResult',
-            stopReason: 'maxTurnsExceeded',
-            lastMessage: expect.objectContaining({ role: 'assistant', content: [] }),
-            metrics: expectLoopMetrics({ cycleCount: 0 }),
-          })
-        )
-      })
-    })
-
     describe('when the same agent is reused across invocations', () => {
       it('scopes the budget to the current invocation, not lifetime', async () => {
         // Each turn uses 50 output tokens. With maxOutputTokens: 75, a single
@@ -2175,10 +2157,24 @@ describe('normalizeToolUseNames', () => {
         const agent = new Agent({ model })
 
         const r1 = await agent.invoke('go', { maxOutputTokens: 75 })
-        const r2 = await agent.invoke('go again', { maxOutputTokens: 75 })
-
         expect(r1.stopReason).toBe('endTurn')
+        expect(r1.metrics?.latestAgentInvocation?.cycles.length).toBe(1)
+
+        const r2 = await agent.invoke('go again', { maxOutputTokens: 75 })
         expect(r2.stopReason).toBe('endTurn')
+        expect(r2.metrics?.latestAgentInvocation?.cycles.length).toBe(1)
+      })
+    })
+
+    describe('when a budget option is invalid', () => {
+      it.each([
+        ['negative', { maxTurns: -1 }],
+        ['zero', { maxTurns: 0 }],
+        ['NaN', { maxOutputTokens: NaN }],
+        ['Infinity', { maxTotalTokens: Infinity }],
+      ])('rejects %s with TypeError', async (_label, options) => {
+        const agent = new Agent({ model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'never reached' }) })
+        await expect(agent.invoke('go', options)).rejects.toThrow(TypeError)
       })
     })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -15,6 +15,7 @@ import {
   type ContentBlockData,
   Message,
   type MessageData,
+  type StopReason,
   type SystemPrompt,
   type SystemPromptData,
   TextBlock,
@@ -494,6 +495,41 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
+   * Evaluates the per-invocation budget caps in {@link InvokeOptions} against
+   * the current invocation's metrics. Called at the top of each agent-loop
+   * iteration, after `_throwIfCancelled` and before `startCycle`.
+   *
+   * Reads from {@link AgentMetrics.latestAgentInvocation} (scoped to the
+   * current invocation) — not `cycleCount` / `accumulatedUsage`, which are
+   * lifetime accumulators that would cause caps to fire prematurely on the
+   * second `invoke()` call against a reused agent.
+   *
+   * Priority on simultaneous trip: maxTurns → maxTotalTokens → maxOutputTokens.
+   *
+   * Returns the {@link StopReason} the loop should terminate with, or
+   * `undefined` if every configured cap is still within budget.
+   */
+  private _checkMaxBudgets(options: InvokeOptions | undefined): StopReason | undefined {
+    if (!options) return undefined
+    const invocation = this._meter.metrics.latestAgentInvocation
+    if (!invocation) return undefined
+
+    const cycleCount = invocation.cycles.length
+    const { outputTokens, totalTokens } = invocation.usage
+
+    if (options.maxTurns !== undefined && cycleCount >= options.maxTurns) {
+      return 'maxTurnsExceeded'
+    }
+    if (options.maxTotalTokens !== undefined && totalTokens >= options.maxTotalTokens) {
+      return 'maxTotalTokensExceeded'
+    }
+    if (options.maxOutputTokens !== undefined && outputTokens >= options.maxOutputTokens) {
+      return 'maxOutputTokensExceeded'
+    }
+    return undefined
+  }
+
+  /**
    * The tools this agent can use.
    */
   get tools(): Tool[] {
@@ -928,6 +964,19 @@ export class Agent implements LocalAgent, InvokableAgent {
       // Main agent loop - continues until model stops without requesting tools
       while (true) {
         this._throwIfCancelled()
+
+        const budgetStopReason = this._checkMaxBudgets(options)
+        if (budgetStopReason) {
+          // Fallback: a zero-valued cap can trip on iteration 1 before any messages are appended.
+          const lastMessage = this.messages.at(-1) ?? new Message({ role: 'assistant', content: [] })
+          return new AgentResult({
+            stopReason: budgetStopReason,
+            lastMessage,
+            traces: this._tracer.localTraces,
+            metrics: this._meter.metrics,
+            invocationState,
+          })
+        }
 
         // Start metrics cycle tracking
         const { cycleId, startTime: cycleStartTime } = this._meter.startCycle()

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -495,58 +495,59 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Validates the per-invocation budget caps in {@link InvokeOptions}. Called
-   * once at the top of `_stream` so bad inputs fail fast with a clear error
-   * instead of silently no-op'ing (`NaN`, `Infinity`) or tripping pathologically
-   * (zero swallows the user input; negative trips immediately).
+   * Validates the per-invocation budget caps in {@link InvokeOptions.limits}.
+   * Called once at the top of `_stream` so bad inputs fail fast with a clear
+   * error instead of silently no-op'ing (`NaN`, `Infinity`) or tripping
+   * pathologically (zero swallows the user input; negative trips immediately).
    *
    * Each cap, when set, must be a positive finite number. Fractional values
    * are accepted — harmless, and useful for token budgets derived from
    * arithmetic.
    */
-  private _validateMaxBudgets(options: InvokeOptions | undefined): void {
-    if (!options) return
+  private _validateLimits(options: InvokeOptions | undefined): void {
+    if (!options?.limits) return
     const assertPositive = (name: string, value: number | undefined): void => {
       if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
         throw new TypeError(`${name} must be a positive finite number, got ${value}`)
       }
     }
-    assertPositive('maxTurns', options.maxTurns)
-    assertPositive('maxOutputTokens', options.maxOutputTokens)
-    assertPositive('maxTotalTokens', options.maxTotalTokens)
+    assertPositive('limits.turns', options.limits.turns)
+    assertPositive('limits.outputTokens', options.limits.outputTokens)
+    assertPositive('limits.totalTokens', options.limits.totalTokens)
   }
 
   /**
-   * Evaluates the per-invocation budget caps in {@link InvokeOptions} against
-   * the current invocation's metrics. Called at the top of each agent-loop
-   * iteration, after `_throwIfCancelled` and before `startCycle`.
+   * Evaluates the per-invocation budget caps in {@link InvokeOptions.limits}
+   * against the current invocation's metrics. Called at the top of each
+   * agent-loop iteration, after `_throwIfCancelled` and before `startCycle`.
    *
    * Reads from {@link AgentMetrics.latestAgentInvocation} (scoped to the
    * current invocation) — not `cycleCount` / `accumulatedUsage`, which are
    * lifetime accumulators that would cause caps to fire prematurely on the
    * second `invoke()` call against a reused agent.
    *
-   * Priority on simultaneous trip: maxTurns → maxTotalTokens → maxOutputTokens.
+   * Priority on simultaneous trip: turns → totalTokens → outputTokens.
    *
    * Returns the {@link StopReason} the loop should terminate with, or
    * `undefined` if every configured cap is still within budget.
    */
-  private _checkMaxBudgets(options: InvokeOptions | undefined): StopReason | undefined {
-    if (!options) return undefined
+  private _checkLimits(options: InvokeOptions | undefined): StopReason | undefined {
+    const limits = options?.limits
+    if (!limits) return undefined
     const invocation = this._meter.metrics.latestAgentInvocation
     if (!invocation) return undefined
 
     const cycleCount = invocation.cycles.length
     const { outputTokens, totalTokens } = invocation.usage
 
-    if (options.maxTurns !== undefined && cycleCount >= options.maxTurns) {
-      return 'maxTurnsExceeded'
+    if (limits.turns !== undefined && cycleCount >= limits.turns) {
+      return 'limitTurns'
     }
-    if (options.maxTotalTokens !== undefined && totalTokens >= options.maxTotalTokens) {
-      return 'maxTotalTokensExceeded'
+    if (limits.totalTokens !== undefined && totalTokens >= limits.totalTokens) {
+      return 'limitTotalTokens'
     }
-    if (options.maxOutputTokens !== undefined && outputTokens >= options.maxOutputTokens) {
-      return 'maxOutputTokensExceeded'
+    if (limits.outputTokens !== undefined && outputTokens >= limits.outputTokens) {
+      return 'limitOutputTokens'
     }
     return undefined
   }
@@ -920,7 +921,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     let currentArgs: InvokeArgs | undefined = args
     let result: AgentResult | undefined
 
-    this._validateMaxBudgets(options)
+    this._validateLimits(options)
 
     // Resolve structured output schema from per-invocation options or constructor config
     const structuredOutputSchema = options?.structuredOutputSchema ?? this._structuredOutputSchema
@@ -989,10 +990,10 @@ export class Agent implements LocalAgent, InvokableAgent {
       while (true) {
         this._throwIfCancelled()
 
-        const budgetStopReason = this._checkMaxBudgets(options)
-        if (budgetStopReason) {
+        const limitStopReason = this._checkLimits(options)
+        if (limitStopReason) {
           result = new AgentResult({
-            stopReason: budgetStopReason,
+            stopReason: limitStopReason,
             lastMessage: this.messages.at(-1)!,
             traces: this._tracer.localTraces,
             metrics: this._meter.metrics,

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -495,6 +495,28 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
+   * Validates the per-invocation budget caps in {@link InvokeOptions}. Called
+   * once at the top of `_stream` so bad inputs fail fast with a clear error
+   * instead of silently no-op'ing (`NaN`, `Infinity`) or tripping pathologically
+   * (zero swallows the user input; negative trips immediately).
+   *
+   * Each cap, when set, must be a positive finite number. Fractional values
+   * are accepted — harmless, and useful for token budgets derived from
+   * arithmetic.
+   */
+  private _validateMaxBudgets(options: InvokeOptions | undefined): void {
+    if (!options) return
+    const assertPositive = (name: string, value: number | undefined): void => {
+      if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
+        throw new TypeError(`${name} must be a positive finite number, got ${value}`)
+      }
+    }
+    assertPositive('maxTurns', options.maxTurns)
+    assertPositive('maxOutputTokens', options.maxOutputTokens)
+    assertPositive('maxTotalTokens', options.maxTotalTokens)
+  }
+
+  /**
    * Evaluates the per-invocation budget caps in {@link InvokeOptions} against
    * the current invocation's metrics. Called at the top of each agent-loop
    * iteration, after `_throwIfCancelled` and before `startCycle`.
@@ -898,6 +920,8 @@ export class Agent implements LocalAgent, InvokableAgent {
     let currentArgs: InvokeArgs | undefined = args
     let result: AgentResult | undefined
 
+    this._validateMaxBudgets(options)
+
     // Resolve structured output schema from per-invocation options or constructor config
     const structuredOutputSchema = options?.structuredOutputSchema ?? this._structuredOutputSchema
     const structuredOutputTool = structuredOutputSchema ? new StructuredOutputTool(structuredOutputSchema) : undefined
@@ -967,15 +991,14 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         const budgetStopReason = this._checkMaxBudgets(options)
         if (budgetStopReason) {
-          // Fallback: a zero-valued cap can trip on iteration 1 before any messages are appended.
-          const lastMessage = this.messages.at(-1) ?? new Message({ role: 'assistant', content: [] })
-          return new AgentResult({
+          result = new AgentResult({
             stopReason: budgetStopReason,
-            lastMessage,
+            lastMessage: this.messages.at(-1)!,
             traces: this._tracer.localTraces,
             metrics: this._meter.metrics,
             invocationState,
           })
+          return result
         }
 
         // Start metrics cycle tracking

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -118,6 +118,73 @@ export interface InvokeOptions {
    * ```
    */
   cancelSignal?: AbortSignal
+
+  /**
+   * Maximum number of agent loop iterations (turns) for this invocation.
+   * A turn is one model call plus any tool execution that follows.
+   *
+   * Per-invocation: counted from this `invoke()` / `stream()` call, not
+   * cumulative across reuses of the same agent. Checked at the top of each
+   * loop iteration against
+   * `metrics.latestAgentInvocation.cycles.length`. Tools requested by the
+   * previous turn always run to completion before the cap fires, so
+   * `agent.messages` remains in a reinvokable state.
+   *
+   * Setting `maxTurns: 0` returns immediately with
+   * `stopReason: 'maxTurnsExceeded'` and a synthesized empty assistant
+   * message — no model call is made and no user input is appended.
+   *
+   * Omit (or set to `undefined`) for no limit.
+   */
+  maxTurns?: number
+
+  /**
+   * Maximum cumulative model-generated tokens for this invocation, summed
+   * across every model call in the agent loop
+   * (`metrics.latestAgentInvocation.usage.outputTokens`).
+   *
+   * Per-invocation: counted from this call, not cumulative across reuses of
+   * the same agent. Distinct from per-call provider-level `maxTokens`
+   * settings (e.g. `GoogleModelConfig.params.maxOutputTokens`), which bound
+   * a single model call's output. This option bounds the loop's cumulative
+   * output across however many calls it makes.
+   *
+   * Checked at the top of each loop iteration. When the count is at or above
+   * `maxOutputTokens`, the agent returns with
+   * `stopReason: 'maxOutputTokensExceeded'`.
+   *
+   * Soft cap: a single oversized model response can overshoot the budget.
+   * The agent stops at the first turn boundary on or after the budget is
+   * reached; it does not bound any individual model call.
+   *
+   * Omit for no limit.
+   */
+  maxOutputTokens?: number
+
+  /**
+   * Maximum cumulative input + output tokens for this invocation
+   * (`metrics.latestAgentInvocation.usage.totalTokens`). Each model call's
+   * input includes prior turns, so this counter compounds across the run —
+   * it approximates the total token spend you would be billed for.
+   *
+   * Per-invocation: counted from this call, not cumulative across reuses of
+   * the same agent.
+   *
+   * Checked at the top of each loop iteration. When the count is at or above
+   * `maxTotalTokens`, the agent returns with
+   * `stopReason: 'maxTotalTokensExceeded'`.
+   *
+   * Soft cap: a single oversized model response can overshoot the budget.
+   * The agent stops at the first turn boundary on or after the budget is
+   * reached; it does not bound any individual model call.
+   *
+   * If both `maxOutputTokens` and `maxTotalTokens` would trip on the same
+   * iteration, `maxTotalTokensExceeded` wins. If `maxTurns` would also trip,
+   * `maxTurnsExceeded` wins over both.
+   *
+   * Omit for no limit.
+   */
+  maxTotalTokens?: number
 }
 
 /**

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -120,68 +120,58 @@ export interface InvokeOptions {
   cancelSignal?: AbortSignal
 
   /**
-   * Maximum number of agent loop iterations (turns) for this invocation.
-   * A turn is one model call plus any tool execution that follows.
+   * Per-invocation budget caps. Each cap, when set, bounds the agent loop
+   * for this `invoke()` / `stream()` call only — counters are not cumulative
+   * across reuses of the same agent.
    *
-   * Per-invocation: counted from this `invoke()` / `stream()` call, not
-   * cumulative across reuses of the same agent. Checked at the top of each
-   * loop iteration against
-   * `metrics.latestAgentInvocation.cycles.length`. Tools requested by the
-   * previous turn always run to completion before the cap fires, so
+   * Caps are checked at the top of each loop iteration. Tools requested by
+   * the previous turn always run to completion before a cap fires, so
    * `agent.messages` remains in a reinvokable state.
    *
-   * Must be a positive finite number. Omit (or set to `undefined`) for no
-   * limit.
+   * Each cap, when set, must be a positive finite number. Omit any field
+   * (or `limits` itself) for no limit on that dimension.
+   *
+   * Priority on simultaneous trip (highest first): `turns`, `totalTokens`,
+   * `outputTokens`. The corresponding `stopReason` is `'limitTurns'`,
+   * `'limitTotalTokens'`, or `'limitOutputTokens'`.
    */
-  maxTurns?: number
+  limits?: {
+    /**
+     * Maximum number of agent loop iterations (turns). A turn is one model
+     * call plus any tool execution that follows. Counted against
+     * `metrics.latestAgentInvocation.cycles.length`.
+     */
+    turns?: number
 
-  /**
-   * Maximum cumulative model-generated tokens for this invocation, summed
-   * across every model call in the agent loop
-   * (`metrics.latestAgentInvocation.usage.outputTokens`).
-   *
-   * Per-invocation: counted from this call, not cumulative across reuses of
-   * the same agent. Distinct from per-call provider-level `maxTokens`
-   * settings (e.g. `GoogleModelConfig.params.maxOutputTokens`), which bound
-   * a single model call's output. This option bounds the loop's cumulative
-   * output across however many calls it makes.
-   *
-   * Checked at the top of each loop iteration. When the count is at or above
-   * `maxOutputTokens`, the agent returns with
-   * `stopReason: 'maxOutputTokensExceeded'`.
-   *
-   * Soft cap: a single oversized model response can overshoot the budget.
-   * The agent stops at the first turn boundary on or after the budget is
-   * reached; it does not bound any individual model call.
-   *
-   * Must be a positive finite number. Omit for no limit.
-   */
-  maxOutputTokens?: number
+    /**
+     * Maximum cumulative model-generated tokens, summed across every model
+     * call in the agent loop
+     * (`metrics.latestAgentInvocation.usage.outputTokens`).
+     *
+     * Distinct from per-call provider-level `maxTokens` settings (e.g.
+     * `GoogleModelConfig.params.maxOutputTokens`), which bound a single
+     * model call's output. This cap bounds the loop's cumulative output
+     * across however many calls it makes.
+     *
+     * Soft cap: a single oversized model response can overshoot the budget.
+     * The agent stops at the first turn boundary on or after the budget is
+     * reached; it does not bound any individual model call.
+     */
+    outputTokens?: number
 
-  /**
-   * Maximum cumulative input + output tokens for this invocation
-   * (`metrics.latestAgentInvocation.usage.totalTokens`). Each model call's
-   * input includes prior turns, so this counter compounds across the run —
-   * it approximates the total token spend you would be billed for.
-   *
-   * Per-invocation: counted from this call, not cumulative across reuses of
-   * the same agent.
-   *
-   * Checked at the top of each loop iteration. When the count is at or above
-   * `maxTotalTokens`, the agent returns with
-   * `stopReason: 'maxTotalTokensExceeded'`.
-   *
-   * Soft cap: a single oversized model response can overshoot the budget.
-   * The agent stops at the first turn boundary on or after the budget is
-   * reached; it does not bound any individual model call.
-   *
-   * If both `maxOutputTokens` and `maxTotalTokens` would trip on the same
-   * iteration, `maxTotalTokensExceeded` wins. If `maxTurns` would also trip,
-   * `maxTurnsExceeded` wins over both.
-   *
-   * Must be a positive finite number. Omit for no limit.
-   */
-  maxTotalTokens?: number
+    /**
+     * Maximum cumulative input + output tokens
+     * (`metrics.latestAgentInvocation.usage.totalTokens`). Each model
+     * call's input includes prior turns, so this counter compounds across
+     * the run — it approximates the total token spend you would be billed
+     * for.
+     *
+     * Soft cap: a single oversized model response can overshoot the budget.
+     * The agent stops at the first turn boundary on or after the budget is
+     * reached; it does not bound any individual model call.
+     */
+    totalTokens?: number
+  }
 }
 
 /**

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -130,11 +130,8 @@ export interface InvokeOptions {
    * previous turn always run to completion before the cap fires, so
    * `agent.messages` remains in a reinvokable state.
    *
-   * Setting `maxTurns: 0` returns immediately with
-   * `stopReason: 'maxTurnsExceeded'` and a synthesized empty assistant
-   * message — no model call is made and no user input is appended.
-   *
-   * Omit (or set to `undefined`) for no limit.
+   * Must be a positive finite number. Omit (or set to `undefined`) for no
+   * limit.
    */
   maxTurns?: number
 
@@ -157,7 +154,7 @@ export interface InvokeOptions {
    * The agent stops at the first turn boundary on or after the budget is
    * reached; it does not bound any individual model call.
    *
-   * Omit for no limit.
+   * Must be a positive finite number. Omit for no limit.
    */
   maxOutputTokens?: number
 
@@ -182,7 +179,7 @@ export interface InvokeOptions {
    * iteration, `maxTotalTokensExceeded` wins. If `maxTurns` would also trip,
    * `maxTurnsExceeded` wins over both.
    *
-   * Omit for no limit.
+   * Must be a positive finite number. Omit for no limit.
    */
   maxTotalTokens?: number
 }

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -658,9 +658,9 @@ export class JsonBlock implements JsonBlockData, JSONSerializable<JsonBlockData>
  * - `guardrailIntervened` - A guardrail policy stopped generation
  * - `interrupt` - Agent execution was interrupted for human input
  * - `maxTokens` - The model provider's per-call token cap was reached
- * - `maxOutputTokensExceeded` - Agent loop stopped because `InvokeOptions.maxOutputTokens` was reached
- * - `maxTotalTokensExceeded` - Agent loop stopped because `InvokeOptions.maxTotalTokens` was reached
- * - `maxTurnsExceeded` - Agent loop stopped because `InvokeOptions.maxTurns` was reached
+ * - `limitOutputTokens` - Agent loop stopped because `InvokeOptions.limits.outputTokens` was reached
+ * - `limitTotalTokens` - Agent loop stopped because `InvokeOptions.limits.totalTokens` was reached
+ * - `limitTurns` - Agent loop stopped because `InvokeOptions.limits.turns` was reached
  * - `pauseTurn` - Model paused a long-running turn; the response should be sent back to continue
  * - `refusal` - A streaming classifier intervened to handle a potential policy violation
  * - `stopSequence` - A stop sequence was encountered
@@ -674,9 +674,9 @@ export type StopReason =
   | 'guardrailIntervened'
   | 'interrupt'
   | 'maxTokens'
-  | 'maxOutputTokensExceeded'
-  | 'maxTotalTokensExceeded'
-  | 'maxTurnsExceeded'
+  | 'limitOutputTokens'
+  | 'limitTotalTokens'
+  | 'limitTurns'
   | 'pauseTurn'
   | 'refusal'
   | 'stopSequence'

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -657,7 +657,10 @@ export class JsonBlock implements JsonBlockData, JSONSerializable<JsonBlockData>
  * - `endTurn` - Natural end of the model's turn
  * - `guardrailIntervened` - A guardrail policy stopped generation
  * - `interrupt` - Agent execution was interrupted for human input
- * - `maxTokens` - Maximum token limit was reached
+ * - `maxTokens` - The model provider's per-call token cap was reached
+ * - `maxOutputTokensExceeded` - Agent loop stopped because `InvokeOptions.maxOutputTokens` was reached
+ * - `maxTotalTokensExceeded` - Agent loop stopped because `InvokeOptions.maxTotalTokens` was reached
+ * - `maxTurnsExceeded` - Agent loop stopped because `InvokeOptions.maxTurns` was reached
  * - `pauseTurn` - Model paused a long-running turn; the response should be sent back to continue
  * - `refusal` - A streaming classifier intervened to handle a potential policy violation
  * - `stopSequence` - A stop sequence was encountered
@@ -671,6 +674,9 @@ export type StopReason =
   | 'guardrailIntervened'
   | 'interrupt'
   | 'maxTokens'
+  | 'maxOutputTokensExceeded'
+  | 'maxTotalTokensExceeded'
+  | 'maxTurnsExceeded'
   | 'pauseTurn'
   | 'refusal'
   | 'stopSequence'


### PR DESCRIPTION
## Description

Adds an optional `limits` object to `Agent.invoke()` / `Agent.stream()` via `InvokeOptions`, with three per-invocation caps: `turns`, `outputTokens`, and `totalTokens`.

Today an agent loop runs until the model stops requesting tools, a hook halts it, or it's cancelled — there is no caller-side guardrail on cost or runaway behavior. Callers who want to bound a run have to wire a hook themselves or wrap the call in a timeout, which races against the model rather than terminating cleanly at a turn boundary.

When a cap is reached, the agent loop terminates gracefully at the next turn boundary and returns an `AgentResult` with a new `stopReason` — no throw, mirroring how `'cancelled'` already works. `lastMessage` and `metrics` remain accessible on the result.

```typescript
// Cap loop iterations
const result = await agent.invoke('Plan a trip', { limits: { turns: 5 } })
if (result.stopReason === 'limitTurns') { /* ... */ }

// Cap cumulative model-generated tokens
const result = await agent.invoke('Summarize', { limits: { outputTokens: 10_000 } })
if (result.stopReason === 'limitOutputTokens') { /* ... */ }

// Cap cumulative input + output tokens (compounds across turns; approximates billed spend)
const result = await agent.invoke('Research X', { limits: { totalTokens: 100_000 } })
if (result.stopReason === 'limitTotalTokens') { /* ... */ }

// Combine
const result = await agent.invoke('Plan a trip', {
  limits: { turns: 10, outputTokens: 50_000, totalTokens: 200_000 },
})
```

`StopReason` gains three string variants: `'limitTurns'`, `'limitOutputTokens'`, `'limitTotalTokens'`. The existing `'maxTokens'` (and `MaxTokensError`) is unchanged — that one signals the model provider's per-call output cap and still throws. The new caller-set caps are graceful.

### Why a `limits` object instead of top-level options

Grouping under `limits` keeps the top-level `InvokeOptions` surface stable as future caps (wall-clock, cost, etc.) are added, and reads naturally as a cohesive concept. The stopReasons are namespaced with a `limit` prefix so granular telemetry / log buckets are preserved — a single `limitExceeded` reason would force callers to derive which cap tripped from `result.metrics` + `limits`, losing the dashboard-level cardinality.

### Semantics

- **Per-invocation, not lifetime**: counters reset on each `invoke()` / `stream()` call against the same agent.
- **Priority on simultaneous trip**: `turns` → `totalTokens` → `outputTokens`.
- **Reinvokable state**: tools requested by the previous turn always run to completion before a cap fires, so `agent.messages` stays in a state the agent can be reinvoked from.
- **Soft cap**: a single oversized model response can overshoot the budget by one turn — the cap is checked at turn boundaries, not within an individual model call.
- **Validation**: each cap, when set, must be a positive finite number; invalid values throw `TypeError` at the start of the invocation.

Backward compatible; omitting `limits` preserves prior behavior.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
