### PR TITLE
feat: simplify DockerSandbox interface to take container ID

### DIFF
--- a/strands-ts/src/sandbox/__tests__/docker.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/docker.test.node.ts
@@ -4,7 +4,6 @@ import { streamProcess } from '../stream-process.js'
 import type { ExecutionResult } from '../types.js'
 
 const OK: ExecutionResult = { type: 'executionResult', exitCode: 0, stdout: '', stderr: '', outputFiles: [] }
-const FAIL: ExecutionResult = { type: 'executionResult', exitCode: 1, stdout: '', stderr: 'boom', outputFiles: [] }
 
 vi.mock('../stream-process.js', () => ({
   streamProcess: vi.fn(async function* () {
@@ -12,123 +11,32 @@ vi.mock('../stream-process.js', () => ({
   }),
 }))
 
-const findRunArgs = (): string[] => {
-  const call = vi.mocked(streamProcess).mock.calls.find(([, args]) => args[0] === 'run')
-  if (!call) throw new Error('docker run was never called')
-  return call[1]
-}
-
 describe('DockerSandbox', () => {
   beforeEach(() => {
     vi.mocked(streamProcess).mockClear()
   })
 
-  it('throws when a volume mount exposes a sensitive host path', () => {
-    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/etc:/mnt/etc'] })).toThrow(/sensitive host path/)
+  it('defaults user to 1000:1000', async () => {
+    const sandbox = new DockerSandbox({ containerId: 'c' })
+    await sandbox.execute('x')
+
+    const args = vi.mocked(streamProcess).mock.calls[0]![1]
+    expect(args[args.indexOf('--user') + 1]).toBe('1000:1000')
   })
 
-  it('allows dangerous mounts when allowDangerousMounts is true', () => {
-    expect(
-      () => new DockerSandbox({ image: 'alpine', volumes: ['/etc:/mnt/etc'], allowDangerousMounts: true })
-    ).not.toThrow()
+  it('defaults workingDir to /tmp', async () => {
+    const sandbox = new DockerSandbox({ containerId: 'c' })
+    await sandbox.execute('x')
+
+    const args = vi.mocked(streamProcess).mock.calls[0]![1]
+    expect(args[args.indexOf('-w') + 1]).toBe('/tmp')
   })
 
-  it('catches path traversal attempts in volume mounts', () => {
-    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/var/../etc:/mnt'] })).toThrow(/sensitive host path/)
-  })
+  it('cwd option overrides workingDir', async () => {
+    const sandbox = new DockerSandbox({ containerId: 'c', workingDir: '/app' })
+    await sandbox.execute('x', { cwd: '/override' })
 
-  it('does not throw for safe volume mounts', () => {
-    expect(() => new DockerSandbox({ image: 'alpine', volumes: ['/opt/myproject:/app'] })).not.toThrow()
-  })
-
-  it('runs the container as a non-root user by default', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    const userIdx = args.indexOf('--user')
-    expect(args[userIdx + 1]).toBe('1000:1000')
-  })
-
-  it('drops all capabilities and disables new privileges by default', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    expect(args).toEqual(expect.arrayContaining(['--cap-drop', 'ALL', '--security-opt', 'no-new-privileges']))
-  })
-
-  it('omits cap-drop and no-new-privileges when allowPrivilegeEscalation is true', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine', allowPrivilegeEscalation: true })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    expect(args).not.toContain('--cap-drop')
-    expect(args).not.toContain('no-new-privileges')
-  })
-
-  it('throws a clear error when the Docker daemon is unavailable', async () => {
-    vi.mocked(streamProcess).mockImplementationOnce(async function* () {
-      yield FAIL
-    })
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await expect(sandbox.start()).rejects.toThrow(/Docker is not available/)
-  })
-
-  it('throws when executeStreaming is called before start()', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await expect(sandbox.execute('echo hi')).rejects.toThrow(/not running.*start\(\)/)
-  })
-
-  it('removes the container on stop()', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine', name: 'test-stop' })
-    await sandbox.start()
-    vi.mocked(streamProcess).mockClear()
-    await sandbox.stop()
-
-    expect(streamProcess).toHaveBeenCalledWith('docker', ['rm', '-f', 'test-stop'], {
-      enoentMessage: 'docker is not installed or not on PATH',
-    })
-  })
-
-  it('passes resource limits to docker run', async () => {
-    const sandbox = new DockerSandbox({
-      image: 'alpine',
-      memory: '512m',
-      cpus: 1.5,
-      pidsLimit: 100,
-      network: 'none',
-    })
-    await sandbox.start()
-
-    const args = findRunArgs()
-    expect(args).toEqual(
-      expect.arrayContaining(['--memory', '512m', '--cpus', '1.5', '--pids-limit', '100', '--network', 'none'])
-    )
-  })
-
-  it('executes commands via docker exec with correct args', async () => {
-    const sandbox = new DockerSandbox({ image: 'alpine', name: 'test-exec' })
-    await sandbox.start()
-    vi.mocked(streamProcess).mockClear()
-    await sandbox.execute('echo hi')
-
-    expect(streamProcess).toHaveBeenCalledWith('docker', ['exec', 'test-exec', 'sh', '-c', "cd '/tmp' && echo hi"], {
-      timeout: undefined,
-      signal: undefined,
-    })
-  })
-
-  it('resets _running on start() failure so retry is possible', async () => {
-    vi.mocked(streamProcess).mockImplementationOnce(async function* () {
-      yield FAIL
-    })
-    const sandbox = new DockerSandbox({ image: 'alpine' })
-    await expect(sandbox.start()).rejects.toThrow(/Docker is not available/)
-
-    vi.mocked(streamProcess).mockImplementation(async function* () {
-      yield OK
-    })
-    await sandbox.start()
+    const args = vi.mocked(streamProcess).mock.calls[0]![1]
+    expect(args[args.indexOf('-w') + 1]).toBe('/override')
   })
 })

--- a/strands-ts/src/sandbox/docker.ts
+++ b/strands-ts/src/sandbox/docker.ts
@@ -1,59 +1,18 @@
 /**
- * Docker sandbox — executes commands inside a Docker container via `docker exec`.
+ * Docker sandbox — executes commands in a Docker container via `docker exec`.
  */
 
-import { randomUUID } from 'crypto'
-import path from 'path'
 import type { ExecuteOptions } from './base.js'
-import { PosixShellSandbox, shellQuote } from './posix-shell.js'
+import { PosixShellSandbox } from './posix-shell.js'
 import { streamProcess } from './stream-process.js'
 import type { ExecutionResult, StreamChunk } from './types.js'
-
-// Host paths that bypass container isolation when bind-mounted. Covers system
-// directories, runtime sockets, and user data that would expose the host to
-// LLM-generated commands running inside the container.
-const DANGEROUS_MOUNTS = [
-  '/',
-  '/boot',
-  '/dev',
-  '/etc',
-  '/home',
-  '/lib',
-  '/lib64',
-  '/proc',
-  '/root',
-  '/run',
-  '/sys',
-  '/tmp',
-  '/usr',
-  '/var/run',
-]
-
-// Windows drive roots (C:, D:) are flagged; POSIX paths are checked against DANGEROUS_MOUNTS.
-// Docker volume format: host:container[:options]. Windows paths (C:\...) have a colon after
-// the drive letter, so the separator search starts at index 2 to avoid splitting on it.
-function isHostPathDangerous(vol: string): boolean {
-  const sep = vol.indexOf(':', /^[a-zA-Z]:[/\\]/.test(vol) ? 2 : 0)
-  let hostPath = (sep > 0 ? vol.slice(0, sep) : vol).replace(/[/\\]+$/, '') || '/'
-  if (hostPath.startsWith('/')) hostPath = path.posix.normalize(hostPath).replace(/\/+$/, '') || '/'
-  return /^[a-zA-Z]:$/.test(hostPath) || DANGEROUS_MOUNTS.some((d) => hostPath === d || hostPath.startsWith(d + '/'))
-}
-
-async function dockerCmd(args: string[]): Promise<ExecutionResult> {
-  for await (const chunk of streamProcess('docker', args, {
-    enoentMessage: 'docker is not installed or not on PATH',
-  })) {
-    if (chunk.type === 'executionResult') return chunk
-  }
-  throw new Error(`docker command did not produce a result: docker ${args.join(' ')}`)
-}
 
 /**
  * Options for constructing a {@link DockerSandbox}.
  */
 export interface DockerSandboxOptions {
-  /** Docker image to use (e.g., `"python:3.12"`, `"node:20-alpine"`). */
-  image: string
+  /** ID or name of a running Docker container. */
+  containerId: string
   /**
    * Working directory inside the container. Defaults to `"/tmp"`.
    *
@@ -62,169 +21,36 @@ export interface DockerSandboxOptions {
    * If you specify a custom path, it must already exist in the image and be writable by `user`.
    */
   workingDir?: string
-  /** Container name. Auto-generated if not provided. */
-  name?: string
-  /**
-   * Volume mounts in `"host:container"` format.
-   *
-   * By default, mounts exposing sensitive host paths (`/`, `/etc`, `/proc`, `/sys`,
-   * `/var/run`, etc.) throw at construction time. Set {@link allowDangerousMounts}
-   * to bypass validation.
-   */
-  volumes?: string[]
-  /** Environment variables to set in the container. */
-  env?: Record<string, string>
-  /** Memory limit (e.g., `"512m"`, `"2g"`). */
-  memory?: string
-  /** CPU limit (e.g., `1.5` for one and a half cores). */
-  cpus?: number
-  /** Maximum number of PIDs in the container. Prevents fork bombs. */
-  pidsLimit?: number
-  /** Docker network mode. Use `"none"` to disable network access. */
-  network?: string
   /**
    * User to run as inside the container. Defaults to `"1000:1000"` (non-root).
    * Pass `"root"` to run as root.
    */
   user?: string
-  /**
-   * Allow mounting sensitive host paths.
-   *
-   * When `false` (default), volumes exposing dangerous host paths throw at construction time.
-   * When `true`, all volume mounts are permitted without validation.
-   */
-  allowDangerousMounts?: boolean
-  /**
-   * Allow privilege escalation inside the container.
-   *
-   * When `false` (default), applies `--cap-drop ALL` and `--security-opt no-new-privileges`
-   * to prevent setuid escalation and drop all Linux capabilities.
-   */
-  allowPrivilegeEscalation?: boolean
 }
 
-/**
- * Execute commands inside a Docker container.
- *
- * The container is created on {@link start} and destroyed on {@link stop}.
- * All sandbox operations route through `docker exec`.
- */
+/** Execute commands in a Docker container via `docker exec`. */
 export class DockerSandbox extends PosixShellSandbox {
-  readonly image: string
   readonly workingDir: string
-  private readonly _name: string
-  private readonly _volumes: string[]
-  private readonly _env: Record<string, string>
-  private readonly _memory: string | undefined
-  private readonly _cpus: number | undefined
-  private readonly _pidsLimit: number | undefined
-  private readonly _network: string | undefined
+  private readonly _containerId: string
   private readonly _user: string
-  private readonly _allowPrivilegeEscalation: boolean
-  private _running = false
 
   constructor(options: DockerSandboxOptions) {
     super()
-    this.image = options.image
-    // /tmp is world-writable on all base images — works with non-root user + cap-drop ALL.
+    this._containerId = options.containerId
     this.workingDir = options.workingDir ?? '/tmp'
-    this._name = options.name ?? `strands-sandbox-${randomUUID()}`
-    this._volumes = options.volumes ?? []
-    if (!options.allowDangerousMounts) {
-      for (const vol of this._volumes) {
-        if (isHostPathDangerous(vol)) {
-          throw new Error(
-            `Volume "${vol}" mounts a sensitive host path. ` + 'Set allowDangerousMounts: true to bypass validation.'
-          )
-        }
-      }
-    }
-    this._env = options.env ?? {}
-    this._memory = options.memory
-    this._cpus = options.cpus
-    this._pidsLimit = options.pidsLimit
-    this._network = options.network
-    // Non-root by default to limit blast radius of container escapes and in-container misbehavior.
     this._user = options.user ?? '1000:1000'
-    this._allowPrivilegeEscalation = options.allowPrivilegeEscalation ?? false
-  }
-
-  /**
-   * Create and start the Docker container.
-   *
-   * @throws If Docker is not available or the container fails to start.
-   */
-  async start(): Promise<void> {
-    if (this._running) return
-    this._running = true
-
-    try {
-      const info = await dockerCmd(['info'])
-      if (info.exitCode !== 0) {
-        throw new Error('Docker is not available. Ensure Docker is installed and running.')
-      }
-
-      const args: string[] = ['run', '-d', '--rm', '--name', this._name, '-w', this.workingDir]
-
-      for (const vol of this._volumes) {
-        args.push('-v', vol)
-      }
-      for (const [key, value] of Object.entries(this._env)) {
-        args.push('-e', `${key}=${value}`)
-      }
-      if (this._memory !== undefined) args.push('--memory', this._memory)
-      if (this._cpus !== undefined) args.push('--cpus', String(this._cpus))
-      if (this._pidsLimit !== undefined) args.push('--pids-limit', String(this._pidsLimit))
-      if (this._network !== undefined) args.push('--network', this._network)
-      args.push('--user', this._user)
-      if (!this._allowPrivilegeEscalation) {
-        args.push('--cap-drop', 'ALL')
-        args.push('--security-opt', 'no-new-privileges')
-      }
-
-      // docker run requires the image name after all flags. Furthermore, '--' terminates
-      // flag parsing so the image is always treated as a positional argument. Without
-      // this, an image like '--privileged' would be parsed as a flag, overriding --cap-drop ALL.
-      args.push('--', this.image, 'tail', '-f', '/dev/null')
-
-      const result = await dockerCmd(args)
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to start Docker container "${this._name}": ${result.stderr}`)
-      }
-    } catch (err) {
-      this._running = false
-      throw err
-    }
-  }
-
-  /** Stop and remove the Docker container. */
-  async stop(): Promise<void> {
-    if (!this._running) return
-    try {
-      await dockerCmd(['rm', '-f', this._name])
-    } finally {
-      this._running = false
-    }
   }
 
   async *executeStreaming(
     command: string,
     options?: ExecuteOptions
   ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
-    if (!this._running) {
-      throw new Error(`Docker container "${this._name}" is not running. Call start() before executing commands.`)
-    }
-
     const cwd = options?.cwd ?? this.workingDir
-    const execCommand = `cd ${shellQuote(cwd)} && ${command}`
 
-    yield* streamProcess('docker', ['exec', this._name, 'sh', '-c', execCommand], {
+    yield* streamProcess('docker', ['exec', '--user', this._user, '-w', cwd, this._containerId, 'sh', '-c', command], {
       timeout: options?.timeout,
       signal: options?.signal,
+      enoentMessage: 'docker is not installed or not on PATH',
     })
-  }
-
-  async [Symbol.asyncDispose](): Promise<void> {
-    await this.stop()
   }
 }

--- a/strands-ts/test/integ/sandbox/docker.test.node.ts
+++ b/strands-ts/test/integ/sandbox/docker.test.node.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { spawnSync } from 'child_process'
-import fs from 'fs'
-import os from 'os'
-import path from 'path'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execSync, spawnSync } from 'child_process'
 import { DockerSandbox } from '../../../src/sandbox/docker.js'
+
+const CONTAINER_NAME = 'strands-integ-docker-sandbox'
 
 function dockerAvailable(): boolean {
   if (process.platform === 'win32') return false
@@ -11,37 +10,17 @@ function dockerAvailable(): boolean {
 }
 
 describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
-  let sandbox: DockerSandbox | undefined
-
-  afterEach(async () => {
-    if (sandbox) {
-      await sandbox.stop()
-      sandbox = undefined
-    }
+  beforeAll(() => {
+    spawnSync('docker', ['rm', '-f', CONTAINER_NAME], { stdio: 'pipe' })
+    execSync(`docker run -d --name ${CONTAINER_NAME} python:3.12-slim tail -f /dev/null`, { stdio: 'pipe' })
   })
 
-  it('start() creates a container, stop() removes it', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest', name: 'strands-integ-lifecycle' })
-    await sandbox.start()
-
-    const ps = spawnSync('docker', ['ps', '--filter', 'name=strands-integ-lifecycle', '--format', '{{.Names}}'], {
-      encoding: 'utf-8',
-    })
-    expect(ps.stdout.trim()).toBe('strands-integ-lifecycle')
-
-    await sandbox.stop()
-
-    const psAfter = spawnSync(
-      'docker',
-      ['ps', '-a', '--filter', 'name=strands-integ-lifecycle', '--format', '{{.Names}}'],
-      { encoding: 'utf-8' }
-    )
-    expect(psAfter.stdout.trim()).toBe('')
+  afterAll(() => {
+    spawnSync('docker', ['rm', '-f', CONTAINER_NAME], { stdio: 'pipe' })
   })
 
   it('runs commands and captures stdout, stderr, and exit code', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ containerId: CONTAINER_NAME })
 
     const result = await sandbox.execute('echo hello && echo err >&2')
     expect(result).toStrictEqual({
@@ -57,8 +36,7 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
   })
 
   it('runs python via executeCode', async () => {
-    sandbox = new DockerSandbox({ image: 'python:3.12-slim' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ containerId: CONTAINER_NAME })
 
     const result = await sandbox.executeCode('print(6 * 7)', 'python3')
     expect(result.exitCode).toBe(0)
@@ -66,8 +44,7 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
   })
 
   it('round-trips text and binary files', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ containerId: CONTAINER_NAME })
 
     await sandbox.writeText('greeting.txt', 'hello docker')
     expect(await sandbox.readText('greeting.txt')).toBe('hello docker')
@@ -78,8 +55,7 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
   })
 
   it('lists and removes files', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
+    const sandbox = new DockerSandbox({ containerId: CONTAINER_NAME })
 
     await sandbox.writeText('a.txt', 'a')
     await sandbox.writeText('b.txt', 'b')
@@ -92,43 +68,17 @@ describe.skipIf(!dockerAvailable())('DockerSandbox (integration)', () => {
     await expect(sandbox.readFile('a.txt')).rejects.toThrow()
   })
 
-  it('mounts host volumes when configured', async () => {
-    const hostDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strands-integ-vol-'))
-    fs.writeFileSync(path.join(hostDir, 'file.txt'), 'from-host\n')
+  it('respects custom workingDir', async () => {
+    const sandbox = new DockerSandbox({ containerId: CONTAINER_NAME, workingDir: '/opt' })
 
-    try {
-      sandbox = new DockerSandbox({
-        image: 'alpine:latest',
-        volumes: [`${hostDir}:/mnt/shared`],
-        allowDangerousMounts: true,
-      })
-      await sandbox.start()
-
-      const result = await sandbox.execute('cat /mnt/shared/file.txt')
-      expect(result.stdout.trim()).toBe('from-host')
-    } finally {
-      fs.rmSync(hostDir, { recursive: true, force: true })
-    }
+    const result = await sandbox.execute('pwd')
+    expect(result.stdout.trim()).toBe('/opt')
   })
 
-  it('passes environment variables into the container', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest', env: { MY_VAR: 'hello-env' } })
-    await sandbox.start()
+  it('respects per-command cwd override', async () => {
+    const sandbox = new DockerSandbox({ containerId: CONTAINER_NAME })
 
-    const result = await sandbox.execute('echo $MY_VAR')
-    expect(result.stdout.trim()).toBe('hello-env')
-  })
-
-  it('files inside the container do not exist on the host', async () => {
-    sandbox = new DockerSandbox({ image: 'alpine:latest' })
-    await sandbox.start()
-
-    const marker = `strands-isolation-${Date.now()}`
-    await sandbox.writeText(marker, 'sandbox-only')
-
-    const content = await sandbox.readText(marker)
-    expect(content).toBe('sandbox-only')
-
-    expect(fs.existsSync(`/tmp/${marker}`)).toBe(false)
+    const result = await sandbox.execute('pwd', { cwd: '/usr' })
+    expect(result.stdout.trim()).toBe('/usr')
   })
 })


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Simplify `DockerSandbox` to "bring-your-own-container" (thin docker exec wrapper). The SDK no longer manages container lifecycle, security policies, volumes, or resource limits. Users create and configure their container externally.

Removed:
- Lifecycle control: `start()`/`stop()` methods, AsyncDisposable usage
- Low-level params: `image`, `name`, `volumes`, `env`, `memory`, `cpus`, `pidsLimit`, network options
- Various now-obsolete internal helper methods and security checks

What remains:
- `containerId` (required), `workingDir` (default /tmp), `user` (default 1000:1000)
- Single `executeStreaming` method that shells out to `docker exec`

## Related Issues

<!-- Link to related issues using #issue-number format -->

Updates #1110 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

Not yet

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

(breaking) change

## Testing

How have you tested the change?

- [ ] I ran the relevant checks (`hatch run prepare` for Python, `npm run check` for TypeScript)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
