### PR TITLE
feat: export McpTool from package index

### DIFF
--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -140,6 +140,9 @@ export type { ZodToolConfig } from './tools/zod-tool.js'
 // Tool factory function
 export { tool } from './tools/tool-factory.js'
 
+// McpTool implementation
+export { McpTool } from './tools/mcp-tool.js'
+
 // Streaming event types
 export type {
   Usage,


### PR DESCRIPTION
## Description
`McpTool` is already a public class in `tools/mcp-tool.ts`, but it isn't re-exported from the package index, so it's unreachable from outside the package: the `exports` field only whitelists `.`, and Node's subpath enforcement blocks any deeper imports. This makes it impossible to subclass McpClient (which is exported) and return McpTool instances from a custom `listTools()`, since the McpTool constructor reference isn't accessible.

Note that the Python SDK exports this as `MCPAgentTool` so this gives us compatibility.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
